### PR TITLE
Add `additional_query_pairs` support for `#[derive(WpDerivedRequest)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internal Changes
 
 - `WpDerivedRequest` now supports plain `get` requests
+- `WpDerivedRequest` now supports `additional_query_pairs`
 
 ## 0.1
 

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -150,6 +150,18 @@ impl UrlExtension for Url {
 }
 
 trait DerivedRequest {
+    // This can be used to add additional parameters to a request if it has no params type.
+    //
+    // For example, `/posts` request has `Trash` & `Delete` variants. These variants don't have a
+    // params type such as `PostTrashParams` or `PostDeleteParams`. However, they still need to
+    // pass some static parameters, `force=false` and `force=true` respectively.
+    //
+    // In most cases overriding this shouldn't be necessary and `[AppendUrlQueryPairs]` trait for
+    // the request's params type should be used instead.
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        Vec::new()
+    }
+
     fn namespace() -> Namespace;
 }
 

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -171,6 +171,8 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
             fn_body_get_url_from_api_base_url(&parsed_enum.enum_ident, url_parts);
         let query_pairs =
             fn_body_query_pairs(&config.crate_ident, params_type.as_ref(), request_type);
+        let additional_query_pairs =
+            fn_body_additional_query_pairs(&parsed_enum.enum_ident, &variant.variant_ident);
 
         ContextAndFilterHandler::from_request_type(request_type, variant.attr.filter_by.clone())
             .into_iter()
@@ -192,6 +194,7 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
                         #url_from_api_base_url
                         #context_query_pair
                         #query_pairs
+                        #additional_query_pairs
                         #fields_query_pairs
                         url.into()
                     }

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -299,6 +299,15 @@ pub fn fn_body_query_pairs(
     }
 }
 
+pub fn fn_body_additional_query_pairs(enum_ident: &Ident, variant_ident: &Ident) -> TokenStream {
+    quote! {
+        let additional_query_pairs = #enum_ident::additional_query_pairs(&#enum_ident::#variant_ident);
+        if !additional_query_pairs.is_empty() {
+            url.query_pairs_mut().extend_pairs(additional_query_pairs);
+        }
+    }
+}
+
 pub fn fn_body_fields_query_pairs(
     crate_ident: &Ident,
     context_and_filter_handler: &ContextAndFilterHandler,


### PR DESCRIPTION
In some cases, we want to be able to add query pairs to a request without requiring a params type. For example, we want to pass in a `force` parameter to delete `/posts` endpoint, but we want to do it statically - without requiring a params type.

The changes in this PR allows implementing the `DerivedRequest::additional_query_pairs` trait method to do that as such:

```
impl DerivedRequest for PostsRequest {
    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
        match self {
            PostsRequest::Delete => vec![("force", true.to_string())],
            PostsRequest::Trash => vec![("force", false.to_string())],
            _ => vec![],
        }
    }
}
```

In most cases this won't be necessary, but WordPress API is full of surprises, so there will be some cases like this one where this will come in handy.

---

For context, we don't want to use a `PostDeleteParams` type with a `force` field because the response from the endpoint changes depending on whether `force` is `true` or `false`. If it's `force=false`, it'll return a `PostWithEditContext` type. However, if it's `force=false`, it'll return the below type instead. In order to define separate return types, we need to use different variants for trashing and deleting a post in `PostsRequest`. If we do that, there is no need to ask for clients to pass an empty params type. So, this solution keeps the client code cleaner.

```
pub struct PostDeleteResponse {
    pub deleted: bool,
    pub previous: PostWithEditContext,
}
```