### PR TITLE
Add failing test cases for autodiscovery

### DIFF
--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -50,6 +50,10 @@ const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
     "https://jetpack.wpmt.co",
     "https://jetpack.wpmt.co/wp-admin/authorize-application.php"
 )]
+#[case(
+    "https://aggressive-caching.wpmt.co",
+    "https://jetpack.wpmt.co/wp-admin/authorize-application.php"
+)] // Returns gzip responses, may not always include Link header
 #[tokio::test]
 #[parallel]
 async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str) {


### PR DESCRIPTION
Adds some test cases for issues I've seen on real sites:

- Sometimes caching is so aggressive that there's no Link header – we could probably fix that by speculatively loading `/wp-json` and seeing if it works. Worst-case, we'd need an entire HTML parser to read the site and see if it's there.
- IDN URLs can be a bit weird, we should make sure that's covered (it seems to work fine!)
- Sites will use compression in their responses, and the test runner needs to handle it (so I've included all of `reqwest`'s options related to that)