### PR TITLE
Add Swift Pagination

### DIFF
--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -14,8 +14,7 @@ struct ExampleApp: App {
                 .map { $0.asListViewData }
         }),
         RootListData(name: "Users", callback: {
-            try await WordPressAPI.globalInstance.users.listWithEditContext(params: .init())
-                .data
+            try await WordPressAPI.globalInstance.users.paginatedWithEditContext(params: UserListParams(perPage: 100))
                 .map { $0.asListViewData }
         }),
         RootListData(name: "Plugins", callback: {
@@ -27,6 +26,10 @@ struct ExampleApp: App {
             try await WordPressAPI.globalInstance.postTypes.listWithViewContext().data.postTypes.map { _, value in
                 value.asListViewData
             }
+        }),
+        RootListData(name: "Posts", callback: {
+            try await WordPressAPI.globalInstance.posts.paginatedWithEditContext(params: PostListParams(perPage: 100))
+                .map { $0.asListViewData }
         }),
         RootListData(name: "Site Health Tests", callback: {
             let items: [any ListViewDataConvertable] = [

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -141,3 +141,13 @@ extension SiteSettingsWithEditContext {
         }
     }
 }
+
+extension PostWithEditContext: ListViewDataConvertable {
+    public var id: String {
+        self.slug
+    }
+    
+    var asListViewData: ListViewData {
+        ListViewData(id: self.id, title: self.title.raw, subtitle: self.slug, fields: [:])
+    }
+}

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -146,7 +146,7 @@ extension PostWithEditContext: ListViewDataConvertable {
     public var id: String {
         self.slug
     }
-    
+
     var asListViewData: ListViewData {
         ListViewData(id: self.id, title: self.title.raw, subtitle: self.slug, fields: [:])
     }

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -67,6 +67,13 @@ public typealias PostTypeDetailsWithEditContext = WordPressAPIInternal.PostTypeD
 public typealias PostTypeDetailsWithViewContext = WordPressAPIInternal.PostTypeDetailsWithViewContext
 public typealias PostTypeDetailsWithEmbedContext = WordPressAPIInternal.PostTypeDetailsWithEmbedContext
 
+// MARK: - Posts
+public typealias SparsePost = WordPressAPIInternal.SparsePost
+public typealias PostWithEditContext = WordPressAPIInternal.PostWithEditContext
+public typealias PostWithViewContext = WordPressAPIInternal.PostWithViewContext
+public typealias PostWithEmbedContext = WordPressAPIInternal.PostWithEmbedContext
+public typealias PostListParams = WordPressAPIInternal.PostListParams
+
 // MARK: – Site Settings
 public typealias SparseSiteSettings = WordPressAPIInternal.SparseSiteSettings
 public typealias SiteSettingsWithEditContext = WordPressAPIInternal.SiteSettingsWithEditContext

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -42,13 +42,19 @@ extension PaginationAwareExecutor {
     public func paginatedWithEditContext(
         params: EditContextResponseType.ParamsType
     ) async throws -> [EditContextResponseType.DataType] {
-        var workingResponse = try await self.listWithEditContext(params: params)
-        var allObjects: [EditContextResponseType.DataType] = workingResponse.data
+        var allObjects: [EditContextResponseType.DataType] = []
+        var mutableParams: EditContextResponseType.ParamsType = params
 
-        while let nextPageParams = workingResponse.nextPageParams {
-            workingResponse = try await self.listWithEditContext(params: nextPageParams)
-            allObjects.append(contentsOf: workingResponse.data)
-        }
+        repeat {
+            let response = try await self.listWithEditContext(params: mutableParams)
+            allObjects.append(contentsOf: response.data)
+
+            guard let newParams = response.nextPageParams else {
+                break
+            }
+
+            mutableParams = newParams
+        } while true
 
         return allObjects
     }
@@ -60,13 +66,19 @@ extension PaginationAwareExecutor {
     public func paginatedWithViewContext(
         params: ViewContextResponseType.ParamsType
     ) async throws -> [ViewContextResponseType.DataType] {
-        var workingResponse = try await self.listWithViewContext(params: params)
-        var allObjects: [ViewContextResponseType.DataType] = workingResponse.data
+        var allObjects: [ViewContextResponseType.DataType] = []
+        var mutableParams: ViewContextResponseType.ParamsType = params
 
-        while let nextPageParams = workingResponse.nextPageParams {
-            workingResponse = try await self.listWithViewContext(params: nextPageParams)
-            allObjects.append(contentsOf: workingResponse.data)
-        }
+        repeat {
+            let response = try await self.listWithViewContext(params: mutableParams)
+            allObjects.append(contentsOf: response.data)
+
+            guard let newParams = response.nextPageParams else {
+                break
+            }
+
+            mutableParams = newParams
+        } while true
 
         return allObjects
     }
@@ -78,13 +90,19 @@ extension PaginationAwareExecutor {
     public func paginatedWithEmbedContext(
         params: EmbedContextResponseType.ParamsType
     ) async throws -> [EmbedContextResponseType.DataType] {
-        var workingResponse = try await self.listWithEmbedContext(params: params)
-        var allObjects: [EmbedContextResponseType.DataType] = workingResponse.data
+        var allObjects: [EmbedContextResponseType.DataType] = []
+        var mutableParams: EmbedContextResponseType.ParamsType = params
 
-        while let nextPageParams = workingResponse.nextPageParams {
-            workingResponse = try await self.listWithEmbedContext(params: nextPageParams)
-            allObjects.append(contentsOf: workingResponse.data)
-        }
+        repeat {
+            let response = try await self.listWithEmbedContext(params: mutableParams)
+            allObjects.append(contentsOf: response.data)
+
+            guard let newParams = response.nextPageParams else {
+                break
+            }
+
+            mutableParams = newParams
+        } while true
 
         return allObjects
     }

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -1,0 +1,91 @@
+import WordPressAPIInternal
+
+public protocol PaginatableResponse {
+    associatedtype ParamsType
+    associatedtype DataType
+
+    var nextPageParams: ParamsType? { get }
+    var prevPageParams: ParamsType? { get }
+
+    var data: [DataType] { get }
+}
+
+public protocol PaginationAwareExecutor {
+    associatedtype EditContextResponseType: PaginatableResponse
+    associatedtype ViewContextResponseType: PaginatableResponse
+    associatedtype EmbedContextResponseType: PaginatableResponse
+
+    /// Known function signatures for Request Executors
+    func listWithEditContext(params: EditContextResponseType.ParamsType) async throws -> EditContextResponseType
+    func listWithViewContext(params: ViewContextResponseType.ParamsType) async throws -> ViewContextResponseType
+    func listWithEmbedContext(params: EmbedContextResponseType.ParamsType) async throws -> EmbedContextResponseType
+
+    /// Generated implementation
+    func paginatedWithEditContext(
+        params: EditContextResponseType.ParamsType
+    ) async throws -> [EditContextResponseType.DataType]
+}
+
+extension PaginationAwareExecutor {
+    /// Fetches all objects from all pages
+    ///
+    /// This method waits until all objects have been downloaded then returns the results. This can have unexpected memory and time implications.
+    public func paginatedWithEditContext(
+        params: EditContextResponseType.ParamsType
+    ) async throws -> [EditContextResponseType.DataType] {
+        var workingResponse = try await self.listWithEditContext(params: params)
+        var allObjects: [EditContextResponseType.DataType] = workingResponse.data
+
+        while let nextPageParams = workingResponse.nextPageParams {
+            workingResponse = try await self.listWithEditContext(params: nextPageParams)
+            allObjects.append(contentsOf: workingResponse.data)
+        }
+
+        return allObjects
+    }
+}
+
+// MARK: - Posts
+
+extension PostsRequestListWithEditContextResponse: PaginatableResponse {
+    public typealias ParamsType = PostListParams
+    public typealias DataType = PostWithEditContext
+}
+
+extension PostsRequestListWithViewContextResponse: PaginatableResponse {
+    public typealias ParamsType = PostListParams
+    public typealias DataType = PostWithViewContext
+}
+
+extension PostsRequestListWithEmbedContextResponse: PaginatableResponse {
+    public typealias ParamsType = PostListParams
+    public typealias DataType = PostWithEmbedContext
+}
+
+extension PostsRequestExecutor: PaginationAwareExecutor {
+    public typealias EditContextResponseType = PostsRequestListWithEditContextResponse
+    public typealias ViewContextResponseType = PostsRequestListWithViewContextResponse
+    public typealias EmbedContextResponseType = PostsRequestListWithEmbedContextResponse
+}
+
+// MARK: - Users
+extension UsersRequestListWithEditContextResponse: PaginatableResponse {
+    public typealias ParamsType = UserListParams
+    public typealias DataType = UserWithEditContext
+}
+
+extension UsersRequestListWithViewContextResponse: PaginatableResponse {
+    public typealias ParamsType = UserListParams
+    public typealias DataType = UserWithViewContext
+}
+
+extension UsersRequestListWithEmbedContextResponse: PaginatableResponse {
+    public typealias ParamsType = UserListParams
+    public typealias DataType = UserWithEmbedContext
+}
+
+extension UsersRequestExecutor: PaginationAwareExecutor {
+    public typealias EditContextResponseType = UsersRequestListWithEditContextResponse
+    public typealias ViewContextResponseType = UsersRequestListWithViewContextResponse
+    public typealias EmbedContextResponseType = UsersRequestListWithEmbedContextResponse
+}

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -46,7 +46,6 @@ extension PaginationAwareExecutor {
 }
 
 // MARK: - Posts
-
 extension PostsRequestListWithEditContextResponse: PaginatableResponse {
     public typealias ParamsType = PostListParams
     public typealias DataType = PostWithEditContext

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -24,12 +24,21 @@ public protocol PaginationAwareExecutor {
     func paginatedWithEditContext(
         params: EditContextResponseType.ParamsType
     ) async throws -> [EditContextResponseType.DataType]
+
+    func paginatedWithViewContext(
+        params: ViewContextResponseType.ParamsType
+    ) async throws -> [ViewContextResponseType.DataType]
+
+    func paginatedWithEmbedContext(
+        params: EmbedContextResponseType.ParamsType
+    ) async throws -> [EmbedContextResponseType.DataType]
 }
 
 extension PaginationAwareExecutor {
     /// Fetches all objects from all pages
     ///
-    /// This method waits until all objects have been downloaded then returns the results. This can have unexpected memory and time implications.
+    /// This method waits until all objects have been downloaded then returns the results. This can have
+    /// unexpected memory and time implications.
     public func paginatedWithEditContext(
         params: EditContextResponseType.ParamsType
     ) async throws -> [EditContextResponseType.DataType] {
@@ -38,6 +47,42 @@ extension PaginationAwareExecutor {
 
         while let nextPageParams = workingResponse.nextPageParams {
             workingResponse = try await self.listWithEditContext(params: nextPageParams)
+            allObjects.append(contentsOf: workingResponse.data)
+        }
+
+        return allObjects
+    }
+
+    /// Fetches all objects from all pages
+    ///
+    /// This method waits until all objects have been downloaded then returns the results. This can have
+    /// unexpected memory and time implications.
+    public func paginatedWithViewContext(
+        params: ViewContextResponseType.ParamsType
+    ) async throws -> [ViewContextResponseType.DataType] {
+        var workingResponse = try await self.listWithViewContext(params: params)
+        var allObjects: [ViewContextResponseType.DataType] = workingResponse.data
+
+        while let nextPageParams = workingResponse.nextPageParams {
+            workingResponse = try await self.listWithViewContext(params: nextPageParams)
+            allObjects.append(contentsOf: workingResponse.data)
+        }
+
+        return allObjects
+    }
+
+    /// Fetches all objects from all pages
+    ///
+    /// This method waits until all objects have been downloaded then returns the results. This can have
+    /// unexpected memory and time implications.
+    public func paginatedWithEmbedContext(
+        params: EmbedContextResponseType.ParamsType
+    ) async throws -> [EmbedContextResponseType.DataType] {
+        var workingResponse = try await self.listWithEmbedContext(params: params)
+        var allObjects: [EmbedContextResponseType.DataType] = workingResponse.data
+
+        while let nextPageParams = workingResponse.nextPageParams {
+            workingResponse = try await self.listWithEmbedContext(params: nextPageParams)
             allObjects.append(contentsOf: workingResponse.data)
         }
 

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -59,6 +59,10 @@ public struct WordPressAPI {
         self.requestBuilder.postTypes()
     }
 
+    public var posts: PostsRequestExecutor {
+        self.requestBuilder.posts()
+    }
+
     public var siteSettings: SiteSettingsRequestExecutor {
         self.requestBuilder.siteSettings()
     }


### PR DESCRIPTION
Adds basic Swift auto-pagination based on #375 and #376.

To Test:
- Launch the example app
- Sign into https://content-heavy.wpmt.co
- Note that > 100 users and posts are loaded