### PR TITLE
Publishing Kotlin artifacts no longer depends on Detekt

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,8 +144,6 @@ steps:
       - label: ":kotlin: Publish `rs.wordpress.api:kotlin`"
         key: "publish-wp-api-kotlin"
         plugins: *common_plugins
-        depends_on:
-          - "kotlin-detekt"
         command: |
           echo "--- :rust: Installing Rust"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y


### PR DESCRIPTION
There is no reason to prevent publishing Kotlin/Android artifacts from publishing if Detekt fails. So, this should speed up the time it takes for a PR to be ready to be merged.