### PR TITLE
Only remove ignored files in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docke
 docker_build_and_run := docker build -t foo . && docker run $(docker_opts_shared) -it foo
 
 clean:
-	git clean -ffxd
+	git clean -ffXd
 
 _generate-jni-libs:
 	rm -rf $(jni_libs_root)


### PR DESCRIPTION
My main concern with the current `make clean` command is it would remove untracked files. That would be quite devastating if I have untracked new source files and they are gone after a `make clean` re-build.

This PR replaces the `-x` option with `-X`.

```
       -x
           Don’t use the standard ignore rules (see gitignore(5)), but still use the ignore rules given with -e options from the command line. This
           allows removing all untracked files, including build products. This can be used (possibly in conjunction with git restore or git reset) to
           create a pristine working directory to test a clean build.

       -X
           Remove only files ignored by Git. This may be useful to rebuild everything from scratch, but keep manually created files.
```