### PR TITLE
Install specific nightly toolchain for supporting watchOS

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,14 +36,7 @@ steps:
           source "/Users/builder/.cargo/env"
 
           echo "--- :package: Installing Rust Toolchains"
-          rustup target add x86_64-apple-ios
-          rustup target add aarch64-apple-ios
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-ios-sim
-
-          rustup toolchain install nightly
-          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+          make setup-rust
 
           echo "--- :swift: Building xcframework"
           make xcframework


### PR DESCRIPTION
This PR fixes [build errors](https://buildkite.com/automattic/wordpress-rs/builds/220#018ea06b-eac6-49cf-8da7-cbdc3109d580/352-361) on watchOS.