### PR TITLE
Integration tests for filter `/posts` endpoint

### DIFF
--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -40,11 +40,32 @@ impl DerivedRequest for PostsRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(SparsePostFieldWithEditContext);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(SparsePostFieldWithViewContext);
+impl SparseField for SparsePostFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparsePostFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparsePostFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
It also fixes the field name for `SparsePostField::PostType` for `edit`, `embed` & `view` contexts, something I've unfortunately missed until these integration tests.

`type` is a reserved keyword in Rust, so we use `post_type` as the field name in `SparsePost` and override the JSON field name using `#[serde(rename = "type")]`. However, this rename will not effect how the `SparseField` types are generated by `#[derive(WpContextual)]`, so we need to manually override the type name. This is one of the reasons why we generate `as_field_name` instead of `as_str`, as otherwise we wouldn't be override the name in cases like this.

Note that, it should be possible to use the value from `serde` rename in our macro to generate the correct value. However, I don't believe the extra complexity is worth it at the moment. I am not even sure if it'd be a good change because that logic would be buried under documentation whereas the override logic we have now makes it very clear how it works - especially once we tackle #184 and all of this logic lives in the same place as the `Sparse` type is implemented.