### PR TITLE
Support both Integer and String for `WPApiDetails.gmt_offset`

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -11,6 +11,7 @@ use users::*;
 mod api_client; // re-exported relevant types
 mod api_error; // re-exported relevant types
 mod parsed_url; // re-exported relevant types
+mod serde_helper; // internal module
 
 pub mod application_passwords;
 pub mod login;

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -1,3 +1,4 @@
+use crate::serde_helper::deserialize_i64_or_string;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str;
@@ -51,7 +52,8 @@ pub struct WpApiDetails {
     pub description: String,
     pub url: String,
     pub home: String,
-    pub gmt_offset: String,
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub gmt_offset: i64,
     pub timezone_string: String,
     pub namespaces: Vec<String>,
     pub authentication: HashMap<String, WpRestApiAuthenticationScheme>,

--- a/wp_api/src/serde_helper.rs
+++ b/wp_api/src/serde_helper.rs
@@ -1,0 +1,69 @@
+use serde::{
+    de::{self, Unexpected},
+    Deserializer,
+};
+use std::fmt;
+
+struct DeserializeI64OrStringVisitor;
+
+impl<'de> de::Visitor<'de> for DeserializeI64OrStringVisitor {
+    type Value = i64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("i64 or a string")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        i64::try_from(v).map_err(|e| E::invalid_value(Unexpected::Unsigned(v), &self))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        v.parse::<i64>()
+            .map_err(|e| E::invalid_value(Unexpected::Str(v), &self))
+    }
+}
+
+pub fn deserialize_i64_or_string<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(DeserializeI64OrStringVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    pub struct Foo {
+        #[serde(deserialize_with = "deserialize_i64_or_string")]
+        pub bar: i64,
+    }
+
+    #[rstest]
+    #[case(r#"{"bar": "1"}"#, 1)]
+    #[case(r#"{"bar": 1}"#, 1)]
+    #[case(r#"{"bar": -1}"#, -1)]
+    fn test_deserialize_i64_or_string_as_option(
+        #[case] test_case: &str,
+        #[case] expected_result: i64,
+    ) {
+        let foo: Foo = serde_json::from_str(test_case).expect("Test case should be a valid JSON");
+        assert_eq!(expected_result, foo.bar);
+    }
+}


### PR DESCRIPTION
Fixes #208.

---

**To Test**

Add the following test case to `test_login_immut::test_login_flow` and run `cargo test --test 'test_login_immut'`
```
#[case(
    "https://pastapantry.ca",
    "https://pastapantry.ca/wp-admin/authorize-application.php"
)]
```