### PR TITLE
`/wp-site-health/v1/tests/page-cache` & `/wp-site-health/v1/directory-sizes` endpoints

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpSiteHealthTestsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpSiteHealthTestsEndpointTest.kt
@@ -68,4 +68,12 @@ class WpSiteHealthTestsEndpointTest {
         val wpSiteHealthTest = (result as WpRequestSuccess).data
         assert(wpSiteHealthTest.test?.isBlank() == false)
     }
+
+    @Test
+    fun testDirectorySizes() = runTest {
+        val result = client.request { requestBuilder ->
+            requestBuilder.wpSiteHealthTests().directorySizes()
+        }
+        assert(result is WpRequestSuccess)
+    }
 }

--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -36,13 +36,17 @@ struct ExampleApp: App {
             ]
         }),
         RootListData(name: "Site Health Tests", callback: {
-            return try await [
+            let items: [any ListViewDataConvertable] = try await [
                 WordPressAPI.globalInstance.siteHealthTests.authorizationHeader(),
-                WordPressAPI.globalInstance.siteHealthTests.httpsStatus(),
-                WordPressAPI.globalInstance.siteHealthTests.dotorgCommunication(),
                 WordPressAPI.globalInstance.siteHealthTests.backgroundUpdates(),
-                WordPressAPI.globalInstance.siteHealthTests.loopbackRequests()
-            ].map { $0.asListViewData }
+                WordPressAPI.globalInstance.siteHealthTests.directorySizes(),
+                WordPressAPI.globalInstance.siteHealthTests.dotorgCommunication(),
+                WordPressAPI.globalInstance.siteHealthTests.httpsStatus(),
+                WordPressAPI.globalInstance.siteHealthTests.loopbackRequests(),
+                WordPressAPI.globalInstance.siteHealthTests.pageCache()
+            ]
+
+            return items.map { $0.asListViewData }
         })
     ]
 

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -72,12 +72,43 @@ extension ApplicationPasswordWithEditContext: ListViewDataConvertable {
 }
 
 extension SiteHealthTest: ListViewDataConvertable {
+    public var id: String {
+        self.label
+    }
+
     var asListViewData: ListViewData {
         ListViewData(id: self.label, title: self.label, subtitle: self.status, fields: [:])
     }
+}
 
+extension SiteHealthDirectorySizes: ListViewDataConvertable {
     public var id: String {
-        self.label
+        [
+            self.databaseSize.size,
+            self.fontsSize.size,
+            self.pluginsSize.size,
+            self.themesSize.size,
+            self.totalSize.size,
+            self.uploadsSize.size,
+            self.wordpressSize.size
+        ].joined(separator: "-")
+    }
+
+    var asListViewData: ListViewData {
+        ListViewData(
+            id: self.id,
+            title: "Site Health Directory Sizes",
+            subtitle: "Total Size: \(totalSize.size)",
+            fields: [
+                "Database Size": databaseSize.size,
+                "Fonts Size": fontsSize.size,
+                "Plugins Size": pluginsSize.size,
+                "Themes Size": themesSize.size,
+                "Total Size": totalSize.size,
+                "Uploads Size": uploadsSize.size,
+                "WordPress Size": wordpressSize.size
+            ]
+        )
     }
 }
 

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -51,6 +51,7 @@ public typealias ApplicationPasswordWithEmbedContext = WordPressAPIInternal.Appl
 
 // MARK: - Site Health Checks
 public typealias SiteHealthTest = WordPressAPIInternal.WpSiteHealthTest
+public typealias SiteHealthDirectorySizes = WordPressAPIInternal.WpSiteHealthDirectorySizes
 
 // MARK: – Post Types
 public typealias SparsePostType = WordPressAPIInternal.SparsePostTypeDetails

--- a/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
+++ b/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
@@ -1,7 +1,9 @@
 use wp_derive_request_builder::WpDerivedRequest;
 
 use crate::wp_site_health_tests::{
-    SparseWpSiteHealthTest, SparseWpSiteHealthTestField, WpSiteHealthTest,
+    SparseWpSiteHealthDirectorySizes, SparseWpSiteHealthDirectorySizesField,
+    SparseWpSiteHealthTest, SparseWpSiteHealthTestField, WpSiteHealthDirectorySizes,
+    WpSiteHealthTest,
 };
 
 use super::{DerivedRequest, Namespace};
