### PR TITLE
Remove unnecessary JNI configuration

### DIFF
--- a/native/kotlin/api/android/build.gradle.kts
+++ b/native/kotlin/api/android/build.gradle.kts
@@ -59,8 +59,6 @@ android {
     // Instead of completely ignoring this issue, we are tracking it through the baseline lint
     // file - at least for now.
     lint.baseline = file("${project.rootDir}/config/lint/baseline.xml")
-
-    sourceSets["androidTest"].jniLibs.srcDirs.plus("${layout.buildDirectory.get()}/rustJniLibs/android")
 }
 
 dependencies {
@@ -110,11 +108,6 @@ cargo {
     }
 }
 tasks.matching { it.name.matches("merge.*JniLibFolders".toRegex()) }.configureEach {
-    inputs.dir(File("${layout.buildDirectory.get()}/rustJniLibs/android"))
-    dependsOn("cargoBuild")
-}
-
-tasks.matching { it.name.matches("test".toRegex()) }.configureEach {
     dependsOn("cargoBuild")
 }
 


### PR DESCRIPTION
It looks like all of this configuration is already handled by `org.mozilla.rust-android-gradle.rust-android` plugin.

**To Test**

If publishing is successful, that should be enough. However, double checking that the JNI artifacts are included can be done by:

1. Running the `UsersEndpointAndroidTest` which runs on Android device/emulator and will require android JNI artifacts to be there.
2. By updating the dependency version for [WPAndroid integration PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21108) and by testing the integration.

---

I've tested this in https://github.com/wordpress-mobile/WordPress-Android/pull/21108/commits/8899eb39d3800f36bba3aff179e41dfe0cd79344 and validated that it works correctly.