### PR TITLE
Update Gems to address rexml vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.959.0)
+    aws-partitions (1.962.0)
     aws-sdk-core (3.201.3)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
@@ -32,7 +32,7 @@ GEM
     aws-sdk-kms (1.88.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.156.0)
+    aws-sdk-s3 (1.157.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -187,7 +187,8 @@ GEM
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
       xcodeproj (~> 1.22)
-    ffi (1.16.3)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -210,7 +211,7 @@ GEM
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-storage_v1 (0.31.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-cloud-core (1.7.0)
+    google-cloud-core (1.7.1)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
@@ -253,9 +254,9 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.16.6-arm64-darwin)
+    nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
@@ -269,7 +270,7 @@ GEM
       highline (>= 1.6)
       options (~> 2.3.0)
     public_suffix (4.0.7)
-    racc (1.8.0)
+    racc (1.8.1)
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
@@ -279,7 +280,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.9)
+    rexml (3.3.4)
       strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
@@ -313,13 +314,13 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.5.0)
     word_wrap (1.0.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.2, < 4.0)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -327,6 +328,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -335,4 +337,4 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 11.1)
 
 BUNDLED WITH
-   2.3.23
+   2.4.10


### PR DESCRIPTION
Addresses:

- https://github.com/Automattic/wordpress-rs/security/dependabot/4
- https://github.com/Automattic/wordpress-rs/security/dependabot/6
- https://github.com/Automattic/wordpress-rs/security/dependabot/7

