### PR TITLE
Make `ApiBaseUrl` support WPCom API endpoint

### DIFF
--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -80,13 +80,6 @@ impl ApiBaseUrl {
         site_base_url.try_into()
     }
 
-    fn by_appending(&self, segment: &str) -> Url {
-        self.url
-            .clone()
-            .append(segment)
-            .expect("ApiBaseUrl is already parsed, so this can't result in an error")
-    }
-
     pub fn by_extending_and_splitting_by_forward_slash<I>(&self, segments: I) -> Url
     where
         I: IntoIterator,
@@ -223,10 +216,6 @@ mod tests {
         let api_base_url: ApiBaseUrl = test_base_url.try_into().unwrap();
         let expected_wp_json_url = wp_json_endpoint(test_base_url);
         assert_eq!(expected_wp_json_url, api_base_url.as_str());
-        assert_eq!(
-            api_base_url.by_appending("bar").as_str(),
-            format!("{}/bar", expected_wp_json_url)
-        );
         assert_eq!(
             api_base_url
                 .by_extending_and_splitting_by_forward_slash(["bar", "baz"])

--- a/wp_api/src/request/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/request/endpoint/plugins_endpoint.rs
@@ -123,7 +123,7 @@ mod tests {
         "/plugins?context=edit&status=active&_fields=name%2Cplugin_uri"
     )]
     #[case(
-        generate!(PluginListParams, (search, Some("foo".to_string())), (status, Some(PluginStatus::Inactive))), 
+        generate!(PluginListParams, (search, Some("foo".to_string())), (status, Some(PluginStatus::Inactive))),
         &[SparsePluginFieldWithEditContext::NetworkOnly, SparsePluginFieldWithEditContext::RequiresPhp, SparsePluginFieldWithEditContext::Textdomain],
         "/plugins?context=edit&search=foo&status=inactive&_fields=network_only%2Crequires_php%2Ctextdomain"
     )]

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -237,8 +237,7 @@ pub fn fn_body_get_url_from_api_base_url(enum_ident: &Ident, url_parts: &[UrlPar
         })
         .collect::<Vec<TokenStream>>();
     quote! {
-        let mut url = self.api_base_url
-            .by_extending_and_splitting_by_forward_slash([ #enum_ident::namespace().as_str() , #(#url_parts,)* ]);
+        let mut url = self.api_base_url.by_extending_and_splitting_by_forward_slash(Some(&#enum_ident::namespace()), [ #(#url_parts,)* ]);
     }
 }
 
@@ -880,27 +879,27 @@ mod tests {
     #[rstest]
     #[case(
         url_static_users(),
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , \"users\" ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [\"users\" ,]) ;"
     )]
     #[case(
         url_users_with_user_id(),
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , \"users\" , & user_id . to_string () ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [\"users\" , & user_id . to_string () ,]) ;"
     )]
     #[case(
         url_users_with_user_id(),
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , \"users\" , & user_id . to_string () ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [\"users\" , & user_id . to_string () ,]) ;"
     )]
     #[case(
         vec![UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string())],
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , & user_id . to_string () , & user_type . to_string () ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [& user_id . to_string () , & user_type . to_string () ,]) ;"
     )]
     #[case(
         vec![UrlPart::Static("users".to_string()), UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string()), ],
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , \"users\" , & user_id . to_string () , & user_type . to_string () ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [\"users\" , & user_id . to_string () , & user_type . to_string () ,]) ;"
     )]
     #[case(
         vec![UrlPart::Static("users".to_string()), UrlPart::Static("me".to_string()), UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string()), ],
-        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash ([Foo :: namespace () . as_str () , \"users\" , \"me\" , & user_id . to_string () , & user_type . to_string () ,]) ;"
+        "let mut url = self . api_base_url . by_extending_and_splitting_by_forward_slash (Some (& Foo :: namespace ()) , [\"users\" , \"me\" , & user_id . to_string () , & user_type . to_string () ,]) ;"
     )]
     fn test_fn_body_get_url_from_api_base_url(
         #[case] url_parts: Vec<UrlPart>,


### PR DESCRIPTION
This PR makes minimal changes to `ApiBaseUrl`, to make it be able to return `https://public-api.wordpress.com/wp/v2` URLs (see [this blog](https://wordpress.com/blog/2016/11/11/wordpress-rest-api-on-wordpress-com/) for details about the URL structure comparing to .org REST API endpoints).

Let me know what you think. I'll add more changes to make API client types support WP.com site, if you think this direction is worth perusing.  