### PR TITLE
Implements update `/posts` endpoint and its integration tests

### DIFF
--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -108,6 +108,10 @@ wp plugin install classic-editor
 # Used in `test_posts_immut`. If the resulting ID changes, `PASSWORD_PROTECTED_POST_ID` needs to be updated
 wp post create --post_type=post --post_password=INTEGRATION_TEST --post_title=Password_Protected
 
+# Update the timezone, so that the `date` & `date_gmt` values will be different
+# Otherwise, the integration tests might result in false positives
+wp option update timezone_string "America/New_York"
+
 cp -rp wp-content/plugins wp-content/plugins-backup
 
 wp db export --add-drop-table wp-content/dump.sql

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -430,7 +430,7 @@ pub struct SparsePost {
     #[WpContextualField]
     pub excerpt: Option<SparsePostExcerpt>,
     #[WpContext(edit, embed, view)]
-    pub featured_media: Option<i64>,
+    pub featured_media: Option<MediaId>,
     #[WpContext(edit, view)]
     pub comment_status: Option<PostCommentStatus>,
     #[WpContext(edit, view)]
@@ -543,6 +543,16 @@ pub enum PostCommentStatus {
     Custom(String),
 }
 
+impl PostCommentStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::Custom(comment_status) => comment_status,
+        }
+    }
+}
+
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
 )]
@@ -552,6 +562,16 @@ pub enum PostPingStatus {
     Closed,
     #[serde(untagged)]
     Custom(String),
+}
+
+impl PostPingStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::Custom(ping_status) => ping_status,
+        }
+    }
 }
 
 #[derive(
