### PR TITLE
Change Swift Package name to WordPressAPI

### DIFF
--- a/.buildkite/swift-test.sh
+++ b/.buildkite/swift-test.sh
@@ -18,7 +18,7 @@ function build_for_real_device() {
     echo "--- :swift: Building for $platform device"
     export NSUnbufferedIO=YES
     xcodebuild -destination "generic/platform=$platform" \
-        -scheme WordPress \
+        -scheme WordPressAPI \
         -derivedDataPath DerivedData \
         -skipPackagePluginValidation \
         build | xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let libwordpressFFI: Target = libwordpressFFIVersion.target
 #endif
 
 var package = Package(
-    name: "WordPress",
+    name: "WordPressAPI",
     platforms: [
         .iOS(.v13),
         .macOS(.v11),

--- a/scripts/xcodebuild-test.sh
+++ b/scripts/xcodebuild-test.sh
@@ -11,7 +11,7 @@ device_id=$(xcrun simctl list --json devices available | jq -re ".devices.\"com.
 export NSUnbufferedIO=YES
 
 xcodebuild \
-    -scheme WordPress \
+    -scheme WordPressAPI \
     -derivedDataPath DerivedData \
     -destination "id=${device_id}" \
     -skipPackagePluginValidation \


### PR DESCRIPTION
The module names are not changed. So, there should not be any impact on how this package is used in the app.