### PR TITLE
Add uniffi generated code to kotlin main sources

### DIFF
--- a/native/android/wp_api/build.gradle
+++ b/native/android/wp_api/build.gradle
@@ -39,6 +39,7 @@ android {
 
     sourceSets {
         androidTest.jniLibs.srcDirs += "$buildDir/rustJniLibs/android"
+        main.kotlin.srcDirs += "../lib/build/generated/source/uniffi/wp_api"
     }
 }
 


### PR DESCRIPTION
👋 When I generated bindings, I've noticed that IDE didn't recognize them, making it difficult to navigate and work with. I'd like to suggest a change of adding those generated bindings to the sources.

| Before | After |
| --- | --- | 
| ![image](https://github.com/Automattic/wordpress-rs/assets/5845095/fefa1278-6e22-4091-befd-2b41ab1bbb12) | ![image](https://github.com/Automattic/wordpress-rs/assets/5845095/1c5c57ff-973f-44c3-a6df-0095494c2366) |
