### PR TITLE
Update UniFFI version to 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,13 +1302,14 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "uniffi"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
  "clap",
- "uniffi_bindgen 0.25.3",
+ "uniffi_bindgen 0.26.1",
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
@@ -1323,8 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -1347,18 +1349,20 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.25.3",
+ "uniffi_bindgen 0.26.1",
 ]
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn",
@@ -1366,8 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1381,8 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -1399,8 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1410,8 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -1422,8 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -1554,8 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?rev=22a9192162744b8a46997dcdcf628a7dba769570#22a9192162744b8a46997dcdcf628a7dba769570"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.dependencies]
 # External traits in UDL is only available since https://github.com/mozilla/uniffi-rs/pull/1867
 # Point to a specific commit until a new version is released
-uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "22a9192162744b8a46997dcdcf628a7dba769570" }
+uniffi = "0.26.1"
 # We need to match the version used in `reqwest`: https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L84
 # So that we can implement our own traits and it'll work with both reqwest types as well as http types
 #


### PR DESCRIPTION
I've tested both Kotlin and Swift instrumentation tests and they work as expected.