### PR TITLE
Add configurations to include full debug info in static libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ swift_package_platform_ios := $(call swift_package_platform_version,ios)
 swift_package_platform_watchos := $(call swift_package_platform_version,watchos)
 swift_package_platform_tvos :=	$(call swift_package_platform_version,tvos)
 
+cargo_config_library = --config profile.release.debug=true --config 'profile.release.panic="abort"'
+
 # Required for supporting tvOS and watchOS. We can update the nightly toolchain version if needed.
 rust_nightly_toolchain := nightly-2024-04-30
 
@@ -72,11 +74,11 @@ xcframework-libraries:
 	env WATCHOS_DEPLOYMENT_TARGET=$(swift_package_platform_watchos) $(MAKE) x86_64-apple-watchos-sim-xcframework-library-with-nightly
 
 %-xcframework-library:
-	cargo build --target $* --package wp_api --release
+	cargo $(cargo_config_library) build --target $* --package wp_api --release
 	$(MAKE) $*-combine-libraries
 
 %-xcframework-library-with-nightly:
-	cargo +$(rust_nightly_toolchain) build --target $* --package wp_api --release -Zbuild-std
+	cargo +$(rust_nightly_toolchain) $(cargo_config_library) build --target $* --package wp_api --release -Z build-std=panic_abort,std
 	$(MAKE) $*-combine-libraries
 
 # Xcode doesn't properly support multiple XCFrameworks being used by the same target, so we need


