### PR TITLE
Add .gitignore file to the native/swift subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ local.properties
 # Swift
 .build
 .swiftpm/xcode
+xcuserdata
 
 # Auto-generated Swift Files
 native/swift/Sources/wordpress-api-wrapper/*.swift


### PR DESCRIPTION
The .gitignore file content was taken from [the github/gitignore repo](https://github.com/github/gitignore/blob/main/Swift.gitignore).