### PR TITLE
Fix an issue where swift and jq commands run on all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ docker_container_repo_dir=/app
 # Common docker options
 rust_docker_container := public.ecr.aws/docker/library/rust:1.76
 
-docker_opts_shared :=  --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
+docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e CARGO_HOME=/app/.cargo $(rust_docker_container)
 docker_build_and_run := docker build -t foo . && docker run $(docker_opts_shared) -it foo
 
 swift_package_platform_version = $(shell swift package dump-package | jq -r '.platforms[] | select(.platformName=="$1") | .version')
-swift_package_platform_macos := $(call swift_package_platform_version,macos)
-swift_package_platform_ios := $(call swift_package_platform_version,ios)
-swift_package_platform_watchos := $(call swift_package_platform_version,watchos)
-swift_package_platform_tvos :=	$(call swift_package_platform_version,tvos)
+swift_package_platform_macos = $(call swift_package_platform_version,macos)
+swift_package_platform_ios = $(call swift_package_platform_version,ios)
+swift_package_platform_watchos = $(call swift_package_platform_version,watchos)
+swift_package_platform_tvos = $(call swift_package_platform_version,tvos)
 
 # Required for supporting tvOS and watchOS. We can update the nightly toolchain version if needed.
 rust_nightly_toolchain := nightly-2024-04-30


### PR DESCRIPTION
This PR resolves the `/bin/sh: jq: command not found` messages on CI.