### PR TITLE
Parametrize list users integration tests

### DIFF
--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -447,21 +447,22 @@ impl SparseUserField {
     }
 }
 
+#[macro_export]
+macro_rules! user_list_params {
+    () => {
+        UserListParams::default()
+    };
+    ($(($f:ident, $v:expr)), *) => {{
+        let mut params = UserListParams::default();
+        $(params.$f = $v;)*
+        params
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::*;
-
-    macro_rules! user_list_params {
-        () => {
-            UserListParams::default()
-        };
-        ($(($f:ident, $v:expr)), *) => {{
-            let mut params = UserListParams::default();
-            $(params.$f = $v;)*
-            params
-        }};
-    }
 
     #[rstest]
     #[case(user_list_params!(), &[])]


### PR DESCRIPTION
As a follow up to https://github.com/Automattic/wordpress-rs/pull/72, this PR uses the same approach to increase our integration test coverage by using parametrized tests.

I am not sure about publishing the macro, but I think we might end up removing the `wp_networking` crate all together and move the tests to `wp_api` which will resolve the issue. For now, this is a quick win and publishing the macro - at least for now - is harmless.

The better way to do this would be through proper builder pattern, but I didn't like `derive_builder` and - at this stage, we shouldn't spend time on things that won't have any added value besides syntactic sugar. Also, even the most concise builder pattern might be too verbose as a `rstest` case.