### PR TITLE
Implement delete & trash `/posts` endpoint and their integration tests

### DIFF
--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -200,6 +200,12 @@ impl AppendUrlQueryPairs for PostRetrieveParams {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostDeleteResponse {
+    pub deleted: bool,
+    pub previous: PostWithEditContext,
+}
+
 impl_as_query_value_for_new_type!(PostId);
 uniffi::custom_newtype!(PostId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -15,9 +15,21 @@ enum PostsRequest {
     List,
     #[contextual_get(url = "/posts/<post_id>", params = &crate::posts::PostRetrieveParams, output = crate::posts::SparsePost, filter_by = crate::posts::SparsePostField)]
     Retrieve,
+    #[delete(url = "/posts/<post_id>", output = crate::posts::PostDeleteResponse)]
+    Delete,
+    #[delete(url = "/posts/<post_id>", output = crate::posts::PostWithEditContext)]
+    Trash,
 }
 
 impl DerivedRequest for PostsRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            PostsRequest::Delete => vec![("force", true.to_string())],
+            PostsRequest::Trash => vec![("force", false.to_string())],
+            _ => vec![],
+        }
+    }
+
     fn namespace() -> Namespace {
         Namespace::WpV2
     }
@@ -28,3 +40,29 @@ super::macros::default_sparse_field_implementation_from_field_name!(
     SparsePostFieldWithEmbedContext
 );
 super::macros::default_sparse_field_implementation_from_field_name!(SparsePostFieldWithViewContext);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request::endpoint::{
+        tests::{fixture_api_base_url, validate_wp_v2_endpoint},
+        ApiBaseUrl,
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    fn delete_post(endpoint: PostsRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.delete(&PostId(54)), "/posts/54?force=true");
+    }
+
+    #[rstest]
+    fn trash_post(endpoint: PostsRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.trash(&PostId(54)), "/posts/54?force=false");
+    }
+
+    #[fixture]
+    fn endpoint(fixture_api_base_url: Arc<ApiBaseUrl>) -> PostsRequestEndpoint {
+        PostsRequestEndpoint::new(fixture_api_base_url)
+    }
+}

--- a/wp_api_integration_tests/src/backend.rs
+++ b/wp_api_integration_tests/src/backend.rs
@@ -1,10 +1,11 @@
 use serde::{de::DeserializeOwned, Serialize};
 use wp_api::users::UserId;
-use wp_cli::{WpCliSiteSettings, WpCliUser, WpCliUserMeta};
+use wp_cli::{WpCliPost, WpCliSiteSettings, WpCliUser, WpCliUserMeta};
 
 const BACKEND_ADDRESS: &str = "http://127.0.0.1:4000";
 const BACKEND_PATH_RESTORE: &str = "/restore";
 const BACKEND_PATH_SITE_SETTINGS: &str = "/wp-cli/site-settings";
+const BACKEND_PATH_POSTS: &str = "/wp-cli/posts";
 const BACKEND_PATH_USER: &str = "/wp-cli/user";
 const BACKEND_PATH_USERS: &str = "/wp-cli/users";
 const BACKEND_PATH_USER_META: &str = "/wp-cli/user-meta";
