### PR TITLE
List `/posts` endpoint

### DIFF
--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -5,6 +5,7 @@ use crate::request::{
         },
         plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
         post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
+        posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
         site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
         users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
         wp_site_health_tests_endpoint::{
@@ -35,10 +36,11 @@ impl UniffiWpApiRequestBuilder {
 #[derive(Debug)]
 pub struct WpApiRequestBuilder {
     application_passwords: Arc<ApplicationPasswordsRequestBuilder>,
-    users: Arc<UsersRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
     post_types: Arc<PostTypesRequestBuilder>,
+    posts: Arc<PostsRequestBuilder>,
     site_settings: Arc<SiteSettingsRequestBuilder>,
+    users: Arc<UsersRequestBuilder>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestBuilder>,
 }
 
@@ -49,9 +51,10 @@ impl WpApiRequestBuilder {
             api_base_url,
             authentication;
             application_passwords,
-            users,
-            post_types,
             plugins,
+            post_types,
+            posts,
+            users,
             site_settings,
             wp_site_health_tests
         )
@@ -80,10 +83,11 @@ impl UniffiWpApiClient {
 #[derive(Debug)]
 pub struct WpApiClient {
     application_passwords: Arc<ApplicationPasswordsRequestExecutor>,
-    users: Arc<UsersRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
     post_types: Arc<PostTypesRequestExecutor>,
+    posts: Arc<PostsRequestExecutor>,
     site_settings: Arc<SiteSettingsRequestExecutor>,
+    users: Arc<UsersRequestExecutor>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestExecutor>,
 }
 
@@ -100,10 +104,11 @@ impl WpApiClient {
             authentication,
             request_executor;
             application_passwords,
-            users,
-            post_types,
             plugins,
+            post_types,
+            posts,
             site_settings,
+            users,
             wp_site_health_tests
         )
     }
@@ -112,6 +117,7 @@ impl WpApiClient {
 macro_helper::generate_endpoint_impl!(application_passwords);
 macro_helper::generate_endpoint_impl!(plugins);
 macro_helper::generate_endpoint_impl!(post_types);
+macro_helper::generate_endpoint_impl!(posts);
 macro_helper::generate_endpoint_impl!(site_settings);
 macro_helper::generate_endpoint_impl!(users);
 macro_helper::generate_endpoint_impl!(wp_site_health_tests);

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -16,6 +16,7 @@ pub mod application_passwords;
 pub mod login;
 pub mod plugins;
 pub mod post_types;
+pub mod posts;
 pub mod request;
 pub mod site_settings;
 pub mod users;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,7 +1,28 @@
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
-use crate::UserId;
+use crate::{UserId, WpApiParamOrder};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum WpApiParamPostsOrderBy {
+    Author,
+    #[default]
+    Date,
+    Id,
+    Include,
+    IncludeSlugs,
+    Modified,
+    Parent,
+    Relevance,
+    Slug,
+    Title,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum WpApiParamPostsTaxRelation {
+    And,
+    Or,
+}
 
 #[derive(Debug, Default, uniffi::Record)]
 pub struct PostListParams {
@@ -9,6 +30,79 @@ pub struct PostListParams {
     /// Default: `1`
     #[uniffi(default = None)]
     pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    /// Default: `10`
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Limit response to posts published after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub after: Option<String>,
+    /// Limit response to posts modified after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_after: Option<String>,
+    /// Limit result set to posts assigned to specific authors.
+    #[uniffi(default = None)]
+    pub author: Option<Vec<UserId>>,
+    /// Ensure result set excludes posts assigned to specific authors.
+    #[uniffi(default = None)]
+    pub author_exclude: Option<Vec<UserId>>,
+    /// Limit response to posts published before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub before: Option<String>,
+    /// Limit response to posts modified before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_before: Option<String>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = None)]
+    pub exclude: Option<Vec<PostId>>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = None)]
+    pub include: Option<Vec<PostId>>,
+    /// Offset the result set by a specific number of items.
+    #[uniffi(default = None)]
+    pub offset: Option<u32>,
+    /// Order sort attribute ascending or descending.
+    /// Default: desc
+    /// One of: asc, desc
+    #[uniffi(default = None)]
+    pub order: Option<WpApiParamOrder>,
+    /// Sort collection by post attribute.
+    /// Default: date
+    /// One of: author, date, id, include, modified, parent, relevance, slug, include_slugs, title
+    #[uniffi(default = None)]
+    pub orderby: Option<WpApiParamPostsOrderBy>,
+    /// Array of column names to be searched.
+    #[uniffi(default = None)]
+    pub search_columns: Option<Vec<String>>,
+    /// Limit result set to posts with one or more specific slugs.
+    #[uniffi(default = None)]
+    pub slug: Option<Vec<String>>,
+    /// Limit result set to posts assigned one or more statuses.
+    /// Default: publish
+    #[uniffi(default = None)]
+    pub status: Option<PostStatus>,
+    /// Limit result set based on relationship between multiple taxonomies.
+    /// One of: AND, OR
+    #[uniffi(default = None)]
+    pub tax_relation: Option<WpApiParamPostsTaxRelation>,
+    /// Limit result set to items with specific terms assigned in the categories taxonomy.
+    #[uniffi(default = None)]
+    pub categories: Option<Vec<CategoryId>>,
+    /// Limit result set to items except those with specific terms assigned in the categories taxonomy.
+    #[uniffi(default = None)]
+    pub categories_exclude: Option<Vec<CategoryId>>,
+    /// Limit result set to items with specific terms assigned in the tags taxonomy.
+    #[uniffi(default = None)]
+    pub tags: Option<Vec<TagId>>,
+    /// Limit result set to items except those with specific terms assigned in the tags taxonomy.
+    #[uniffi(default = None)]
+    pub tags_exclude: Option<Vec<TagId>>,
+    /// Limit result set to items that are sticky.
+    #[uniffi(default = None)]
+    pub sticky: Option<bool>,
 }
 
 impl PostListParams {
@@ -24,9 +118,13 @@ uniffi::custom_newtype!(PostId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PostId(pub i32);
 
-uniffi::custom_newtype!(PostTag, i32);
+uniffi::custom_newtype!(TagId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PostTag(pub i32);
+pub struct TagId(pub i32);
+
+uniffi::custom_newtype!(CategoryId, i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CategoryId(pub i32);
 
 impl std::fmt::Display for PostId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -88,7 +186,7 @@ pub struct SparsePost {
     #[WpContext(edit, view)]
     pub categories: Option<Vec<i64>>,
     #[WpContext(edit, view)]
-    pub tags: Option<Vec<PostTag>>,
+    pub tags: Option<Vec<TagId>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
@@ -119,15 +217,26 @@ pub struct PostMeta {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum PostStatus {
-    Publish,
-    Future,
     Draft,
+    Future,
     Pending,
     Private,
+    #[default]
+    Publish,
     #[serde(untagged)]
     Custom(String),
 }

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -44,11 +44,11 @@ pub struct PostListParams {
     #[uniffi(default = None)]
     pub modified_after: Option<String>,
     /// Limit result set to posts assigned to specific authors.
-    #[uniffi(default = None)]
-    pub author: Option<Vec<UserId>>,
+    #[uniffi(default = [])]
+    pub author: Vec<UserId>,
     /// Ensure result set excludes posts assigned to specific authors.
-    #[uniffi(default = None)]
-    pub author_exclude: Option<Vec<UserId>>,
+    #[uniffi(default = [])]
+    pub author_exclude: Vec<UserId>,
     /// Limit response to posts published before a given ISO8601 compliant date.
     #[uniffi(default = None)]
     pub before: Option<String>,
@@ -56,11 +56,11 @@ pub struct PostListParams {
     #[uniffi(default = None)]
     pub modified_before: Option<String>,
     /// Ensure result set excludes specific IDs.
-    #[uniffi(default = None)]
-    pub exclude: Option<Vec<PostId>>,
+    #[uniffi(default = [])]
+    pub exclude: Vec<PostId>,
     /// Limit result set to specific IDs.
-    #[uniffi(default = None)]
-    pub include: Option<Vec<PostId>>,
+    #[uniffi(default = [])]
+    pub include: Vec<PostId>,
     /// Offset the result set by a specific number of items.
     #[uniffi(default = None)]
     pub offset: Option<u32>,
@@ -75,11 +75,11 @@ pub struct PostListParams {
     #[uniffi(default = None)]
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Array of column names to be searched.
-    #[uniffi(default = None)]
-    pub search_columns: Option<Vec<String>>,
+    #[uniffi(default = [])]
+    pub search_columns: Vec<String>,
     /// Limit result set to posts with one or more specific slugs.
-    #[uniffi(default = None)]
-    pub slug: Option<Vec<String>>,
+    #[uniffi(default = [])]
+    pub slug: Vec<String>,
     /// Limit result set to posts assigned one or more statuses.
     /// Default: publish
     #[uniffi(default = None)]
@@ -89,17 +89,17 @@ pub struct PostListParams {
     #[uniffi(default = None)]
     pub tax_relation: Option<WpApiParamPostsTaxRelation>,
     /// Limit result set to items with specific terms assigned in the categories taxonomy.
-    #[uniffi(default = None)]
-    pub categories: Option<Vec<CategoryId>>,
+    #[uniffi(default = [])]
+    pub categories: Vec<CategoryId>,
     /// Limit result set to items except those with specific terms assigned in the categories taxonomy.
-    #[uniffi(default = None)]
-    pub categories_exclude: Option<Vec<CategoryId>>,
+    #[uniffi(default = [])]
+    pub categories_exclude: Vec<CategoryId>,
     /// Limit result set to items with specific terms assigned in the tags taxonomy.
-    #[uniffi(default = None)]
-    pub tags: Option<Vec<TagId>>,
+    #[uniffi(default = [])]
+    pub tags: Vec<TagId>,
     /// Limit result set to items except those with specific terms assigned in the tags taxonomy.
-    #[uniffi(default = None)]
-    pub tags_exclude: Option<Vec<TagId>>,
+    #[uniffi(default = [])]
+    pub tags_exclude: Vec<TagId>,
     /// Limit result set to items that are sticky.
     #[uniffi(default = None)]
     pub sticky: Option<bool>,
@@ -107,10 +107,58 @@ pub struct PostListParams {
 
 impl PostListParams {
     pub fn query_pairs(&self) -> impl IntoIterator<Item = (&str, String)> {
-        [("page", self.page.map(|x| x.to_string()))]
-            .into_iter()
-            // Remove `None` values
-            .filter_map(|(k, opt_v)| opt_v.map(|v| (k, v)))
+        [
+            ("page", self.page.map(|x| x.to_string())),
+            ("per_page", self.per_page.map(|x| x.to_string())),
+            ("search", self.search.clone()),
+            ("after", self.after.clone()),
+            ("modified_after", self.modified_after.clone()),
+            (
+                "author",
+                (!self.author.is_empty()).then_some(
+                    self.author
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                ),
+            ),
+            (
+                "author_exclude",
+                (!self.author_exclude.is_empty()).then_some(
+                    self.author_exclude
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                ),
+            ),
+            ("before", self.before.clone()),
+            ("modified_before", self.modified_before.clone()),
+            (
+                "exclude",
+                (!self.exclude.is_empty()).then_some(
+                    self.exclude
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                ),
+            ),
+            (
+                "include",
+                (!self.include.is_empty()).then_some(
+                    self.include
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(","),
+                ),
+            ),
+        ]
+        .into_iter()
+        // Remove `None` values
+        .filter_map(|(k, opt_v)| opt_v.map(|v| (k, v)))
     }
 }
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+use wp_contextual::WpContextual;
+
+use crate::UserId;
+
+#[derive(Debug, Default, uniffi::Record)]
+pub struct PostListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+}
+
+impl PostListParams {
+    pub fn query_pairs(&self) -> impl IntoIterator<Item = (&str, String)> {
+        [("page", self.page.map(|x| x.to_string()))]
+            .into_iter()
+            // Remove `None` values
+            .filter_map(|(k, opt_v)| opt_v.map(|v| (k, v)))
+    }
+}
+
+uniffi::custom_newtype!(PostId, i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostId(pub i32);
+
+uniffi::custom_newtype!(PostTag, i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostTag(pub i32);
+
+impl std::fmt::Display for PostId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePost {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<PostId>,
+    #[WpContext(edit, view)]
+    pub date: Option<String>,
+    #[WpContext(edit, view)]
+    pub date_gmt: Option<String>,
+    #[WpContext(edit, view)]
+    pub guid: Option<PostGuid>,
+    #[WpContext(edit, embed, view)]
+    pub link: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified_gmt: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, view)]
+    pub status: Option<PostStatus>,
+    #[serde(rename = "type")]
+    #[WpContext(edit, embed, view)]
+    pub post_type: Option<String>,
+    #[WpContext(edit)]
+    pub password: Option<String>,
+    #[WpContext(edit)]
+    pub permalink_template: Option<String>,
+    #[WpContext(edit)]
+    pub generated_slug: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub title: Option<PostTitle>,
+    #[WpContext(edit, view)]
+    pub content: Option<PostContent>,
+    #[WpContext(edit, embed, view)]
+    pub author: Option<UserId>,
+    #[WpContext(edit, embed, view)]
+    pub excerpt: Option<PostExcerpt>,
+    #[WpContext(edit, embed, view)]
+    pub featured_media: Option<i64>,
+    #[WpContext(edit, view)]
+    pub comment_status: Option<String>,
+    #[WpContext(edit, view)]
+    pub ping_status: Option<String>,
+    #[WpContext(edit, view)]
+    pub format: Option<String>,
+    #[WpContext(edit, view)]
+    pub meta: Option<PostMeta>,
+    #[WpContext(edit, view)]
+    pub sticky: Option<bool>,
+    #[WpContext(edit, view)]
+    pub template: Option<String>,
+    #[WpContext(edit, view)]
+    pub categories: Option<Vec<i64>>,
+    #[WpContext(edit, view)]
+    pub tags: Option<Vec<PostTag>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostGuid {
+    pub rendered: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostTitle {
+    pub rendered: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostContent {
+    pub rendered: String,
+    pub protected: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostExcerpt {
+    pub rendered: String,
+    pub protected: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostMeta {
+    pub footnotes: String,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum PostStatus {
+    Publish,
+    Future,
+    Draft,
+    Pending,
+    Private,
+    #[serde(untagged)]
+    Custom(String),
+}

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -5,6 +5,7 @@ use crate::SparseField;
 pub(crate) mod application_passwords_endpoint;
 pub(crate) mod plugins_endpoint;
 pub(crate) mod post_types_endpoint;
+pub(crate) mod posts_endpoint;
 pub(crate) mod site_settings_endpoint;
 pub(crate) mod users_endpoint;
 pub(crate) mod wp_site_health_tests_endpoint;

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -1,0 +1,28 @@
+use crate::{
+    posts::{
+        PostListParams, SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
+        SparsePostFieldWithViewContext,
+    },
+    SparseField,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+use super::{DerivedRequest, Namespace};
+
+#[derive(WpDerivedRequest)]
+enum PostsRequest {
+    #[contextual_get(url = "/posts", params = &PostListParams, output = Vec<crate::posts::SparsePost>, filter_by = crate::posts::SparsePostField)]
+    List,
+}
+
+impl DerivedRequest for PostsRequest {
+    fn namespace() -> Namespace {
+        Namespace::WpV2
+    }
+}
+
+super::macros::default_sparse_field_implementation_from_field_name!(SparsePostFieldWithEditContext);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparsePostFieldWithEmbedContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(SparsePostFieldWithViewContext);

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,8 +1,11 @@
 use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
-use wp_api::generate;
-use wp_api::posts::{PostId, PostListParams};
+use wp_api::posts::{
+    CategoryId, PostId, PostListParams, PostStatus, TagId, WpApiParamPostsOrderBy,
+    WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+};
+use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
 
 #[tokio::test]
@@ -52,4 +55,16 @@ async fn list_with_view_context(#[case] params: PostListParams) {
 #[case::modified_before(generate!(PostListParams, (modified_before, Some("2024-01-14 17:00:00.000".to_string()))))]
 #[case::exclude(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])))]
 #[case::include(generate!(PostListParams, (include, vec![PostId(1)])))]
+#[case::offset(generate!(PostListParams, (offset, Some(2))))]
+#[case::order(generate!(PostListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))))]
+#[case::search_columns(generate!(PostListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt])))]
+#[case::slug(generate!(PostListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+#[case::status(generate!(PostListParams, (status, vec![PostStatus::Publish, PostStatus::Pending])))]
+#[case::tax_relation(generate!(PostListParams, (tax_relation, Some(WpApiParamPostsTaxRelation::And))))]
+#[case::categories(generate!(PostListParams, (categories, vec![CategoryId(1)])))]
+#[case::categories_exclude(generate!(PostListParams, (categories_exclude, vec![CategoryId(1)])))]
+#[case::tags(generate!(PostListParams, (tags, vec![TagId(1)])))]
+#[case::tags_exclude(generate!(PostListParams, (tags_exclude, vec![TagId(1)])))]
+#[case::sticky(generate!(PostListParams, (sticky, Some(true))))]
 pub fn list_cases(#[case] params: PostListParams) {}

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,0 +1,36 @@
+use serial_test::parallel;
+use wp_api::posts::PostListParams;
+use wp_api_integration_tests::{api_client, AssertResponse};
+
+#[tokio::test]
+#[parallel]
+async fn list_with_edit_context() {
+    let posts = api_client()
+        .posts()
+        .list_with_edit_context(&PostListParams::default())
+        .await
+        .assert_response();
+    println!("{:#?}", posts);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_embed_context() {
+    let posts = api_client()
+        .posts()
+        .list_with_embed_context(&PostListParams::default())
+        .await
+        .assert_response();
+    println!("{:#?}", posts);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_view_context() {
+    let posts = api_client()
+        .posts()
+        .list_with_view_context(&PostListParams::default())
+        .await
+        .assert_response();
+    println!("{:#?}", posts);
+}

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,36 +1,55 @@
+use rstest::*;
+use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
-use wp_api::posts::PostListParams;
-use wp_api_integration_tests::{api_client, AssertResponse};
+use wp_api::generate;
+use wp_api::posts::{PostId, PostListParams};
+use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
 
 #[tokio::test]
+#[apply(list_cases)]
 #[parallel]
-async fn list_with_edit_context() {
-    let posts = api_client()
+async fn list_with_edit_context(#[case] params: PostListParams) {
+    api_client()
         .posts()
-        .list_with_edit_context(&PostListParams::default())
+        .list_with_edit_context(&params)
         .await
         .assert_response();
-    println!("{:#?}", posts);
 }
 
 #[tokio::test]
+#[apply(list_cases)]
 #[parallel]
-async fn list_with_embed_context() {
-    let posts = api_client()
+async fn list_with_embed_context(#[case] params: PostListParams) {
+    api_client()
         .posts()
-        .list_with_embed_context(&PostListParams::default())
+        .list_with_embed_context(&params)
         .await
         .assert_response();
-    println!("{:#?}", posts);
 }
 
 #[tokio::test]
+#[apply(list_cases)]
 #[parallel]
-async fn list_with_view_context() {
-    let posts = api_client()
+async fn list_with_view_context(#[case] params: PostListParams) {
+    api_client()
         .posts()
-        .list_with_view_context(&PostListParams::default())
+        .list_with_view_context(&params)
         .await
         .assert_response();
-    println!("{:#?}", posts);
 }
+
+#[template]
+#[rstest]
+#[case::default(PostListParams::default())]
+#[case::page(generate!(PostListParams, (page, Some(1))))]
+#[case::per_page(generate!(PostListParams, (per_page, Some(3))))]
+#[case::search(generate!(PostListParams, (search, Some("foo".to_string()))))]
+#[case::after(generate!(PostListParams, (after, Some("2020-08-14 17:00:00.000".to_string()))))]
+#[case::modified_after(generate!(PostListParams, (modified_after, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::author(generate!(PostListParams, (author, vec![FIRST_USER_ID, SECOND_USER_ID])))]
+#[case::author_exclude(generate!(PostListParams, (author_exclude, vec![SECOND_USER_ID])))]
+#[case::before(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))))]
+#[case::modified_before(generate!(PostListParams, (modified_before, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::exclude(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])))]
+#[case::include(generate!(PostListParams, (include, vec![PostId(1)])))]
+pub fn list_cases(#[case] params: PostListParams) {}


### PR DESCRIPTION
This PR handles the initial setup for the `/posts` endpoint and implements the `List` variant and its integration tests.

For `/posts`, I'd like to try opening smaller work-in-progress type PRs. These won't contain any major issues, but it also won't be as polished as a fully completed endpoint. Completely implementing an endpoint takes time and makes it harder to work on anything else until that work is completed. It also results in a harder to review PR. So, I want to give this approach a shot for bigger endpoints.

There are several improvements to this implementation that I'll tackle in the upcoming PRs:
* `PostListParams::query_pairs` contains _a lot_ of code duplication and the same is true for some other params types. I think there is an easy way to improve this and also make it less error prone. I currently copy/paste one of the field implementations and then update the field name and anything else necessary. However, I am always worried that I'll update the name of the parameter name and not the field name and then end up including the incorrect data. Unit tests address this to a degree, but it's possible to make a similar mistake in unit test implementation, so I want our implementation to help us avoid these issues.
* Add unit tests for `list_posts` endpoint. These are currently missing because I want to use the integration tests to verify that we are making the correct requests before implementing the unit tests. If I do it now and we are not building our query correctly, the unit tests will also need to be updated.
* Go through each integration test and verify that each parameter actually works. The integration tests validate that we are sending the correct parameters, but it can't validate that we are getting back the expected data. That's something we _could_ implement since we control the test server. However, that'd require us to maintain a data set to compare against - which might be worth it specifically for `/posts` as it's arguably the most important endpoint.
* The `date` fields use `String` at the moment and should be replaced with a strong type #262