### PR TITLE
Replace `user_list_params!` with a more generic `modified!` macro

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -443,7 +443,7 @@ macro_rules! add_uniffi_exported_parser {
 }
 
 #[macro_export]
-macro_rules! modified {
+macro_rules! generate {
     ($type_name:ident) => {
         $type_name::default()
     };

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -420,27 +420,27 @@ impl SparseUserField {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modified;
+    use crate::generate;
     use rstest::*;
 
     #[rstest]
     #[case(UserListParams::default(), &[])]
-    #[case(modified!(UserListParams, (page, Some(1))), &[("page", "1")])]
-    #[case(modified!(UserListParams, (page, Some(2)), (per_page, Some(5))), &[("page", "2"), ("per_page", "5")])]
-    #[case(modified!(UserListParams, (search, Some("foo".to_string()))), &[("search", "foo")])]
-    #[case(modified!(UserListParams, (exclude, vec![UserId(1), UserId(2)])), &[("exclude", "1,2")])]
-    #[case(modified!(UserListParams, (include, vec![UserId(1)])), &[("include", "1")])]
-    #[case(modified!(UserListParams, (per_page, Some(100)), (offset, Some(20))), &[("per_page", "100"), ("offset", "20")])]
-    #[case(modified!(UserListParams, (order, Some(WPApiParamOrder::Asc))), &[("order", "asc")])]
-    #[case(modified!(UserListParams, (orderby, Some(WPApiParamUsersOrderBy::Id))), &[("orderby", "id")])]
-    #[case(modified!(UserListParams, (order, Some(WPApiParamOrder::Desc)), (orderby, Some(WPApiParamUsersOrderBy::Email))), &[("order", "desc"), ("orderby", "email")])]
-    #[case(modified!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), &[("slug", "foo,bar")])]
-    #[case(modified!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])), &[("roles", "author,editor")])]
-    #[case(modified!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])), &[("slug", "foo,bar"), ("roles", "author,editor")])]
-    #[case(modified!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])), &[("capabilities", "edit_themes,delete_pages")])]
-    #[case::who_all_param_should_be_empty(modified!(UserListParams, (who, Some(WPApiParamUsersWho::All))), &[])]
-    #[case(modified!(UserListParams, (who, Some(WPApiParamUsersWho::Authors))), &[("who", "authors")])]
-    #[case(modified!(UserListParams, (has_published_posts, Some(true))), &[("has_published_posts", "true")])]
+    #[case(generate!(UserListParams, (page, Some(1))), &[("page", "1")])]
+    #[case(generate!(UserListParams, (page, Some(2)), (per_page, Some(5))), &[("page", "2"), ("per_page", "5")])]
+    #[case(generate!(UserListParams, (search, Some("foo".to_string()))), &[("search", "foo")])]
+    #[case(generate!(UserListParams, (exclude, vec![UserId(1), UserId(2)])), &[("exclude", "1,2")])]
+    #[case(generate!(UserListParams, (include, vec![UserId(1)])), &[("include", "1")])]
+    #[case(generate!(UserListParams, (per_page, Some(100)), (offset, Some(20))), &[("per_page", "100"), ("offset", "20")])]
+    #[case(generate!(UserListParams, (order, Some(WPApiParamOrder::Asc))), &[("order", "asc")])]
+    #[case(generate!(UserListParams, (orderby, Some(WPApiParamUsersOrderBy::Id))), &[("orderby", "id")])]
+    #[case(generate!(UserListParams, (order, Some(WPApiParamOrder::Desc)), (orderby, Some(WPApiParamUsersOrderBy::Email))), &[("order", "desc"), ("orderby", "email")])]
+    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), &[("slug", "foo,bar")])]
+    #[case(generate!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])), &[("roles", "author,editor")])]
+    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])), &[("slug", "foo,bar"), ("roles", "author,editor")])]
+    #[case(generate!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])), &[("capabilities", "edit_themes,delete_pages")])]
+    #[case::who_all_param_should_be_empty(generate!(UserListParams, (who, Some(WPApiParamUsersWho::All))), &[])]
+    #[case(generate!(UserListParams, (who, Some(WPApiParamUsersWho::Authors))), &[("who", "authors")])]
+    #[case(generate!(UserListParams, (has_published_posts, Some(true))), &[("has_published_posts", "true")])]
     #[trace]
     fn test_user_list_params(
         #[case] params: UserListParams,

--- a/wp_networking/tests/test_users_immut.rs
+++ b/wp_networking/tests/test_users_immut.rs
@@ -1,7 +1,7 @@
 use rstest::*;
 use rstest_reuse::{self, apply, template};
 use wp_api::{
-    modified, SparseUser, SparseUserField, UserListParams, WPApiParamOrder, WPApiParamUsersOrderBy,
+    generate, SparseUser, SparseUserField, UserListParams, WPApiParamOrder, WPApiParamUsersOrderBy,
     WPApiParamUsersWho, WPContext,
 };
 
@@ -55,22 +55,22 @@ async fn filter_retrieve_current_user(#[case] fields: &[SparseUserField]) {
 
 #[rstest]
 #[case(UserListParams::default())]
-#[case(modified!(UserListParams, (page, Some(1))))]
-#[case(modified!(UserListParams, (page, Some(2)), (per_page, Some(5))))]
-#[case(modified!(UserListParams, (search, Some("foo".to_string()))))]
-#[case(modified!(UserListParams, (exclude, vec![FIRST_USER_ID, SECOND_USER_ID])))]
-#[case(modified!(UserListParams, (include, vec![FIRST_USER_ID])))]
-#[case(modified!(UserListParams, (per_page, Some(100)), (offset, Some(20))))]
-#[case(modified!(UserListParams, (order, Some(WPApiParamOrder::Asc))))]
-#[case(modified!(UserListParams, (orderby, Some(WPApiParamUsersOrderBy::Id))))]
-#[case(modified!(UserListParams, (order, Some(WPApiParamOrder::Desc)), (orderby, Some(WPApiParamUsersOrderBy::Email))))]
-#[case(modified!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
-#[case(modified!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])))]
-#[case(modified!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])))]
-#[case(modified!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])))]
-#[case::who_all_param_should_be_empty(modified!(UserListParams, (who, Some(WPApiParamUsersWho::All))))]
-#[case(modified!(UserListParams, (who, Some(WPApiParamUsersWho::Authors))))]
-#[case(modified!(UserListParams, (has_published_posts, Some(true))))]
+#[case(generate!(UserListParams, (page, Some(1))))]
+#[case(generate!(UserListParams, (page, Some(2)), (per_page, Some(5))))]
+#[case(generate!(UserListParams, (search, Some("foo".to_string()))))]
+#[case(generate!(UserListParams, (exclude, vec![FIRST_USER_ID, SECOND_USER_ID])))]
+#[case(generate!(UserListParams, (include, vec![FIRST_USER_ID])))]
+#[case(generate!(UserListParams, (per_page, Some(100)), (offset, Some(20))))]
+#[case(generate!(UserListParams, (order, Some(WPApiParamOrder::Asc))))]
+#[case(generate!(UserListParams, (orderby, Some(WPApiParamUsersOrderBy::Id))))]
+#[case(generate!(UserListParams, (order, Some(WPApiParamOrder::Desc)), (orderby, Some(WPApiParamUsersOrderBy::Email))))]
+#[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+#[case(generate!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])))]
+#[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])))]
+#[case(generate!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])))]
+#[case::who_all_param_should_be_empty(generate!(UserListParams, (who, Some(WPApiParamUsersWho::All))))]
+#[case(generate!(UserListParams, (who, Some(WPApiParamUsersWho::Authors))))]
+#[case(generate!(UserListParams, (has_published_posts, Some(true))))]
 #[trace]
 #[tokio::test]
 async fn test_user_list_params_parametrized(


### PR DESCRIPTION
I'd like to avoid adding a bunch of macros such as `plugin_list_params`, `post_list_params` etc, so this PR replaces `user_list_params!` macro with a more generic `modified!` macro that takes a type.