@@ -571,4 +591,22 @@ pub enum PostFormat {
     Audio,
     #[serde(untagged)]
     Custom(String),
+}
+
+impl PostFormat {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Standard => "standard",
+            Self::Aside => "aside",
+            Self::Chat => "chat",
+            Self::Gallery => "gallery",
+            Self::Link => "link",
+            Self::Image => "image",
+            Self::Quote => "quote",
+            Self::Status => "status",
+            Self::Video => "video",
+            Self::Audio => "audio",
+            Self::Custom(post_format) => post_format,
+        }
+    }
 }

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -520,7 +520,7 @@ pub enum PostStatus {
 impl_as_query_value_from_as_str!(PostStatus);
 
 impl PostStatus {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Draft => "draft",
             Self::Future => "future",

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -444,7 +444,7 @@ pub struct SparsePost {
     #[WpContext(edit, view)]
     pub template: Option<String>,
     #[WpContext(edit, view)]
-    pub categories: Option<Vec<i64>>,
+    pub categories: Option<Vec<CategoryId>>,
     #[WpContext(edit, view)]
     pub tags: Option<Vec<TagId>>,
 }

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
+use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
@@ -265,7 +266,7 @@ pub struct PostCreateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<PostFormat>,
     // Meta fields.
-    pub meta: Option<String>,
+    pub meta: Option<PostMeta>,
     // Whether or not the post should be treated as sticky.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -343,7 +344,7 @@ pub struct PostUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<PostFormat>,
     // Meta fields.
-    pub meta: Option<String>,
+    pub meta: Option<PostMeta>,
     // Whether or not the post should be treated as sticky.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -489,7 +490,15 @@ pub struct SparsePostExcerpt {
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct PostMeta {
-    pub footnotes: String,
+    #[serde(deserialize_with = "deserialize_from_string_of_json_array")]
+    #[serde(serialize_with = "serialize_as_json_string")]
+    pub footnotes: Vec<PostFootnote>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, uniffi::Record)]
+pub struct PostFootnote {
+    pub id: String,
+    pub content: String,
 }
 
 #[derive(

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -284,6 +284,84 @@ pub struct PostCreateParams {
     pub tags: Vec<TagId>,
 }
 
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct PostUpdateParams {
+    // The date the post was published, in the site's timezone.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    // The date the post was published, as GMT.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_gmt: Option<String>,
+    // An alphanumeric identifier for the post unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    // A named status for the post.
+    // One of: publish, future, draft, pending, private
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PostStatus>,
+    // A password to protect access to the content and excerpt.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    // The title for the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    // The content for the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    // The ID for the author of the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    // The excerpt for the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excerpt: Option<String>,
+    // The ID of the featured media for the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub featured_media: Option<MediaId>,
+    // Whether or not comments are open on the post.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_status: Option<PostCommentStatus>,
+    // Whether or not the post can be pinged.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ping_status: Option<PostPingStatus>,
+    // The format for the post.
+    // One of: standard, aside, chat, gallery, link, image, quote, status, video, audio
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<PostFormat>,
+    // Meta fields.
+    pub meta: Option<String>,
+    // Whether or not the post should be treated as sticky.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sticky: Option<bool>,
+    // The theme file to use to display the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+    // The terms assigned to the post in the category taxonomy.
+    #[uniffi(default = [])]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<CategoryId>,
+    // The terms assigned to the post in the post_tag taxonomy.
+    #[uniffi(default = [])]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<TagId>,
+}
+
 impl_as_query_value_for_new_type!(PostId);
 uniffi::custom_newtype!(PostId, i32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -1,6 +1,7 @@
 use crate::{
     posts::{
-        PostId, PostListParams, SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
+        PostId, PostListParams, PostUpdateParams, PostWithEditContext,
+        SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
         SparsePostFieldWithViewContext,
     },
     SparseField,
@@ -21,6 +22,8 @@ enum PostsRequest {
     Delete,
     #[delete(url = "/posts/<post_id>", output = crate::posts::PostWithEditContext)]
     Trash,
+    #[post(url = "/posts/<post_id>", params = &PostUpdateParams, output = PostWithEditContext)]
+    Update,
 }
 
 impl DerivedRequest for PostsRequest {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use wp_api::{
-    posts::PostId,
+    posts::{MediaId, PostId},
     request::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
@@ -38,6 +38,7 @@ pub const FIRST_POST_ID: PostId = PostId(1);
 pub const PASSWORD_PROTECTED_POST_ID: PostId = PostId(1832);
 pub const PASSWORD_PROTECTED_POST_TITLE: &str = "Password_Protected";
 pub const PASSWORD_PROTECTED_POST_PASSWORD: &str = "INTEGRATION_TEST";
+pub const MEDIA_ID_611: MediaId = MediaId(611);
 
 pub fn api_client() -> WpApiClient {
     let authentication = WpAuthentication::from_username_and_password(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use wp_api::{
-    posts::{MediaId, PostId},
+    posts::{CategoryId, MediaId, PostId, TagId},
     request::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
@@ -39,6 +39,8 @@ pub const PASSWORD_PROTECTED_POST_ID: PostId = PostId(1832);
 pub const PASSWORD_PROTECTED_POST_TITLE: &str = "Password_Protected";
 pub const PASSWORD_PROTECTED_POST_PASSWORD: &str = "INTEGRATION_TEST";
 pub const MEDIA_ID_611: MediaId = MediaId(611);
+pub const CATEGORY_ID_1: CategoryId = CategoryId(1);
+pub const TAG_ID_100: TagId = TagId(100);
 
 pub fn api_client() -> WpApiClient {
     let authentication = WpAuthentication::from_username_and_password(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -41,6 +41,7 @@ pub const PASSWORD_PROTECTED_POST_PASSWORD: &str = "INTEGRATION_TEST";
 pub const MEDIA_ID_611: MediaId = MediaId(611);
 pub const CATEGORY_ID_1: CategoryId = CategoryId(1);
 pub const TAG_ID_100: TagId = TagId(100);
+pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 
 pub fn api_client() -> WpApiClient {
     let authentication = WpAuthentication::from_username_and_password(

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -152,6 +152,44 @@ async fn update_date() {
     .await;
 }
 
+#[tokio::test]
+#[serial]
+async fn update_date_gmt() {
+    let new_date_gmt = "2024-09-09T12:00:00";
+    test_update_post(
+        &PostUpdateParams {
+            date_gmt: Some(new_date_gmt.to_string()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.date_gmt, new_date_gmt);
+            assert_eq!(
+                updated_post_from_wp_cli.date_gmt,
+                new_date_gmt.replace('T', " ")
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn update_slug() {
+    let new_slug = "new_slug";
+    test_update_post(
+        &PostUpdateParams {
+            slug: Some(new_slug.to_string()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.slug, new_slug);
+            assert_eq!(updated_post_from_wp_cli.slug, new_slug);
+        },
+    )
+    .await;
+}
+
 async fn test_create_post<F>(params: &PostCreateParams, assert: F)
 where
     F: Fn(PostWithEditContext, WpCliPost),

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -1,3 +1,4 @@
+use macro_helper::generate_update_test;
 use serial_test::serial;
 use wp_api::posts::{PostCreateParams, PostStatus, PostUpdateParams, PostWithEditContext};
 use wp_api_integration_tests::{
@@ -118,128 +119,78 @@ async fn trash_post() {
     RestoreServer::db().await;
 }
 
-#[tokio::test]
-#[serial]
-async fn update_date() {
-    let new_date = "2024-09-09T12:00:00";
-    test_update_post(
-        &PostUpdateParams {
-            date: Some(new_date.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.date, new_date);
-            assert_eq!(updated_post_from_wp_cli.date, new_date.replace('T', " "));
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_date,
+    date,
+    "2024-09-09T12:00:00".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.date, "2024-09-09T12:00:00");
+        assert_eq!(updated_post_from_wp_cli.date, "2024-09-09 12:00:00");
+    }
+);
 
-#[tokio::test]
-#[serial]
-async fn update_date_gmt() {
-    let new_date_gmt = "2024-09-09T12:00:00";
-    test_update_post(
-        &PostUpdateParams {
-            date_gmt: Some(new_date_gmt.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.date_gmt, new_date_gmt);
-            assert_eq!(
-                updated_post_from_wp_cli.date_gmt,
-                new_date_gmt.replace('T', " ")
-            );
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_date_gmt,
+    date_gmt,
+    "2024-09-09T12:00:00".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.date_gmt, "2024-09-09T12:00:00");
+        assert_eq!(updated_post_from_wp_cli.date_gmt, "2024-09-09 12:00:00");
+    }
+);
 
-#[tokio::test]
-#[serial]
-async fn update_slug() {
-    let new_slug = "new_slug";
-    test_update_post(
-        &PostUpdateParams {
-            slug: Some(new_slug.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.slug, new_slug);
-            assert_eq!(updated_post_from_wp_cli.slug, new_slug);
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_slug,
+    slug,
+    "new_slug".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.slug, "new_slug");
+        assert_eq!(updated_post_from_wp_cli.slug, "new_slug");
+    }
+);
 
-#[tokio::test]
-#[serial]
-async fn update_status_to_draft() {
-    let new_status = PostStatus::Draft;
-    test_update_post(
-        &PostUpdateParams {
-            status: Some(new_status.clone()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.status, new_status);
-            assert_eq!(updated_post_from_wp_cli.post_status, new_status.as_str());
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_status_to_draft,
+    status,
+    PostStatus::Draft,
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.status, PostStatus::Draft);
+        assert_eq!(
+            updated_post_from_wp_cli.post_status,
+            PostStatus::Draft.as_str()
+        );
+    }
+);
 
-#[tokio::test]
-#[serial]
-async fn update_password() {
-    let new_password = "new_password";
-    test_update_post(
-        &PostUpdateParams {
-            password: Some(new_password.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.password, new_password);
-            assert_eq!(updated_post_from_wp_cli.password, new_password);
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_password,
+    password,
+    "new_password".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.password, "new_password");
+        assert_eq!(updated_post_from_wp_cli.password, "new_password");
+    }
+);
 
-#[tokio::test]
-#[serial]
-async fn update_title() {
-    let new_title = "new_title";
-    test_update_post(
-        &PostUpdateParams {
-            title: Some(new_title.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.title.raw, new_title);
-            assert_eq!(updated_post_from_wp_cli.title, new_title);
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_title,
+    title,
+    "new_title".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.title.raw, "new_title");
+        assert_eq!(updated_post_from_wp_cli.title, "new_title");
+    }
+);
 
-#[tokio::test]
-#[serial]
-#[ignore]
-async fn update_content() {
-    let new_content = "new_content";
-    test_update_post(
-        &PostUpdateParams {
-            content: Some(new_content.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.content.raw, new_content);
-            assert_eq!(updated_post_from_wp_cli.content, new_content);
-        },
-    )
-    .await;
-}
+generate_update_test!(
+    update_content,
+    content,
+    "new_content".to_string(),
+    |updated_post, updated_post_from_wp_cli| {
+        assert_eq!(updated_post.content.raw, "new_content");
+        assert_eq!(updated_post_from_wp_cli.content, "new_content");
+    }
+);
 
 async fn test_create_post<F>(params: &PostCreateParams, assert: F)
 where
@@ -263,4 +214,26 @@ where
     let updated_post_from_wp_cli = Backend::post(&FIRST_POST_ID).await;
     assert(updated_post, updated_post_from_wp_cli);
     RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_post(
+                        &PostUpdateParams {
+                            $field: Some(updated_value.clone()),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
 }

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -276,13 +276,35 @@ generate_update_test!(
     }
 );
 
-generate_update_test!(update_sticky_to_true, sticky, true, |updated_post, _| {
-    assert_eq!(updated_post.sticky, true);
-});
+#[tokio::test]
+#[serial]
+async fn update_sticky_to_true() {
+    test_update_post(
+        &PostUpdateParams {
+            sticky: Some(true),
+            ..Default::default()
+        },
+        |updated_post, _| {
+            assert!(updated_post.sticky);
+        },
+    )
+    .await;
+}
 
-generate_update_test!(update_sticky_to_false, sticky, false, |updated_post, _| {
-    assert_eq!(updated_post.sticky, false);
-});
+#[tokio::test]
+#[serial]
+async fn update_sticky_to_false() {
+    test_update_post(
+        &PostUpdateParams {
+            sticky: Some(false),
+            ..Default::default()
+        },
+        |updated_post, _| {
+            assert!(!updated_post.sticky);
+        },
+    )
+    .await;
+}
 
 #[tokio::test]
 #[serial]

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -1,5 +1,5 @@
 use serial_test::serial;
-use wp_api::posts::{PostCreateParams, PostUpdateParams, PostWithEditContext};
+use wp_api::posts::{PostCreateParams, PostStatus, PostUpdateParams, PostWithEditContext};
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
@@ -174,7 +174,6 @@ async fn update_date_gmt() {
 
 #[tokio::test]
 #[serial]
-#[ignore]
 async fn update_slug() {
     let new_slug = "new_slug";
     test_update_post(
@@ -185,6 +184,23 @@ async fn update_slug() {
         |updated_post, updated_post_from_wp_cli| {
             assert_eq!(updated_post.slug, new_slug);
             assert_eq!(updated_post_from_wp_cli.slug, new_slug);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn update_status_to_draft() {
+    let new_status = PostStatus::Draft;
+    test_update_post(
+        &PostUpdateParams {
+            status: Some(new_status.clone()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.status, new_status);
+            assert_eq!(updated_post_from_wp_cli.post_status, new_status.as_str());
         },
     )
     .await;

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -7,7 +7,8 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, SECOND_USER_ID, TAG_ID_100,
+    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
+    SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
 
@@ -273,6 +274,15 @@ generate_update_test!(
             updated_post_from_wp_cli.ping_status,
             PostPingStatus::Closed.as_str()
         );
+    }
+);
+
+generate_update_test!(
+    update_template,
+    template,
+    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string(),
+    |updated_post, _| {
+        assert_eq!(updated_post.template, POST_TEMPLATE_SINGLE_WITH_SIDEBAR);
     }
 );
 

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -120,23 +120,6 @@ async fn trash_post() {
 
 #[tokio::test]
 #[serial]
-async fn update_title() {
-    let new_title = "new_title";
-    test_update_post(
-        &PostUpdateParams {
-            title: Some(new_title.to_string()),
-            ..Default::default()
-        },
-        |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.title.raw, new_title);
-            assert_eq!(updated_post_from_wp_cli.title, new_title);
-        },
-    )
-    .await;
-}
-
-#[tokio::test]
-#[serial]
 async fn update_date() {
     let new_date = "2024-09-09T12:00:00";
     test_update_post(
@@ -201,6 +184,58 @@ async fn update_status_to_draft() {
         |updated_post, updated_post_from_wp_cli| {
             assert_eq!(updated_post.status, new_status);
             assert_eq!(updated_post_from_wp_cli.post_status, new_status.as_str());
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn update_password() {
+    let new_password = "new_password";
+    test_update_post(
+        &PostUpdateParams {
+            password: Some(new_password.to_string()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.password, new_password);
+            assert_eq!(updated_post_from_wp_cli.password, new_password);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn update_title() {
+    let new_title = "new_title";
+    test_update_post(
+        &PostUpdateParams {
+            title: Some(new_title.to_string()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.title.raw, new_title);
+            assert_eq!(updated_post_from_wp_cli.title, new_title);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn update_content() {
+    let new_content = "new_content";
+    test_update_post(
+        &PostUpdateParams {
+            content: Some(new_content.to_string()),
+            ..Default::default()
+        },
+        |updated_post, updated_post_from_wp_cli| {
+            assert_eq!(updated_post.content.raw, new_content);
+            assert_eq!(updated_post_from_wp_cli.content, new_content);
         },
     )
     .await;

--- a/wp_cli/src/wp_cli_posts.rs
+++ b/wp_cli/src/wp_cli_posts.rs
@@ -4,7 +4,7 @@ use wp_serde_helper::deserialize_i64_or_string;
 
 use crate::run_wp_cli_command;
 
-const POST_FIELDS_ARG: &str = "--fields=ID, post_title, post_date, post_status, post_author, post_date_gmt, post_content, post_excerpt, comment_status, ping_status, post_password, post_modified, post_modified_gmt, guid, post_type";
+const POST_FIELDS_ARG: &str = "--fields=ID,post_name,post_title,post_date,post_status,post_author,post_date_gmt,post_content,post_excerpt,comment_status,ping_status,post_password,post_modified,post_modified_gmt,guid,post_type";
 
 #[derive(Debug, Default)]
 pub struct WpCliPostListArguments {
@@ -56,6 +56,8 @@ pub struct WpCliPost {
     pub ping_status: String,
     pub post_status: String,
     pub post_type: String,
+    #[serde(rename = "post_name")]
+    pub slug: String,
     #[serde(rename = "post_title")]
     pub title: String,
 }


### PR DESCRIPTION
Implements update `/posts` endpoint and its integration tests following established patterns. It provides 100% integration test coverage - as far as I am aware - for individual field updates. I believe `/posts` is one of the most important endpoints for us, and the extra coverage will provide helpful. I am even thinking about going back to create `/posts` endpoint and adding more tests for it.

I've changed the timezone of the test site, so that the `date` & `date_gmt` values would be different which should help us avoid related false positive tests.

The `meta.footnotes` return a JSON string that contains a JSON array. I've added a custom parser and serializer for this, so that we can work with strong types. It seems to be working well at the moment, but it's entirely possible that I am missing some conditions which hopefully will pop-up as we add more WordPress versions and test sites.