### PR TITLE
Retrieve `/posts` endpoint

### DIFF
--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -88,6 +88,9 @@ wp language core install en_CA
 wp plugin install hello-dolly --activate
 wp plugin install classic-editor
 
+# Used in `test_posts_immut`. If the resulting ID changes, `PASSWORD_PROTECTED_POST_ID` needs to be updated
+wp post create --post_type=post --post_password=INTEGRATION_TEST --post_title=Password_Protected
+
 cp -rp wp-content/plugins wp-content/plugins-backup
 
 wp db export --add-drop-table wp-content/dump.sql

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -104,6 +104,8 @@ pub enum WpErrorCode {
     InvalidParam,
     #[serde(rename = "rest_plugin_not_found")]
     PluginNotFound,
+    #[serde(rename = "rest_post_incorrect_password")]
+    PostIncorrectPassword,
     #[serde(rename = "rest_type_invalid")]
     TypeInvalid,
     #[serde(rename = "rest_not_logged_in")]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -187,6 +187,19 @@ impl AppendUrlQueryPairs for PostListParams {
     }
 }
 
+#[derive(Debug, Default, uniffi::Record)]
+pub struct PostRetrieveParams {
+    /// The password for the post if it is password protected.
+    #[uniffi(default = None)]
+    pub password: Option<String>,
+}
+
+impl AppendUrlQueryPairs for PostRetrieveParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair("password", self.password.as_ref());
+    }
+}
+
 impl_as_query_value_for_new_type!(PostId);
 uniffi::custom_newtype!(PostId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -1,6 +1,6 @@
 use crate::{
     posts::{
-        PostListParams, SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
+        PostId, PostListParams, SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
         SparsePostFieldWithViewContext,
     },
     SparseField,
@@ -13,6 +13,8 @@ use super::{DerivedRequest, Namespace};
 enum PostsRequest {
     #[contextual_get(url = "/posts", params = &PostListParams, output = Vec<crate::posts::SparsePost>, filter_by = crate::posts::SparsePostField)]
     List,
+    #[contextual_get(url = "/posts/<post_id>", params = &crate::posts::PostRetrieveParams, output = crate::posts::SparsePost, filter_by = crate::posts::SparsePostField)]
+    Retrieve,
 }
 
 impl DerivedRequest for PostsRequest {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -23,6 +23,9 @@ pub const HELLO_DOLLY_PLUGIN_SLUG: &str = "hello-dolly/hello";
 pub const CLASSIC_EDITOR_PLUGIN_SLUG: &str = "classic-editor/classic-editor";
 pub const WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS: &str = "classic-widgets";
 pub const FIRST_POST_ID: PostId = PostId(1);
+pub const PASSWORD_PROTECTED_POST_ID: PostId = PostId(1832);
+pub const PASSWORD_PROTECTED_POST_TITLE: &str = "Password_Protected";
+pub const PASSWORD_PROTECTED_POST_PASSWORD: &str = "INTEGRATION_TEST";
 
 pub fn api_client() -> WpApiClient {
     let authentication = WpAuthentication::from_username_and_password(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use wp_api::{
+    posts::PostId,
     request::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
@@ -21,6 +22,7 @@ pub const SECOND_USER_SLUG: &str = "themedemos";
 pub const HELLO_DOLLY_PLUGIN_SLUG: &str = "hello-dolly/hello";
 pub const CLASSIC_EDITOR_PLUGIN_SLUG: &str = "classic-editor/classic-editor";
 pub const WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS: &str = "classic-widgets";
+pub const FIRST_POST_ID: PostId = PostId(1);
 
 pub fn api_client() -> WpApiClient {
     let authentication = WpAuthentication::from_username_and_password(

--- a/wp_api_integration_tests/tests/test_posts_err.rs
+++ b/wp_api_integration_tests/tests/test_posts_err.rs
@@ -1,0 +1,18 @@
+use serial_test::parallel;
+use wp_api::{posts::PostRetrieveParams, WpErrorCode};
+use wp_api_integration_tests::{api_client, AssertWpError, PASSWORD_PROTECTED_POST_ID};
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_err_() {
+    api_client()
+        .posts()
+        .retrieve_with_view_context(
+            &PASSWORD_PROTECTED_POST_ID,
+            &PostRetrieveParams {
+                password: Some("wrong_password".to_string()),
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostIncorrectPassword);
+}

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -2,11 +2,13 @@ use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
 use wp_api::posts::{
-    CategoryId, PostId, PostListParams, PostStatus, TagId, WpApiParamPostsOrderBy,
-    WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+    CategoryId, PostId, PostListParams, PostRetrieveParams, PostStatus, TagId,
+    WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
 };
 use wp_api::{generate, WpApiParamOrder};
-use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
+use wp_api_integration_tests::{
+    api_client, AssertResponse, FIRST_POST_ID, FIRST_USER_ID, SECOND_USER_ID,
+};
 
 #[tokio::test]
 #[apply(list_cases)]
@@ -37,6 +39,36 @@ async fn list_with_view_context(#[case] params: PostListParams) {
     api_client()
         .posts()
         .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .posts()
+        .retrieve_with_edit_context(&FIRST_POST_ID, &PostRetrieveParams::default())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context(#[case] params: PostRetrieveParams) {
+    api_client()
+        .posts()
+        .retrieve_with_embed_context(&FIRST_POST_ID, &PostRetrieveParams::default())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context(#[case] params: PostRetrieveParams) {
+    api_client()
+        .posts()
+        .retrieve_with_view_context(&FIRST_POST_ID, &PostRetrieveParams::default())
         .await
         .assert_response();
 }

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -7,7 +7,8 @@ use wp_api::posts::{
 };
 use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
-    api_client, AssertResponse, FIRST_POST_ID, FIRST_USER_ID, SECOND_USER_ID,
+    api_client, AssertResponse, FIRST_POST_ID, FIRST_USER_ID, PASSWORD_PROTECTED_POST_ID,
+    PASSWORD_PROTECTED_POST_PASSWORD, PASSWORD_PROTECTED_POST_TITLE, SECOND_USER_ID,
 };
 
 #[tokio::test]
@@ -71,6 +72,54 @@ async fn retrieve_with_view_context(#[case] params: PostRetrieveParams) {
         .retrieve_with_view_context(&FIRST_POST_ID, &PostRetrieveParams::default())
         .await
         .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_edit_context() {
+    let post = api_client()
+        .posts()
+        .retrieve_with_edit_context(
+            &PASSWORD_PROTECTED_POST_ID,
+            &PostRetrieveParams {
+                password: Some(PASSWORD_PROTECTED_POST_PASSWORD.to_string()),
+            },
+        )
+        .await
+        .assert_response();
+    assert_eq!(post.title.rendered, PASSWORD_PROTECTED_POST_TITLE);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_embed_context() {
+    let post = api_client()
+        .posts()
+        .retrieve_with_embed_context(
+            &PASSWORD_PROTECTED_POST_ID,
+            &PostRetrieveParams {
+                password: Some(PASSWORD_PROTECTED_POST_PASSWORD.to_string()),
+            },
+        )
+        .await
+        .assert_response();
+    assert_eq!(post.title.rendered, PASSWORD_PROTECTED_POST_TITLE);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_view_context() {
+    let post = api_client()
+        .posts()
+        .retrieve_with_view_context(
+            &PASSWORD_PROTECTED_POST_ID,
+            &PostRetrieveParams {
+                password: Some(PASSWORD_PROTECTED_POST_PASSWORD.to_string()),
+            },
+        )
+        .await
+        .assert_response();
+    assert_eq!(post.title.rendered, PASSWORD_PROTECTED_POST_TITLE);
 }
 
 #[template]


### PR DESCRIPTION
Implements retrieve endpoint for `/posts`.

In order to test the `password` parameter, it creates a post with password in `scripts/setup-test-site.sh`. It also implements `WpErrorCode::PostIncorrectPassword ` and adds an integration test for it. I usually add the errors and their tests after finishing an endpoint, but I thought it made sense to include this one in this case to showcase that it works as expected.

Note that, similar to #264, it's missing the unit tests for the endpoint. I think I'll add all of the endpoint unit tests once I am done with the endpoint. That way I'll have a better chance of finishing the endpoint this week and can postpone the unit tests until I am back from my AFK if necessary.