### PR TITLE
`AppendUrlQueryPairs` & `QueryPairsExtension` traits

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -4,6 +4,7 @@ pub use api_client::{WpApiClient, WpApiRequestBuilder};
 pub use api_error::{RequestExecutionError, WpApiError, WpErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
+use url_query::AsQueryValue;
 use users::*;
 pub use uuid::{WpUuid, WpUuidParseError};
 
@@ -19,6 +20,7 @@ pub mod post_types;
 pub mod posts;
 pub mod request;
 pub mod site_settings;
+pub mod url_query;
 pub mod users;
 pub mod wp_site_health_tests;
 
@@ -71,6 +73,12 @@ pub enum WpApiParamOrder {
     #[default]
     Asc,
     Desc,
+}
+
+impl AsQueryValue for WpApiParamOrder {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.as_str()
+    }
 }
 
 impl WpApiParamOrder {

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -75,11 +75,7 @@ pub enum WpApiParamOrder {
     Desc,
 }
 
-impl AsQueryValue for WpApiParamOrder {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.as_str()
-    }
-}
+impl_as_query_value_from_as_str!(WpApiParamOrder);
 
 impl WpApiParamOrder {
     fn as_str(&self) -> &str {

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -3,7 +3,10 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
-use crate::url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension};
+use crate::{
+    impl_as_query_value_from_as_str,
+    url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
+};
 
 #[derive(Debug, Default, uniffi::Record)]
 pub struct PluginListParams {
@@ -125,11 +128,7 @@ pub enum PluginStatus {
     NetworkActive,
 }
 
-impl AsQueryValue for PluginStatus {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.as_str()
-    }
-}
+impl_as_query_value_from_as_str!(PluginStatus);
 
 impl PluginStatus {
     fn as_str(&self) -> &str {

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
-use crate::{UserId, WpApiParamOrder};
+use crate::{
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    UserId, WpApiParamOrder,
+};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WpApiParamPostsOrderBy {
@@ -148,141 +151,32 @@ pub struct PostListParams {
     pub sticky: Option<bool>,
 }
 
-impl PostListParams {
-    pub fn query_pairs(&self) -> impl IntoIterator<Item = (&str, String)> {
-        [
-            ("page", self.page.map(|x| x.to_string())),
-            ("per_page", self.per_page.map(|x| x.to_string())),
-            ("search", self.search.clone()),
-            ("after", self.after.clone()),
-            ("modified_after", self.modified_after.clone()),
-            (
-                "author",
-                (!self.author.is_empty()).then_some(
-                    self.author
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "author_exclude",
-                (!self.author_exclude.is_empty()).then_some(
-                    self.author_exclude
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            ("before", self.before.clone()),
-            ("modified_before", self.modified_before.clone()),
-            (
-                "exclude",
-                (!self.exclude.is_empty()).then_some(
-                    self.exclude
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "include",
-                (!self.include.is_empty()).then_some(
-                    self.include
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            ("offset", self.offset.map(|x| x.to_string())),
-            ("order", self.order.as_ref().map(|x| x.as_str().to_string())),
-            (
-                "orderby",
-                self.orderby.as_ref().map(|x| x.as_str().to_string()),
-            ),
-            (
-                "search_columns",
-                (!self.search_columns.is_empty()).then_some(
-                    self.search_columns
-                        .iter()
-                        .map(|x| x.as_str().to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "slug",
-                (!self.slug.is_empty()).then_some(
-                    self.slug
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "status",
-                (!self.status.is_empty()).then_some(
-                    self.status
-                        .iter()
-                        .map(|x| x.as_str().to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "tax_relation",
-                self.tax_relation.as_ref().map(|x| x.as_str().to_string()),
-            ),
-            (
-                "categories",
-                (!self.categories.is_empty()).then_some(
-                    self.categories
-                        .iter()
-                        .map(|x| x.0.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "categories_exclude",
-                (!self.categories_exclude.is_empty()).then_some(
-                    self.categories_exclude
-                        .iter()
-                        .map(|x| x.0.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "tags",
-                (!self.tags.is_empty()).then_some(
-                    self.tags
-                        .iter()
-                        .map(|x| x.0.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "tags_exclude",
-                (!self.tags_exclude.is_empty()).then_some(
-                    self.tags_exclude
-                        .iter()
-                        .map(|x| x.0.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            ("sticky", self.sticky.map(|x| x.to_string())),
-        ]
-        .into_iter()
-        // Remove `None` values
-        .filter_map(|(k, opt_v)| opt_v.map(|v| (k, v)))
+impl AppendUrlQueryPairs for PostListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("page", self.page.as_ref())
+            .append_option_query_value_pair("per_page", self.per_page.as_ref())
+            .append_option_query_value_pair("search", self.search.as_ref())
+            .append_option_query_value_pair("after", self.after.as_ref())
+            .append_option_query_value_pair("modified_after", self.modified_after.as_ref())
+            .append_vec_query_value_pair("author", &self.author)
+            .append_vec_query_value_pair("author_exclude", &self.author_exclude)
+            .append_option_query_value_pair("before", self.before.as_ref())
+            .append_option_query_value_pair("modified_before", self.modified_before.as_ref())
+            //.append_vec_query_value_pair("exclude", &self.exclude)
+            //.append_vec_query_value_pair("include", &self.include)
+            .append_option_query_value_pair("offset", self.offset.as_ref())
+            .append_option_query_value_pair("order", self.order.as_ref())
+            //.append_option_query_value_pair("orderby", self.orderby.as_ref())
+            //.append_vec_query_value_pair("search_columns", &self.search_columns)
+            .append_vec_query_value_pair("slug", &self.slug)
+            //.append_vec_query_value_pair("status", &self.status)
+            //.append_option_query_value_pair("tax_relation", self.tax_relation.as_ref())
+            //.append_vec_query_value_pair("categories", &self.categories)
+            //.append_vec_query_value_pair("categories_exclude", &self.categories_exclude)
+            //.append_vec_query_value_pair("tags", &self.tags)
+            //.append_vec_query_value_pair("tags_exclude", &self.tags_exclude)
+            .append_option_query_value_pair("sticky", self.sticky.as_ref());
     }
 }
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
 use crate::{
-    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
     UserId, WpApiParamOrder,
 };
 
@@ -20,6 +21,8 @@ pub enum WpApiParamPostsOrderBy {
     Slug,
     Title,
 }
+
+impl_as_query_value_from_as_str!(WpApiParamPostsOrderBy);
 
 impl WpApiParamPostsOrderBy {
     fn as_str(&self) -> &str {
@@ -44,6 +47,8 @@ pub enum WpApiParamPostsTaxRelation {
     Or,
 }
 
+impl_as_query_value_from_as_str!(WpApiParamPostsTaxRelation);
+
 impl WpApiParamPostsTaxRelation {
     fn as_str(&self) -> &str {
         match self {
@@ -59,6 +64,8 @@ pub enum WpApiParamPostsSearchColumn {
     PostExcerpt,
     PostTitle,
 }
+
+impl_as_query_value_from_as_str!(WpApiParamPostsSearchColumn);
 
 impl WpApiParamPostsSearchColumn {
     fn as_str(&self) -> &str {
@@ -163,31 +170,34 @@ impl AppendUrlQueryPairs for PostListParams {
             .append_vec_query_value_pair("author_exclude", &self.author_exclude)
             .append_option_query_value_pair("before", self.before.as_ref())
             .append_option_query_value_pair("modified_before", self.modified_before.as_ref())
-            //.append_vec_query_value_pair("exclude", &self.exclude)
-            //.append_vec_query_value_pair("include", &self.include)
+            .append_vec_query_value_pair("exclude", &self.exclude)
+            .append_vec_query_value_pair("include", &self.include)
             .append_option_query_value_pair("offset", self.offset.as_ref())
             .append_option_query_value_pair("order", self.order.as_ref())
-            //.append_option_query_value_pair("orderby", self.orderby.as_ref())
-            //.append_vec_query_value_pair("search_columns", &self.search_columns)
+            .append_option_query_value_pair("orderby", self.orderby.as_ref())
+            .append_vec_query_value_pair("search_columns", &self.search_columns)
             .append_vec_query_value_pair("slug", &self.slug)
-            //.append_vec_query_value_pair("status", &self.status)
-            //.append_option_query_value_pair("tax_relation", self.tax_relation.as_ref())
-            //.append_vec_query_value_pair("categories", &self.categories)
-            //.append_vec_query_value_pair("categories_exclude", &self.categories_exclude)
-            //.append_vec_query_value_pair("tags", &self.tags)
-            //.append_vec_query_value_pair("tags_exclude", &self.tags_exclude)
+            .append_vec_query_value_pair("status", &self.status)
+            .append_option_query_value_pair("tax_relation", self.tax_relation.as_ref())
+            .append_vec_query_value_pair("categories", &self.categories)
+            .append_vec_query_value_pair("categories_exclude", &self.categories_exclude)
+            .append_vec_query_value_pair("tags", &self.tags)
+            .append_vec_query_value_pair("tags_exclude", &self.tags_exclude)
             .append_option_query_value_pair("sticky", self.sticky.as_ref());
     }
 }
 
+impl_as_query_value_for_new_type!(PostId);
 uniffi::custom_newtype!(PostId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PostId(pub i32);
 
+impl_as_query_value_for_new_type!(TagId);
 uniffi::custom_newtype!(TagId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TagId(pub i32);
 
+impl_as_query_value_for_new_type!(CategoryId);
 uniffi::custom_newtype!(CategoryId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CategoryId(pub i32);
@@ -306,6 +316,8 @@ pub enum PostStatus {
     #[serde(untagged)]
     Custom(String),
 }
+
+impl_as_query_value_from_as_str!(PostStatus);
 
 impl PostStatus {
     fn as_str(&self) -> &str {

--- a/wp_api/src/request/endpoint/users_endpoint.rs
+++ b/wp_api/src/request/endpoint/users_endpoint.rs
@@ -66,7 +66,7 @@ mod tests {
                     reassign: UserId(98),
                 },
             ),
-            "/users/54?reassign=98&force=true",
+            "/users/54?force=true&reassign=98",
         );
     }
 
@@ -76,7 +76,7 @@ mod tests {
             endpoint.delete_me(&UserDeleteParams {
                 reassign: UserId(98),
             }),
-            "/users/me?reassign=98&force=true",
+            "/users/me?force=true&reassign=98",
         );
     }
 

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -5,5 +5,5 @@ use url::Url;
 pub fn assert_expected_query_pairs(params: impl AppendUrlQueryPairs, expected_query: &str) {
     let mut url = Url::parse("https://example.com").unwrap();
     params.append_query_pairs(&mut url.query_pairs_mut());
-    assert_eq!(url.query().unwrap(), expected_query);
+    assert_eq!(url.query(), Some(expected_query));
 }

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -1,15 +1,9 @@
+use crate::url_query::AppendUrlQueryPairs;
+use url::Url;
+
 #[cfg(test)]
-pub fn assert_expected_query_pairs<'a>(
-    query_pairs: impl IntoIterator<Item = (&'a str, String)>,
-    expected_pairs: &[(&'a str, &str)],
-) {
-    let mut query_pairs = query_pairs.into_iter().collect::<Vec<_>>();
-    let mut expected_pairs: Vec<(&str, String)> = expected_pairs
-        .iter()
-        .map(|(k, v)| (*k, v.to_string()))
-        .collect();
-    // The order of query pairs doesn't matter
-    query_pairs.sort();
-    expected_pairs.sort();
-    assert_eq!(query_pairs, expected_pairs);
+pub fn assert_expected_query_pairs(params: impl AppendUrlQueryPairs, expected_query: &str) {
+    let mut url = Url::parse("https://example.com").unwrap();
+    params.append_query_pairs(&mut url.query_pairs_mut());
+    assert_eq!(url.query().unwrap(), expected_query);
 }

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -1,5 +1,7 @@
 use url::{form_urlencoded, UrlQuery};
 
+use crate::impl_as_query_value_from_to_string;
+
 pub(crate) type QueryPairs<'a> = form_urlencoded::Serializer<'a, UrlQuery<'a>>;
 
 pub(crate) trait AppendUrlQueryPairs {
@@ -58,23 +60,9 @@ pub(crate) trait AsQueryValue {
     fn as_query_value(&self) -> impl AsRef<str>;
 }
 
-impl AsQueryValue for u32 {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.to_string()
-    }
-}
-
-impl AsQueryValue for i32 {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.to_string()
-    }
-}
-
-impl AsQueryValue for bool {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.to_string()
-    }
-}
+impl_as_query_value_from_to_string!(u32);
+impl_as_query_value_from_to_string!(i32);
+impl_as_query_value_from_to_string!(bool);
 
 impl AsQueryValue for &str {
     fn as_query_value(&self) -> impl AsRef<str> {
@@ -85,5 +73,40 @@ impl AsQueryValue for &str {
 impl AsQueryValue for String {
     fn as_query_value(&self) -> impl AsRef<str> {
         self
+    }
+}
+
+mod macro_helper {
+    #[macro_export]
+    macro_rules! impl_as_query_value_from_as_str {
+        ($ident: ident) => {
+            impl AsQueryValue for $ident {
+                fn as_query_value(&self) -> impl AsRef<str> {
+                    self.as_str()
+                }
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! impl_as_query_value_from_to_string {
+        ($ident: ident) => {
+            impl AsQueryValue for $ident {
+                fn as_query_value(&self) -> impl AsRef<str> {
+                    self.to_string()
+                }
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! impl_as_query_value_for_new_type {
+        ($ident: ident) => {
+            impl AsQueryValue for $ident {
+                fn as_query_value(&self) -> impl AsRef<str> {
+                    self.0.as_query_value()
+                }
+            }
+        };
     }
 }

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -110,3 +110,59 @@ mod macro_helper {
         };
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+    use url::Url;
+
+    #[rstest]
+    #[case("foo", 1, "foo=1")]
+    #[case("foo", "2", "foo=2")]
+    #[case("foo", "2".to_string(), "foo=2")]
+    #[case("foo", true, "foo=true")]
+    fn test_append_query_value_pair(
+        #[case] key: &str,
+        #[case] value: impl AsQueryValue,
+        #[case] expected_str: &str,
+    ) {
+        let mut url = Url::parse("https://example.com").unwrap();
+        url.query_pairs_mut().append_query_value_pair(key, &value);
+        assert_eq!(url.query(), Some(expected_str));
+    }
+
+    #[rstest]
+    #[case("foo", Some(1), "foo=1")]
+    #[case("foo", Some("2"), "foo=2")]
+    #[case("foo", Some("2".to_string()), "foo=2")]
+    #[case("foo", Some(true), "foo=true")]
+    #[case("foo", None::<bool>, "")]
+    fn test_append_option_query_value_pair(
+        #[case] key: &str,
+        #[case] value: Option<impl AsQueryValue>,
+        #[case] expected_str: &str,
+    ) {
+        let mut url = Url::parse("https://example.com").unwrap();
+        url.query_pairs_mut()
+            .append_option_query_value_pair(key, value.as_ref());
+        assert_eq!(url.query(), Some(expected_str));
+    }
+
+    #[rstest]
+    #[case("foo", vec![1], "foo=1")]
+    #[case("foo", vec!["2"], "foo=2")]
+    #[case("foo", vec!["1".to_string(), "2".to_string()], "foo=1%2C2")]
+    #[case("foo", vec![true, false], "foo=true%2Cfalse")]
+    #[case("foo", Vec::<bool>::new(), "")]
+    fn test_append_vec_query_value_pair(
+        #[case] key: &str,
+        #[case] value: Vec<impl AsQueryValue>,
+        #[case] expected_str: &str,
+    ) {
+        let mut url = Url::parse("https://example.com").unwrap();
+        url.query_pairs_mut()
+            .append_vec_query_value_pair(key, &value);
+        assert_eq!(url.query(), Some(expected_str));
+    }
+}

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -1,0 +1,89 @@
+use url::{form_urlencoded, UrlQuery};
+
+pub(crate) type QueryPairs<'a> = form_urlencoded::Serializer<'a, UrlQuery<'a>>;
+
+pub(crate) trait AppendUrlQueryPairs {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs);
+}
+
+pub(crate) trait QueryPairsExtension {
+    fn append_query_value_pair<T>(&mut self, key: &str, value: &T) -> &mut Self
+    where
+        T: AsQueryValue;
+    fn append_option_query_value_pair<T>(&mut self, key: &str, value: Option<&T>) -> &mut Self
+    where
+        T: AsQueryValue;
+    fn append_vec_query_value_pair<T>(&mut self, key: &str, value: &[T]) -> &mut Self
+    where
+        T: AsQueryValue;
+}
+
+impl QueryPairsExtension for QueryPairs<'_> {
+    fn append_query_value_pair<T>(&mut self, key: &str, value: &T) -> &mut Self
+    where
+        T: AsQueryValue,
+    {
+        self.append_pair(key, value.as_query_value().as_ref());
+        self
+    }
+
+    fn append_option_query_value_pair<T>(&mut self, key: &str, value: Option<&T>) -> &mut Self
+    where
+        T: AsQueryValue,
+    {
+        if let Some(value) = value {
+            self.append_query_value_pair(key, value);
+        }
+        self
+    }
+
+    fn append_vec_query_value_pair<T>(&mut self, key: &str, value: &[T]) -> &mut Self
+    where
+        T: AsQueryValue,
+    {
+        if !value.is_empty() {
+            let mut csv = value.iter().fold(String::new(), |mut acc, s| {
+                acc.push_str(s.as_query_value().as_ref());
+                acc.push(',');
+                acc
+            });
+            csv.pop(); // remove the last ','
+            self.append_pair(key, &csv);
+        }
+        self
+    }
+}
+
+pub(crate) trait AsQueryValue {
+    fn as_query_value(&self) -> impl AsRef<str>;
+}
+
+impl AsQueryValue for u32 {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.to_string()
+    }
+}
+
+impl AsQueryValue for i32 {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.to_string()
+    }
+}
+
+impl AsQueryValue for bool {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.to_string()
+    }
+}
+
+impl AsQueryValue for &str {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self
+    }
+}
+
+impl AsQueryValue for String {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self
+    }
+}

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, fmt::Display};
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
-use crate::WpApiParamOrder;
+use crate::{
+    url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
+    WpApiParamOrder,
+};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WpApiParamUsersOrderBy {
@@ -16,6 +19,12 @@ pub enum WpApiParamUsersOrderBy {
     IncludeSlugs,
     Email,
     Url,
+}
+
+impl AsQueryValue for WpApiParamUsersOrderBy {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.as_str()
+    }
 }
 
 impl WpApiParamUsersOrderBy {
@@ -55,6 +64,12 @@ pub enum WpApiParamUsersHasPublishedPosts {
     True,
     False,
     PostTypes(Vec<String>),
+}
+
+impl AsQueryValue for WpApiParamUsersHasPublishedPosts {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.to_string()
+    }
 }
 
 impl Display for WpApiParamUsersHasPublishedPosts {
@@ -121,59 +136,28 @@ pub struct UserListParams {
     pub has_published_posts: Option<WpApiParamUsersHasPublishedPosts>,
 }
 
-impl UserListParams {
-    pub fn query_pairs(&self) -> impl IntoIterator<Item = (&str, String)> {
-        [
-            ("page", self.page.map(|x| x.to_string())),
-            ("per_page", self.per_page.map(|x| x.to_string())),
-            ("search", self.search.clone()),
-            (
-                "exclude",
-                (!self.exclude.is_empty()).then_some(
-                    self.exclude
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            (
-                "include",
-                (!self.include.is_empty()).then_some(
-                    self.include
-                        .iter()
-                        .map(|x| x.to_string())
-                        .collect::<Vec<String>>()
-                        .join(","),
-                ),
-            ),
-            ("offset", self.offset.map(|x| x.to_string())),
-            ("order", self.order.map(|x| x.as_str().to_string())),
-            ("orderby", self.orderby.map(|x| x.as_str().to_string())),
-            (
-                "slug",
-                (!self.slug.is_empty()).then_some(self.slug.join(",")),
-            ),
-            (
-                "roles",
-                (!self.roles.is_empty()).then_some(self.roles.join(",")),
-            ),
-            (
-                "capabilities",
-                (!self.capabilities.is_empty()).then_some(self.capabilities.join(",")),
-            ),
-            (
+impl AppendUrlQueryPairs for UserListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("page", self.page.as_ref())
+            .append_option_query_value_pair("per_page", self.per_page.as_ref())
+            .append_option_query_value_pair("search", self.search.as_ref())
+            .append_vec_query_value_pair("exclude", &self.exclude)
+            .append_vec_query_value_pair("include", &self.include)
+            .append_option_query_value_pair("offset", self.offset.as_ref())
+            .append_option_query_value_pair("order", self.order.as_ref())
+            .append_option_query_value_pair("orderby", self.orderby.as_ref())
+            .append_vec_query_value_pair("slug", &self.slug)
+            .append_vec_query_value_pair("roles", &self.roles)
+            .append_vec_query_value_pair("capabilities", &self.capabilities)
+            .append_option_query_value_pair(
                 "who",
-                self.who.and_then(|x| x.as_str().map(|s| s.to_string())),
-            ),
-            (
+                self.who.as_ref().and_then(|w| w.as_str()).as_ref(),
+            )
+            .append_option_query_value_pair(
                 "has_published_posts",
-                self.has_published_posts.as_ref().map(|x| x.to_string()),
-            ),
-        ]
-        .into_iter()
-        // Remove `None` values
-        .filter_map(|(k, opt_v)| opt_v.map(|v| (k, v)))
+                self.has_published_posts.as_ref(),
+            );
     }
 }
 
@@ -311,17 +295,17 @@ impl UserDeleteParams {
     pub fn new(reassign: UserId) -> Self {
         Self { reassign }
     }
+}
 
-    pub fn query_pairs(&self) -> impl IntoIterator<Item = (&str, String)> {
-        [
-            ("reassign", self.reassign.to_string()),
-            // From the [documentation](https://developer.wordpress.org/rest-api/reference/users/#delete-a-user):
-            // > Required to be true, as users do not support trashing.
-            // Since this argument always has to be `true`, we don't include it in the parameter
-            // fields
-            ("force", true.to_string()),
-        ]
-        .into_iter()
+impl AppendUrlQueryPairs for UserDeleteParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        // From the [documentation](https://developer.wordpress.org/rest-api/reference/users/#delete-a-user):
+        // > Required to be true, as users do not support trashing.
+        // Since this argument always has to be `true`, we don't include it in the parameter
+        // fields
+        query_pairs_mut
+            .append_query_value_pair("force", &true)
+            .append_query_value_pair("reassign", &self.reassign);
     }
 }
 
@@ -334,6 +318,12 @@ pub struct UserDeleteResponse {
 uniffi::custom_newtype!(UserId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UserId(pub i32);
+
+impl AsQueryValue for UserId {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.0.as_query_value()
+    }
+}
 
 impl std::fmt::Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -390,38 +380,32 @@ mod tests {
     use rstest::*;
 
     #[rstest]
-    #[case(UserListParams::default(), &[])]
-    #[case(generate!(UserListParams, (page, Some(1))), &[("page", "1")])]
-    #[case(generate!(UserListParams, (page, Some(2)), (per_page, Some(5))), &[("page", "2"), ("per_page", "5")])]
-    #[case(generate!(UserListParams, (search, Some("foo".to_string()))), &[("search", "foo")])]
-    #[case(generate!(UserListParams, (exclude, vec![UserId(1), UserId(2)])), &[("exclude", "1,2")])]
-    #[case(generate!(UserListParams, (include, vec![UserId(1)])), &[("include", "1")])]
-    #[case(generate!(UserListParams, (per_page, Some(100)), (offset, Some(20))), &[("per_page", "100"), ("offset", "20")])]
-    #[case(generate!(UserListParams, (order, Some(WpApiParamOrder::Asc))), &[("order", "asc")])]
-    #[case(generate!(UserListParams, (orderby, Some(WpApiParamUsersOrderBy::Id))), &[("orderby", "id")])]
-    #[case(generate!(UserListParams, (order, Some(WpApiParamOrder::Desc)), (orderby, Some(WpApiParamUsersOrderBy::Email))), &[("order", "desc"), ("orderby", "email")])]
-    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), &[("slug", "foo,bar")])]
-    #[case(generate!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])), &[("roles", "author,editor")])]
-    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])), &[("slug", "foo,bar"), ("roles", "author,editor")])]
-    #[case(generate!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])), &[("capabilities", "edit_themes,delete_pages")])]
-    #[case::who_all_param_should_be_empty(generate!(UserListParams, (who, Some(WpApiParamUsersWho::All))), &[])]
-    #[case(generate!(UserListParams, (who, Some(WpApiParamUsersWho::Authors))), &[("who", "authors")])]
-    #[case(generate!(UserListParams, (has_published_posts, Some(WpApiParamUsersHasPublishedPosts::True))), &[("has_published_posts", "true")])]
-    #[case(generate!(UserListParams, (has_published_posts, Some(WpApiParamUsersHasPublishedPosts::PostTypes(vec!["post".to_string(), "page".to_string()])))), &[("has_published_posts", "post,page")])]
+    #[case(UserListParams::default(), "")]
+    #[case(generate!(UserListParams, (page, Some(1))), "page=1")]
+    #[case(generate!(UserListParams, (page, Some(2)), (per_page, Some(5))), "page=2&per_page=5")]
+    #[case(generate!(UserListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(UserListParams, (exclude, vec![UserId(1), UserId(2)])), "exclude=1%2C2")]
+    #[case(generate!(UserListParams, (include, vec![UserId(1)])), "include=1")]
+    #[case(generate!(UserListParams, (per_page, Some(100)), (offset, Some(20))), "per_page=100&offset=20")]
+    #[case(generate!(UserListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(UserListParams, (orderby, Some(WpApiParamUsersOrderBy::Id))), "orderby=id")]
+    #[case(generate!(UserListParams, (order, Some(WpApiParamOrder::Desc)), (orderby, Some(WpApiParamUsersOrderBy::Email))), "order=desc&orderby=email")]
+    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
+    #[case(generate!(UserListParams, (roles, vec!["author".to_string(), "editor".to_string()])), "roles=author%2Ceditor")]
+    #[case(generate!(UserListParams, (slug, vec!["foo".to_string(), "bar".to_string()]), (roles, vec!["author".to_string(), "editor".to_string()])), "slug=foo%2Cbar&roles=author%2Ceditor")]
+    #[case(generate!(UserListParams, (capabilities, vec!["edit_themes".to_string(), "delete_pages".to_string()])), "capabilities=edit_themes%2Cdelete_pages")]
+    #[case::who_all_param_should_be_empty(generate!(UserListParams, (who, Some(WpApiParamUsersWho::All))), "")]
+    #[case(generate!(UserListParams, (who, Some(WpApiParamUsersWho::Authors))), "who=authors")]
+    #[case(generate!(UserListParams, (has_published_posts, Some(WpApiParamUsersHasPublishedPosts::True))), "has_published_posts=true")]
+    #[case(generate!(UserListParams, (has_published_posts, Some(WpApiParamUsersHasPublishedPosts::PostTypes(vec!["post".to_string(), "page".to_string()])))), "has_published_posts=post%2Cpage")]
     #[trace]
-    fn test_user_list_params(
-        #[case] params: UserListParams,
-        #[case] expected_pairs: &[(&str, &str)],
-    ) {
-        assert_expected_query_pairs(params.query_pairs(), expected_pairs);
+    fn test_user_list_params2(#[case] params: UserListParams, #[case] expected_query: &str) {
+        assert_expected_query_pairs(params, expected_query);
     }
 
     #[test]
     fn test_user_delete_params() {
         let params = UserDeleteParams::new(UserId(987));
-        assert_expected_query_pairs(
-            params.query_pairs(),
-            &[("force", "true"), ("reassign", "987")],
-        );
+        assert_expected_query_pairs(params, "force=true&reassign=987");
     }
 }

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
 use crate::{
+    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
     WpApiParamOrder,
 };
@@ -21,11 +23,7 @@ pub enum WpApiParamUsersOrderBy {
     Url,
 }
 
-impl AsQueryValue for WpApiParamUsersOrderBy {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.as_str()
-    }
-}
+impl_as_query_value_from_as_str!(WpApiParamUsersOrderBy);
 
 impl WpApiParamUsersOrderBy {
     fn as_str(&self) -> &str {
@@ -66,11 +64,7 @@ pub enum WpApiParamUsersHasPublishedPosts {
     PostTypes(Vec<String>),
 }
 
-impl AsQueryValue for WpApiParamUsersHasPublishedPosts {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.to_string()
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamUsersHasPublishedPosts);
 
 impl Display for WpApiParamUsersHasPublishedPosts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -315,15 +309,10 @@ pub struct UserDeleteResponse {
     pub previous: UserWithEditContext,
 }
 
+impl_as_query_value_for_new_type!(UserId);
 uniffi::custom_newtype!(UserId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UserId(pub i32);
-
-impl AsQueryValue for UserId {
-    fn as_query_value(&self) -> impl AsRef<str> {
-        self.0.as_query_value()
-    }
-}
 
 impl std::fmt::Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -169,7 +169,8 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
         let request_type = variant.attr.request_type;
         let url_from_api_base_url =
             fn_body_get_url_from_api_base_url(&parsed_enum.enum_ident, url_parts);
-        let query_pairs = fn_body_query_pairs(params_type.as_ref(), request_type);
+        let query_pairs =
+            fn_body_query_pairs(&config.crate_ident, params_type.as_ref(), request_type);
 
         ContextAndFilterHandler::from_request_type(request_type, variant.attr.filter_by.clone())
             .into_iter()


### PR DESCRIPTION
This PR implements a more structured way to generate the url query for our `Params` types. This helps avoid duplicating the same logic for these types and makes it less error prone. It's both easier to work with and easier to read.

For the `AppendUrlQueryPairs` implementation, I've opted for the `fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {}` function signature. In general, I'd prefer us to return data as oppose to mutating given data. However, in this case, that meant that we had to clone some of the fields. That's _probably_ OK for the gained ergonomics, but I don't feel comfortable with just _probably_. There is also no practical downside in this case and it sort of works like a unit function because we start with a completely empty query. Another option could be to return a `form_urlencoded::Serializer` type, then turn that into `&str` and pass it into [`url::Url::set_query`](https://docs.rs/url/latest/url/struct.Url.html#method.set_query), but we would still pay an extra cost.

It's also possible I might have missed an approach that can return an `IntoIterator`, but I don't think it's worth spending too much time on it when we have an acceptable implementation.