### PR TITLE
Initial design for Post Request scaffolding

### DIFF
--- a/wordpress_api/src/lib.rs
+++ b/wordpress_api/src/lib.rs
@@ -1,3 +1,10 @@
+#![allow(dead_code)]
+use std::sync::Arc;
+
+use posts::*;
+
+mod posts;
+
 pub fn add_custom(left: i32, right: i32) -> i32 {
     left + right
 }
@@ -8,6 +15,14 @@ pub fn combine_strings(a: String, b: String) -> String {
 
 pub fn panic_from_rust() {
     std::fs::read_to_string("doesnt_exist.txt").unwrap();
+}
+
+struct RequestBuilder {}
+
+impl RequestBuilder {
+    fn posts(&self) -> Arc<PostsRequestBuilder> {
+        Arc::new(PostsRequestBuilder {})
+    }
 }
 
 #[cfg(test)]

--- a/wordpress_api/src/posts.rs
+++ b/wordpress_api/src/posts.rs
@@ -1,0 +1,51 @@
+pub struct PostsRequestBuilder {}
+
+impl PostsRequestBuilder {
+    pub fn list(&self, params: Option<PostsListParams>) -> PostsRequest {
+        todo!()
+    }
+
+    pub fn create(&self, params: Option<PostsCreateParams>) -> PostsRequest {
+        todo!()
+    }
+
+    pub fn retrieve(&self, post_id: u32, params: Option<PostsRetrieveParams>) -> PostsRequest {
+        todo!()
+    }
+
+    pub fn update(&self, post_id: u32, params: Option<PostsUpdateParams>) -> PostsRequest {
+        todo!()
+    }
+
+    pub fn delete(&self, post_id: u32, params: Option<PostsDeleteParams>) -> PostsRequest {
+        todo!()
+    }
+}
+
+pub struct PostsListParams {
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
+}
+
+pub struct PostsCreateParams {
+    pub title: Option<String>,
+    pub content: Option<String>,
+}
+
+pub struct PostsRetrieveParams {
+    pub password: Option<String>,
+}
+
+pub struct PostsUpdateParams {
+    pub title: Option<String>,
+    pub content: Option<String>,
+}
+
+pub struct PostsDeleteParams {
+    pub force: Option<bool>,
+}
+
+pub struct PostsRequest {
+    pub endpoint: String,
+    pub params: Option<String>,
+}

--- a/wordpress_api/src/wordpress_api.udl
+++ b/wordpress_api/src/wordpress_api.udl
@@ -1,5 +1,62 @@
+// These are test functions that we are keeping while we figure out the design in case
+// we need them for further testing.
 namespace wordpress_api {
   i32 add_custom(i32 a, i32 b);
   string combine_strings(string a, string b);
   void panic_from_rust();
+};
+
+interface RequestBuilder {
+  PostsRequestBuilder posts();
+};
+
+// https://developer.wordpress.org/rest-api/reference/posts/
+// TODO: The schema and some of the action arguments for `/posts` endpoint has the notion of `context`.
+// This is an `enum` value, but it can only contain partial values per field.
+// This is an important design element to get right, because it's a common pattern for the API.
+//
+// IMPORTANT: This design does not include error handling yet!
+interface PostsRequestBuilder {
+  PostsRequest list(PostsListParams? params);
+  PostsRequest create(PostsCreateParams? params);
+  PostsRequest retrieve(u32 post_id, PostsRetrieveParams? params);
+  PostsRequest update(u32 post_id, PostsUpdateParams? params);
+  PostsRequest delete(u32 post_id, PostsDeleteParams? params);
+};
+
+// If we can represent a trait relationship in UDL, we could use a common Request trait
+// However, we'd still want a specific `PostsRequest` type so that we can have a strongly typed
+// return value for it.
+//
+// The reason we can use a `PostsRequest` type and not need a more specific type such as
+// `PostsListRequest` is because the API documentation states that the return value for
+// all `/posts` requests have the same schema: https://developer.wordpress.org/rest-api/reference/posts/#schema
+// If this is not the case, we'll need more specific types.
+dictionary PostsRequest {
+  string endpoint;
+  string? params;
+};
+
+// We should check if it's possible to use the same params for update & create
+dictionary PostsCreateParams {
+  string? title;
+  string? content;
+};
+
+dictionary PostsListParams {
+  u32? page;
+  u32? per_page;
+};
+
+dictionary PostsRetrieveParams {
+  string? password;
+};
+
+dictionary PostsUpdateParams {
+  string? title;
+  string? content;
+};
+
+dictionary PostsDeleteParams {
+  boolean? force;
 };


### PR DESCRIPTION

This PR proposes an initial design for the `/posts` endpoint of WordPress.org API: https://developer.wordpress.org/rest-api/reference/posts/. It's the result of investigating several approaches in a time-boxed manner and it is not a final design.

_P.S: There is no PR review process for this repository yet, because it's all part of a prototype. So, I'll merge this PR without waiting for feedback. However, if you have any feedback, I'd love to hear about it!_

---

The first design approach we have explored was to use a `Builder` pattern for the request parameters. [It's a common design pattern for Rust](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html) and it's something developers from most programming languages are familiar with - which is important for a cross-platform project. It's also an ergonomic design when there are a lot of optional types.

The main issue we found with `Builder` pattern, in the context of using it in FFI layer, is that we can't have a mutable `self` type. For example, the following code doesn't work through FFI layer - [because it's not safe](https://mozilla.github.io/uniffi-rs/udl/interfaces.html#concurrent-access):

```
impl Counter {
    // No mutable references to self allowed in UniFFI interfaces.
    fn increment(&mut self) {
        self.value = self.value + 1;
    }
}
```

Similarly, we can't use the following approach because we can't force the accessor to give up ownership of the memory through FFI layer - not without custom code anyway:

```
struct FooBuilder {
    bar: String,
}

impl FooBuilder {
    fn name(mut self, bar: String) -> Self {
        // Set the name on the builder itself, and return the builder by value.
        self.bar = bar;
        self
    }
}
```

We have the option to use interior mutability, so for example, we could do:

```
struct FooBuilder {
    bar: RwLock<String>,
}

impl FooBuilder {
    fn name(&self, bar: String) {
        *self.bar.write().unwrap() = bar;
    }
}
```

However, notice the method signature and specifically the return type. We are no longer returning `Self` because we only have a reference to the memory. That means we can't chain commands such as `self.bar().baz()` which arguably is one of the primary reasons to utilize a `Builder` pattern.

---

From what we have learned through the `Builder` pattern exploration, the design in this PR made sense to us as an initial approach.

The primary components that were supposed to utilize the `Builder` pattern are `*Params` objects such as `PostsListParams`. The reason we thought that this design made sense as an alternative is that we'd need these components even if we used a `Builder` pattern because when we call `.build()` on a `Builder` pattern object, it's supposed to return an object such as `PostsListParams` anyway. That's all to say that, if we really want to use the `Builder` pattern in each native layer, this design will accommodate that. And in general, it's a flexible design that's meant to be built on through higher layers.

One last note is that how we are going to make requests is not investigated at all in this PR. So, the `PostsRequestBuilder` methods are returning a `PostsRequest` is mostly a placeholder at this stage.