### PR TITLE
Make uniffi generate default nil values for optional properties

### DIFF
--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -234,35 +234,43 @@ pub struct UserCreateParams {
     /// Password for the user (never included).
     pub password: String,
     /// Display name for the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// First name for the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
     /// Last name for the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
     /// URL of the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// Description of the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Locale for the user.
     /// One of: , `en_US`
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
     /// The nickname for the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nickname: Option<String>,
     /// An alphanumeric identifier for the user.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
@@ -271,6 +279,7 @@ pub struct UserCreateParams {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub roles: Vec<String>,
     /// Meta fields.
+    #[uniffi(default = None)]
     #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<String>,


### PR DESCRIPTION
Use `#[uniffi(default = None)]` to save us from passing `nil` to initialiser. I feel like we talked about default values before, but I can't remember the exact conversation. Let me know if you have any concerns.

<details>
<summary>Here is the generated Swift code</summary>

```swift
public struct UserCreateParams {
    /**
     * Login name for the user.
     */
    public let username: String
    /**
     * The email address for the user.
     */
    public let email: String
    /**
     * Password for the user (never included).
     */
    public let password: String
    /**
     * Display name for the user.
     */
    public let name: String?
    /**
     * First name for the user.
     */
    public let firstName: String?
    /**
     * Last name for the user.
     */
    public let lastName: String?
    /**
     * URL of the user.
     */
    public let url: String?
    /**
     * Description of the user.
     */
    public let description: String?
    /**
     * Locale for the user.
     * One of: , `en_US`
     */
    public let locale: String?
    /**
     * The nickname for the user.
     */
    public let nickname: String?
    /**
     * An alphanumeric identifier for the user.
     */
    public let slug: String?
    /**
     * Roles assigned to the user.
     */
    public let roles: [String]
    /**
     * Meta fields.
     */
    public let meta: String?

    // Default memberwise initializers are never public by default, so we
    // declare one manually.
    public init(
        /**
         * Login name for the user.
         */username: String, 
        /**
         * The email address for the user.
         */email: String, 
        /**
         * Password for the user (never included).
         */password: String, 
        /**
         * Display name for the user.
         */name: String? = nil, 
        /**
         * First name for the user.
         */firstName: String? = nil, 
        /**
         * Last name for the user.
         */lastName: String? = nil, 
        /**
         * URL of the user.
         */url: String? = nil, 
        /**
         * Description of the user.
         */description: String? = nil, 
        /**
         * Locale for the user.
         * One of: , `en_US`
         */locale: String? = nil, 
        /**
         * The nickname for the user.
         */nickname: String? = nil, 
        /**
         * An alphanumeric identifier for the user.
         */slug: String? = nil, 
        /**
         * Roles assigned to the user.
         */roles: [String], 
        /**
         * Meta fields.
         */meta: String? = nil) {
        self.username = username
        self.email = email
        self.password = password
        self.name = name
        self.firstName = firstName
        self.lastName = lastName
        self.url = url
        self.description = description
        self.locale = locale
        self.nickname = nickname
        self.slug = slug
        self.roles = roles
        self.meta = meta
    }
}
```

</details>

<details>
<summary>Here is the generated Kotlin code</summary>

```kotlin
data class UserCreateParams (
    /**
     * Login name for the user.
     */
    val `username`: kotlin.String,
    /**
     * The email address for the user.
     */
    val `email`: kotlin.String,
    /**
     * Password for the user (never included).
     */
    val `password`: kotlin.String,
    /**
     * Display name for the user.
     */
    val `name`: kotlin.String? = null,
    /**
     * First name for the user.
     */
    val `firstName`: kotlin.String? = null,
    /**
     * Last name for the user.
     */
    val `lastName`: kotlin.String? = null,
    /**
     * URL of the user.
     */
    val `url`: kotlin.String? = null,
    /**
     * Description of the user.
     */
    val `description`: kotlin.String? = null,
    /**
     * Locale for the user.
     * One of: , `en_US`
     */
    val `locale`: kotlin.String? = null,
    /**
     * The nickname for the user.
     */
    val `nickname`: kotlin.String? = null,
    /**
     * An alphanumeric identifier for the user.
     */
    val `slug`: kotlin.String? = null,
    /**
     * Roles assigned to the user.
     */
    val `roles`: List<kotlin.String>,
    /**
     * Meta fields.
     */
    val `meta`: kotlin.String? = null
) {

    companion object
}
```

</details>