### PR TITLE
Adds `add_uniffi_exported_parser` macro

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -432,4 +432,14 @@ pub fn get_link_header(response: &WPNetworkResponse, name: &str) -> Option<WPRes
     None
 }
 
+#[macro_export]
+macro_rules! add_uniffi_exported_parser {
+    ($fn_name:ident, $return_type: ty) => {
+        #[uniffi::export]
+        pub fn $fn_name(response: &WPNetworkResponse) -> Result<$return_type, WPApiError> {
+            parse_wp_response(response)
+        }
+    };
+}
+
 uniffi::setup_scaffolding!();

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -3,70 +3,37 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use wp_derive::WPContextual;
 
-use crate::{parse_wp_response, WPApiError, WPApiParamOrder, WPNetworkResponse};
+use crate::{
+    add_uniffi_exported_parser, parse_wp_response, WPApiError, WPApiParamOrder, WPNetworkResponse,
+};
 
-#[uniffi::export]
-pub fn parse_filter_users_response(
-    response: &WPNetworkResponse,
-) -> Result<Vec<SparseUser>, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_filter_retrieve_user_response(
-    response: &WPNetworkResponse,
-) -> Result<SparseUser, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_list_users_response_with_edit_context(
-    response: &WPNetworkResponse,
-) -> Result<Vec<UserWithEditContext>, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_list_users_response_with_embed_context(
-    response: &WPNetworkResponse,
-) -> Result<Vec<UserWithEmbedContext>, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_list_users_response_with_view_context(
-    response: &WPNetworkResponse,
-) -> Result<Vec<UserWithViewContext>, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_retrieve_user_response_with_edit_context(
-    response: &WPNetworkResponse,
-) -> Result<UserWithEditContext, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_retrieve_user_response_with_embed_context(
-    response: &WPNetworkResponse,
-) -> Result<UserWithEmbedContext, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_retrieve_user_response_with_view_context(
-    response: &WPNetworkResponse,
-) -> Result<UserWithViewContext, WPApiError> {
-    parse_wp_response(response)
-}
-
-#[uniffi::export]
-pub fn parse_delete_user_response(
-    response: &WPNetworkResponse,
-) -> Result<UserDeleteResponse, WPApiError> {
-    parse_wp_response(response)
-}
+add_uniffi_exported_parser!(parse_filter_users_response, Vec<SparseUser>);
+add_uniffi_exported_parser!(parse_filter_retrieve_user_response, SparseUser);
+add_uniffi_exported_parser!(
+    parse_list_users_response_with_edit_context,
+    Vec<UserWithEditContext>
+);
+add_uniffi_exported_parser!(
+    parse_list_users_response_with_embed_context,
+    Vec<UserWithEmbedContext>
+);
+add_uniffi_exported_parser!(
+    parse_list_users_response_with_view_context,
+    Vec<UserWithViewContext>
+);
+add_uniffi_exported_parser!(
+    parse_retrieve_user_response_with_edit_context,
+    UserWithEditContext
+);
+add_uniffi_exported_parser!(
+    parse_retrieve_user_response_with_embed_context,
+    UserWithEmbedContext
+);
+add_uniffi_exported_parser!(
+    parse_retrieve_user_response_with_view_context,
+    UserWithViewContext
+);
+add_uniffi_exported_parser!(parse_delete_user_response, UserDeleteResponse);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WPApiParamUsersOrderBy {


### PR DESCRIPTION
Builds on https://github.com/Automattic/wordpress-rs/pull/85. We use custom parsers that we export through UniFFI, so consumers can use the correct parser for the response type. However, all our parsers' signatures are identical, with the only change being the return type and it adds a lot of boilerplate.

This PR introduces the convenience macro `add_uniffi_exported_parser!` that generates these functions - we just need to pass a name and return type to it. Besides the decreased noise in the code, this should help us ensure that we are building our parsers in a consistent manner.

Note that this will not result in any change to the code that we are executing, it's just a syntactic sugar.