### PR TITLE
Adds `PluginSlug` & `PluginWpOrgDirectorySlug`

### DIFF
--- a/wp_api/src/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/endpoint/plugins_endpoint.rs
@@ -1,6 +1,6 @@
 use url::Url;
 
-use crate::{plugins::PluginListParams, ApiBaseUrl, WPContext};
+use crate::{plugins::PluginListParams, ApiBaseUrl, PluginSlug, WPContext};
 
 pub struct PluginsEndpoint {
     api_base_url: ApiBaseUrl,
@@ -15,7 +15,7 @@ impl PluginsEndpoint {
         self.plugins_base_url()
     }
 
-    pub fn delete(&self, plugin: &str) -> Url {
+    pub fn delete(&self, plugin: &PluginSlug) -> Url {
         self.plugins_url_with_slug(plugin)
     }
 
@@ -29,14 +29,14 @@ impl PluginsEndpoint {
         url
     }
 
-    pub fn retrieve(&self, context: WPContext, plugin: &str) -> Url {
+    pub fn retrieve(&self, context: WPContext, plugin: &PluginSlug) -> Url {
         let mut url = self.plugins_url_with_slug(plugin);
         url.query_pairs_mut()
             .append_pair("context", context.as_str());
         url
     }
 
-    pub fn update(&self, plugin: &str) -> Url {
+    pub fn update(&self, plugin: &PluginSlug) -> Url {
         self.plugins_url_with_slug(plugin)
     }
 
@@ -44,10 +44,10 @@ impl PluginsEndpoint {
         self.api_base_url.by_appending("plugins")
     }
 
-    fn plugins_url_with_slug(&self, plugin: &str) -> Url {
+    fn plugins_url_with_slug(&self, plugin: &PluginSlug) -> Url {
         self.api_base_url
             // The '/' character has to be preserved and not get encoded
-            .by_extending(["plugins"].into_iter().chain(plugin.split('/')))
+            .by_extending(["plugins"].into_iter().chain(plugin.slug.split('/')))
     }
 }
 
@@ -66,19 +66,19 @@ mod tests {
     }
 
     #[rstest]
-    #[case("hello-dolly/hello", "/plugins/hello-dolly/hello")]
+    #[case("hello-dolly/hello".into(), "/plugins/hello-dolly/hello")]
     #[case(
-        "classic-editor/classic-editor",
+        "classic-editor/classic-editor".into(),
         "/plugins/classic-editor/classic-editor"
     )]
-    #[case("foo/bar%baz", "/plugins/foo/bar%25baz")]
-    #[case("foo/です", "/plugins/foo/%E3%81%A7%E3%81%99")]
+    #[case("foo/bar%baz".into(), "/plugins/foo/bar%25baz")]
+    #[case("foo/です".into(), "/plugins/foo/%E3%81%A7%E3%81%99")]
     fn delete_plugin(
         plugins_endpoint: PluginsEndpoint,
-        #[case] plugin_slug: &str,
+        #[case] plugin_slug: PluginSlug,
         #[case] expected_path: &str,
     ) {
-        validate_endpoint(plugins_endpoint.delete(plugin_slug), expected_path);
+        validate_endpoint(plugins_endpoint.delete(&plugin_slug), expected_path);
     }
 
     #[rstest]
@@ -96,47 +96,47 @@ mod tests {
 
     #[rstest]
     #[case(
-        "hello-dolly/hello",
+        "hello-dolly/hello".into(),
         WPContext::View,
         "/plugins/hello-dolly/hello?context=view"
     )]
     #[case(
-        "classic-editor/classic-editor",
+        "classic-editor/classic-editor".into(),
         WPContext::Embed,
         "/plugins/classic-editor/classic-editor?context=embed"
     )]
-    #[case("foo/bar%baz", WPContext::Edit, "/plugins/foo/bar%25baz?context=edit")]
+    #[case("foo/bar%baz".into(), WPContext::Edit, "/plugins/foo/bar%25baz?context=edit")]
     #[case(
-        "foo/です",
+        "foo/です".into(),
         WPContext::View,
         "/plugins/foo/%E3%81%A7%E3%81%99?context=view"
     )]
     fn retrieve_plugin(
         plugins_endpoint: PluginsEndpoint,
-        #[case] plugin_slug: &str,
+        #[case] plugin_slug: PluginSlug,
         #[case] context: WPContext,
         #[case] expected_path: &str,
     ) {
         validate_endpoint(
-            plugins_endpoint.retrieve(context, plugin_slug),
+            plugins_endpoint.retrieve(context, &plugin_slug),
             expected_path,
         );
     }
 
     #[rstest]
