### PR TITLE
Fix parsing url with trailing slash in ApiBaseUrl

### DIFF
--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -121,9 +121,8 @@ trait UrlExtension {
 }
 
 impl UrlExtension for Url {
-    fn append(mut self, segment: &str) -> Result<Url, ()> {
-        self.path_segments_mut()?.push(segment);
-        Ok(self)
+    fn append(self, segment: &str) -> Result<Url, ()> {
+        self.extend([segment])
     }
 
     fn extend<I>(mut self, segments: I) -> Result<Url, ()>
@@ -131,6 +130,13 @@ impl UrlExtension for Url {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
+        // Drop the trailing slash, so that `foo/` and `bar` turn into `foo/bar` instead of `foo//bar`.
+        if let Some(segments) = self.path_segments() {
+            if segments.last() == Some("") {
+                self.path_segments_mut()?.pop();
+            }
+        }
+
         self.path_segments_mut()?.extend(segments);
         Ok(self)
     }

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -229,10 +229,15 @@ mod tests {
     fn api_base_url(
         #[values(
             "http://example.com",
+            "http://example.com/",
             "https://example.com",
+            "https://example.com/",
             "https://www.example.com",
+            "https://www.example.com/",
             "https://f.example.com",
-            "https://example.com/f"
+            "https://f.example.com/",
+            "https://example.com/f",
+            "https://example.com/f/"
         )]
         test_base_url: &str,
     ) {
@@ -264,7 +269,13 @@ mod tests {
     }
 
     fn wp_json_endpoint(base_url: &str) -> String {
-        format!("{}/{}", base_url, WP_JSON_PATH_SEGMENTS.join("/"))
+        let mut url = base_url.to_string();
+        if !url.ends_with("/") {
+            url.push('/')
+        }
+        url.push_str(WP_JSON_PATH_SEGMENTS.join("/").as_str());
+
+        url
     }
 
     fn wp_json_endpoint_by_appending(base_url: &str, suffix: &str) -> String {


### PR DESCRIPTION
### Issue

`ApiBaseUrl` has issue parsing url with trailing slash.

```rust
let api_base_url: ApiBaseUrl = "https://example.com/f/".try_into().unwrap();
assert_eq!(api_base_url.as_str(), "https://example.com/f/wp-json");
```

Result:
```
assertion `left == right` failed
  left: "https://example.com/f//wp-json"
 right: "https://example.com/f/wp-json"
```