### PR TITLE
Introduce `ParsedRequestError` & `AsNamespace` traits and export `api_client` macros

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
-pub use api_error::{RequestExecutionError, WpApiError, WpErrorCode};
+pub use api_error::{ParsedRequestError, RequestExecutionError, WpApiError, WpError, WpErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use url_query::AsQueryValue;

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    api_error::{RequestExecutionError, WpError},
+    api_error::{ParsedRequestError, RequestExecutionError, WpError},
     WpApiError, WpAuthentication,
 };
 
@@ -18,16 +18,16 @@ const CONTENT_TYPE_JSON: &str = "application/json";
 const LINK_HEADER_KEY: &str = "Link";
 
 #[derive(Debug)]
-struct InnerRequestBuilder {
+pub struct InnerRequestBuilder {
     authentication: WpAuthentication,
 }
 
 impl InnerRequestBuilder {
-    fn new(authentication: WpAuthentication) -> Self {
+    pub fn new(authentication: WpAuthentication) -> Self {
         Self { authentication }
     }
 
-    fn get(&self, url: ApiEndpointUrl) -> WpNetworkRequest {
+    pub fn get(&self, url: ApiEndpointUrl) -> WpNetworkRequest {
         WpNetworkRequest {
             method: RequestMethod::GET,
             url: url.into(),
@@ -36,7 +36,7 @@ impl InnerRequestBuilder {
         }
     }
 
-    fn post<T>(&self, url: ApiEndpointUrl, json_body: &T) -> WpNetworkRequest
+    pub fn post<T>(&self, url: ApiEndpointUrl, json_body: &T) -> WpNetworkRequest
     where
         T: ?Sized + Serialize,
     {
@@ -50,7 +50,7 @@ impl InnerRequestBuilder {
         }
     }
 
-    fn delete(&self, url: ApiEndpointUrl) -> WpNetworkRequest {
+    pub fn delete(&self, url: ApiEndpointUrl) -> WpNetworkRequest {
         WpNetworkRequest {
             method: RequestMethod::DELETE,
             url: url.into(),
@@ -141,7 +141,9 @@ impl WpNetworkRequest {
     }
 
     pub fn body_as_string(&self) -> Option<String> {
-        self.body.as_ref().map(|b| body_as_string(&b.inner))
+        self.body
+            .as_ref()
+            .map(|b| request_or_response_body_as_string(&b.inner))
     }
 }
 
@@ -296,15 +298,19 @@ impl WpNetworkResponse {
     }
 
     pub fn body_as_string(&self) -> String {
-        body_as_string(&self.body)
+        request_or_response_body_as_string(&self.body)
     }
 
-    pub fn parse<'de, T: Deserialize<'de>>(&'de self) -> Result<T, WpApiError> {
-        self.parse_response_for_errors()?;
-        serde_json::from_slice(&self.body).map_err(|err| WpApiError::ResponseParsingError {
-            reason: err.to_string(),
-            response: self.body_as_string(),
-        })
+    pub fn parse<'de, T, E>(&'de self) -> Result<T, E>
+    where
+        T: Deserialize<'de>,
+        E: ParsedRequestError,
+    {
+        if let Some(err) = E::try_parse(&self.body, self.status_code) {
+            return Err(err);
+        }
+        serde_json::from_slice(&self.body)
+            .map_err(|err| E::as_parse_error(err.to_string(), self.body_as_string()))
     }
 
     pub fn parse_with<F, T>(&self, parser: F) -> Result<T, WpApiError>
@@ -368,7 +374,7 @@ pub enum RequestMethod {
     HEAD,
 }
 
-fn body_as_string(body: &[u8]) -> String {
+pub fn request_or_response_body_as_string(body: &[u8]) -> String {
     String::from_utf8_lossy(body).to_string()
 }
 

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -23,7 +23,7 @@ impl From<Url> for WpEndpointUrl {
 }
 
 #[derive(Debug)]
-pub(crate) struct ApiEndpointUrl {
+pub struct ApiEndpointUrl {
     url: Url,
 }
 
@@ -54,7 +54,7 @@ impl From<ApiEndpointUrl> for WpEndpointUrl {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ApiBaseUrl {
+pub struct ApiBaseUrl {
     url: Url,
 }
 
@@ -149,7 +149,7 @@ impl UrlExtension for Url {
     }
 }
 
-trait DerivedRequest {
+pub trait DerivedRequest {
     // This can be used to add additional parameters to a request if it has no params type.
     //
     // For example, `/posts` request has `Trash` & `Delete` variants. These variants don't have a
@@ -162,16 +162,20 @@ trait DerivedRequest {
         Vec::new()
     }
 
-    fn namespace() -> Namespace;
+    fn namespace() -> impl AsNamespace;
+}
+
+pub trait AsNamespace {
+    fn as_str(&self) -> &str;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum Namespace {
+enum WpNamespace {
     WpSiteHealthV1,
     WpV2,
 }
 
-impl Namespace {
+impl AsNamespace for WpNamespace {
     fn as_str(&self) -> &str {
         match self {
             Self::WpSiteHealthV1 => "/wp-site-health/v1",
@@ -273,14 +277,14 @@ mod tests {
     }
 
     pub fn validate_wp_v2_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
-        validate_endpoint(Namespace::WpV2, endpoint_url, path);
+        validate_endpoint(WpNamespace::WpV2, endpoint_url, path);
     }
 
     pub fn validate_wp_site_health_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
-        validate_endpoint(Namespace::WpSiteHealthV1, endpoint_url, path);
+        validate_endpoint(WpNamespace::WpSiteHealthV1, endpoint_url, path);
     }
 
-    fn validate_endpoint(namespace: Namespace, endpoint_url: ApiEndpointUrl, path: &str) {
+    fn validate_endpoint(namespace: WpNamespace, endpoint_url: ApiEndpointUrl, path: &str) {
         assert_eq!(
             endpoint_url.as_str(),
             format!(

--- a/wp_api/src/request/endpoint/application_passwords_endpoint.rs
+++ b/wp_api/src/request/endpoint/application_passwords_endpoint.rs
@@ -12,7 +12,7 @@ use crate::application_passwords::{
 use crate::users::UserId;
 use crate::SparseField;
 
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum ApplicationPasswordsRequest {
@@ -33,8 +33,8 @@ enum ApplicationPasswordsRequest {
 }
 
 impl DerivedRequest for ApplicationPasswordsRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/request/endpoint/plugins_endpoint.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum PluginsRequest {
@@ -21,8 +21,8 @@ enum PluginsRequest {
 }
 
 impl DerivedRequest for PluginsRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/post_types_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_types_endpoint.rs
@@ -1,4 +1,4 @@
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::post_types::{
     PostType, SparsePostTypeDetailsFieldWithEditContext,
     SparsePostTypeDetailsFieldWithEmbedContext, SparsePostTypeDetailsFieldWithViewContext,
@@ -15,8 +15,8 @@ enum PostTypesRequest {
 }
 
 impl DerivedRequest for PostTypesRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum PostsRequest {
@@ -35,8 +35,8 @@ impl DerivedRequest for PostsRequest {
         }
     }
 
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/site_settings_endpoint.rs
+++ b/wp_api/src/request/endpoint/site_settings_endpoint.rs
@@ -1,4 +1,4 @@
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::site_settings::{
     SparseSiteSettingsFieldWithEditContext, SparseSiteSettingsFieldWithEmbedContext,
     SparseSiteSettingsFieldWithViewContext,
@@ -15,8 +15,8 @@ enum SiteSettingsRequest {
 }
 
 impl DerivedRequest for SiteSettingsRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/users_endpoint.rs
+++ b/wp_api/src/request/endpoint/users_endpoint.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum UsersRequest {
@@ -28,8 +28,8 @@ enum UsersRequest {
 }
 
 impl DerivedRequest for UsersRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpV2
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
     }
 }
 

--- a/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
+++ b/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
@@ -6,7 +6,7 @@ use crate::wp_site_health_tests::{
     WpSiteHealthTest,
 };
 
-use super::{DerivedRequest, Namespace};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum WpSiteHealthTestsRequest {
@@ -27,8 +27,8 @@ enum WpSiteHealthTestsRequest {
 }
 
 impl DerivedRequest for WpSiteHealthTestsRequest {
-    fn namespace() -> Namespace {
-        Namespace::WpSiteHealthV1
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpSiteHealthV1
     }
 }
 

--- a/wp_api_integration_tests/tests/test_manual_request_builder_immut.rs
+++ b/wp_api_integration_tests/tests/test_manual_request_builder_immut.rs
@@ -4,12 +4,11 @@ use rstest_reuse::{self, apply};
 use serial_test::parallel;
 use wp_api::{
     generate,
-    users::UserWithEditContext,
     users::{
-        UserListParams, WpApiParamUsersHasPublishedPosts, WpApiParamUsersOrderBy,
-        WpApiParamUsersWho,
+        UserListParams, UserWithEditContext, WpApiParamUsersHasPublishedPosts,
+        WpApiParamUsersOrderBy, WpApiParamUsersWho,
     },
-    WpApiParamOrder, WpApiRequestBuilder, WpAuthentication,
+    WpApiError, WpApiParamOrder, WpApiRequestBuilder, WpAuthentication,
 };
 use wp_api_integration_tests::{
     test_site_url, AsyncWpNetworking, TestCredentials, FIRST_USER_ID, SECOND_USER_ID,
@@ -30,6 +29,8 @@ async fn list_users_with_edit_context(#[case] params: UserListParams) {
     let request_builder = WpApiRequestBuilder::new(test_site_url(), authentication);
     let wp_request = request_builder.users().list_with_edit_context(&params);
     let response = async_wp_networking.async_request(wp_request.into()).await;
-    let result = response.unwrap().parse::<Vec<UserWithEditContext>>();
+    let result = response
+        .unwrap()
+        .parse::<Vec<UserWithEditContext>, WpApiError>();
     assert!(result.is_ok(), "Response was: '{:?}'", result);
 }


### PR DESCRIPTION
This PR introduces `ParsedRequestError` & `AsNamespace` traits and exports the macros from `api_client`. These changes are all made to make it possible to implement the necessary types in other crates/repos and still be able to work with the `wp_api` crate.

* 1c27a71d6619a9df39f278d110cf70e07f14eeb1 exports `api_client` macros and allows for changing the prefix for the implemented types
* 4a6399b46336daab11fa76aa25edc626041f6fbf adds `AsNamespace` trait which allows other namespace types to be implemented besides the `WpNamespace` type
* dc7cf3f48e1407bf4e0b24b19f672e9bc3930d1a introduces `ParsedRequestError` type that provides a baseline for error types such as `WpApiError`. This will make it easier for other crates to introduce error types and still work with the `wp_api` crate. This commit also updates some internal types/functions to be `pub` so they can be used from other crates.

Note that all these changes are all refactors that introduce no functional changes.