-    #[case("hello-dolly/hello", "/plugins/hello-dolly/hello")]
+    #[case("hello-dolly/hello".into(), "/plugins/hello-dolly/hello")]
     #[case(
-        "classic-editor/classic-editor",
+        "classic-editor/classic-editor".into(),
         "/plugins/classic-editor/classic-editor"
     )]
-    #[case("foo/bar%baz", "/plugins/foo/bar%25baz")]
-    #[case("foo/です", "/plugins/foo/%E3%81%A7%E3%81%99")]
+    #[case("foo/bar%baz".into(), "/plugins/foo/bar%25baz")]
+    #[case("foo/です".into(), "/plugins/foo/%E3%81%A7%E3%81%99")]
     fn update_plugin(
         plugins_endpoint: PluginsEndpoint,
-        #[case] plugin_slug: &str,
+        #[case] plugin_slug: PluginSlug,
         #[case] expected_path: &str,
     ) {
-        validate_endpoint(plugins_endpoint.update(plugin_slug), expected_path);
+        validate_endpoint(plugins_endpoint.update(&plugin_slug), expected_path);
     }
 
     #[fixture]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -251,7 +251,11 @@ impl WPApiHelper {
         }
     }
 
-    pub fn retrieve_plugin_request(&self, context: WPContext, plugin: &str) -> WPNetworkRequest {
+    pub fn retrieve_plugin_request(
+        &self,
+        context: WPContext,
+        plugin: &PluginSlug,
+    ) -> WPNetworkRequest {
         WPNetworkRequest {
             method: RequestMethod::GET,
             url: self.api_endpoint.plugins.retrieve(context, plugin).into(),
@@ -262,7 +266,7 @@ impl WPApiHelper {
 
     pub fn update_plugin_request(
         &self,
-        plugin: &str,
+        plugin: &PluginSlug,
         params: PluginUpdateParams,
     ) -> WPNetworkRequest {
         WPNetworkRequest {
@@ -273,7 +277,7 @@ impl WPApiHelper {
         }
     }
 
-    pub fn delete_plugin_request(&self, plugin: &str) -> WPNetworkRequest {
+    pub fn delete_plugin_request(&self, plugin: &PluginSlug) -> WPNetworkRequest {
         WPNetworkRequest {
             method: RequestMethod::DELETE,
             url: self.api_endpoint.plugins.delete(plugin).into(),

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -54,7 +54,7 @@ impl PluginListParams {
 #[derive(Debug, Serialize, uniffi::Record)]
 pub struct PluginCreateParams {
     /// WordPress.org plugin directory slug.
-    pub slug: String,
+    pub slug: PluginWpOrgDirectorySlug,
     /// The plugin activation status.
     pub status: PluginStatus,
 }
@@ -72,7 +72,7 @@ pub struct PluginUpdateParams {
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WPContextual)]
 pub struct SparsePlugin {
     #[WPContext(edit, embed, view)]
-    pub plugin: Option<String>,
+    pub plugin: Option<PluginSlug>,
     #[WPContext(edit, embed, view)]
     pub status: Option<PluginStatus>,
     #[WPContext(edit, embed, view)]
@@ -97,6 +97,34 @@ pub struct SparsePlugin {
 pub struct PluginDeleteResponse {
     pub deleted: bool,
     pub previous: PluginWithEditContext,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(transparent)]
+pub struct PluginSlug {
+    pub slug: String,
+}
+
+impl From<&str> for PluginSlug {
+    fn from(value: &str) -> Self {
+        Self {
+            slug: value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[serde(transparent)]
+pub struct PluginWpOrgDirectorySlug {
+    pub slug: String,
+}
+
+impl From<&str> for PluginWpOrgDirectorySlug {
+    fn from(value: &str) -> Self {
+        Self {
+            slug: value.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, uniffi::Enum)]

--- a/wp_networking/tests/test_plugins_immut.rs
+++ b/wp_networking/tests/test_plugins_immut.rs
@@ -1,5 +1,5 @@
 use rstest::*;
-use wp_api::{generate, plugins::PluginListParams, plugins::PluginStatus, WPContext};
+use wp_api::{generate, plugins::PluginListParams, plugins::PluginStatus, PluginSlug, WPContext};
 
 use crate::test_helpers::{
     api, WPNetworkRequestExecutor, WPNetworkResponseParser, CLASSIC_EDITOR_PLUGIN_SLUG,
@@ -53,24 +53,24 @@ async fn test_plugin_list_params_parametrized(
 }
 
 #[rstest]
-#[case(CLASSIC_EDITOR_PLUGIN_SLUG, "WordPress Contributors")]
-#[case(HELLO_DOLLY_PLUGIN_SLUG, "Matt Mullenweg")]
+#[case(CLASSIC_EDITOR_PLUGIN_SLUG.into(), "WordPress Contributors")]
+#[case(HELLO_DOLLY_PLUGIN_SLUG.into(), "Matt Mullenweg")]
 #[trace]
 #[tokio::test]
-async fn retrieve_plugin(
-    #[case] plugin_slug: &str,
+async fn retrieve_plugin_with_edit_context(
+    #[case] plugin_slug: PluginSlug,
     #[case] expected_author: &str,
     #[values(WPContext::Edit, WPContext::Embed, WPContext::View)] context: WPContext,
 ) {
     let parsed_response = api()
-        .retrieve_plugin_request(context, plugin_slug)
+        .retrieve_plugin_request(context, &plugin_slug)
         .execute()
         .await
         .unwrap()
         .parse(wp_api::parse_retrieve_plugin_response_with_edit_context);
     assert!(
         parsed_response.is_ok(),
-        "Retrieve plugin failed!\nContext: {:?}\nPlugin: {}\nResponse was: '{:?}'",
+        "Retrieve plugin failed!\nContext: {:?}\nPlugin: {:?}\nResponse was: '{:?}'",
         context,
         plugin_slug,
         parsed_response

--- a/wp_networking/tests/test_plugins_mut.rs
+++ b/wp_networking/tests/test_plugins_mut.rs
@@ -14,7 +14,7 @@ async fn create_plugin() {
         wp_db::run_and_restore(|mut _db| async move {
             let status = PluginStatus::Active;
             let params = PluginCreateParams {
-                slug: WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS.to_string(),
+                slug: WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS.into(),
                 status,
             };
             let created_plugin = api()
@@ -36,7 +36,10 @@ async fn update_plugin() {
         wp_db::run_and_restore(|mut _db| async move {
             let status = PluginStatus::Active;
             let updated_plugin = api()
-                .update_plugin_request(HELLO_DOLLY_PLUGIN_SLUG, PluginUpdateParams { status })
+                .update_plugin_request(
+                    &HELLO_DOLLY_PLUGIN_SLUG.into(),
+                    PluginUpdateParams { status },
+                )
                 .execute()
                 .await
                 .unwrap()
@@ -53,7 +56,7 @@ async fn delete_plugin() {
     run_and_restore_wp_content_plugins(|| {
         wp_db::run_and_restore(|mut _db| async move {
             let deleted_plugin = api()
-                .delete_plugin_request(CLASSIC_EDITOR_PLUGIN_SLUG)
+                .delete_plugin_request(&CLASSIC_EDITOR_PLUGIN_SLUG.into())
                 .execute()
                 .await
                 .unwrap()


### PR DESCRIPTION
Builds on #90.

> * The plugin slugs returned from the `/plugins` endpoint will be in `foo/bar` format, for example `hello-dolly/hello` & `classic-editor/classic-editor`
> * The plugin slugs in WordPress.org directory is in `foo` format: `hello-dolly` & `classic-editor`

As explained in #90, there are two different plugin slugs and if we use `String` type for both, they'll be easy to mix up. The PR introduces `PluginSlug` & `PluginWpOrgDirectorySlug` types to address the issue.

Note that we don't use the new type pattern for this, because new type pattern will allow passing the original type as a valid value, making it less effective. I think we might even want to make `UserId` to be a proper type to avoid this issue - although with `UserId` it's more of a heads up to developers rather than a guard against a practical issue. So, I could see an argument for using the new type pattern for those cases.

---

**To Test**
* `make test-server && make dump-mysql && make backup-wp-content-plugins`
* `cargo test --test '*' -- --nocapture --test-threads 1`