### PR TITLE
Skip rust-cache step from GitHub Action Swift pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,11 +69,6 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Restore Rust Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: "${{ matrix.language }}"
-
     - name: Prepare Kotlin Project
       if: matrix.language == 'java-kotlin'
       shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,12 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Restore Rust Cache
+      if: matrix.language != 'swift'
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: "${{ matrix.language }}"
+
     - name: Prepare Kotlin Project
       if: matrix.language == 'java-kotlin'
       shell: bash

--- a/xcframework/src/main.rs
+++ b/xcframework/src/main.rs
@@ -353,8 +353,10 @@ impl ExecuteCommand for Command {
             Ok(output)
         } else {
             anyhow::bail!(
-                "Command failed with exit code: {}\n$ {:?}",
+                "Command failed with exit code: {}\nstdout: {:?}\nstderr: {:?}\n$ {:?}",
                 output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
                 self
             )
         }

--- a/xcframework/src/main.rs
+++ b/xcframework/src/main.rs
@@ -198,7 +198,8 @@ impl LibraryGroup {
         recreate_directory(&dir)?;
 
         let dest = dir.join(LIBRARY_FILENAME);
-        Command::new("lipo")
+        Command::new("xcrun")
+            .arg("lipo")
             .arg("-create")
             .args(libraries)
             .arg("-output")


### PR DESCRIPTION
The Swift part of the GitHub actions fails due to [no disk space](https://github.com/Automattic/wordpress-rs/actions/runs/10821373034/job/30023240356#step:8:634). The issue went away after I removed [the rust-cache step](https://github.com/Automattic/wordpress-rs/actions/runs/10821672827/job/30024168374?pr=305). It seems rust-cache is not optimized for taking less disk space: https://github.com/Swatinem/rust-cache/issues/158.

The Swift pipeline with and without rust-cache both take about 22m to complete. The kotline pipeline with rust-cache runs faster though.
- One of the commits in trunk: https://github.com/Automattic/wordpress-rs/actions/runs/10817741523/job/30011786468
- This PR: https://github.com/Automattic/wordpress-rs/actions/runs/10821672827/job/30024168374

Based on that, this PR disables rust-cache only for the Swift pipeline.