### PR TITLE
Replace foo.com with example.com

### DIFF
--- a/wp_api/src/endpoint.rs
+++ b/wp_api/src/endpoint.rs
@@ -93,27 +93,30 @@ mod tests {
 
     #[test]
     fn append_url() {
-        let url = Url::parse("https://foo.com").unwrap();
-        assert_eq!(url.append("bar").unwrap().as_str(), "https://foo.com/bar");
+        let url = Url::parse("https://example.com").unwrap();
+        assert_eq!(
+            url.append("bar").unwrap().as_str(),
+            "https://example.com/bar"
+        );
     }
 
     #[test]
     fn extend_url() {
-        let url = Url::parse("https://foo.com").unwrap();
+        let url = Url::parse("https://example.com").unwrap();
         assert_eq!(
             url.extend(["bar", "baz"]).unwrap().as_str(),
-            "https://foo.com/bar/baz"
+            "https://example.com/bar/baz"
         );
     }
 
     #[rstest]
     fn api_base_url(
         #[values(
-            "http://foo.com",
-            "https://foo.com",
-            "https://www.foo.com",
-            "https://f.foo.com",
-            "https://foo.com/f"
+            "http://example.com",
+            "https://example.com",
+            "https://www.example.com",
+            "https://f.example.com",
+            "https://example.com/f"
         )]
         test_base_url: &str,
     ) {
@@ -140,7 +143,7 @@ mod tests {
 
     #[fixture]
     pub fn fixture_api_base_url() -> ApiBaseUrl {
-        ApiBaseUrl::new("https://foo.com").unwrap()
+        ApiBaseUrl::new("https://example.com").unwrap()
     }
 
     pub fn validate_endpoint(endpoint_url: Url, path: &str) {

--- a/wp_networking/tests/test_users_err.rs
+++ b/wp_networking/tests/test_users_err.rs
@@ -321,7 +321,7 @@ async fn delete_user_err_trash_not_supported() {
 fn valid_user_create_params() -> UserCreateParams {
     UserCreateParams::new(
         "t_username".to_string(),
-        "t_email@foo.com".to_string(),
+        "t_email@example.com".to_string(),
         "t_password".to_string(),
     )
 }

--- a/wp_networking/tests/test_users_mut.rs
+++ b/wp_networking/tests/test_users_mut.rs
@@ -12,7 +12,7 @@ pub mod wp_db;
 async fn create_user() {
     wp_db::run_and_restore(|mut db| async move {
         let username = "t_username";
-        let email = "t_email@foo.com";
+        let email = "t_email@example.com";
         let password = "t_password";
 
         // Create a user using the API
@@ -121,7 +121,7 @@ async fn update_user_last_name() {
 
 #[tokio::test]
 async fn update_user_email() {
-    let new_email = "new_email@foo.com";
+    let new_email = "new_email@example.com";
     let mut params = UserUpdateParams::default();
     params.email = Some(new_email.to_string());
     test_update_user(params, |user, _| {


### PR DESCRIPTION
As requested by @jkmassel [here](https://github.com/Automattic/wordpress-rs/pull/88#discussion_r1602249464).