### PR TITLE
Build for watchOS real devices

### DIFF
--- a/.buildkite/swift-test.sh
+++ b/.buildkite/swift-test.sh
@@ -18,12 +18,6 @@ function run_tests() {
 function build_for_real_device() {
     local platform; platform=$1
 
-    # See https://github.com/Automattic/wordpress-rs/issues/48
-    if [[ $platform == "watchOS" ]]; then
-        echo "~~~ watchOS is not supported yet"
-        return
-    fi
-
     echo "--- :swift: Building for $platform device"
     export NSUnbufferedIO=YES
     xcodebuild -destination "generic/platform=$platform" \

--- a/Makefile
+++ b/Makefile
@@ -81,12 +81,10 @@ xcframework-headers: bindings
 	cp target/swift-bindings/*.h target/swift-bindings/headers
 	cp target/swift-bindings/libwordpressFFI.modulemap target/swift-bindings/headers/module.modulemap
 
-
-# TODO: Add arm64_32-apple-watchos to the list
 apple-platform-targets-macos := x86_64-apple-darwin aarch64-apple-darwin
 apple-platform-targets-ios := aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 apple-platform-targets-tvos := aarch64-apple-tvos aarch64-apple-tvos-sim
-apple-platform-targets-watchos := x86_64-apple-watchos-sim aarch64-apple-watchos-sim
+apple-platform-targets-watchos := arm64_32-apple-watchos x86_64-apple-watchos-sim aarch64-apple-watchos-sim
 apple-platform-targets := \
 	$(apple-platform-targets-macos) \
 	$(apple-platform-targets-ios) \


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/Automattic/wordpress-rs/pull/61.

The compilation issue on watchOS device was fixed in the most recent nightly toolchain, which is already used in the trunk branch. This PR adds building steps for the watchOS device target and include it in the xcframework.