### PR TITLE
Change url discovery `attempts` type from `Vec` to `HashMap`

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -71,8 +71,8 @@ impl WpLoginClient {
         let attempts = attempts
             .into_iter()
             .map(|a| match a {
-                Ok(s) => UrlDiscoveryState::Success(s),
-                Err(e) => UrlDiscoveryState::Failure(e),
+                Ok(s) => (s.site_url.url(), UrlDiscoveryState::Success(s)),
+                Err(e) => (e.site_url(), UrlDiscoveryState::Failure(e)),
             })
             .collect();
         if let Some(s) = successful_attempt {

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     request::{WpNetworkHeaderMap, WpNetworkResponse},
@@ -55,18 +55,30 @@ pub enum UrlDiscoveryAttemptError {
     },
 }
 
+impl UrlDiscoveryAttemptError {
+    pub fn site_url(&self) -> String {
+        match self {
+            UrlDiscoveryAttemptError::FailedToParseSiteUrl { site_url, .. } => site_url.clone(),
+            UrlDiscoveryAttemptError::FetchApiRootUrlFailed { site_url, .. } => site_url.url(),
+            UrlDiscoveryAttemptError::FetchApiDetailsFailed { site_url, .. } => site_url.url(),
+        }
+    }
+}
+
 #[derive(Debug, uniffi::Record)]
 pub struct UrlDiscoverySuccess {
     pub site_url: Arc<ParsedUrl>,
     pub api_details: Arc<WpApiDetails>,
     pub api_root_url: Arc<ParsedUrl>,
-    pub attempts: Vec<UrlDiscoveryState>,
+    pub attempts: HashMap<String, UrlDiscoveryState>,
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum UrlDiscoveryError {
     #[error("Url discovery failed: {:?}", attempts)]
-    UrlDiscoveryFailed { attempts: Vec<UrlDiscoveryState> },
+    UrlDiscoveryFailed {
+        attempts: HashMap<String, UrlDiscoveryState>,
+    },
 }
 
 #[derive(Debug)]

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -171,7 +171,11 @@ impl<T: std::fmt::Debug, E: std::error::Error> AssertResponse for Result<T, E> {
     type Item = T;
 
     fn assert_response(self) -> T {
-        assert!(self.is_ok(), "Request failed with: {}", self.unwrap_err());
+        assert!(
+            self.is_ok(),
+            "Request failed with: {:#?}",
+            self.unwrap_err()
+        );
         self.unwrap()
     }
 }


### PR DESCRIPTION
Since the `site_url` that's attempted is not available at the top level for the `UrlDiscoveryAttemptError`, it was a bit cumbersome to access that information. Using a `HashMap` should make it easier to find the original attempt information.