### PR TITLE
Condense error variants into `WpError`

### DIFF
--- a/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
+++ b/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 import rs.wordpress.api.kotlin.WpApiClient
-import rs.wordpress.api.kotlin.WpRequestSuccess
+import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.UserListParams
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
@@ -25,8 +25,8 @@ class UsersEndpointAndroidTest {
         val result = client.request { requestBuilder ->
             requestBuilder.users().listWithEditContext(params = UserListParams())
         }
-        assert(result is WpRequestSuccess)
-        val userList = (result as WpRequestSuccess).data
+        assert(result is WpRequestResult.WpRequestSuccess)
+        val userList = (result as WpRequestResult.WpRequestSuccess).data
         Assert.assertEquals(NUMBER_OF_USERS, userList.count())
         Assert.assertEquals(FIRST_USER_EMAIL, userList.first().email)
     }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -9,10 +9,10 @@ class ApiUrlDiscoveryTest {
 
     @Test
     fun testFindsCorrectApiUrls() = runTest {
-        val urlDiscovery = loginClient.apiDiscovery("https://orchestremetropolitain.com/fr/").getOrThrow()
-        assertEquals("https://orchestremetropolitain.com/wp-json/", urlDiscovery.apiRootUrl.url())
+        val urlDiscovery = loginClient.apiDiscovery("https://automatticwidgets.wpcomstaging.com/").getOrThrow()
+        assertEquals("https://automatticwidgets.wpcomstaging.com/wp-json/", urlDiscovery.apiRootUrl.url())
         assertEquals(
-            "https://orchestremetropolitain.com/wp-admin/authorize-application.php",
+            "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php",
             urlDiscovery.apiDetails.findApplicationPasswordsAuthenticationUrl()
         )
     }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApplicationPasswordsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApplicationPasswordsEndpointTest.kt
@@ -16,11 +16,9 @@ class ApplicationPasswordsEndpointTest {
 
     @Test
     fun testApplicationPasswordListRequest() = runTest {
-        val result = client.request { requestBuilder ->
+        val applicationPasswordList = client.request { requestBuilder ->
             requestBuilder.applicationPasswords().listWithEditContext(FIRST_USER_ID)
-        }
-        assert(result is WpRequestSuccess)
-        val applicationPasswordList = (result as WpRequestSuccess).data
+        }.assertSuccessAndRetrieveData()
         assertEquals(
             ApplicationPasswordUuid(testCredentials.adminPasswordUuid),
             applicationPasswordList.first().uuid
@@ -30,21 +28,17 @@ class ApplicationPasswordsEndpointTest {
     @Test
     fun testApplicationPasswordRetrieveRequest() = runTest {
         val uuid = ApplicationPasswordUuid(testCredentials.adminPasswordUuid)
-        val result = client.request { requestBuilder ->
+        val applicationPasswordList = client.request { requestBuilder ->
             requestBuilder.applicationPasswords().retrieveWithEditContext(FIRST_USER_ID, uuid)
-        }
-        assert(result is WpRequestSuccess)
-        val applicationPasswordList = (result as WpRequestSuccess).data
+        }.assertSuccessAndRetrieveData()
         assertEquals(uuid, applicationPasswordList.uuid)
     }
 
     @Test
     fun testApplicationPasswordRetrieveCurrentRequest() = runTest {
-        val result = client.request { requestBuilder ->
+        val applicationPasswordList = client.request { requestBuilder ->
             requestBuilder.applicationPasswords().retrieveCurrentWithEditContext(FIRST_USER_ID)
-        }
-        assert(result is WpRequestSuccess)
-        val applicationPasswordList = (result as WpRequestSuccess).data
+        }.assertSuccessAndRetrieveData()
         assertEquals(
             ApplicationPasswordUuid(testCredentials.adminPasswordUuid),
             applicationPasswordList.uuid

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
@@ -1,6 +1,7 @@
 package rs.wordpress.api.kotlin
 
 import uniffi.wp_api.UserId
+import uniffi.wp_api.WpErrorCode
 
 const val FIRST_USER_ID: UserId = 1
 const val SECOND_USER_ID: UserId = 2
@@ -11,3 +12,17 @@ const val NUMBER_OF_USERS = 3
 const val NUMBER_OF_PLUGINS = 4
 const val HELLO_DOLLY_PLUGIN_SLUG = "hello-dolly/hello"
 const val WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS = "classic-widgets"
+
+fun <T> WpRequestResult<T>.assertSuccess() {
+    assert(this is WpRequestResult.WpRequestSuccess)
+}
+
+fun <T> WpRequestResult<T>.assertSuccessAndRetrieveData(): T {
+    assert(this is WpRequestResult.WpRequestSuccess)
+    return (this as WpRequestResult.WpRequestSuccess).data
+}
+
+fun <T> WpRequestResult<T>.wpErrorCode(): WpErrorCode {
+    assert(this is WpRequestResult.WpError)
+    return (this as WpRequestResult.WpError).errorCode
+}

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpSiteHealthTestsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpSiteHealthTestsEndpointTest.kt
@@ -15,65 +15,57 @@ class WpSiteHealthTestsEndpointTest {
 
     @Test
     fun testBackgroundUpdates() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().backgroundUpdates()
-        }
-        assert(result is WpRequestSuccess)
-        assert((result as WpRequestSuccess).data.test.isNotBlank())
+        }.assertSuccessAndRetrieveData()
+        assert(wpSiteHealthTest.test.isNotBlank())
     }
 
     @Test
     fun testLoopbackRequests() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().loopbackRequests()
-        }
-        assert(result is WpRequestSuccess)
-        assert((result as WpRequestSuccess).data.test.isNotBlank())
+        }.assertSuccessAndRetrieveData()
+        assert(wpSiteHealthTest.test.isNotBlank())
     }
 
     @Test
     fun testHttpsStatus() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().httpsStatus()
-        }
-        assert(result is WpRequestSuccess)
-        assert((result as WpRequestSuccess).data.test.isNotBlank())
+        }.assertSuccessAndRetrieveData()
+        assert(wpSiteHealthTest.test.isNotBlank())
     }
 
     @Test
     fun testDotOrgCommunication() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().dotorgCommunication()
