### PR TITLE
Use Xcode 16 in Github Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,8 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.app
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       # required for all workflows


### PR DESCRIPTION
There is [a build failure](https://github.com/Automattic/wordpress-rs/actions/runs/11580696452/job/32239795020) on the Swift part of GitHub actions. I don't think it's our project that crashed the compiler. I switched to Xcode 16 in this PR to keep the build env consistent with Buildkite CI jobs.

```
  = note: clang: error: unable to execute command: Segmentation fault: 11
          clang: error: linker command failed due to signal (use -v to see invocation)
          

error: could not compile `askama_derive` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
make: *** [bindings] Error 101
```