@@ -19,6 +20,16 @@ impl Backend {
     }
     pub async fn site_settings() -> Result<WpCliSiteSettings, reqwest::Error> {
         Self::get(BACKEND_PATH_SITE_SETTINGS).await
+    }
+    pub async fn posts(post_status: Option<&str>) -> Vec<WpCliPost> {
+        let url = if let Some(post_status) = post_status {
+            format!("{}?post_status={}", BACKEND_PATH_POSTS, post_status)
+        } else {
+            BACKEND_PATH_POSTS.to_string()
+        };
+        Self::get(url)
+            .await
+            .expect("Failed to parse fetched posts from wp_cli")
     }
     pub async fn user(user_id: &UserId) -> WpCliUser {
         Self::get(format!("{}?user_id={}", BACKEND_PATH_USER, user_id))

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -1,0 +1,47 @@
+use serial_test::serial;
+use wp_api_integration_tests::{
+    api_client,
+    backend::{Backend, RestoreServer},
+    FIRST_POST_ID,
+};
+
+#[tokio::test]
+#[serial]
+async fn delete_post() {
+    // Delete the post using the API and ensure it's successful
+    let post_delete_response = api_client().posts().delete(&FIRST_POST_ID).await;
+    assert!(post_delete_response.is_ok(), "{:#?}", post_delete_response);
+
+    // Assert that the post was deleted
+    assert!(
+        !Backend::posts(None)
+            .await
+            .into_iter()
+            .any(|u| u.id == FIRST_POST_ID.0 as i64),
+        "Post wasn't deleted"
+    );
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn trash_post() {
+    // Trash the post using the API and ensure it's successful
+    let post_trash_response = api_client().posts().trash(&FIRST_POST_ID).await;
+    assert!(post_trash_response.is_ok(), "{:#?}", post_trash_response);
+
+    // Assert that the post was trashed
+    let trashed_post = Backend::posts(Some("trash"))
+        .await
+        .into_iter()
+        .find(|u| u.id == FIRST_POST_ID.0 as i64);
+    assert!(trashed_post.is_some(), "Can't find the trashed post");
+    assert_eq!(
+        trashed_post.unwrap().post_status,
+        "trash",
+        "Post wasn't trashed"
+    );
+
+    RestoreServer::db().await;
+}

--- a/wp_api_integration_tests_backend/src/main.rs
+++ b/wp_api_integration_tests_backend/src/main.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::fs::metadata;
 use std::io;
 use std::path::Path;
-use wp_cli::{WpCliSiteSettings, WpCliUser, WpCliUserMeta};
+use wp_cli::{WpCliPost, WpCliPostListArguments, WpCliSiteSettings, WpCliUser, WpCliUserMeta};
 
 pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
 
@@ -18,6 +18,13 @@ enum Error {
 #[get("/site-settings")]
 fn wp_cli_site_settings() -> Result<Json<WpCliSiteSettings>, Error> {
     WpCliSiteSettings::list()
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
+}
+
+#[get("/posts?<post_status>")]
+fn wp_cli_posts(post_status: Option<String>) -> Result<Json<Vec<WpCliPost>>, Error> {
+    WpCliPost::list(Some(WpCliPostListArguments { post_status }))
         .map(Json)
         .map_err(|e| Error::AsString(e.to_string()))
 }
@@ -65,6 +72,7 @@ fn rocket() -> _ {
     rocket::build()
         .mount("/", routes![restore_wp_server])
         .mount("/wp-cli/", routes![wp_cli_site_settings])
+        .mount("/wp-cli/", routes![wp_cli_posts])
         .mount("/wp-cli/", routes![wp_cli_user])
         .mount("/wp-cli/", routes![wp_cli_users])
         .mount("/wp-cli/", routes![wp_cli_user_meta])

--- a/wp_cli/src/lib.rs
+++ b/wp_cli/src/lib.rs
@@ -1,8 +1,10 @@
 use std::{ffi::OsStr, process::Command};
 
+mod wp_cli_posts;
 mod wp_cli_settings;
 mod wp_cli_users;
 
+pub use wp_cli_posts::*;
 pub use wp_cli_settings::*;
 pub use wp_cli_users::*;
 

--- a/wp_cli/src/wp_cli_posts.rs
+++ b/wp_cli/src/wp_cli_posts.rs
@@ -1,0 +1,57 @@
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use wp_serde_helper::deserialize_i64_or_string;
+
+use crate::run_wp_cli_command;
+
+#[derive(Debug, Default)]
+pub struct WpCliPostListArguments {
+    pub post_status: Option<String>,
+}
+
+impl WpCliPostListArguments {
+    fn as_wp_cli_arguments(&self) -> Option<String> {
+        let mut s = String::new();
+        Self::add_field_arg(&mut s, "post_status", self.post_status.as_ref());
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+
+    fn add_field_arg(args: &mut String, field_name: &str, field: Option<&String>) {
+        if let Some(f) = field {
+            args.push_str(format!("--{}={}", field_name, f).as_str());
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpCliPost {
+    #[serde(rename = "ID")]
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub id: i64,
+    pub post_status: String,
+}
+
+impl WpCliPost {
+    pub fn get(post_id: i64) -> Result<Self> {
+        // Some `wp` commands return different fields/information for `get` or `list`. To avoid
+        // this, always use `wp post list` and then find the post we are interested in.
+        Self::list(None).and_then(|v| {
+            v.into_iter()
+                .find(|u| u.id == post_id)
+                .ok_or(anyhow!("Can't find the post with post_id: {}", post_id,))
+        })
+    }
+    pub fn list(arguments: Option<WpCliPostListArguments>) -> Result<Vec<Self>> {
+        let output = if let Some(cli_arguments) = arguments.and_then(|a| a.as_wp_cli_arguments()) {
+            run_wp_cli_command(["post", "list", cli_arguments.as_str()])
+        } else {
+            run_wp_cli_command(["post", "list"])
+        };
+        serde_json::from_slice::<Vec<Self>>(&output.stdout)
+            .with_context(|| "Failed to parse `wp post list --format=json` into Vec<WpCliPost>")
+    }
+}


### PR DESCRIPTION
Deleting and trashing was split into separate variants because the server returns different responses for each one. Other than that, the implementation follows the established patterns.