-        }
-        assert(result is WpRequestSuccess)
-        assert((result as WpRequestSuccess).data.test.isNotBlank())
+        }.assertSuccessAndRetrieveData()
+        assert(wpSiteHealthTest.test.isNotBlank())
     }
 
     @Test
     fun testAuthorizationHeader() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().authorizationHeader()
-        }
-        assert(result is WpRequestSuccess)
-        assert((result as WpRequestSuccess).data.test.isNotBlank())
+        }.assertSuccessAndRetrieveData()
+        assert(wpSiteHealthTest.test.isNotBlank())
     }
 
     @Test
     fun testFilterBackgroundUpdates() = runTest {
-        val result = client.request { requestBuilder ->
+        val wpSiteHealthTest = client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests()
                 .filterBackgroundUpdates(listOf(SparseWpSiteHealthTestField.TEST))
-        }
-        assert(result is WpRequestSuccess)
-        val wpSiteHealthTest = (result as WpRequestSuccess).data
+        }.assertSuccessAndRetrieveData()
         assert(wpSiteHealthTest.test?.isBlank() == false)
     }
 
     @Test
     fun testDirectorySizes() = runTest {
-        val result = client.request { requestBuilder ->
+        client.request { requestBuilder ->
             requestBuilder.wpSiteHealthTests().directorySizes()
-        }
-        assert(result is WpRequestSuccess)
+        }.assertSuccess()
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -8,7 +8,6 @@ import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpApiClient
 import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpAuthentication
-import uniffi.wp_api.WpRestErrorWrapper
 
 class WpApiClient
 @Throws(WpApiException::class)
@@ -33,16 +32,30 @@ constructor(
         executeRequest: suspend (UniffiWpApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
-            WpRequestSuccess(data = executeRequest(requestBuilder))
-        } catch (restException: WpApiException.RestException) {
-            when (restException.restError) {
-                is WpRestErrorWrapper.Recognized -> {
-                    RecognizedRestError(error = restException.restError.v1)
-                }
-
-                is WpRestErrorWrapper.Unrecognized -> {
-                    UnrecognizedRestError(error = restException.restError.v1)
-                }
+            WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
+        } catch (exception: WpApiException) {
+            when (exception) {
+                is WpApiException.WpException -> WpRequestResult.WpError(
+                    errorCode = exception.errorCode,
+                    errorMessage = exception.errorMessage,
+                    statusCode = exception.statusCode,
+                    response = exception.response,
+                )
+                is WpApiException.RequestExecutionFailed -> WpRequestResult.RequestExecutionFailed(
+                    statusCode = exception.statusCode,
+                    reason = exception.reason
+                )
+                is WpApiException.ResponseParsingException -> WpRequestResult.ResponseParsingError(
+                    reason = exception.reason,
+                    response = exception.response,
+                )
+                is WpApiException.SiteUrlParsingException -> WpRequestResult.SiteUrlParsingError(
+                    reason = exception.reason,
+                )
+                is WpApiException.UnknownException -> WpRequestResult.UnknownError(
+                    statusCode = exception.statusCode,
+                    response = exception.response,
+                )
             }
         }
     }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -35,11 +35,8 @@ constructor(
             WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
             when (exception) {
-                is WpApiException.WpException -> WpRequestResult.WpError(
-                    errorCode = exception.errorCode,
-                    errorMessage = exception.errorMessage,
+                is WpApiException.InvalidStatusCode -> WpRequestResult.InvalidStatusCode(
                     statusCode = exception.statusCode,
-                    response = exception.response,
                 )
                 is WpApiException.RequestExecutionFailed -> WpRequestResult.RequestExecutionFailed(
                     statusCode = exception.statusCode,
@@ -53,6 +50,12 @@ constructor(
                     reason = exception.reason,
                 )
                 is WpApiException.UnknownException -> WpRequestResult.UnknownError(
+                    statusCode = exception.statusCode,
+                    response = exception.response,
+                )
+                is WpApiException.WpException -> WpRequestResult.WpError(
+                    errorCode = exception.errorCode,
+                    errorMessage = exception.errorMessage,
                     statusCode = exception.statusCode,
                     response = exception.response,
                 )

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -1,9 +1,32 @@
 package rs.wordpress.api.kotlin
 
-import uniffi.wp_api.UnrecognizedWpRestError
-import uniffi.wp_api.WpRestError
+import uniffi.wp_api.WpErrorCode
 
-sealed class WpRequestResult<T>
-class RecognizedRestError<T>(val error: WpRestError) : WpRequestResult<T>()
-class UnrecognizedRestError<T>(val error: UnrecognizedWpRestError) : WpRequestResult<T>()
-class WpRequestSuccess<T>(val data: T) : WpRequestResult<T>()
+sealed class WpRequestResult<T> {
+    class WpRequestSuccess<T>(val data: T) : WpRequestResult<T>()
+    class WpError<T>(
+        val errorCode: WpErrorCode,
+        val errorMessage: String,
+        val statusCode: UShort,
+        val response: String,
+    ) : WpRequestResult<T>()
+
+    class RequestExecutionFailed<T>(
+        val statusCode: UShort?,
+        val reason: String,
+    ) : WpRequestResult<T>()
+
+    class SiteUrlParsingError<T>(
+        val reason: String,
+    ) : WpRequestResult<T>()
+
+    class ResponseParsingError<T>(
+        val reason: String,
+        val response: String,
+    ) : WpRequestResult<T>()
+
+    class UnknownError<T>(
+        val statusCode: UShort,
+        val response: String,
+    ) : WpRequestResult<T>()
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -11,6 +11,10 @@ sealed class WpRequestResult<T> {
         val response: String,
     ) : WpRequestResult<T>()
 
+    class InvalidStatusCode<T>(
+        val statusCode: UShort
+    ) : WpRequestResult<T>()
+
     class RequestExecutionFailed<T>(
         val statusCode: UShort?,
         val reason: String,

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -24,9 +24,10 @@ pub enum WpApiError {
         status_code: Option<u16>,
         reason: String,
     },
-    #[error("Rest error '{:?}' with Status Code '{}'", rest_error, status_code)]
-    RestError {
-        rest_error: WpRestError,
+    #[error("Rest error '{:?}' with Status Code '{}'", error_code, status_code)]
+    WpError {
+        error_code: WpRestErrorCode,
+        error_message: String,
         status_code: u16,
         response: String,
     },
@@ -42,8 +43,9 @@ pub enum WpApiError {
     UnknownError { status_code: u16, response: String },
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Record)]
-pub struct WpRestError {
+// Used to parse the errors from API then converted to `WpApiError::WpError`
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub(crate) struct WpError {
     pub code: WpRestErrorCode,
     pub message: String,
 }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -26,7 +26,7 @@ pub enum WpApiError {
     },
     #[error("Rest error '{:?}' with Status Code '{}'", rest_error, status_code)]
     RestError {
-        rest_error: WpRestErrorWrapper,
+        rest_error: WpRestError,
         status_code: u16,
         response: String,
     },
@@ -42,22 +42,9 @@ pub enum WpApiError {
     UnknownError { status_code: u16, response: String },
 }
 
-#[derive(serde::Deserialize, PartialEq, Eq, Debug, uniffi::Enum)]
-#[serde(untagged)]
-pub enum WpRestErrorWrapper {
-    Recognized(WpRestError),
-    Unrecognized(UnrecognizedWpRestError),
-}
-
 #[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Record)]
 pub struct WpRestError {
     pub code: WpRestErrorCode,
-    pub message: String,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Record)]
-pub struct UnrecognizedWpRestError {
-    pub code: String,
     pub message: String,
 }
 

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -15,6 +15,8 @@ pub enum RequestExecutionError {
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
 pub enum WpApiError {
+    #[error("Status code ({}) is not valid", status_code)]
+    InvalidStatusCode { status_code: u16 },
     #[error(
         "Request execution failed!\nStatus Code: '{:?}'.\nResponse: '{}'",
         status_code,
@@ -24,6 +26,16 @@ pub enum WpApiError {
         status_code: Option<u16>,
         reason: String,
     },
+    #[error("Error while parsing. \nReason: {}\nResponse: {}", reason, response)]
+    ResponseParsingError { reason: String, response: String },
+    #[error("Error while parsing site url: {}", reason)]
+    SiteUrlParsingError { reason: String },
+    #[error(
+        "Error that's not yet handled by the library:\nStatus Code: '{}'.\nResponse: '{}'",
+        status_code,
+        response
+    )]
+    UnknownError { status_code: u16, response: String },
     #[error(
         "WpError {{\n\tstatus_code: {}\n\terror_code: {:?}\n\terror_message: \"{}\"\n\tresponse: \"{}\"\n}}",
         status_code,
@@ -37,18 +49,6 @@ pub enum WpApiError {
         status_code: u16,
         response: String,
     },
-    #[error("Error while parsing site url: {}", reason)]
-    SiteUrlParsingError { reason: String },
-    #[error("Error while parsing. \nReason: {}\nResponse: {}", reason, response)]
-    ResponseParsingError { reason: String, response: String },
-    #[error("Status code ({}) is not valid", status_code)]
-    InvalidStatusCode { status_code: u16 },
-    #[error(
-        "Error that's not yet handled by the library:\nStatus Code: '{}'.\nResponse: '{}'",
-        status_code,
-        response
-    )]
-    UnknownError { status_code: u16, response: String },
 }
 
 // This type is used to parse the API errors. It then gets converted to `WpApiError::WpError`.

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -176,6 +176,8 @@ pub enum WpErrorCode {
     WpCoreCouldNotRemovePlugin,
     #[serde(rename = "could_not_resume_plugin")]
     WpCoreCouldNotResumePlugin,
+    #[serde(rename = "folder_exists")]
+    WpCoreFolderExists,
     #[serde(rename = "fs_error")]
     WpCoreFsError,
     #[serde(rename = "fs_no_plugins_dir")]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -212,7 +212,7 @@ pub enum WpErrorCode {
     // Fallback to a `String` error code
     // ------------------------------------------------------------------------------------
     #[serde(untagged)]
-    Fallback(String),
+    CustomError(String),
 }
 
 impl From<RequestExecutionError> for WpApiError {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -204,6 +204,11 @@ pub enum WpErrorCode {
     WpCoreUnableToDetermineInstalledPlugin,
     #[serde(rename = "unexpected_output")]
     WpCoreUnexpectedOutput,
+    // ------------------------------------------------------------------------------------
+    // Fallback to a `String` error code
+    // ------------------------------------------------------------------------------------
+    #[serde(untagged)]
+    Fallback(String),
 }
 
 impl From<RequestExecutionError> for WpApiError {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -198,6 +198,8 @@ pub enum WpErrorCode {
     WpCorePluginWpPhpIncompatible,
     #[serde(rename = "plugins_invalid")]
     WpCorePluginsInvalid,
+    #[serde(rename = "plugins_api_failed")]
+    WpCorePluginsApiFailed,
     #[serde(rename = "unable_to_connect_to_filesystem")]
     WpCoreUnableToConnectToFilesystem,
     #[serde(rename = "unable_to_determine_installed_plugin")]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -40,7 +40,7 @@ pub enum WpApiError {
     #[error("Error while parsing site url: {}", reason)]
     SiteUrlParsingError { reason: String },
     #[error("Error while parsing. \nReason: {}\nResponse: {}", reason, response)]
-    ParsingError { reason: String, response: String },
+    ResponseParsingError { reason: String, response: String },
     #[error(
         "Error that's not yet handled by the library:\nStatus Code: '{}'.\nResponse: '{}'",
         status_code,

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -41,6 +41,8 @@ pub enum WpApiError {
     SiteUrlParsingError { reason: String },
     #[error("Error while parsing. \nReason: {}\nResponse: {}", reason, response)]
     ResponseParsingError { reason: String, response: String },
+    #[error("Status code ({}) is not valid", status_code)]
+    InvalidStatusCode { status_code: u16 },
     #[error(
         "Error that's not yet handled by the library:\nStatus Code: '{}'.\nResponse: '{}'",
         status_code,

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -26,7 +26,7 @@ pub enum WpApiError {
     },
     #[error("Rest error '{:?}' with Status Code '{}'", error_code, status_code)]
     WpError {
-        error_code: WpRestErrorCode,
+        error_code: WpErrorCode,
         error_message: String,
         status_code: u16,
         response: String,
@@ -46,12 +46,12 @@ pub enum WpApiError {
 // Used to parse the errors from API then converted to `WpApiError::WpError`
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct WpError {
-    pub code: WpRestErrorCode,
+    pub code: WpErrorCode,
     pub message: String,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Error)]
-pub enum WpRestErrorCode {
+pub enum WpErrorCode {
     #[serde(rename = "rest_application_password_not_found")]
     ApplicationPasswordNotFound,
     #[serde(rename = "rest_cannot_create_application_passwords")]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -162,49 +162,41 @@ pub enum WpRestErrorCode {
     UserInvalidUsername,
     #[serde(rename = "rest_user_invalid_password")]
     UserInvalidPassword,
-}
-
-// All internal errors _should_ be wrapped as a `WpRestErrorCode` by the server. However, there
-// is a good chance that some internal errors do make it into the response, so these error types
-// are provided.
-//
-// Currently, we don't parse the response for these error types, but we could consider adding it
-// as a fallback. For the moment, clients can manually try parsing an `Unrecognized` error
-// into this type.
-#[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Error)]
-pub enum WpInternalErrorCode {
+    // All WpCore internal errors _should_ be wrapped as a `WpRestErrorCode` by the server. However,
+    // there is a good chance that some internal errors do make it into the response, so these error
+    // types are provided.
     #[serde(rename = "fs_error")]
-    FsError,
+    WpCoreFsError,
     #[serde(rename = "fs_no_plugins_dir")]
-    FsNoPluginsDir,
+    WpCoreFsNoPluginsDir,
     #[serde(rename = "fs_unavailable")]
-    FsUnavailable,
+    WpCoreFsUnavailable,
     #[serde(rename = "could_not_remove_plugin")]
-    CouldNotRemovePlugin,
+    WpCoreCouldNotRemovePlugin,
     #[serde(rename = "could_not_resume_plugin")]
-    CouldNotResumePlugin,
+    WpCoreCouldNotResumePlugin,
     #[serde(rename = "no_plugin_header")]
-    NoPluginHeader,
+    WpCoreNoPluginHeader,
     #[serde(rename = "plugin_missing_dependencies")]
-    PluginMissingDependencies,
+    WpCorePluginMissingDependencies,
     #[serde(rename = "plugin_not_found")]
-    PluginNotFound,
+    WpCorePluginNotFound,
     #[serde(rename = "plugin_invalid")]
-    PluginInvalid,
+    WpCorePluginInvalid,
     #[serde(rename = "plugin_php_incompatible")]
-    PluginPhpIncompatible,
+    WpCorePluginPhpIncompatible,
     #[serde(rename = "plugin_wp_incompatible")]
-    PluginWpIncompatible,
+    WpCorePluginWpIncompatible,
     #[serde(rename = "plugin_wp_php_incompatible")]
-    PluginWpPhpIncompatible,
+    WpCorePluginWpPhpIncompatible,
     #[serde(rename = "plugins_invalid")]
-    PluginsInvalid,
+    WpCorePluginsInvalid,
     #[serde(rename = "unable_to_connect_to_filesystem")]
-    UnableToConnectToFilesystem,
+    WpCoreUnableToConnectToFilesystem,
     #[serde(rename = "unable_to_determine_installed_plugin")]
-    UnableToDetermineInstalledPlugin,
+    WpCoreUnableToDetermineInstalledPlugin,
     #[serde(rename = "unexpected_output")]
-    UnexpectedOutput,
+    WpCoreUnexpectedOutput,
 }
 
 impl From<RequestExecutionError> for WpApiError {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -24,7 +24,13 @@ pub enum WpApiError {
         status_code: Option<u16>,
         reason: String,
     },
-    #[error("Rest error '{:?}' with Status Code '{}'", error_code, status_code)]
+    #[error(
+        "WpError {{\n\tstatus_code: {}\n\terror_code: {:?}\n\terror_message: \"{}\"\n\tresponse: \"{}\"\n}}",
+        status_code,
+        error_code,
+        error_message,
+        response
+    )]
     WpError {
         error_code: WpErrorCode,
         error_message: String,
@@ -43,7 +49,7 @@ pub enum WpApiError {
     UnknownError { status_code: u16, response: String },
 }
 
-// Used to parse the errors from API then converted to `WpApiError::WpError`
+// This type is used to parse the API errors. It then gets converted to `WpApiError::WpError`.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub(crate) struct WpError {
     pub code: WpErrorCode,
@@ -114,9 +120,9 @@ pub enum WpErrorCode {
     UserInvalidRole,
     #[serde(rename = "rest_user_invalid_slug")]
     UserInvalidSlug,
-    // ---
+    // ------------------------------------------------------------------------------------
     // Untested, because we are unable to create the necessary conditions for them
-    // ---
+    // ------------------------------------------------------------------------------------
     #[serde(rename = "application_passwords_disabled")]
     ApplicationPasswordsDisabled,
     #[serde(rename = "application_passwords_disabled_for_user")]
@@ -127,18 +133,18 @@ pub enum WpErrorCode {
     CannotReadType,
     #[serde(rename = "rest_no_authenticated_app_password")]
     NoAuthenticatedAppPassword,
-    // ---
+    // ------------------------------------------------------------------------------------
     // Untested, because we believe these errors require multisite
-    // ---
+    // ------------------------------------------------------------------------------------
     #[serde(rename = "rest_cannot_manage_network_plugins")]
     CannotManageNetworkPlugins,
     #[serde(rename = "rest_network_only_plugin")]
     NetworkOnlyPlugin,
     #[serde(rename = "rest_user_create")]
     UserCreate,
-    // ---
+    // ------------------------------------------------------------------------------------
     // Untested, because we don't think these errors are possible to get while using this library
-    // ---
+    // ------------------------------------------------------------------------------------
     /// If a plugin is tried to be activated without the `activate_plugin` permission.
     /// However, in a default setup a prior check of `activate_plugins` will fail
     /// resulting in `CannotManagePlugins` error instead.
@@ -162,27 +168,28 @@ pub enum WpErrorCode {
     UserInvalidUsername,
     #[serde(rename = "rest_user_invalid_password")]
     UserInvalidPassword,
-    // All WpCore internal errors _should_ be wrapped as a `WpRestErrorCode` by the server. However,
-    // there is a good chance that some internal errors do make it into the response, so these error
-    // types are provided.
+    // ------------------------------------------------------------------------------------
+    // All WpCore internal errors _should_ be wrapped as a `WpRestErrorCode` by the server.
+    // However, in some cases they are sent back directly.
+    // ------------------------------------------------------------------------------------
+    #[serde(rename = "could_not_remove_plugin")]
+    WpCoreCouldNotRemovePlugin,
+    #[serde(rename = "could_not_resume_plugin")]
+    WpCoreCouldNotResumePlugin,
     #[serde(rename = "fs_error")]
     WpCoreFsError,
     #[serde(rename = "fs_no_plugins_dir")]
     WpCoreFsNoPluginsDir,
     #[serde(rename = "fs_unavailable")]
     WpCoreFsUnavailable,
-    #[serde(rename = "could_not_remove_plugin")]
-    WpCoreCouldNotRemovePlugin,
-    #[serde(rename = "could_not_resume_plugin")]
-    WpCoreCouldNotResumePlugin,
     #[serde(rename = "no_plugin_header")]
     WpCoreNoPluginHeader,
+    #[serde(rename = "plugin_invalid")]
+    WpCorePluginInvalid,
     #[serde(rename = "plugin_missing_dependencies")]
     WpCorePluginMissingDependencies,
     #[serde(rename = "plugin_not_found")]
     WpCorePluginNotFound,
-    #[serde(rename = "plugin_invalid")]
-    WpCorePluginInvalid,
     #[serde(rename = "plugin_php_incompatible")]
     WpCorePluginPhpIncompatible,
     #[serde(rename = "plugin_wp_incompatible")]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
-pub use api_error::{RequestExecutionError, WpApiError, WpRestError, WpRestErrorCode};
+pub use api_error::{RequestExecutionError, WpApiError, WpRestErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use users::*;

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
-pub use api_error::{
-    RequestExecutionError, WpApiError, WpRestError, WpRestErrorCode, WpRestErrorWrapper,
-};
+pub use api_error::{RequestExecutionError, WpApiError, WpRestError, WpRestErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use users::*;

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
-pub use api_error::{RequestExecutionError, WpApiError, WpRestErrorCode};
+pub use api_error::{RequestExecutionError, WpApiError, WpErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use users::*;

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -301,7 +301,7 @@ impl WpNetworkResponse {
 
     pub fn parse<'de, T: Deserialize<'de>>(&'de self) -> Result<T, WpApiError> {
         self.parse_response_for_generic_errors()?;
-        serde_json::from_slice(&self.body).map_err(|err| WpApiError::ParsingError {
+        serde_json::from_slice(&self.body).map_err(|err| WpApiError::ResponseParsingError {
             reason: err.to_string(),
             response: self.body_as_string(),
         })

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -5,7 +5,10 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::{api_error::RequestExecutionError, WpApiError, WpAuthentication};
+use crate::{
+    api_error::{RequestExecutionError, WpError},
+    WpApiError, WpAuthentication,
+};
 
 use self::endpoint::WpEndpointUrl;
 
@@ -315,9 +318,10 @@ impl WpNetworkResponse {
         // TODO: Further parse the response body to include error message
         // TODO: Lots of unwraps to get a basic setup working
         let status = http::StatusCode::from_u16(self.status_code).unwrap();
-        if let Ok(rest_error) = serde_json::from_slice(&self.body) {
-            Err(WpApiError::RestError {
-                rest_error,
+        if let Ok(wp_error) = serde_json::from_slice::<WpError>(&self.body) {
+            Err(WpApiError::WpError {
+                error_code: wp_error.code,
+                error_message: wp_error.message,
                 status_code: self.status_code,
                 response: self.body_as_string(),
             })

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -6,7 +6,7 @@ use wp_api::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
     users::UserId,
-    ParsedUrl, RequestExecutionError, WpApiClient, WpApiError, WpAuthentication, WpRestErrorCode,
+    ParsedUrl, RequestExecutionError, WpApiClient, WpApiError, WpAuthentication, WpErrorCode,
 };
 
 // `pub` to avoid 'unused' & 'dead_code' warnings
@@ -62,11 +62,11 @@ pub fn test_site_url() -> Arc<ParsedUrl> {
 }
 
 pub trait AssertWpError<T: std::fmt::Debug> {
-    fn assert_wp_error(self, expected_error_code: WpRestErrorCode);
+    fn assert_wp_error(self, expected_error_code: WpErrorCode);
 }
 
 impl<T: std::fmt::Debug> AssertWpError<T> for Result<T, WpApiError> {
-    fn assert_wp_error(self, expected_error_code: WpRestErrorCode) {
+    fn assert_wp_error(self, expected_error_code: WpErrorCode) {
         let err = self.unwrap_err();
         if let WpApiError::WpError {
             error_code,

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -7,7 +7,7 @@ use wp_api::{
     },
     users::UserId,
     ParsedUrl, RequestExecutionError, WpApiClient, WpApiError, WpAuthentication, WpRestError,
-    WpRestErrorCode, WpRestErrorWrapper,
+    WpRestErrorCode,
 };
 
 // `pub` to avoid 'unused' & 'dead_code' warnings
@@ -71,10 +71,10 @@ impl<T: std::fmt::Debug> AssertWpError<T> for Result<T, WpApiError> {
         let err = self.unwrap_err();
         if let WpApiError::RestError {
             rest_error:
-                WpRestErrorWrapper::Recognized(WpRestError {
+                WpRestError {
                     code: error_code,
                     message: _,
-                }),
+                },
             response,
             ..
         } = err
@@ -83,16 +83,6 @@ impl<T: std::fmt::Debug> AssertWpError<T> for Result<T, WpApiError> {
                 expected_error_code, error_code,
                 "Incorrect error code. Expected '{:?}', found '{:?}'. Response was: '{:?}'",
                 expected_error_code, error_code, response
-            );
-        } else if let WpApiError::RestError {
-            rest_error: WpRestErrorWrapper::Unrecognized(unrecognized_error),
-            status_code,
-            response,
-        } = err
-        {
-            panic!(
-                "Received unhandled WpRestError variant: '{:?}' with status_code: '{}'. Response was: '{:?}'",
-                unrecognized_error, status_code, response
             );
         } else {
             panic!("Unexpected wp_error '{:?}'", err);

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -173,7 +173,7 @@ impl<T: std::fmt::Debug, E: std::error::Error> AssertResponse for Result<T, E> {
     type Item = T;
 
     fn assert_response(self) -> T {
-        assert!(self.is_ok(), "Response was: '{:?}'", self);
+        assert!(self.is_ok(), "Request failed with: {}", self.unwrap_err());
         self.unwrap()
     }
 }

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -6,8 +6,7 @@ use wp_api::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
     users::UserId,
-    ParsedUrl, RequestExecutionError, WpApiClient, WpApiError, WpAuthentication, WpRestError,
-    WpRestErrorCode,
+    ParsedUrl, RequestExecutionError, WpApiClient, WpApiError, WpAuthentication, WpRestErrorCode,
 };
 
 // `pub` to avoid 'unused' & 'dead_code' warnings
@@ -69,12 +68,8 @@ pub trait AssertWpError<T: std::fmt::Debug> {
 impl<T: std::fmt::Debug> AssertWpError<T> for Result<T, WpApiError> {
     fn assert_wp_error(self, expected_error_code: WpRestErrorCode) {
         let err = self.unwrap_err();
-        if let WpApiError::RestError {
-            rest_error:
-                WpRestError {
-                    code: error_code,
-                    message: _,
-                },
+        if let WpApiError::WpError {
+            error_code,
             response,
             ..
         } = err

--- a/wp_api_integration_tests/tests/test_application_passwords_err.rs
+++ b/wp_api_integration_tests/tests/test_application_passwords_err.rs
@@ -3,7 +3,7 @@ use serial_test::parallel;
 use wp_api::application_passwords::{
     ApplicationPasswordCreateParams, ApplicationPasswordUpdateParams, ApplicationPasswordUuid,
 };
-use wp_api::WpRestErrorCode;
+use wp_api::WpErrorCode;
 
 use wp_api_integration_tests::{
     api_client, api_client_as_subscriber, api_client_as_unauthenticated, AssertWpError,
@@ -21,7 +21,7 @@ async fn list_application_passwords_err_cannot_list_application_passwords() {
         .application_passwords()
         .list_with_edit_context(&FIRST_USER_ID)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotListApplicationPasswords);
+        .assert_wp_error(WpErrorCode::CannotListApplicationPasswords);
 }
 
 #[rstest]
@@ -38,7 +38,7 @@ async fn retrieve_application_password_err_cannot_read_application_password() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::CannotReadApplicationPassword);
+        .assert_wp_error(WpErrorCode::CannotReadApplicationPassword);
 }
 
 #[rstest]
@@ -56,7 +56,7 @@ async fn create_application_password_err_cannot_create_application_passwords() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::CannotCreateApplicationPasswords);
+        .assert_wp_error(WpErrorCode::CannotCreateApplicationPasswords);
 }
 
 #[rstest]
@@ -77,7 +77,7 @@ async fn update_application_password_err_cannot_edit_application_password() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::CannotEditApplicationPassword);
+        .assert_wp_error(WpErrorCode::CannotEditApplicationPassword);
 }
 
 #[rstest]
@@ -94,7 +94,7 @@ async fn delete_application_password_err_cannot_delete_application_password() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::CannotDeleteApplicationPassword);
+        .assert_wp_error(WpErrorCode::CannotDeleteApplicationPassword);
 }
 
 #[rstest]
@@ -106,7 +106,7 @@ async fn delete_application_passwords_err_cannot_delete_application_passwords() 
         .application_passwords()
         .delete_all(&FIRST_USER_ID)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotDeleteApplicationPasswords);
+        .assert_wp_error(WpErrorCode::CannotDeleteApplicationPasswords);
 }
 
 #[rstest]
@@ -119,7 +119,7 @@ async fn retrieve_application_password_err_cannot_introspect_app_password_for_no
         .application_passwords()
         .retrieve_current_with_edit_context(&SECOND_USER_ID)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
+        .assert_wp_error(WpErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
 }
 
 #[rstest]
@@ -131,7 +131,7 @@ async fn retrieve_application_password_err_cannot_introspect_app_password_for_an
         .application_passwords()
         .retrieve_current_with_edit_context(&SECOND_USER_ID)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
+        .assert_wp_error(WpErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
 }
 
 #[rstest]
@@ -147,5 +147,5 @@ async fn retrieve_application_password_err_application_password_not_found() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::ApplicationPasswordNotFound);
+        .assert_wp_error(WpErrorCode::ApplicationPasswordNotFound);
 }

--- a/wp_api_integration_tests/tests/test_plugins_err.rs
+++ b/wp_api_integration_tests/tests/test_plugins_err.rs
@@ -2,8 +2,8 @@ use wp_api::plugins::{PluginCreateParams, PluginListParams, PluginStatus, Plugin
 use wp_api::WpErrorCode;
 
 use wp_api_integration_tests::{
-    api_client, api_client_as_subscriber, AssertWpError, HELLO_DOLLY_PLUGIN_SLUG,
-    WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS,
+    api_client, api_client_as_subscriber, AssertWpError, CLASSIC_EDITOR_PLUGIN_SLUG,
+    HELLO_DOLLY_PLUGIN_SLUG, WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS,
 };
 
 #[tokio::test]
@@ -16,6 +16,18 @@ async fn create_plugin_err_cannot_install_plugin() {
         })
         .await
         .assert_wp_error(WpErrorCode::CannotInstallPlugin);
+}
+
+#[tokio::test]
+async fn create_plugin_err_plugins_api_failed() {
+    api_client()
+        .plugins()
+        .create(&PluginCreateParams {
+            slug: CLASSIC_EDITOR_PLUGIN_SLUG.into(),
+            status: PluginStatus::Active,
+        })
+        .await
+        .assert_wp_error(WpErrorCode::Fallback("plugins_api_failed".to_string()));
 }
 
 #[tokio::test]

--- a/wp_api_integration_tests/tests/test_plugins_err.rs
+++ b/wp_api_integration_tests/tests/test_plugins_err.rs
@@ -1,5 +1,5 @@
 use wp_api::plugins::{PluginCreateParams, PluginListParams, PluginStatus, PluginUpdateParams};
-use wp_api::WpRestErrorCode;
+use wp_api::WpErrorCode;
 
 use wp_api_integration_tests::{
     api_client, api_client_as_subscriber, AssertWpError, HELLO_DOLLY_PLUGIN_SLUG,
@@ -15,7 +15,7 @@ async fn create_plugin_err_cannot_install_plugin() {
             status: PluginStatus::Active,
         })
         .await
-        .assert_wp_error(WpRestErrorCode::CannotInstallPlugin);
+        .assert_wp_error(WpErrorCode::CannotInstallPlugin);
 }
 
 #[tokio::test]
@@ -24,7 +24,7 @@ async fn delete_plugin_err_cannot_delete_active_plugin() {
         .plugins()
         .delete(&HELLO_DOLLY_PLUGIN_SLUG.into())
         .await
-        .assert_wp_error(WpRestErrorCode::CannotDeleteActivePlugin);
+        .assert_wp_error(WpErrorCode::CannotDeleteActivePlugin);
 }
 
 #[tokio::test]
@@ -33,7 +33,7 @@ async fn list_plugins_err_cannot_view_plugins() {
         .plugins()
         .list_with_edit_context(&PluginListParams::default())
         .await
-        .assert_wp_error(WpRestErrorCode::CannotViewPlugins);
+        .assert_wp_error(WpErrorCode::CannotViewPlugins);
 }
 
 #[tokio::test]
@@ -42,7 +42,7 @@ async fn retrieve_plugin_err_cannot_view_plugin() {
         .plugins()
         .retrieve_with_edit_context(&HELLO_DOLLY_PLUGIN_SLUG.into())
         .await
-        .assert_wp_error(WpRestErrorCode::CannotViewPlugin);
+        .assert_wp_error(WpErrorCode::CannotViewPlugin);
 }
 
 #[tokio::test]
@@ -56,7 +56,7 @@ async fn update_plugin_err_plugin_not_found() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::PluginNotFound);
+        .assert_wp_error(WpErrorCode::PluginNotFound);
 }
 
 #[tokio::test]
@@ -70,5 +70,5 @@ async fn update_plugin_err_cannot_manage_plugins() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::CannotManagePlugins);
+        .assert_wp_error(WpErrorCode::CannotManagePlugins);
 }

--- a/wp_api_integration_tests/tests/test_plugins_err.rs
+++ b/wp_api_integration_tests/tests/test_plugins_err.rs
@@ -19,6 +19,18 @@ async fn create_plugin_err_cannot_install_plugin() {
 }
 
 #[tokio::test]
+async fn create_plugin_err_folder_exists() {
+    api_client()
+        .plugins()
+        .create(&PluginCreateParams {
+            slug: "classic-editor".into(),
+            status: PluginStatus::Active,
+        })
+        .await
+        .assert_wp_error(WpErrorCode::WpCoreFolderExists);
+}
+
+#[tokio::test]
 async fn create_plugin_err_plugins_api_failed() {
     api_client()
         .plugins()

--- a/wp_api_integration_tests/tests/test_plugins_err.rs
+++ b/wp_api_integration_tests/tests/test_plugins_err.rs
@@ -27,7 +27,7 @@ async fn create_plugin_err_plugins_api_failed() {
             status: PluginStatus::Active,
         })
         .await
-        .assert_wp_error(WpErrorCode::Fallback("plugins_api_failed".to_string()));
+        .assert_wp_error(WpErrorCode::WpCorePluginsApiFailed);
 }
 
 #[tokio::test]

--- a/wp_api_integration_tests/tests/test_post_types_err.rs
+++ b/wp_api_integration_tests/tests/test_post_types_err.rs
@@ -1,6 +1,6 @@
 use rstest::*;
 use serial_test::parallel;
-use wp_api::{post_types::PostType, WpRestErrorCode};
+use wp_api::{post_types::PostType, WpErrorCode};
 use wp_api_integration_tests::{api_client, api_client_as_subscriber, AssertWpError};
 
 #[rstest]
@@ -11,7 +11,7 @@ async fn list_post_types_err_forbidden_context() {
         .post_types()
         .list_with_edit_context()
         .await
-        .assert_wp_error(WpRestErrorCode::CannotView);
+        .assert_wp_error(WpErrorCode::CannotView);
 }
 
 #[rstest]
@@ -36,7 +36,7 @@ async fn retrieve_post_types_err_forbidden_context(
         .post_types()
         .retrieve_with_edit_context(&post_type)
         .await
-        .assert_wp_error(WpRestErrorCode::ForbiddenContext);
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
 }
 
 #[rstest]
@@ -47,7 +47,7 @@ async fn retrieve_post_types_err_type_invalid() {
         .post_types()
         .retrieve_with_edit_context(&PostType::Custom("does_not_exist".to_string()))
         .await
-        .assert_wp_error(WpRestErrorCode::TypeInvalid);
+        .assert_wp_error(WpErrorCode::TypeInvalid);
 }
 
 #[rstest]
@@ -58,5 +58,5 @@ async fn retrieve_post_types_err_cannot_read_type() {
         .post_types()
         .retrieve_with_edit_context(&PostType::Custom("oembed_cache".to_string()))
         .await
-        .assert_wp_error(WpRestErrorCode::CannotReadType);
+        .assert_wp_error(WpErrorCode::CannotReadType);
 }

--- a/wp_api_integration_tests/tests/test_users_err.rs
+++ b/wp_api_integration_tests/tests/test_users_err.rs
@@ -3,7 +3,7 @@ use wp_api::{
         UserCreateParams, UserDeleteParams, UserId, UserListParams, UserUpdateParams,
         WpApiParamUsersHasPublishedPosts, WpApiParamUsersOrderBy, WpApiParamUsersWho,
     },
-    WpRestErrorCode,
+    WpErrorCode,
 };
 use wp_api_integration_tests::{
     api_client, api_client_as_subscriber, api_client_as_unauthenticated, AssertWpError,
@@ -16,7 +16,7 @@ async fn create_user_err_cannot_create_user() {
         .users()
         .create(&valid_user_create_params())
         .await
-        .assert_wp_error(WpRestErrorCode::CannotCreateUser);
+        .assert_wp_error(WpErrorCode::CannotCreateUser);
 }
 
 #[tokio::test]
@@ -30,7 +30,7 @@ async fn delete_user_err_user_cannot_delete() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::UserCannotDelete);
+        .assert_wp_error(WpErrorCode::UserCannotDelete);
 }
 
 #[tokio::test]
@@ -44,7 +44,7 @@ async fn delete_user_err_user_invalid_reassign() {
             },
         )
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidReassign);
+        .assert_wp_error(WpErrorCode::UserInvalidReassign);
 }
 
 #[tokio::test]
@@ -55,7 +55,7 @@ async fn delete_current_user_err_user_invalid_reassign() {
             reassign: UserId(987654321),
         })
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidReassign);
+        .assert_wp_error(WpErrorCode::UserInvalidReassign);
 }
 
 #[tokio::test]
@@ -64,7 +64,7 @@ async fn list_users_err_forbidden_context() {
         .users()
         .list_with_edit_context(&UserListParams::default())
         .await
-        .assert_wp_error(WpRestErrorCode::ForbiddenContext);
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
 }
 
 #[tokio::test]
@@ -77,7 +77,7 @@ async fn list_users_err_forbidden_orderby_email() {
         .users()
         .list_with_view_context(&params)
         .await
-        .assert_wp_error(WpRestErrorCode::ForbiddenOrderBy);
+        .assert_wp_error(WpErrorCode::ForbiddenOrderBy);
 }
 
 #[tokio::test]
@@ -90,7 +90,7 @@ async fn list_users_err_forbidden_who() {
         .users()
         .list_with_view_context(&params)
         .await
-        .assert_wp_error(WpRestErrorCode::ForbiddenWho);
+        .assert_wp_error(WpErrorCode::ForbiddenWho);
 }
 
 #[tokio::test]
@@ -103,7 +103,7 @@ async fn list_users_with_capabilities_err_user_cannot_view() {
         .users()
         .list_with_edit_context(&params)
         .await
-        .assert_wp_error(WpRestErrorCode::UserCannotView);
+        .assert_wp_error(WpErrorCode::UserCannotView);
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn list_users_with_roles_err_user_cannot_view() {
         .users()
         .list_with_edit_context(&params)
         .await
-        .assert_wp_error(WpRestErrorCode::UserCannotView);
+        .assert_wp_error(WpErrorCode::UserCannotView);
 }
 
 #[tokio::test]
@@ -129,7 +129,7 @@ async fn list_users_orderby_registered_date_err_forbidden_orderby() {
         .users()
         .list_with_view_context(&params)
         .await
-        .assert_wp_error(WpRestErrorCode::ForbiddenOrderBy);
+        .assert_wp_error(WpErrorCode::ForbiddenOrderBy);
 }
 
 #[tokio::test]
@@ -143,7 +143,7 @@ async fn list_users_has_published_posts_err_invalid_param() {
             ..Default::default()
         })
         .await
-        .assert_wp_error(WpRestErrorCode::InvalidParam);
+        .assert_wp_error(WpErrorCode::InvalidParam);
 }
 
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn retrieve_user_err_user_invalid_id() {
         .users()
         .retrieve_with_edit_context(&UserId(987654321))
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidId);
+        .assert_wp_error(WpErrorCode::UserInvalidId);
 }
 
 #[tokio::test]
@@ -161,7 +161,7 @@ async fn retrieve_user_err_unauthorized() {
         .users()
         .retrieve_me_with_edit_context()
         .await
-        .assert_wp_error(WpRestErrorCode::Unauthorized);
+        .assert_wp_error(WpErrorCode::Unauthorized);
 }
 
 #[tokio::test]
@@ -175,7 +175,7 @@ async fn update_user_err_cannot_edit() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotEdit);
+        .assert_wp_error(WpErrorCode::CannotEdit);
 }
 
 #[tokio::test]
@@ -189,7 +189,7 @@ async fn update_user_err_cannot_edit_roles() {
         .users()
         .update(&SECOND_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::CannotEditRoles);
+        .assert_wp_error(WpErrorCode::CannotEditRoles);
 }
 
 #[tokio::test]
@@ -203,7 +203,7 @@ async fn update_user_err_user_invalid_email() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidEmail);
+        .assert_wp_error(WpErrorCode::UserInvalidEmail);
 }
 
 #[tokio::test]
