### PR TITLE
Generate contextual SparseField `enum`s from `#[derive(WpContextual)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,6 +3071,7 @@ dependencies = [
 name = "wp_contextual"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 
 [workspace.dependencies]
 base64 = "0.22"
+convert_case = "0.6"
 http = "1.1"
 rstest = "0.19"
 rstest_reuse = "0.6.0"

--- a/wp_contextual/Cargo.toml
+++ b/wp_contextual/Cargo.toml
@@ -15,6 +15,7 @@ path = "tests/all_tests.rs"
 trybuild = { version = "1.0", features = ["diff"] }
 
 [dependencies]
+convert_case = { workspace = true }
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { workspace = true }

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -302,6 +302,26 @@
 //! }
 //! ```
 //!
+//! Furthermore, it'll generate the `SparseFooFieldWithEditContext`,
+//! `SparseFooFieldWithEmbedContext` & `SparseFooFieldWithViewContext` types as an `enum` which
+//! will include all the fields from their `Sparse` type counterpart as its `enum` variants. It'll
+//! also generate `fn as_field_name(&self) -> &str` function that maps each `enum` variant to its
+//! field name, making it easier to implement functions such as `as_str`. Note that it
+//! intentionally doesn't generate the `as_str` function directly, as the field names might need to
+//! be mapped to a different casing.
+//!
+//! So, the above example will also generate the following types:
+//!
+//! ```
+//! pub enum SparseFooFieldWithEditContext {
+//!     Bar,
+//!     Baz,
+//! }
+//! pub enum SparseFooFieldWithViewContext {
+//!     Baz,
+//! }
+//! ```
+//!
 //! ---
 //!
 //! Please see the documentation for [`WpContextual`] for technical details.
@@ -401,6 +421,25 @@ mod wp_contextual;
 /// pub struct SparseBazWithEditContext {
 ///     pub baz: Option<String>,
 ///     pub qux: Vec<u32>,
+/// }
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+/// pub enum SparseFooFieldWithEditContext {
+///     Bar,
+///     Baz
+/// }
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+/// pub enum SparseFooFieldWithEmbedContext {
+///     Bar,
+/// }
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+/// pub enum SparseFooFieldWithViewContext {
+///     Bar,
+///     FooBar
+/// }
+/// #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+/// pub enum SparseBazFieldWithEditContext {
+///     Baz,
+///     Qux
 /// }
 /// # // We need these 2 lines for UniFFI
 /// # uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/basic_wp_contextual.rs
+++ b/wp_contextual/tests/basic_wp_contextual.rs
@@ -13,6 +13,12 @@ fn main() {
     let _ = SparseFooWithEditContext { bar: None };
     let _ = SparseFooWithEmbedContext { bar: Some(0) };
     let _ = SparseFooWithViewContext { bar: Some(0) };
+    let bar_field_edit_context = SparseFooFieldWithEditContext::Bar;
+    assert_eq!(bar_field_edit_context.as_field_name(), "bar");
+    let bar_field_embed_context = SparseFooFieldWithEmbedContext::Bar;
+    assert_eq!(bar_field_embed_context.as_field_name(), "bar");
+    let bar_field_view_context = SparseFooFieldWithViewContext::Bar;
+    assert_eq!(bar_field_view_context.as_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/basic_wp_contextual_field.rs
+++ b/wp_contextual/tests/basic_wp_contextual_field.rs
@@ -20,6 +20,8 @@ fn main() {
     let _ = SparseFooWithEditContext {
         bar: Some(SparseBarWithEditContext { baz: Some(0) }),
     };
+    let bar_field = SparseFooFieldWithEditContext::Bar;
+    assert_eq!(bar_field.as_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/basic_wp_contextual_option.rs
+++ b/wp_contextual/tests/basic_wp_contextual_option.rs
@@ -10,6 +10,8 @@ pub struct SparseFoo {
 fn main() {
     let _ = FooWithEditContext { bar: None };
     let _ = SparseFooWithEditContext { bar: Some(0) };
+    let bar_field = SparseFooFieldWithEditContext::Bar;
+    assert_eq!(bar_field.as_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
@@ -30,6 +30,14 @@ fn main() {
         bar_2: Some(vec![SparseBarWithEditContext { baz: Some(0) }]),
         bar_3: Some(vec![vec![SparseBarWithEditContext { baz: Some(0) }]]),
     };
+    let bar_field = SparseFooFieldWithEditContext::Bar;
+    let bar_2_field = SparseFooFieldWithEditContext::Bar2;
+    let bar_3_field = SparseFooFieldWithEditContext::Bar3;
+    assert_eq!(bar_field.as_field_name(), "bar");
+    assert_eq!(bar_2_field.as_field_name(), "bar_2");
+    assert_eq!(bar_3_field.as_field_name(), "bar_3");
+    let baz_field = SparseBarFieldWithEditContext::Baz;
+    assert_eq!(baz_field.as_field_name(), "baz");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
@@ -23,6 +23,8 @@ fn main() {
             },
         ),
     };
+    let bar_field = SparseFooFieldWithEditContext::Bar;
+    assert_eq!(bar_field.as_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_derive_request_builder/Cargo.toml
+++ b/wp_derive_request_builder/Cargo.toml
@@ -20,7 +20,7 @@ trybuild = { version = "1.0", features = ["diff"] }
 url = { workspace = true }
 
 [dependencies]
-convert_case = "0.6"
+convert_case = { workspace = true }
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
Part of #172.

This PR implements generating `SparseFooFieldWithEditContext`, `SparseFooFieldWithEmbedContext` & `SparseFooFieldWithViewContext` types as an `enum` for `#[derive(WpContextual)]`. These `enum`s will include all the fields from their relevant sparse type as a variant, making it possible to use this type to pass as `_fields` argument when we are making requests to endpoints that supports filtering.

The generated type includes `fn as_field_name(&self) -> &str` function implementation, making it easy to implement `as_str` functions. It intentionally doesn't implement `as_str` directly as that may require converting the string to a different casing.

**To Test**
* `make test-server && make dump-mysql && make backup-wp-content-plugins`
* `cargo test`
* `cd wp_api && cargo expand users > generated_users.rs` and then inspect the generated `SparseUserFieldWithEditContext`, `SparseUserFieldWithEmbedContext` & `SparseUserFieldWithViewContext` types and their `as_field_name` function implementations