### PR TITLE
Kotlin integration tests in Docker & CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,20 @@
 common_params:
   plugins: &common_plugins
     - automattic/a8c-ci-toolkit#3.4.1
-  # Common environment values to use with the `env` key.
+  matrix: &wordpress_version_matrix
+    # All versions except for the latest have been disabled until we have version specific 
+    # integration tests
+    # - '5.6' # First version to introduce appliation passwords
+    # - '5.7'
+    # - '5.8'
+    # - '5.9'
+    # - '6.0'
+    # - '6.1'
+    # - '6.2'
+    # - '6.3'
+    # - '6.4'
+    # - '6.5'
+    - '6.6'
 
 steps:
   #
@@ -181,7 +194,7 @@ steps:
   - group: ":wordpress: End-to-end Tests"
     key: "e2e"
     steps:
-      - label: ":wordpress: WordPress {{matrix}}"
+      - label: ":wordpress: :rust: WordPress {{matrix}}"
         command: |
           # Give read/write permissions to `./` for all users
           chmod -R a+rw ./
@@ -189,26 +202,27 @@ steps:
           echo "--- :docker: Setting up Test Server"
           make test-server
 
-          echo "--- 🧪 Running Tests"
+          echo "--- 🧪 Running Rust Integration Tests"
           make test-rust-integration
         env:
           WORDPRESS_VERSION: "{{matrix}}"
-        matrix:
-          # All versions except for the latest have been disabled until we have version specific 
-          # integration tests
-          # - '5.6' # First version to introduce appliation passwords
-          # - '5.7'
-          # - '5.8'
-          # - '5.9'
-          # - '6.0'
-          # - '6.1'
-          # - '6.2'
-          # - '6.3'
-          # - '6.4'
-          # - '6.5'
-          - '6.6'
+        matrix: *wordpress_version_matrix
 
-  - label: ":rocket: Publish release $NEW_VERSION"
+      - label: ":wordpress: :kotlin: WordPress {{matrix}}"
+        command: |
+          # Give read/write permissions to `./` for all users
+          chmod -R a+rw ./
+
+          echo "--- :docker: Setting up Test Server"
+          make test-server
+
+          echo "--- 🧪 Running Kotlin Integration Tests"
+          make test-kotlin-integration
+        env:
+          WORDPRESS_VERSION: "{{matrix}}"
+        matrix: *wordpress_version_matrix
+
+  - label: ":rocket: Publish Swift release $NEW_VERSION"
     command: .buildkite/release.sh $NEW_VERSION
     depends_on: swift
     plugins: *common_plugins

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,11 @@ test-rust-wp-derived-request-parser:
 	$(rust_docker_run) cargo test --package wp_derive_request_builder
 
 test-rust-integration:
-	@# Help: Run integration tests in test server.
+	@# Help: Run Rust integration tests in test server.
+	docker exec -i wordpress /bin/bash < ./scripts/run-integration-tests.sh
+
+test-kotlin-integration:
+	@# Help: Run Kotlin integration tests in test server.
 	docker exec -i wordpress /bin/bash < ./scripts/run-integration-tests.sh
 
 restore-test-server:

--- a/Makefile
+++ b/Makefile
@@ -201,11 +201,11 @@ test-rust-wp-derived-request-parser:
 
 test-rust-integration:
 	@# Help: Run Rust integration tests in test server.
-	docker exec -i wordpress /bin/bash < ./scripts/run-integration-tests.sh
+	docker exec -i wordpress /bin/bash < ./scripts/run-rust-integration-tests.sh
 
 test-kotlin-integration:
 	@# Help: Run Kotlin integration tests in test server.
-	docker exec -i wordpress /bin/bash < ./scripts/run-integration-tests.sh
+	docker exec -i wordpress /bin/bash < ./scripts/run-kotlin-integration-tests.sh
 
 restore-test-server:
 	@# Help: Restore the test server from backup.
@@ -213,7 +213,7 @@ restore-test-server:
 
 test-server: stop-server
 	@# Help: Start the test server.
-	docker-compose up -d
+	docker-compose up -d --build
 	docker exec -i wordpress /bin/bash < ./scripts/setup-test-site.sh
 
 stop-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
     wordpress:
-        image: 'public.ecr.aws/docker/library/wordpress:${WORDPRESS_VERSION:-latest}'
+        build:
+            context: .
+            dockerfile: wordpress.Dockerfile
         container_name: 'wordpress'
         ports:
             - '80:80'

--- a/scripts/run-kotlin-integration-tests.sh
+++ b/scripts/run-kotlin-integration-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+cd ./native/kotlin
+./gradlew :api:kotlin:integrationTest

--- a/scripts/run-kotlin-integration-tests.sh
+++ b/scripts/run-kotlin-integration-tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -eu
 
