### PR TITLE
Refactor WPApiError type

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -5,13 +5,13 @@ use crate::WPNetworkResponse;
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum WPApiError {
-    #[error("Endpoint error with code '{}'", error.code)]
-    EndpointError {
+    #[error("Client error with status code {}", status_code)]
+    ClientError {
         status_code: u16,
-        error: WPRestError,
+        error: Option<WPRestError>,
     },
-    #[error("Unacceptable status code: {}\n", response.status_code)]
-    UnacceptableStatusCodeError { response: WPNetworkResponse },
+    #[error("Server error with status_code '{}'", status_code)]
+    ServerError { status_code: u16 },
     #[error("Error while parsing. \nReason: {}\n", reason)]
     ParsingError {
         reason: String,


### PR DESCRIPTION
Relates to #22. Please treat this PR as a proposal.

This PR makes `WPApiError` similar to the [WordPressAPIError](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/14.1.0/WordPressKit/WordPressAPIError.swift#L12-L23) I recently worked on in WordPressKit.

The new error struct provides the full HTTP response, which means the developers can easily inspect the error response during developing.

It also parse [the REST API error structure](https://github.com/WordPress/wordpress-develop/blob/ae751035ac4e79b5badf895990337ecf156d5f3d/src/wp-includes/rest-api/class-wp-rest-response.php#L225-L246), so that developers can programmatically check error code (i.e. `"rest_post_invalid_page_number"` in their code).

The existing "client error" and "server error" was merged into an "unacceptable status code" error, because IMO, it's pretty easy to distinguish client/server error based on status code: 4xx is client error and 5xx is server error.