### PR TITLE
Enable url discovery tests for `automatticwidgets.wpcomstaging.com`

### DIFF
--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -5,8 +5,8 @@ use wp_api::login::WpLoginClient;
 use wp_api_integration_tests::{AssertResponse, AsyncWpNetworking};
 
 const LOCALHOST_AUTH_URL: &str = "http://localhost/wp-admin/authorize-application.php";
-//const AUTOMATTIC_WIDGETS_AUTH_URL: &str =
-//    "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php";
+const AUTOMATTIC_WIDGETS_AUTH_URL: &str =
+    "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php";
 
 #[rstest]
 #[case("http://localhost", LOCALHOST_AUTH_URL)]
@@ -14,27 +14,27 @@ const LOCALHOST_AUTH_URL: &str = "http://localhost/wp-admin/authorize-applicatio
 #[case("http://localhost/wp-admin.php", LOCALHOST_AUTH_URL)]
 #[case("http://localhost/wp-admin/", LOCALHOST_AUTH_URL)]
 #[case("http://localhost/wp-json", LOCALHOST_AUTH_URL)]
-//#[case(
-//    "https://automatticwidgets.wpcomstaging.com/",
-//    AUTOMATTIC_WIDGETS_AUTH_URL
-//)]
-//#[case(
-//    "https://automatticwidgets.wpcomstaging.com/wp-admin",
-//    AUTOMATTIC_WIDGETS_AUTH_URL
-//)]
-//#[case(
-//    "https://automatticwidgets.wpcomstaging.com/wp-admin.php",
-//    AUTOMATTIC_WIDGETS_AUTH_URL
-//)]
-//#[case(
-//    "https://automatticwidgets.wpcomstaging.com/wp-admin/",
-//    AUTOMATTIC_WIDGETS_AUTH_URL
-//)]
-//#[case(
-//    "https://automatticwidgets.wpcomstaging.com/wp-json",
-//    AUTOMATTIC_WIDGETS_AUTH_URL
-//)]
-//#[case("automatticwidgets.wpcomstaging.com/ ", AUTOMATTIC_WIDGETS_AUTH_URL)]
+#[case(
+    "https://automatticwidgets.wpcomstaging.com/",
+    AUTOMATTIC_WIDGETS_AUTH_URL
+)]
+#[case(
+    "https://automatticwidgets.wpcomstaging.com/wp-admin",
+    AUTOMATTIC_WIDGETS_AUTH_URL
+)]
+#[case(
+    "https://automatticwidgets.wpcomstaging.com/wp-admin.php",
+    AUTOMATTIC_WIDGETS_AUTH_URL
+)]
+#[case(
+    "https://automatticwidgets.wpcomstaging.com/wp-admin/",
+    AUTOMATTIC_WIDGETS_AUTH_URL
+)]
+#[case(
+    "https://automatticwidgets.wpcomstaging.com/wp-json",
+    AUTOMATTIC_WIDGETS_AUTH_URL
+)]
+#[case("automatticwidgets.wpcomstaging.com/ ", AUTOMATTIC_WIDGETS_AUTH_URL)]
 #[tokio::test]
 #[serial]
 async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str) {


### PR DESCRIPTION
I tried to investigate intermittent failures of these tests in 2 days in a row and had failed to reproduce them no matter how many times I re-ran them. I think the day I had the failures there was a server issue. I propose that we enable them in CI and investigate when they start failing again.