### PR DESCRIPTION
I added an unit test (see the Rust and Swift code changes in https://github.com/Automattic/wordpress-rs/commit/c3e848e5e48c7491f39e95067c66ab616386ce2d) to see if debug symbols are included in crash reports.

Here are steps I used to generate a crash report:
1. Apply the Rust and Swift code changes in the commit above
2. Run `make test-swift-iOS`
3. Open the latest crash report in `~/Library/Logs/DiagnosticReports/xctest-<date>-<time>.ips`

### uniffi-rs wraps Rust crashes into Swift errors

Here is the crash report on the trunk branch

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libswiftCore.dylib            	       0x192fcb2e0 _assertionFailure(_:_:file:line:flags:) + 244
1   libswiftCore.dylib            	       0x19301ebe8 swift_unexpectedError + 660
2   wordpress-api-tests           	       0x1060a5d18 wordpressCrash() + 152 (wp_api.swift:3280)
3   wordpress-api-tests           	       0x1060776a8 WordPressAPITests.testCrash() + 40 (WordPressAPITests.swift:15)
...
```

The main issue here is there is no rust function name in this stack trace. Because [uniffi-rs wraps rust code panics into a Swift Error](https://mozilla.github.io/uniffi-rs/swift/overview.html#swift-bindings), which is thrown out at the generated Swift wrapper code.
> Failing assertions, Rust panics, and other unexpected errors in the generated code are translated into a private enum conforming to the Error protocol.

In this PR, the above mechanism is disabled by using Rust's `panic="abort" configuration.

### Include debug info in release build

After building the rust library with panic="abort", here is a new crash report:

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x101c453b0 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x100db7124 pthread_kill + 256
2   libsystem_c.dylib             	       0x1801655c0 abort + 104
3   wordpress-api-tests           	       0x106f1e3b0 panic_abort::__rust_start_panic::abort::h050f5428dab8614b + 12 (lib.rs:48)
4   wordpress-api-tests           	       0x106f1e3a4 __rust_start_panic + 12 (lib.rs:43)
5   wordpress-api-tests           	       0x106f0c2b8 rust_panic + 16 (panicking.rs:833)
6   wordpress-api-tests           	       0x106f0c0fc std::panicking::rust_panic_with_hook::hda07239e7b806705 + 592 (panicking.rs:803)
7   wordpress-api-tests           	       0x106f0be78 std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hd85c1c7af9f010e0 + 156 (panicking.rs:659)
8   wordpress-api-tests           	       0x106f09324 std::sys_common::backtrace::__rust_end_short_backtrace::h2d1546eda356cc44 + 12 (backtrace.rs:171)
9   wordpress-api-tests           	       0x106f0bc00 rust_begin_unwind + 52 (panicking.rs:647)
10  wordpress-api-tests           	       0x106f459a4 core::panicking::panic_fmt::h92674dcb9ac27bca + 52 (panicking.rs:72)
11  wordpress-api-tests           	       0x106f45b44 core::panicking::panic_bounds_check::ha858483904aa3172 + 80 (panicking.rs:208)
12  wordpress-api-tests           	       0x106db4760 wp_api::wordpress_crash::h4f19c8d1181ba184 + 28
13  wordpress-api-tests           	       0x106db47d4 uniffi_wp_api_fn_func_wordpress_crash + 116
14  wordpress-api-tests           	       0x106d7ef5c closure #1 in wordpressCrash() + 44 (wp_api.swift:3281)
15  wordpress-api-tests           	       0x106d52c7c makeRustCall<A>(_:errorHandler:) + 272 (wp_api.swift:271)
16  wordpress-api-tests           	       0x106d51008 rustCall<A>(_:) + 80 (wp_api.swift:256)
17  wordpress-api-tests           	       0x106d7eedc wordpressCrash() + 72 (wp_api.swift:3280)
18  wordpress-api-tests           	       0x106d508bc WordPressAPITests.testCrash() + 40 (WordPressAPITests.swift:15)
```

Even though the crashed Rust function is in the stack trace, we still can't know which line caused the crash, because there is no file path nor line number there. This PR adds another configuration `debug=true` to the release builds to include full debug info in the built static libraries.

With this new configuration, we now have all the information we need in crash reports:

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x1046fd3b0 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x104763124 pthread_kill + 256
2   libsystem_c.dylib             	       0x1801655c0 abort + 104
3   wordpress-api-tests           	       0x105081830 panic_abort::__rust_start_panic::abort::h050f5428dab8614b + 12 (lib.rs:48)
4   wordpress-api-tests           	       0x105081824 __rust_start_panic + 12 (lib.rs:43)
5   wordpress-api-tests           	       0x10506f738 rust_panic + 16 (panicking.rs:833)
6   wordpress-api-tests           	       0x10506f57c std::panicking::rust_panic_with_hook::hda07239e7b806705 + 592 (panicking.rs:803)
7   wordpress-api-tests           	       0x10506f2f8 std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hd85c1c7af9f010e0 + 156 (panicking.rs:659)
8   wordpress-api-tests           	       0x10506c7a4 std::sys_common::backtrace::__rust_end_short_backtrace::h2d1546eda356cc44 + 12 (backtrace.rs:171)
9   wordpress-api-tests           	       0x10506f080 rust_begin_unwind + 52 (panicking.rs:647)
10  wordpress-api-tests           	       0x1050a8e24 core::panicking::panic_fmt::h92674dcb9ac27bca + 52 (panicking.rs:72)
11  wordpress-api-tests           	       0x1050a8fc4 core::panicking::panic_bounds_check::ha858483904aa3172 + 80 (panicking.rs:208)
12  wordpress-api-tests           	       0x104f17c44 _$LT$usize$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$::index::ha20ab877f48c13ff + 20 (index.rs:255) [inlined]
13  wordpress-api-tests           	       0x104f17c44 core::slice::index::_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$::index::hf24ae081ebaed243 + 20 (index.rs:18) [inlined]
14  wordpress-api-tests           	       0x104f17c44 _$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..index..Index$LT$I$GT$$GT$::index::h58e892db5c658085 + 20 (mod.rs:2771) [inlined]
15  wordpress-api-tests           	       0x104f17c44 wp_api::wordpress_crash_panic::h593cf8a4d98bde3a + 20 (lib.rs:202) [inlined]
16  wordpress-api-tests           	       0x104f17c44 wp_api::wordpress_crash::hf19e792497b1ee3e + 28 (lib.rs:197)
17  wordpress-api-tests           	       0x104f17cb8 wp_api::uniffi_wp_api_fn_func_wordpress_crash::_$u7b$$u7b$closure$u7d$$u7d$::h9aec620774ddd531 + 4 (lib.rs:195) [inlined]
18  wordpress-api-tests           	       0x104f17cb8 uniffi_core::ffi::rustcalls::rust_call_with_out_status::_$u7b$$u7b$closure$u7d$$u7d$::h4601255af0309db5 + 4 (rustcalls.rs:151) [inlined]
19  wordpress-api-tests           	       0x104f17cb8 std::panicking::try::do_call::h0e75dfd3396496c5 + 4 (panicking.rs:554) [inlined]
20  wordpress-api-tests           	       0x104f17cb8 std::panicking::try::h6f49ca4d40bd9444 + 4 (panicking.rs:518) [inlined]
21  wordpress-api-tests           	       0x104f17cb8 std::panic::catch_unwind::h1e6c72b6e6961855 + 4 (panic.rs:142) [inlined]
22  wordpress-api-tests           	       0x104f17cb8 uniffi_core::ffi::rustcalls::rust_call_with_out_status::hcb42eb996c7a679e + 4 (rustcalls.rs:149) [inlined]
23  wordpress-api-tests           	       0x104f17cb8 uniffi_core::ffi::rustcalls::rust_call::h9509329c8b566c67 + 4 (rustcalls.rs:133) [inlined]
24  wordpress-api-tests           	       0x104f17cb8 uniffi_wp_api_fn_func_wordpress_crash + 116 (lib.rs:195)
25  wordpress-api-tests           	       0x104ee2444 closure #1 in wordpressCrash() + 44 (wp_api.swift:3281)
26  wordpress-api-tests           	       0x104eb6164 makeRustCall<A>(_:errorHandler:) + 272 (wp_api.swift:271)
27  wordpress-api-tests           	       0x104eb44f0 rustCall<A>(_:) + 80 (wp_api.swift:256)
28  wordpress-api-tests           	       0x104ee23c4 wordpressCrash() + 72 (wp_api.swift:3280)
29  wordpress-api-tests           	       0x104eb3da4 WordPressAPITests.testCrash() + 40 (WordPressAPITests.swift:15)
```

### Rust library in Android

In the Android library, the `debug=true` configuration [already exists using `-g` flag](https://github.com/Automattic/wordpress-rs/blob/a4591da27c8b49d89753e7ae8e20dfa0b709fdc6/native/android/common.gradle#L47-L48). So, the symbols should already be included in the static libraries.

I couldn't check if uniffi-rs wraps Rust crashes into exceptions on Android, because I can't compile unit tests due to compilation errors in Rust libraries. The uniffi-rs doc doesn't mention that, so maybe it's not a thing on Android? /cc @oguzkocer .

### Set configurations in Cargo.toml of command line

This PR sets these new configurations for libraries built on Apple platforms only. I can move them to Cargo.toml. But that means all platforms and all rust packages will get these two new configuration. I'm not sure if we want that.