### PR TITLE
Add `api.sh` helper script to run localhost `curl` requests

### DIFF
--- a/api.sh
+++ b/api.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+if [ ! -f ./test_credentials ]; then
+    echo "'test_credentials' file is not found. Make sure to run 'make test-server' before running this script."
+    exit 1
+fi
+
+ADMIN_TOKEN=$(sed '3!d' ./test_credentials)
+
+curl --user test@example.com:"$ADMIN_TOKEN" "http://localhost/wp-json$1"


### PR DESCRIPTION
Adds a helper script that reads the `test_credentials` file and runs an authenticated `curl` request to `localhost`.

The script is set up in a way that copying the request from the API documentation will work without modification. For example, the [Site Settings endpoint](https://developer.wordpress.org/rest-api/reference/settings/)'s [Retrieve a Site Setting](https://developer.wordpress.org/rest-api/reference/settings/#retrieve-a-site-setting) lists `GET /wp/v2/settings`, so we'd make the request by running `./api.sh "/wp/v2/settings"`.

The script only supports `GET` requests, as I usually don't need to run `POST` or `DELETE` requests from `curl`.

**To Test**
* `./api.sh "/wp/v2/settings"`
* `./api.sh "/wp-site-health/v1/tests/background-updates"`