@@ -18,6 +20,10 @@ enum WpSiteHealthTestsRequest {
     DotorgCommunication,
     #[get(url = "/tests/authorization-header", output = SparseWpSiteHealthTest, filter_by = SparseWpSiteHealthTestField)]
     AuthorizationHeader,
+    #[get(url = "/tests/page-cache", output = SparseWpSiteHealthTest, filter_by = SparseWpSiteHealthTestField)]
+    PageCache,
+    #[get(url = "/directory-sizes", output = SparseWpSiteHealthDirectorySizes, filter_by = SparseWpSiteHealthDirectorySizesField)]
+    DirectorySizes,
 }
 
 impl DerivedRequest for WpSiteHealthTestsRequest {
@@ -124,6 +130,42 @@ mod tests {
             );
         } else {
             validate_wp_site_health_endpoint(endpoint.authorization_header(), expected_path);
+        }
+    }
+
+    #[rstest]
+    #[case(None, "/tests/page-cache")]
+    #[case(Some(vec![SparseWpSiteHealthTestField::Test]), "/tests/page-cache?_fields=test")]
+    fn page_cache(
+        endpoint: WpSiteHealthTestsRequestEndpoint,
+        #[case] sparse_fields: Option<Vec<SparseWpSiteHealthTestField>>,
+        #[case] expected_path: &str,
+    ) {
+        if let Some(sparse_fields) = sparse_fields {
+            validate_wp_site_health_endpoint(
+                endpoint.filter_page_cache(&sparse_fields),
+                expected_path,
+            );
+        } else {
+            validate_wp_site_health_endpoint(endpoint.page_cache(), expected_path);
+        }
+    }
+
+    #[rstest]
+    #[case(None, "/directory-sizes")]
+    #[case(Some(vec![SparseWpSiteHealthDirectorySizesField::WordpressSize]), "/directory-sizes?_fields=wordpress_size")]
+    fn directory_sizes(
+        endpoint: WpSiteHealthTestsRequestEndpoint,
+        #[case] sparse_fields: Option<Vec<SparseWpSiteHealthDirectorySizesField>>,
+        #[case] expected_path: &str,
+    ) {
+        if let Some(sparse_fields) = sparse_fields {
+            validate_wp_site_health_endpoint(
+                endpoint.filter_directory_sizes(&sparse_fields),
+                expected_path,
+            );
+        } else {
+            validate_wp_site_health_endpoint(endpoint.directory_sizes(), expected_path);
         }
     }
 