-cd ./native/kotlin
+# The project should be mounted to this location
+cd /app/native/kotlin
+
 ./gradlew :api:kotlin:integrationTest

--- a/scripts/run-rust-integration-tests.sh
+++ b/scripts/run-rust-integration-tests.sh
@@ -1,9 +1,4 @@
-#!/bin/bash
-
-set -e
-
-# Load the Rust toolchain into this shell
-source $HOME/.cargo/env
+#!/bin/bash -eu
 
 # The project should be mounted to this location
 cd /app

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -8,24 +8,6 @@ set -e
 # for each WordPress version – if there are issues with DB migrations, different default themes
 # available, etc we don't want to have to deal with them.
 
-# Install wp-cli
-curl -L https://github.com/wp-cli/wp-cli/releases/download/v2.6.0/wp-cli-2.6.0.phar --output /usr/bin/wp
-chmod +x /usr/bin/wp
-
-# Install `mysqlcheck` – needed for `wp db check`
-apt update && apt install -y default-mysql-client less libssl-dev
-
-# Install `rustup` – needed to run tests
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-# Create wpcli working directory (it can't be created by the `www-data` user`)
-mkdir -p /var/www/.wp-cli
-chown -R www-data:www-data /var/www/.wp-cli/
-
-# Run this command as root user since that's what the Docker will use when we run
-# --http=http://localhost commands
-wp --allow-root package install wp-cli/restful
-
 # Run all the commands below as `www-data` (because that's what WordPress uses itself, so there shouldn't
 # be any weird permissions issues)
 su -s /bin/bash www-data

--- a/wordpress.Dockerfile
+++ b/wordpress.Dockerfile
@@ -1,0 +1,30 @@
+FROM public.ecr.aws/docker/library/wordpress:${WORDPRESS_VERSION:-latest}
+
+RUN apt-get update  \
+  && apt-get install -y openjdk-17-jdk-headless android-sdk wget \
+  && apt-get -y autoclean
+
+ENV ANDROID_HOME=/usr/lib/android-sdk
+
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+	&& unzip commandlinetools-linux-11076708_latest.zip && rm commandlinetools-linux-11076708_latest.zip \
+	&& mkdir /usr/lib/android-sdk/cmdline-tools \
+	&& mv cmdline-tools /usr/lib/android-sdk/cmdline-tools/latest
+
+ENV PATH="//usr/lib/android-sdk/cmdline-tools/latest/bin:${PATH}"
+
+RUN yes | sdkmanager --licenses
+
+RUN sdkmanager --install \
+  "ndk;25.1.8937393"
+
+# Cache Gradle 8.7
+RUN mkdir gradle-cache-tmp \
+        && cd gradle-cache-tmp \
+        && wget https://services.gradle.org/distributions/gradle-8.7-bin.zip \
+        && unzip gradle-8.7-bin.zip \
+        && touch settings.gradle \
+        && gradle-8.7/bin/gradle wrapper --gradle-version 8.7 --distribution-type all \
+        && ./gradlew \
+        && cd .. \
+        && rm -rf ./gradle-cache-tmp

--- a/wordpress.Dockerfile
+++ b/wordpress.Dockerfile
@@ -1,9 +1,26 @@
 FROM public.ecr.aws/docker/library/wordpress:${WORDPRESS_VERSION:-latest}
 
 RUN apt-get update  \
-  && apt-get install -y openjdk-17-jdk-headless android-sdk wget \
+  && apt-get install -y openjdk-17-jdk-headless android-sdk wget default-mysql-client less libssl-dev \
   && apt-get -y autoclean
 
+# Install wp-cli
+RUN curl -L https://github.com/wp-cli/wp-cli/releases/download/v2.6.0/wp-cli-2.6.0.phar --output /usr/bin/wp
+RUN chmod +x /usr/bin/wp
+
+# Create wpcli working directory
+RUN mkdir -p /var/www/.wp-cli
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN chown -R www-data:www-data /var/www/.wp-cli/
+
+# Run this command as root user since that's what the Docker will use when we run --http=http://localhost commands
+RUN wp --allow-root package install wp-cli/restful
+
+# Setup Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
+
+# Setup Kotlin & Android
 ENV ANDROID_HOME=/usr/lib/android-sdk
 
 RUN wget https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \


### PR DESCRIPTION
This PR adds a `wordpress.Dockerfile` that handles some of the setup we have been doing in our scripts, so it's done once and properly cached. It's especially useful to do this now that we will be running most of our integration tests from Docker, even when we need to run them locally. It installs Rust, Kotlin, Android SDK and Gradle on top of the WordPress image.

It also adds a new Make task, `test-kotlin-integration` so we can easily run the Kotlin integration tests from Docker. A new CI step runs Kotlin integration tests and runs the aforementioned Make task.

**To Test**

* `make test-kotlin-integration` to verify that Kotlin integration tests are working locally