@@ -216,7 +216,7 @@ async fn update_user_email_err_invalid_param() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::InvalidParam);
+        .assert_wp_error(WpErrorCode::InvalidParam);
 }
 
 #[tokio::test]
@@ -229,7 +229,7 @@ async fn update_user_password_err_invalid_param() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::InvalidParam);
+        .assert_wp_error(WpErrorCode::InvalidParam);
 }
 
 #[tokio::test]
@@ -243,7 +243,7 @@ async fn update_user_err_user_invalid_role() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidRole);
+        .assert_wp_error(WpErrorCode::UserInvalidRole);
 }
 
 #[tokio::test]
@@ -257,7 +257,7 @@ async fn update_user_err_user_invalid_slug() {
         .users()
         .update(&FIRST_USER_ID, &params)
         .await
-        .assert_wp_error(WpRestErrorCode::UserInvalidSlug);
+        .assert_wp_error(WpErrorCode::UserInvalidSlug);
 }
 
 // Helpers


### PR DESCRIPTION
* Condenses `WpRestErrorWrapper::Recognized` & `WpRestErrorWrapper::UnrecognizedWpRestError` into `WpApiError:WpError`
* Moves `WpInternalErrorCode` variants into `WpRestErrorCode` and adds `WpCore` prefix to them
* Renames the `WpRestErrorCode` as `WpErrorCode`
* Adds `WpApiError::InvalidStatusCode`
* Adds `WpErrorCode::CustomError(String)` as a fallback
* Updates Kotlin's `WpRequestResult` to include all `WpApiError` types directly to make it easier to work with
* Adds helper extension functions to `WpRequestResult` in Kotlin integration tests
* Updates all integration tests for the above changes

---

**To Test**
* `make test-server && make dump-mysql && make backup-wp-content-plugins`
* `cargo test`
* `cd native/kotlin && ./gradlew :api:kotlin:integrationTest`