--- a/wp_api/src/wp_site_health_tests.rs
+++ b/wp_api/src/wp_site_health_tests.rs
@@ -50,3 +50,61 @@ impl SparseField for SparseWpSiteHealthTestField {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct SparseWpSiteHealthDirectorySizes {
+    pub database_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub fonts_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub plugins_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub themes_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub total_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub uploads_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub wordpress_size: Option<WpSiteHealthDirectorySizeInfo>,
+    pub raw: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct WpSiteHealthDirectorySizes {
+    pub database_size: WpSiteHealthDirectorySizeInfo,
+    pub fonts_size: WpSiteHealthDirectorySizeInfo,
+    pub plugins_size: WpSiteHealthDirectorySizeInfo,
+    pub themes_size: WpSiteHealthDirectorySizeInfo,
+    pub total_size: WpSiteHealthDirectorySizeInfo,
+    pub uploads_size: WpSiteHealthDirectorySizeInfo,
+    pub wordpress_size: WpSiteHealthDirectorySizeInfo,
+    pub raw: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct WpSiteHealthDirectorySizeInfo {
+    pub debug: String,
+    pub size: String,
+    pub raw: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum SparseWpSiteHealthDirectorySizesField {
+    DatabaseSize,
+    FontsSize,
+    PluginsSize,
+    ThemesSize,
+    TotalSize,
+    UploadsSize,
+    WordpressSize,
+    Raw,
+}
+
+impl SparseField for SparseWpSiteHealthDirectorySizesField {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::DatabaseSize => "database_size",
+            Self::FontsSize => "fonts_size",
+            Self::PluginsSize => "plugins_size",
+            Self::ThemesSize => "themes_size",
+            Self::TotalSize => "total_size",
+            Self::UploadsSize => "uploads_size",
+            Self::WordpressSize => "wordpress_size",
+            Self::Raw => "raw",
+        }
+    }
+}

--- a/wp_api/src/wp_site_health_tests.rs
+++ b/wp_api/src/wp_site_health_tests.rs
@@ -79,6 +79,9 @@ pub struct WpSiteHealthDirectorySizes {
 pub struct WpSiteHealthDirectorySizeInfo {
     pub debug: String,
     pub size: String,
+    // `raw` is missing from `fonts_size` in our local WordPress test site. It's possible that it
+    // might be missing from other size types in different WordPress installations. We use
+    // `Option<u64>` for all of them to make sure we don't have parsing errors.
     pub raw: Option<u64>,
 }
 

--- a/wp_api_integration_tests/tests/test_wp_site_health_tests_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_site_health_tests_immut.rs
@@ -39,6 +39,7 @@ generate_tests!(loopback_requests);
 generate_tests!(https_status);
 generate_tests!(dotorg_communication);
 generate_tests!(authorization_header);
+generate_tests!(page_cache);
 
 fn validate_sparse_wp_site_health_tests_fields(
     wp_site_health_test: &SparseWpSiteHealthTest,

--- a/wp_api_integration_tests/tests/test_wp_site_health_tests_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_site_health_tests_immut.rs
@@ -1,7 +1,9 @@
 use rstest::*;
-use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
-use wp_api::wp_site_health_tests::{SparseWpSiteHealthTest, SparseWpSiteHealthTestField};
+use wp_api::wp_site_health_tests::{
+    SparseWpSiteHealthDirectorySizes, SparseWpSiteHealthDirectorySizesField,
+    SparseWpSiteHealthTest, SparseWpSiteHealthTestField,
+};
 
 use wp_api_integration_tests::{api_client, AssertResponse};
 
@@ -19,7 +21,16 @@ macro_rules! generate_tests {
                 assert!(!t.test.is_empty());
             }
 
-            #[apply(filter_fields_cases)]
+            #[rstest]
+            #[case(&[])]
+            #[case(&[SparseWpSiteHealthTestField::Actions])]
+            #[case(&[SparseWpSiteHealthTestField::Badge])]
+            #[case(&[SparseWpSiteHealthTestField::Description])]
+            #[case(&[SparseWpSiteHealthTestField::Label])]
+            #[case(&[SparseWpSiteHealthTestField::Status])]
+            #[case(&[SparseWpSiteHealthTestField::Test])]
+            #[case(&[SparseWpSiteHealthTestField::Actions, SparseWpSiteHealthTestField::Badge])]
+            #[case(&[SparseWpSiteHealthTestField::Label, SparseWpSiteHealthTestField::Status, SparseWpSiteHealthTestField::Test])]
             #[tokio::test]
             #[parallel]
             async fn [<filter_$ident>](#[case] fields: &[SparseWpSiteHealthTestField]) {
@@ -75,15 +86,77 @@ fn validate_sparse_wp_site_health_tests_fields(
     );
 }
 
-#[template]
+#[tokio::test]
+#[parallel]
+async fn directory_sizes() {
+    api_client()
+        .wp_site_health_tests()
+        .directory_sizes()
+        .await
+        .assert_response();
+}
+
 #[rstest]
 #[case(&[])]
-#[case(&[SparseWpSiteHealthTestField::Actions])]
-#[case(&[SparseWpSiteHealthTestField::Badge])]
-#[case(&[SparseWpSiteHealthTestField::Description])]
-#[case(&[SparseWpSiteHealthTestField::Label])]
-#[case(&[SparseWpSiteHealthTestField::Status])]
-#[case(&[SparseWpSiteHealthTestField::Test])]
-#[case(&[SparseWpSiteHealthTestField::Actions, SparseWpSiteHealthTestField::Badge])]
-#[case(&[SparseWpSiteHealthTestField::Label, SparseWpSiteHealthTestField::Status, SparseWpSiteHealthTestField::Test])]
-fn filter_fields_cases(#[case] fields: &[SparseWpSiteHealthTestField]) {}
+#[case(&[SparseWpSiteHealthDirectorySizesField::DatabaseSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::FontsSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::PluginsSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::ThemesSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::TotalSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::UploadsSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::WordpressSize])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::Raw])]
+#[case(&[SparseWpSiteHealthDirectorySizesField::DatabaseSize, SparseWpSiteHealthDirectorySizesField::WordpressSize])]
+#[tokio::test]
+#[parallel]
+async fn filter_directory_sizes(#[case] fields: &[SparseWpSiteHealthDirectorySizesField]) {
+    let directory_sizes = api_client()
+        .wp_site_health_tests()
+        .filter_directory_sizes(fields)
+        .await
+        .assert_response();
+    validate_sparse_wp_site_health_directory_sizes_fields(&directory_sizes, fields);
+}
+
+fn validate_sparse_wp_site_health_directory_sizes_fields(
+    wp_site_health_test: &SparseWpSiteHealthDirectorySizes,
+    fields: &[SparseWpSiteHealthDirectorySizesField],
+) {
+    let field_included = |field| {
+        // If "fields" is empty the server will return all fields
+        fields.is_empty() || fields.contains(&field)
+    };
+    assert_eq!(
+        wp_site_health_test.database_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::DatabaseSize)
+    );
+
+    assert_eq!(
+        wp_site_health_test.fonts_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::FontsSize)
+    );
+    assert_eq!(
+        wp_site_health_test.plugins_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::PluginsSize)
+    );
+    assert_eq!(
+        wp_site_health_test.themes_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::ThemesSize)
+    );
+    assert_eq!(
+        wp_site_health_test.total_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::TotalSize)
+    );
+    assert_eq!(
+        wp_site_health_test.uploads_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::UploadsSize)
+    );
+    assert_eq!(
+        wp_site_health_test.wordpress_size.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::WordpressSize)
+    );
+    assert_eq!(
+        wp_site_health_test.raw.is_some(),
+        field_included(SparseWpSiteHealthDirectorySizesField::Raw)
+    );
+}


### PR DESCRIPTION
Implements missing `/wp-site-health/v1/tests/page-cache` & `/wp-site-health/v1/directory-sizes` endpoints from 
#169 as requested [here](https://github.com/Automattic/wordpress-rs/pull/169#pullrequestreview-2169694401).

---

**To Test**
* `make test-server && make dump-mysql && make backup-wp-content-plugins`
* `cargo test`
* `cd native/kotlin && ./gradlew :api:kotlin:integrationTest`