### PR TITLE
Don't generate filter test cases for fields marked with `#[WpContextualOption]`

### DIFF
--- a/wp_api_integration_tests/tests/test_application_passwords_immut.rs
+++ b/wp_api_integration_tests/tests/test_application_passwords_immut.rs
@@ -181,9 +181,6 @@ mod filter {
         #[values(FIRST_USER_ID, SECOND_USER_ID)] user_id: UserId,
         #[case] fields: &[SparseApplicationPasswordFieldWithEditContext],
     ) {
-        if should_skip_filter_with_edit_context_test(fields) {
-            return;
-        }
         api_client()
             .application_passwords()
             .filter_list_with_edit_context(&user_id, fields)
@@ -201,9 +198,6 @@ mod filter {
     async fn filter_retrieve_application_password_with_edit_context(
         #[case] fields: &[SparseApplicationPasswordFieldWithEditContext],
     ) {
-        if should_skip_filter_with_edit_context_test(fields) {
-            return;
-        }
         let p = api_client()
             .application_passwords()
             .filter_retrieve_with_edit_context(
@@ -226,9 +220,6 @@ mod filter {
     async fn filter_retrieve_current_application_password_with_edit_context(
         #[case] fields: &[SparseApplicationPasswordFieldWithEditContext],
     ) {
-        if should_skip_filter_with_edit_context_test(fields) {
-            return;
-        }
         let p = api_client()
             .application_passwords()
             .filter_retrieve_current_with_edit_context(&FIRST_USER_ID, fields)
@@ -342,18 +333,5 @@ mod filter {
             .assert_response()
             .data;
         p.assert_that_instance_fields_nullability_match_provided_fields(fields);
-    }
-
-    fn should_skip_filter_with_edit_context_test(
-        fields: &[SparseApplicationPasswordFieldWithEditContext],
-    ) -> bool {
-        if fields.contains(&SparseApplicationPasswordFieldWithEditContext::Password) {
-            println!(
-            "Requesting password field returns invalid JSON as this field is only available after creating a new application token. Skipping this test..."
-        );
-            true
-        } else {
-            false
-        }
     }
 }

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -284,12 +284,15 @@ fn generate_integration_test_helper(
                         },
                         fields
                     );
-            });
+                });
+                // Only add a single field test case if the field is not a `#[WpContextualOption]`
+                // Otherwise, the server will return invalid JSON where it'll output an empty JSON
+                // array instead of an empty JSON object
+                let case_ident = format_ident!("single_field_{}", f_ident);
+                rs_test_cases.push(quote! {
+                    #[case::#case_ident(&[#sparse_field_type_ident::#variant_ident])]
+                });
             }
-            let case_ident = format_ident!("single_field_{}", f_ident);
-            rs_test_cases.push(quote! {
-                #[case::#case_ident(&[#sparse_field_type_ident::#variant_ident])]
-            });
         }
     }
     let test_cases_ident = format_ident!(


### PR DESCRIPTION
Addresses a minor issue where a filter integration test case is generated and then have to be skipped.

WordPress REST API will return incorrectly formatted JSON when `_fields=` query parameter is used and the resulting object doesn't have any fields. For example, if we make a request to `/users?context=edit&_fields=password` we'll get a response such as `[[],[],[],[]]` instead of `[{},{},{},{}]` which will result in a parsing error.

In `WpContextual` proc macro, we generate integration test cases to help test `_fields=` query parameter for each endpoint. Up until now, we were generating a test case for every field, but if a field is marked with `#[WpContextualOption]` we should skip this case because that attribute means this field might be missing even from the `context=edit` response.

Since we were generating such test cases, we had to manually skip them in `test_application_passwords_immut` which is no longer necessary.