### PR TITLE
Skip filter assertions for `#[WpContextualOption]` fields

### DIFF
--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -20,7 +20,7 @@ pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
     let parsed_fields = parse_fields(fields)?;
 
     let contextual_token_streams = WpContextAttr::iter().map(|current_context| {
-        let generate_type = |ident, generated_fields: &Vec<ContextualField>| {
+        let generate_type = |ident, generated_fields: &Vec<GeneratedContextualField>| {
             if !generated_fields.is_empty() {
                 let fields_to_add = generated_fields.iter().map(|f| &f.field);
                 quote! {
@@ -34,10 +34,16 @@ pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
                 TokenStream::new()
             }
         };
-        let non_sparse_type_fields =
-            generate_contextual_fields(&parsed_fields, current_context, true)?;
-        let sparse_type_fields =
-            generate_contextual_fields(&parsed_fields, current_context, false)?;
+        let non_sparse_type_fields = GeneratedContextualField::generate_contextual_fields(
+            &parsed_fields,
+            current_context,
+            true,
+        )?;
+        let sparse_type_fields = GeneratedContextualField::generate_contextual_fields(
+            &parsed_fields,
+            current_context,
+            false,
+        )?;
 
         let non_sparse_ident = Ident::new(
             &ident_name_for_context(ident_name_without_prefix, current_context),
@@ -208,7 +214,10 @@ fn parse_fields(
     Ok(parsed_fields)
 }
 
-fn generate_sparse_field_type(type_ident: &Ident, fields: &[ContextualField]) -> TokenStream {
+fn generate_sparse_field_type(
+    type_ident: &Ident,
+    fields: &[GeneratedContextualField],
+) -> TokenStream {
     let mut variant_idents = Vec::with_capacity(fields.len());
     let mut as_field_names = Vec::with_capacity(fields.len());
     for f in fields {
@@ -245,7 +254,7 @@ fn generate_sparse_field_type(type_ident: &Ident, fields: &[ContextualField]) ->
 fn generate_integration_test_helper(
     sparse_type_ident: Ident,
     sparse_field_type_ident: Ident,
-    fields: &[ContextualField],
+    fields: &[GeneratedContextualField],
 ) -> TokenStream {
     if fields.is_empty() {
         return TokenStream::new();
@@ -315,82 +324,90 @@ fn generate_integration_test_helper(
     .into()
 }
 
-// Generates fields for the given context.
-//
-// It'll filter out any fields that don't have the given context, handle any mappings due to
-// #[WpContextualField] attribute and remove #[WpContext] and #[WpContextualField] attributes.
-fn generate_contextual_fields(
-    parsed_fields_attrs: &[WpParsedField],
-    context: &WpContextAttr,
-    should_extract_option: bool,
-) -> Result<Vec<ContextualField>, syn::Error> {
-    parsed_fields_attrs
-        .iter()
-        .filter(|pf| {
-            // Filter out any field that doesn't have this context
-            pf.parsed_attrs.iter().any(|parsed_attr| {
-                if let WpParsedAttr::ParsedWpContext { contexts } = parsed_attr {
-                    contexts.iter().any(|c| c == context)
-                } else {
-                    false
-                }
-            })
-        })
-        .map(|pf| {
-            let f = &pf.field;
-            let is_wp_contextual_option = pf
-                .parsed_attrs
-                .contains(&WpParsedAttr::ParsedWpContextualOption);
+#[derive(Debug, PartialEq, Eq)]
+struct GeneratedContextualField {
+    field: syn::Field,
+    is_wp_contextual_option: bool,
+}
 
-            let new_type = if is_wp_contextual_option {
-                f.ty.clone()
-            } else {
-                let mut new_type = if should_extract_option {
-                    extract_inner_type_of_option(&f.ty).unwrap_or(f.ty.clone())
-                } else {
-                    f.ty.clone()
-                };
-                if f.attrs.iter().any(|attr| {
-                    attr.path()
-                        .segments
-                        .iter()
-                        .any(|s| is_wp_contextual_field_ident(&s.ident))
-                }) {
-                    // If the field has #[WpContextualField] attr, map it to its contextual field type
-                    new_type = if should_extract_option {
-                        contextual_non_sparse_field_type(&new_type, context)?
+impl GeneratedContextualField {
+    // Generates fields for the given context.
+    //
+    // It'll filter out any fields that don't have the given context, handle any mappings due to
+    // #[WpContextualField] attribute and remove #[WpContext] and #[WpContextualField] attributes.
+    fn generate_contextual_fields(
+        parsed_fields_attrs: &[WpParsedField],
+        context: &WpContextAttr,
+        should_extract_option: bool,
+    ) -> Result<Vec<Self>, syn::Error> {
+        parsed_fields_attrs
+            .iter()
+            .filter(|pf| {
+                // Filter out any field that doesn't have this context
+                pf.parsed_attrs.iter().any(|parsed_attr| {
+                    if let WpParsedAttr::ParsedWpContext { contexts } = parsed_attr {
+                        contexts.iter().any(|c| c == context)
                     } else {
-                        contextual_sparse_field_type(&new_type, context)?
+                        false
                     }
-                }
-                new_type
-            };
-            let new_field = syn::Field {
-                // Remove the WpContext & WpContextualField attributes from the generated field
-                attrs: pf
-                    .parsed_attrs
-                    .iter()
-                    .filter_map(|parsed_attr| {
-                        // The generated field should only contain external attributes
-                        if let WpParsedAttr::ExternalAttr { attr } = parsed_attr {
-                            Some(attr.to_owned())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect(),
-                vis: f.vis.clone(),
-                mutability: syn::FieldMutability::None,
-                ident: f.ident.clone(),
-                colon_token: f.colon_token,
-                ty: new_type,
-            };
-            Ok(ContextualField {
-                field: new_field,
-                is_wp_contextual_option,
+                })
             })
-        })
-        .collect()
+            .map(|pf| {
+                let f = &pf.field;
+                let is_wp_contextual_option = pf
+                    .parsed_attrs
+                    .contains(&WpParsedAttr::ParsedWpContextualOption);
+
+                let new_type = if is_wp_contextual_option {
+                    f.ty.clone()
+                } else {
+                    let mut new_type = if should_extract_option {
+                        extract_inner_type_of_option(&f.ty).unwrap_or(f.ty.clone())
+                    } else {
+                        f.ty.clone()
+                    };
+                    if f.attrs.iter().any(|attr| {
+                        attr.path()
+                            .segments
+                            .iter()
+                            .any(|s| is_wp_contextual_field_ident(&s.ident))
+                    }) {
+                        // If the field has #[WpContextualField] attr, map it to its contextual field type
+                        new_type = if should_extract_option {
+                            contextual_non_sparse_field_type(&new_type, context)?
+                        } else {
+                            contextual_sparse_field_type(&new_type, context)?
+                        }
+                    }
+                    new_type
+                };
+                let new_field = syn::Field {
+                    // Remove the WpContext & WpContextualField attributes from the generated field
+                    attrs: pf
+                        .parsed_attrs
+                        .iter()
+                        .filter_map(|parsed_attr| {
+                            // The generated field should only contain external attributes
+                            if let WpParsedAttr::ExternalAttr { attr } = parsed_attr {
+                                Some(attr.to_owned())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
+                    vis: f.vis.clone(),
+                    mutability: syn::FieldMutability::None,
+                    ident: f.ident.clone(),
+                    colon_token: f.colon_token,
+                    ty: new_type,
+                };
+                Ok(Self {
+                    field: new_field,
+                    is_wp_contextual_option,
+                })
+            })
+            .collect()
+    }
 }
 
 // Returns a contextual non-sparse type for the given type.
@@ -675,12 +692,6 @@ fn parse_contexts_from_tokens(
 struct WpParsedField {
     field: syn::Field,
     parsed_attrs: Vec<WpParsedAttr>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct ContextualField {
-    field: syn::Field,
-    is_wp_contextual_option: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
In WordPress.org REST API, some fields will be missing from the response (or will be `null`) even if they are specifically requested. We use the `#[WpContextualOption]` macro attribute to mark these fields.

This PR updates the implementation to respect that option while generating the `assert_that_instance_fields_nullability_match_provided_fields` helper function. Since these fields may not be there, we can't assert their existence when requested as a filter field. In order to communicate that we are not doing this assertion, I've temporarily added a `println` statement. We should probably use `info!` for this instead to avoid cluttering stdout, but we don't have logging implemented yet, so I left a `TODO` for that.

---

**To Test**
* `make test-server && make dump-mysql && make backup-wp-content-plugins`
* `cargo test --test 'test_users_immut' -- --nocapture` - Notice that there are several logs saying that `'avatar_urls' field is marked as #[WpContextualOption], skipping assertion...`