### PR TITLE
List `/media` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -2,7 +2,6 @@ package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import uniffi.wp_api.JsonValue
 import uniffi.wp_api.MediaListParams
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
 
@@ -20,12 +19,5 @@ class MediaEndpointTest {
             requestBuilder.media().listWithEditContext(params = MediaListParams())
         }.assertSuccessAndRetrieveData().data
         assert(mediaList.isNotEmpty())
-        mediaList.forEach {
-            assert(it.mediaDetails is JsonValue.Object)
-            val details = it.mediaDetails as JsonValue.Object
-            details.v1["width"]?.let { width ->
-                assert(width is JsonValue.Number)
-            }
-        }
     }
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -1,0 +1,31 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.JsonValue
+import uniffi.wp_api.MediaListParams
+import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+
+class MediaEndpointTest {
+    private val testCredentials = TestCredentials.INSTANCE
+    private val siteUrl = testCredentials.parsedSiteUrl
+    private val authentication = wpAuthenticationFromUsernameAndPassword(
+        username = testCredentials.adminUsername, password = testCredentials.adminPassword
+    )
+    private val client = WpApiClient(siteUrl, authentication)
+
+    @Test
+    fun testMediaListRequest() = runTest {
+        val mediaList = client.request { requestBuilder ->
+            requestBuilder.media().listWithEditContext(params = MediaListParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(mediaList.isNotEmpty())
+        mediaList.forEach {
+            assert(it.mediaDetails is JsonValue.Object)
+            val details = it.mediaDetails as JsonValue.Object
+            details.v1["width"]?.let { width ->
+                assert(width is JsonValue.Number)
+            }
+        }
+    }
+}

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -3,6 +3,7 @@ use crate::request::{
         application_passwords_endpoint::{
             ApplicationPasswordsRequestBuilder, ApplicationPasswordsRequestExecutor,
         },
+        media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
         plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
         post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
         posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
@@ -39,6 +40,7 @@ impl UniffiWpApiRequestBuilder {
 #[derive(Debug)]
 pub struct WpApiRequestBuilder {
     application_passwords: Arc<ApplicationPasswordsRequestBuilder>,
+    media: Arc<MediaRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
     post_types: Arc<PostTypesRequestBuilder>,
     posts: Arc<PostsRequestBuilder>,
@@ -54,6 +56,7 @@ impl WpApiRequestBuilder {
             api_base_url,
             authentication;
             application_passwords,
+            media,
             plugins,
             post_types,
             posts,
@@ -86,6 +89,7 @@ impl UniffiWpApiClient {
 #[derive(Debug)]
 pub struct WpApiClient {
     application_passwords: Arc<ApplicationPasswordsRequestExecutor>,
+    media: Arc<MediaRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
     post_types: Arc<PostTypesRequestExecutor>,
     posts: Arc<PostsRequestExecutor>,
@@ -107,6 +111,7 @@ impl WpApiClient {
             authentication,
             request_executor;
             application_passwords,
+            media,
             plugins,
             post_types,
             posts,
@@ -118,6 +123,7 @@ impl WpApiClient {
 }
 
 api_client_generate_endpoint_impl!(WpApi, application_passwords);
+api_client_generate_endpoint_impl!(WpApi, media);
 api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_types);
 api_client_generate_endpoint_impl!(WpApi, posts);

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -16,6 +16,7 @@ mod uuid; // re-exported relevant types
 
 pub mod application_passwords;
 pub mod login;
+pub mod media;
 pub mod plugins;
 pub mod post_types;
 pub mod posts;

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -4,7 +4,8 @@ pub use api_client::{WpApiClient, WpApiRequestBuilder};
 pub use api_error::{ParsedRequestError, RequestExecutionError, WpApiError, WpError, WpErrorCode};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
-use std::str::FromStr;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
 use url_query::AsQueryValue;
 use users::*;
 pub use uuid::{WpUuid, WpUuidParseError};
@@ -118,6 +119,18 @@ trait OptionFromStr {
 pub enum EnumFromStrParsingError {
     #[error("'{}' is not a valid variant for this enum", value)]
     UnknownVariant { value: String },
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[serde(untagged)]
+pub enum JsonValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    Array(Vec<JsonValue>),
+    Object(HashMap<String, JsonValue>),
 }
 
 #[macro_export]

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -214,10 +214,10 @@ pub struct MediaListParams {
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Limit result set to items with particular parent IDs.
     #[uniffi(default = [])]
-    pub parent: Vec<MediaId>,
+    pub parent: Vec<crate::posts::PostId>,
     /// Limit result set to all items except those of a particular parent ID.
     #[uniffi(default = [])]
-    pub parent_exclude: Vec<MediaId>,
+    pub parent_exclude: Vec<crate::posts::PostId>,
     /// Array of column names to be searched.
     #[uniffi(default = [])]
     pub search_columns: Vec<WpApiParamPostsSearchColumn>,
@@ -443,7 +443,7 @@ pub struct SparseMediaCaption {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{generate, unit_test_common::assert_expected_and_from_query_pairs};
+    use crate::{generate, posts::PostId, unit_test_common::assert_expected_and_from_query_pairs};
     use rstest::*;
 
     #[rstest]
@@ -472,8 +472,8 @@ mod tests {
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
-    #[case(generate!(MediaListParams, (parent, vec![MediaId(44444), MediaId(44445)])), "parent=44444%2C44445")]
-    #[case(generate!(MediaListParams, (parent_exclude, vec![MediaId(55555), MediaId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
@@ -501,8 +501,8 @@ mod tests {
             offset: Some(11111),
             order: Some(WpApiParamOrder::Desc),
             orderby: Some(WpApiParamPostsOrderBy::Slug),
-            parent: vec![MediaId(44444), MediaId(44445)],
-            parent_exclude: vec![MediaId(55555), MediaId(55556)],
+            parent: vec![PostId(44444), PostId(44445)],
+            parent_exclude: vec![PostId(55555), PostId(55556)],
             search_columns: vec![
                 WpApiParamPostsSearchColumn::PostContent,
                 WpApiParamPostsSearchColumn::PostExcerpt,

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,6 +1,6 @@
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
-    posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+    posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
@@ -130,11 +130,8 @@ impl FromStr for MediaTypeParam {
 pub enum MediaStatus {
     #[default]
     Inherit,
-    Draft,
-    Future,
-    Pending,
     Private,
-    Publish,
+    Trash,
     #[serde(untagged)]
     Custom(String),
 }
@@ -145,11 +142,8 @@ impl MediaStatus {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Inherit => "inherit",
-            Self::Draft => "draft",
-            Self::Future => "future",
-            Self::Pending => "pending",
             Self::Private => "private",
-            Self::Publish => "publish",
+            Self::Trash => "trash",
             Self::Custom(status) => status,
         }
     }
@@ -161,11 +155,8 @@ impl FromStr for MediaStatus {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "inherit" => Ok(Self::Inherit),
-            "draft" => Ok(Self::Draft),
-            "future" => Ok(Self::Future),
-            "pending" => Ok(Self::Pending),
             "private" => Ok(Self::Private),
-            "publish" => Ok(Self::Publish),
+            "trash" => Ok(Self::Trash),
             value => Ok(Self::Custom(value.to_string())),
         }
     }
@@ -204,10 +195,10 @@ pub struct MediaListParams {
     pub modified_before: Option<String>,
     /// Ensure result set excludes specific IDs.
     #[uniffi(default = [])]
-    pub exclude: Vec<PostId>,
+    pub exclude: Vec<MediaId>,
     /// Limit result set to specific IDs.
     #[uniffi(default = [])]
-    pub include: Vec<PostId>,
+    pub include: Vec<MediaId>,
     /// Offset the result set by a specific number of items.
     #[uniffi(default = None)]
     pub offset: Option<u32>,
@@ -223,10 +214,10 @@ pub struct MediaListParams {
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Limit result set to items with particular parent IDs.
     #[uniffi(default = [])]
-    pub parent: Vec<PostId>,
+    pub parent: Vec<MediaId>,
     /// Limit result set to all items except those of a particular parent ID.
     #[uniffi(default = [])]
-    pub parent_exclude: Vec<PostId>,
+    pub parent_exclude: Vec<MediaId>,
     /// Array of column names to be searched.
     #[uniffi(default = [])]
     pub search_columns: Vec<WpApiParamPostsSearchColumn>,
@@ -466,8 +457,8 @@ mod tests {
     #[case(generate!(MediaListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
     #[case(generate!(MediaListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
     #[case(generate!(MediaListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(MediaListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
-    #[case(generate!(MediaListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
+    #[case(generate!(MediaListParams, (exclude, vec![MediaId(1), MediaId(2)])), "exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (include, vec![MediaId(1), MediaId(2)])), "include=1%2C2")]
     #[case(generate!(MediaListParams, (offset, Some(2))), "offset=2")]
     #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
     #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
@@ -481,21 +472,18 @@ mod tests {
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
-    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
-    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (parent, vec![MediaId(44444), MediaId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![MediaId(55555), MediaId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt, WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_content%2Cpost_excerpt%2Cpost_title")]
     #[case(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit])), "status=inherit")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Draft])), "status=draft")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Future])), "status=future")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Pending])), "status=pending")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Private])), "status=private")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Publish])), "status=publish")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Trash])), "status=trash")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Custom("foo".to_string())])), "status=foo")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Draft, MediaStatus::Future, MediaStatus::Pending, MediaStatus::Private, MediaStatus::Publish, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cdraft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Private, MediaStatus::Trash, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cprivate%2Ctrash%2Cfoo")]
     #[case(generate!(MediaListParams, (media_type, Some(MediaTypeParam::Image))), "media_type=image")]
     #[case(generate!(MediaListParams, (mime_type, Some("image/jpeg".to_string()))), "mime_type=image%2Fjpeg")]
     #[case(MediaListParams {
@@ -508,23 +496,23 @@ mod tests {
             author_exclude: vec![UserId(211), UserId(212)],
             before: Some("d_b".to_string()),
             modified_before: Some("d_m_b".to_string()),
-            exclude: vec![PostId(1111), PostId(1112)],
-            include: vec![PostId(2111), PostId(2112)],
+            exclude: vec![MediaId(1111), MediaId(1112)],
+            include: vec![MediaId(2111), MediaId(2112)],
             offset: Some(11111),
             order: Some(WpApiParamOrder::Desc),
             orderby: Some(WpApiParamPostsOrderBy::Slug),
-            parent: vec![PostId(44444), PostId(44445)],
-            parent_exclude: vec![PostId(55555), PostId(55556)],
+            parent: vec![MediaId(44444), MediaId(44445)],
+            parent_exclude: vec![MediaId(55555), MediaId(55556)],
             search_columns: vec![
                 WpApiParamPostsSearchColumn::PostContent,
                 WpApiParamPostsSearchColumn::PostExcerpt,
             ],
             slug: vec!["sl_1".to_string(), "sl_2".to_string()],
-            status: vec![MediaStatus::Draft, MediaStatus::Future],
+            status: vec![MediaStatus::Inherit, MediaStatus::Private, MediaStatus::Trash],
             media_type: Some(MediaTypeParam::Image),
             mime_type: Some("image/jpeg".to_string()),
         },
-        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg"
+        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=inherit%2Cprivate%2Ctrash&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg"
     )]
     #[trace]
     fn test_post_list_query_pairs(#[case] params: MediaListParams, #[case] expected_query: &str) {

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -5,10 +5,10 @@ use crate::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, UserId, WpApiParamOrder,
+    EnumFromStrParsingError, JsonValue, UserId, WpApiParamOrder,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, num::ParseIntError, str::FromStr};
+use std::{num::ParseIntError, str::FromStr};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
@@ -421,8 +421,6 @@ pub struct SparseMedia {
     #[WpContext(edit, embed, view)]
     pub mime_type: Option<String>,
     #[WpContext(edit, embed, view)]
-    #[serde(skip_serializing)]
-    // TODO: Do we need serializing?
     pub media_details: Option<JsonValue>,
     #[serde(rename = "post")]
     #[WpContext(edit, view)]
@@ -431,7 +429,6 @@ pub struct SparseMedia {
     #[WpContext(edit, embed, view)]
     pub source_url: Option<String>,
     #[WpContext(edit)]
-    // TODO: What is the type for the array?
     pub missing_image_sizes: Option<Vec<String>>,
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/381
 }
@@ -450,77 +447,6 @@ pub struct SparseMediaCaption {
     pub raw: Option<String>,
     #[WpContext(edit, embed, view)]
     pub rendered: Option<String>,
-}
-
-#[derive(Debug, uniffi::Enum)]
-pub enum JsonValue {
-    Null,
-    Bool(bool),
-    Number(JsonNumber),
-    String(String),
-    Array(Vec<JsonValue>),
-    Object(HashMap<String, JsonValue>),
-}
-
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct JsonNumber {
-    n: JsonNumberType,
-}
-
-#[derive(Debug, Clone, Copy, uniffi::Enum)]
-enum JsonNumberType {
-    PosInt(u64),
-    /// Always less than zero.
-    NegInt(i64),
-    /// Always finite.
-    Float(f64),
-    // Doesn't exist in `serde_json::N` - used as a fallback
-    NotSupported,
-}
-
-impl From<serde_json::Number> for JsonNumber {
-    fn from(value: serde_json::Number) -> Self {
-        if value.is_u64() {
-            Self {
-                n: JsonNumberType::PosInt(value.as_u64().expect("already verified that it's u64")),
-            }
-        } else if value.is_i64() {
-            Self {
-                n: JsonNumberType::NegInt(value.as_i64().expect("already verified that it's i64")),
-            }
-        } else if value.is_f64() {
-            Self {
-                n: JsonNumberType::Float(value.as_f64().expect("already verified that it's f64")),
-            }
-        } else {
-            Self {
-                n: JsonNumberType::NotSupported,
-            }
-        }
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for JsonValue {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        serde_json::Value::deserialize(d).map(|v| v.into())
-    }
-}
-
-impl From<serde_json::Value> for JsonValue {
-    fn from(value: serde_json::Value) -> Self {
-        match value {
-            serde_json::Value::Null => Self::Null,
-            serde_json::Value::Bool(b) => Self::Bool(b),
-            serde_json::Value::Number(number) => Self::Number(JsonNumber::from(number)),
-            serde_json::Value::String(s) => Self::String(s),
-            serde_json::Value::Array(vec) => {
-                Self::Array(vec.into_iter().map(JsonValue::from).collect())
-            }
-            serde_json::Value::Object(map) => {
-                Self::Object(map.into_iter().map(|(k, v)| (k, v.into())).collect())
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,0 +1,607 @@
+use crate::{
+    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+    url_query::{
+        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
+        UrlQueryPairsMap,
+    },
+    EnumFromStrParsingError, UserId, WpApiParamOrder,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, num::ParseIntError, str::FromStr};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+impl_as_query_value_for_new_type!(MediaId);
+uniffi::custom_newtype!(MediaId, i32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaId(pub i32);
+
+impl FromStr for MediaId {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl std::fmt::Display for MediaId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaType {
+    File,
+    Image,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(MediaType);
+
+impl MediaType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::File => "file",
+            Self::Image => "image",
+            Self::Custom(media_type) => media_type,
+        }
+    }
+}
+
+impl FromStr for MediaType {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "file" => Ok(Self::File),
+            "image" => Ok(Self::Image),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+// A separate param type is implemented for `MediaType` because the API will accept types such as
+// "audio" & "application" as a parameter, but it'll return "file" for the value of `media_type`
+// field for these media types.
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaTypeParam {
+    Image,
+    Video,
+    Text,
+    Application,
+    Audio,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(MediaTypeParam);
+
+impl MediaTypeParam {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Image => "image",
+            Self::Video => "video",
+            Self::Text => "text",
+            Self::Application => "application",
+            Self::Audio => "audio",
+            Self::Custom(media_type) => media_type,
+        }
+    }
+}
+
+impl FromStr for MediaTypeParam {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "image" => Ok(Self::Image),
+            "video" => Ok(Self::Video),
+            "text" => Ok(Self::Text),
+            "application" => Ok(Self::Application),
+            "audio" => Ok(Self::Audio),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaStatus {
+    #[default]
+    Inherit,
+    Draft,
+    Future,
+    Pending,
+    Private,
+    Publish,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(MediaStatus);
+
+impl MediaStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::Draft => "draft",
+            Self::Future => "future",
+            Self::Pending => "pending",
+            Self::Private => "private",
+            Self::Publish => "publish",
+            Self::Custom(status) => status,
+        }
+    }
+}
+
+impl FromStr for MediaStatus {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "inherit" => Ok(Self::Inherit),
+            "draft" => Ok(Self::Draft),
+            "future" => Ok(Self::Future),
+            "pending" => Ok(Self::Pending),
+            "private" => Ok(Self::Private),
+            "publish" => Ok(Self::Publish),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+pub struct MediaListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    /// Default: `10`
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Limit response to posts published after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub after: Option<String>,
+    /// Limit response to posts modified after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_after: Option<String>,
+    /// Limit result set to posts assigned to specific authors.
+    #[uniffi(default = [])]
+    pub author: Vec<UserId>,
+    /// Ensure result set excludes posts assigned to specific authors.
+    #[uniffi(default = [])]
+    pub author_exclude: Vec<UserId>,
+    /// Limit response to posts published before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub before: Option<String>,
+    /// Limit response to posts modified before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_before: Option<String>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = [])]
+    pub exclude: Vec<PostId>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = [])]
+    pub include: Vec<PostId>,
+    /// Offset the result set by a specific number of items.
+    #[uniffi(default = None)]
+    pub offset: Option<u32>,
+    /// Order sort attribute ascending or descending.
+    /// Default: desc
+    /// One of: asc, desc
+    #[uniffi(default = None)]
+    pub order: Option<WpApiParamOrder>,
+    /// Sort collection by post attribute.
+    /// Default: date
+    /// One of: author, date, id, include, modified, parent, relevance, slug, include_slugs, title
+    #[uniffi(default = None)]
+    pub orderby: Option<WpApiParamPostsOrderBy>,
+    /// Limit result set to items with particular parent IDs.
+    #[uniffi(default = [])]
+    pub parent: Vec<PostId>,
+    /// Limit result set to all items except those of a particular parent ID.
+    #[uniffi(default = [])]
+    pub parent_exclude: Vec<PostId>,
+    /// Array of column names to be searched.
+    #[uniffi(default = [])]
+    pub search_columns: Vec<WpApiParamPostsSearchColumn>,
+    /// Limit result set to posts with one or more specific slugs.
+    #[uniffi(default = [])]
+    pub slug: Vec<String>,
+    /// Limit result set to posts assigned one or more statuses.
+    /// Default: inherit
+    #[uniffi(default = [])]
+    pub status: Vec<MediaStatus>,
+    /// Limit result set to attachments of a particular media type.
+    /// One of: image, video, text, application, audio
+    #[uniffi(default = None)]
+    pub media_type: Option<MediaTypeParam>,
+    /// Limit result set to attachments of a particular MIME type.
+    #[uniffi(default = None)]
+    pub mime_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum MediaListParamsField {
+    #[strum(serialize = "page")]
+    Page,
+    #[strum(serialize = "per_page")]
+    PerPage,
+    #[strum(serialize = "search")]
+    Search,
+    #[strum(serialize = "after")]
+    After,
+    #[strum(serialize = "modified_after")]
+    ModifiedAfter,
+    #[strum(serialize = "author")]
+    Author,
+    #[strum(serialize = "author_exclude")]
+    AuthorExclude,
+    #[strum(serialize = "before")]
+    Before,
+    #[strum(serialize = "modified_before")]
+    ModifiedBefore,
+    #[strum(serialize = "exclude")]
+    Exclude,
+    #[strum(serialize = "include")]
+    Include,
+    #[strum(serialize = "offset")]
+    Offset,
+    #[strum(serialize = "order")]
+    Order,
+    #[strum(serialize = "orderby")]
+    Orderby,
+    #[strum(serialize = "parent")]
+    Parent,
+    #[strum(serialize = "parent_exclude")]
+    ParentExclude,
+    #[strum(serialize = "search_columns")]
+    SearchColumns,
+    #[strum(serialize = "slug")]
+    Slug,
+    #[strum(serialize = "status")]
+    Status,
+    #[strum(serialize = "media_type")]
+    MediaType,
+    #[strum(serialize = "mime_type")]
+    MimeType,
+}
+
+impl AppendUrlQueryPairs for MediaListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair(MediaListParamsField::Page, self.page.as_ref())
+            .append_option_query_value_pair(MediaListParamsField::PerPage, self.per_page.as_ref())
+            .append_option_query_value_pair(MediaListParamsField::Search, self.search.as_ref())
+            .append_option_query_value_pair(MediaListParamsField::After, self.after.as_ref())
+            .append_option_query_value_pair(
+                MediaListParamsField::ModifiedAfter,
+                self.modified_after.as_ref(),
+            )
+            .append_vec_query_value_pair(MediaListParamsField::Author, &self.author)
+            .append_vec_query_value_pair(MediaListParamsField::AuthorExclude, &self.author_exclude)
+            .append_option_query_value_pair(MediaListParamsField::Before, self.before.as_ref())
+            .append_option_query_value_pair(
+                MediaListParamsField::ModifiedBefore,
+                self.modified_before.as_ref(),
+            )
+            .append_vec_query_value_pair(MediaListParamsField::Exclude, &self.exclude)
+            .append_vec_query_value_pair(MediaListParamsField::Include, &self.include)
+            .append_option_query_value_pair(MediaListParamsField::Offset, self.offset.as_ref())
+            .append_option_query_value_pair(MediaListParamsField::Order, self.order.as_ref())
+            .append_option_query_value_pair(MediaListParamsField::Orderby, self.orderby.as_ref())
+            .append_vec_query_value_pair(MediaListParamsField::Parent, self.parent.as_ref())
+            .append_vec_query_value_pair(MediaListParamsField::SearchColumns, &self.search_columns)
+            .append_vec_query_value_pair(MediaListParamsField::Slug, &self.slug)
+            .append_vec_query_value_pair(MediaListParamsField::Status, &self.status)
+            .append_vec_query_value_pair(
+                MediaListParamsField::ParentExclude,
+                self.parent_exclude.as_ref(),
+            )
+            .append_option_query_value_pair(
+                MediaListParamsField::MediaType,
+                self.media_type.as_ref(),
+            )
+            .append_option_query_value_pair(
+                MediaListParamsField::MimeType,
+                self.mime_type.as_ref(),
+            );
+    }
+}
+
+impl FromUrlQueryPairs for MediaListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            page: query_pairs.get(MediaListParamsField::Page),
+            per_page: query_pairs.get(MediaListParamsField::PerPage),
+            search: query_pairs.get(MediaListParamsField::Search),
+            after: query_pairs.get(MediaListParamsField::After),
+            modified_after: query_pairs.get(MediaListParamsField::ModifiedAfter),
+            author: query_pairs.get_csv(MediaListParamsField::Author),
+            author_exclude: query_pairs.get_csv(MediaListParamsField::AuthorExclude),
+            before: query_pairs.get(MediaListParamsField::Before),
+            modified_before: query_pairs.get(MediaListParamsField::ModifiedBefore),
+            exclude: query_pairs.get_csv(MediaListParamsField::Exclude),
+            include: query_pairs.get_csv(MediaListParamsField::Include),
+            offset: query_pairs.get(MediaListParamsField::Offset),
+            order: query_pairs.get(MediaListParamsField::Order),
+            orderby: query_pairs.get(MediaListParamsField::Orderby),
+            parent: query_pairs.get_csv(MediaListParamsField::Parent),
+            parent_exclude: query_pairs.get_csv(MediaListParamsField::ParentExclude),
+            search_columns: query_pairs.get_csv(MediaListParamsField::SearchColumns),
+            slug: query_pairs.get_csv(MediaListParamsField::Slug),
+            status: query_pairs.get_csv(MediaListParamsField::Status),
+            media_type: query_pairs.get(MediaListParamsField::MediaType),
+            mime_type: query_pairs.get(MediaListParamsField::MimeType),
+        })
+    }
+
+    fn supports_pagination() -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseMedia {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<MediaId>,
+    #[WpContext(edit, embed, view)]
+    pub date: Option<String>,
+    #[WpContext(edit, view)]
+    pub date_gmt: Option<String>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub guid: Option<crate::posts::SparsePostGuid>,
+    #[WpContext(edit, embed, view)]
+    pub link: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified_gmt: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, view)]
+    pub status: Option<MediaStatus>,
+    #[serde(rename = "type")]
+    #[WpContext(edit, embed, view)]
+    pub post_type: Option<String>,
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub password: Option<String>,
+    #[WpContext(edit)]
+    pub permalink_template: Option<String>,
+    #[WpContext(edit)]
+    pub generated_slug: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub title: Option<crate::posts::SparsePostTitle>,
+    #[WpContext(edit, embed, view)]
+    pub author: Option<crate::UserId>,
+    #[WpContext(edit, view)]
+    pub comment_status: Option<crate::posts::PostCommentStatus>,
+    #[WpContext(edit, view)]
+    pub ping_status: Option<crate::posts::PostPingStatus>,
+    #[WpContext(edit, view)]
+    pub template: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub alt_text: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub caption: Option<SparseMediaCaption>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub description: Option<SparseMediaDescription>,
+    #[WpContext(edit, embed, view)]
+    pub media_type: Option<MediaType>,
+    #[WpContext(edit, embed, view)]
+    pub mime_type: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[serde(skip_serializing)]
+    // TODO: Do we need serializing?
+    pub media_details: Option<JsonValue>,
+    #[serde(rename = "post")]
+    #[WpContext(edit, view)]
+    #[WpContextualOption]
+    pub post_id: Option<crate::posts::PostId>,
+    #[WpContext(edit, embed, view)]
+    pub source_url: Option<String>,
+    #[WpContext(edit)]
+    // TODO: What is the type for the array?
+    pub missing_image_sizes: Option<Vec<String>>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/381
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseMediaDescription {
+    #[WpContext(edit)]
+    pub raw: Option<String>,
+    #[WpContext(edit, view)]
+    pub rendered: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseMediaCaption {
+    #[WpContext(edit)]
+    pub raw: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub rendered: Option<String>,
+}
+
+#[derive(Debug, uniffi::Enum)]
+pub enum JsonValue {
+    Null,
+    Bool(bool),
+    Number(JsonNumber),
+    String(String),
+    Array(Vec<JsonValue>),
+    Object(HashMap<String, JsonValue>),
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct JsonNumber {
+    n: JsonNumberType,
+}
+
+#[derive(Debug, Clone, Copy, uniffi::Enum)]
+enum JsonNumberType {
+    PosInt(u64),
+    /// Always less than zero.
+    NegInt(i64),
+    /// Always finite.
+    Float(f64),
+    // Doesn't exist in `serde_json::N` - used as a fallback
+    NotSupported,
+}
+
+impl From<serde_json::Number> for JsonNumber {
+    fn from(value: serde_json::Number) -> Self {
+        if value.is_u64() {
+            Self {
+                n: JsonNumberType::PosInt(value.as_u64().expect("already verified that it's u64")),
+            }
+        } else if value.is_i64() {
+            Self {
+                n: JsonNumberType::NegInt(value.as_i64().expect("already verified that it's i64")),
+            }
+        } else if value.is_f64() {
+            Self {
+                n: JsonNumberType::Float(value.as_f64().expect("already verified that it's f64")),
+            }
+        } else {
+            Self {
+                n: JsonNumberType::NotSupported,
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for JsonValue {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        serde_json::Value::deserialize(d).map(|v| v.into())
+    }
+}
+
+impl From<serde_json::Value> for JsonValue {
+    fn from(value: serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::Null => Self::Null,
+            serde_json::Value::Bool(b) => Self::Bool(b),
+            serde_json::Value::Number(number) => Self::Number(JsonNumber::from(number)),
+            serde_json::Value::String(s) => Self::String(s),
+            serde_json::Value::Array(vec) => {
+                Self::Array(vec.into_iter().map(JsonValue::from).collect())
+            }
+            serde_json::Value::Object(map) => {
+                Self::Object(map.into_iter().map(|(k, v)| (k, v.into())).collect())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{generate, unit_test_common::assert_expected_and_from_query_pairs};
+    use rstest::*;
+
+    #[rstest]
+    #[case(MediaListParams::default(), "")]
+    #[case(generate!(MediaListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(MediaListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(MediaListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(MediaListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
+    #[case(generate!(MediaListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
+    #[case(generate!(MediaListParams, (offset, Some(2))), "offset=2")]
+    #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), "orderby=author")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Date))), "orderby=date")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))), "orderby=id")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Include))), "orderby=include")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::IncludeSlugs))), "orderby=include_slugs")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Modified))), "orderby=modified")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Parent))), "orderby=parent")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
+    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt, WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_content%2Cpost_excerpt%2Cpost_title")]
+    #[case(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit])), "status=inherit")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Draft])), "status=draft")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Future])), "status=future")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Pending])), "status=pending")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Private])), "status=private")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Publish])), "status=publish")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Custom("foo".to_string())])), "status=foo")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Draft, MediaStatus::Future, MediaStatus::Pending, MediaStatus::Private, MediaStatus::Publish, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cdraft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(MediaListParams, (media_type, Some(MediaTypeParam::Image))), "media_type=image")]
+    #[case(generate!(MediaListParams, (mime_type, Some("image/jpeg".to_string()))), "mime_type=image%2Fjpeg")]
+    #[case(MediaListParams {
+            page: Some(11),
+            per_page: Some(22),
+            search: Some("s_q".to_string()),
+            after: Some("d_a".to_string()),
+            modified_after: Some("d_m_a".to_string()),
+            author: vec![UserId(111), UserId(112)],
+            author_exclude: vec![UserId(211), UserId(212)],
+            before: Some("d_b".to_string()),
+            modified_before: Some("d_m_b".to_string()),
+            exclude: vec![PostId(1111), PostId(1112)],
+            include: vec![PostId(2111), PostId(2112)],
+            offset: Some(11111),
+            order: Some(WpApiParamOrder::Desc),
+            orderby: Some(WpApiParamPostsOrderBy::Slug),
+            parent: vec![PostId(44444), PostId(44445)],
+            parent_exclude: vec![PostId(55555), PostId(55556)],
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+            ],
+            slug: vec!["sl_1".to_string(), "sl_2".to_string()],
+            status: vec![MediaStatus::Draft, MediaStatus::Future],
+            media_type: Some(MediaTypeParam::Image),
+            mime_type: Some("image/jpeg".to_string()),
+        },
+        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg"
+    )]
+    #[trace]
+    fn test_post_list_query_pairs(#[case] params: MediaListParams, #[case] expected_query: &str) {
+        assert_expected_and_from_query_pairs(params, expected_query);
+    }
+}

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
@@ -6,6 +6,7 @@ use wp_contextual::WpContextual;
 use crate::{
     impl_as_query_value_from_as_str,
     url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
+    EnumFromStrParsingError,
 };
 
 #[derive(Debug, Default, uniffi::Record)]
@@ -136,6 +137,21 @@ impl PluginStatus {
             Self::Active => "active",
             Self::Inactive => "inactive",
             Self::NetworkActive => "network-active",
+        }
+    }
+}
+
+impl FromStr for PluginStatus {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "inactive" => Ok(Self::Inactive),
+            "network-active" => Ok(Self::NetworkActive),
+            value => Err(EnumFromStrParsingError::UnknownVariant {
+                value: value.to_string(),
+            }),
         }
     }
 }

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -7,6 +7,7 @@ use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_s
 
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    media::MediaId,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
@@ -555,19 +556,6 @@ impl FromStr for CategoryId {
     }
 }
 
-impl_as_query_value_for_new_type!(MediaId);
-uniffi::custom_newtype!(MediaId, i32);
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MediaId(pub i32);
-
-impl FromStr for MediaId {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(Self)
-    }
-}
-
 impl std::fmt::Display for PostId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -578,7 +566,7 @@ impl std::fmt::Display for PostId {
 pub struct SparsePost {
     #[WpContext(edit, embed, view)]
     pub id: Option<PostId>,
-    #[WpContext(edit, view)]
+    #[WpContext(edit, embed, view)]
     pub date: Option<String>,
     #[WpContext(edit, view)]
     pub date_gmt: Option<String>,

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -3,6 +3,7 @@ use url::Url;
 use crate::SparseField;
 
 pub mod application_passwords_endpoint;
+pub mod media_endpoint;
 pub mod plugins_endpoint;
 pub mod post_types_endpoint;
 pub mod posts_endpoint;

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -54,8 +54,8 @@ mod tests {
     use super::*;
     use crate::{
         generate,
-        media::{MediaStatus, MediaTypeParam},
-        posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+        media::{MediaId, MediaStatus, MediaTypeParam},
+        posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
         request::endpoint::{
             tests::{fixture_api_base_url, validate_wp_v2_endpoint},
             ApiBaseUrl,
@@ -76,8 +76,8 @@ mod tests {
     #[case(generate!(MediaListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
     #[case(generate!(MediaListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
     #[case(generate!(MediaListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(MediaListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
-    #[case(generate!(MediaListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
+    #[case(generate!(MediaListParams, (exclude, vec![MediaId(1), MediaId(2)])), "exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (include, vec![MediaId(1), MediaId(2)])), "include=1%2C2")]
     #[case(generate!(MediaListParams, (offset, Some(2))), "offset=2")]
     #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
     #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
@@ -91,21 +91,18 @@ mod tests {
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
-    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
-    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (parent, vec![MediaId(44444), MediaId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![MediaId(55555), MediaId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt, WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_content%2Cpost_excerpt%2Cpost_title")]
     #[case(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit])), "status=inherit")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Draft])), "status=draft")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Future])), "status=future")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Pending])), "status=pending")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Private])), "status=private")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Publish])), "status=publish")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Trash])), "status=trash")]
     #[case(generate!(MediaListParams, (status, vec![MediaStatus::Custom("foo".to_string())])), "status=foo")]
-    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Draft, MediaStatus::Future, MediaStatus::Pending, MediaStatus::Private, MediaStatus::Publish, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cdraft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Private, MediaStatus::Trash, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cprivate%2Ctrash%2Cfoo")]
     #[case(generate!(MediaListParams, (media_type, Some(MediaTypeParam::Image))), "media_type=image")]
     #[case(generate!(MediaListParams, (mime_type, Some("image/jpeg".to_string()))), "mime_type=image%2Fjpeg")]
     #[case(
@@ -187,7 +184,7 @@ mod tests {
     }
 
     const EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS: &str =
-        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg";
+        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=inherit%2Cprivate%2Ctrash&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg";
     fn media_list_params_with_all_fields() -> MediaListParams {
         MediaListParams {
             page: Some(11),
@@ -199,19 +196,23 @@ mod tests {
             author_exclude: vec![UserId(211), UserId(212)],
             before: Some("d_b".to_string()),
             modified_before: Some("d_m_b".to_string()),
-            exclude: vec![PostId(1111), PostId(1112)],
-            include: vec![PostId(2111), PostId(2112)],
+            exclude: vec![MediaId(1111), MediaId(1112)],
+            include: vec![MediaId(2111), MediaId(2112)],
             offset: Some(11111),
             order: Some(WpApiParamOrder::Desc),
             orderby: Some(WpApiParamPostsOrderBy::Slug),
-            parent: vec![PostId(44444), PostId(44445)],
-            parent_exclude: vec![PostId(55555), PostId(55556)],
+            parent: vec![MediaId(44444), MediaId(44445)],
+            parent_exclude: vec![MediaId(55555), MediaId(55556)],
             search_columns: vec![
                 WpApiParamPostsSearchColumn::PostContent,
                 WpApiParamPostsSearchColumn::PostExcerpt,
             ],
             slug: vec!["sl_1".to_string(), "sl_2".to_string()],
-            status: vec![MediaStatus::Draft, MediaStatus::Future],
+            status: vec![
+                MediaStatus::Inherit,
+                MediaStatus::Private,
+                MediaStatus::Trash,
+            ],
             media_type: Some(MediaTypeParam::Image),
             mime_type: Some("image/jpeg".to_string()),
         }

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -1,0 +1,300 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    media::{
+        MediaListParams, SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
+        SparseMediaFieldWithViewContext,
+    },
+    SparseField,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum MediaRequest {
+    #[contextual_paged(url = "/media", params = &MediaListParams, output = Vec<crate::media::SparseMedia>, filter_by = crate::media::SparseMediaField)]
+    List,
+}
+
+impl DerivedRequest for MediaRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+impl SparseField for SparseMediaFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostId => "post",
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseMediaFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseMediaFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostId => "post",
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate,
+        media::{MediaStatus, MediaTypeParam},
+        posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+        request::endpoint::{
+            tests::{fixture_api_base_url, validate_wp_v2_endpoint},
+            ApiBaseUrl,
+        },
+        UserId, WpApiParamOrder,
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[case(MediaListParams::default(), "")]
+    #[case(generate!(MediaListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(MediaListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(MediaListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(MediaListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
+    #[case(generate!(MediaListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(MediaListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
+    #[case(generate!(MediaListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
+    #[case(generate!(MediaListParams, (offset, Some(2))), "offset=2")]
+    #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(MediaListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), "orderby=author")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Date))), "orderby=date")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))), "orderby=id")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Include))), "orderby=include")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::IncludeSlugs))), "orderby=include_slugs")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Modified))), "orderby=modified")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Parent))), "orderby=parent")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
+    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
+    #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt, WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_content%2Cpost_excerpt%2Cpost_title")]
+    #[case(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit])), "status=inherit")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Draft])), "status=draft")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Future])), "status=future")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Pending])), "status=pending")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Private])), "status=private")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Publish])), "status=publish")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Custom("foo".to_string())])), "status=foo")]
+    #[case(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Draft, MediaStatus::Future, MediaStatus::Pending, MediaStatus::Private, MediaStatus::Publish, MediaStatus::Custom("foo".to_string())])), "status=inherit%2Cdraft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(MediaListParams, (media_type, Some(MediaTypeParam::Image))), "media_type=image")]
+    #[case(generate!(MediaListParams, (mime_type, Some("image/jpeg".to_string()))), "mime_type=image%2Fjpeg")]
+    #[case(
+        media_list_params_with_all_fields(),
+        EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS
+    )]
+    fn list_posts(
+        endpoint: MediaRequestEndpoint,
+        #[case] params: MediaListParams,
+        #[case] expected_additional_params: &str,
+    ) {
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/media?context={}", context)
+            } else {
+                format!("/media?context={}&{}", context, expected_additional_params)
+            }
+        };
+        validate_wp_v2_endpoint(
+            endpoint.list_with_edit_context(&params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(&params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(&params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(MediaListParams::default(), &[], "/media?context=edit&_fields=")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithEditContext::Author], "/media?context=edit&orderby=author&_fields=author")]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT, &format!("/media?context=edit&{}&{}", EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT))]
+    fn filter_list_post_with_edit_context(
+        endpoint: MediaRequestEndpoint,
+        #[case] params: MediaListParams,
+        #[case] fields: &[SparseMediaFieldWithEditContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_edit_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(MediaListParams::default(), &[], "/media?context=embed&_fields=")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithEmbedContext::Author], "/media?context=embed&orderby=author&_fields=author")]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT, &format!("/media?context=embed&{}&{}", EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT))]
+    fn filter_list_post_with_embed_context(
+        endpoint: MediaRequestEndpoint,
+        #[case] params: MediaListParams,
+        #[case] fields: &[SparseMediaFieldWithEmbedContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_embed_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(MediaListParams::default(), &[], "/media?context=view&_fields=")]
+    #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithViewContext::Author], "/media?context=view&orderby=author&_fields=author")]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT, &format!("/media?context=view&{}&{}", EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_list_post_with_view_context(
+        endpoint: MediaRequestEndpoint,
+        #[case] params: MediaListParams,
+        #[case] fields: &[SparseMediaFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_view_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_MEDIA_LIST_PARAMS_WITH_ALL_FIELDS: &str =
+        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&parent=44444%2C44445&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&parent_exclude=55555%2C55556&media_type=image&mime_type=image%2Fjpeg";
+    fn media_list_params_with_all_fields() -> MediaListParams {
+        MediaListParams {
+            page: Some(11),
+            per_page: Some(22),
+            search: Some("s_q".to_string()),
+            after: Some("d_a".to_string()),
+            modified_after: Some("d_m_a".to_string()),
+            author: vec![UserId(111), UserId(112)],
+            author_exclude: vec![UserId(211), UserId(212)],
+            before: Some("d_b".to_string()),
+            modified_before: Some("d_m_b".to_string()),
+            exclude: vec![PostId(1111), PostId(1112)],
+            include: vec![PostId(2111), PostId(2112)],
+            offset: Some(11111),
+            order: Some(WpApiParamOrder::Desc),
+            orderby: Some(WpApiParamPostsOrderBy::Slug),
+            parent: vec![PostId(44444), PostId(44445)],
+            parent_exclude: vec![PostId(55555), PostId(55556)],
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+            ],
+            slug: vec!["sl_1".to_string(), "sl_2".to_string()],
+            status: vec![MediaStatus::Draft, MediaStatus::Future],
+            media_type: Some(MediaTypeParam::Image),
+            mime_type: Some("image/jpeg".to_string()),
+        }
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT: &str = "_fields=id%2Cdate%2Cdate_gmt%2Cguid%2Clink%2Cmodified%2Cmodified_gmt%2Cslug%2Cstatus%2Ctype%2Cpassword%2Cpermalink_template%2Cgenerated_slug%2Ctitle%2Cauthor%2Ccomment_status%2Cping_status%2Ctemplate%2Calt_text%2Ccaption%2Cdescription%2Cmedia_type%2Cmime_type%2Cmedia_details%2Cpost%2Csource_url%2Cmissing_image_sizes";
+    const ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT: &[SparseMediaFieldWithEditContext; 27] = &[
+        SparseMediaFieldWithEditContext::Id,
+        SparseMediaFieldWithEditContext::Date,
+        SparseMediaFieldWithEditContext::DateGmt,
+        SparseMediaFieldWithEditContext::Guid,
+        SparseMediaFieldWithEditContext::Link,
+        SparseMediaFieldWithEditContext::Modified,
+        SparseMediaFieldWithEditContext::ModifiedGmt,
+        SparseMediaFieldWithEditContext::Slug,
+        SparseMediaFieldWithEditContext::Status,
+        SparseMediaFieldWithEditContext::PostType,
+        SparseMediaFieldWithEditContext::Password,
+        SparseMediaFieldWithEditContext::PermalinkTemplate,
+        SparseMediaFieldWithEditContext::GeneratedSlug,
+        SparseMediaFieldWithEditContext::Title,
+        SparseMediaFieldWithEditContext::Author,
+        SparseMediaFieldWithEditContext::CommentStatus,
+        SparseMediaFieldWithEditContext::PingStatus,
+        SparseMediaFieldWithEditContext::Template,
+        SparseMediaFieldWithEditContext::AltText,
+        SparseMediaFieldWithEditContext::Caption,
+        SparseMediaFieldWithEditContext::Description,
+        SparseMediaFieldWithEditContext::MediaType,
+        SparseMediaFieldWithEditContext::MimeType,
+        SparseMediaFieldWithEditContext::MediaDetails,
+        SparseMediaFieldWithEditContext::PostId,
+        SparseMediaFieldWithEditContext::SourceUrl,
+        SparseMediaFieldWithEditContext::MissingImageSizes,
+    ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT: &str =
+        "_fields=id%2Cdate%2Clink%2Cslug%2Ctype%2Ctitle%2Cauthor%2Calt_text%2Ccaption%2Cmedia_type%2Cmime_type%2Cmedia_details%2Csource_url";
+    const ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT: &[SparseMediaFieldWithEmbedContext; 13] = &[
+        SparseMediaFieldWithEmbedContext::Id,
+        SparseMediaFieldWithEmbedContext::Date,
+        SparseMediaFieldWithEmbedContext::Link,
+        SparseMediaFieldWithEmbedContext::Slug,
+        SparseMediaFieldWithEmbedContext::PostType,
+        SparseMediaFieldWithEmbedContext::Title,
+        SparseMediaFieldWithEmbedContext::Author,
+        SparseMediaFieldWithEmbedContext::AltText,
+        SparseMediaFieldWithEmbedContext::Caption,
+        SparseMediaFieldWithEmbedContext::MediaType,
+        SparseMediaFieldWithEmbedContext::MimeType,
+        SparseMediaFieldWithEmbedContext::MediaDetails,
+        SparseMediaFieldWithEmbedContext::SourceUrl,
+    ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT: &str = "_fields=id%2Cdate%2Cdate_gmt%2Cguid%2Clink%2Cmodified%2Cmodified_gmt%2Cslug%2Cstatus%2Ctype%2Ctitle%2Cauthor%2Ccomment_status%2Cping_status%2Ctemplate%2Calt_text%2Ccaption%2Cdescription%2Cmedia_type%2Cmime_type%2Cmedia_details%2Cpost%2Csource_url";
+    const ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT: &[SparseMediaFieldWithViewContext; 23] = &[
+        SparseMediaFieldWithViewContext::Id,
+        SparseMediaFieldWithViewContext::Date,
+        SparseMediaFieldWithViewContext::DateGmt,
+        SparseMediaFieldWithViewContext::Guid,
+        SparseMediaFieldWithViewContext::Link,
+        SparseMediaFieldWithViewContext::Modified,
+        SparseMediaFieldWithViewContext::ModifiedGmt,
+        SparseMediaFieldWithViewContext::Slug,
+        SparseMediaFieldWithViewContext::Status,
+        SparseMediaFieldWithViewContext::PostType,
+        SparseMediaFieldWithViewContext::Title,
+        SparseMediaFieldWithViewContext::Author,
+        SparseMediaFieldWithViewContext::CommentStatus,
+        SparseMediaFieldWithViewContext::PingStatus,
+        SparseMediaFieldWithViewContext::Template,
+        SparseMediaFieldWithViewContext::AltText,
+        SparseMediaFieldWithViewContext::Caption,
+        SparseMediaFieldWithViewContext::Description,
+        SparseMediaFieldWithViewContext::MediaType,
+        SparseMediaFieldWithViewContext::MimeType,
+        SparseMediaFieldWithViewContext::MediaDetails,
+        SparseMediaFieldWithViewContext::PostId,
+        SparseMediaFieldWithViewContext::SourceUrl,
+    ];
+
+    #[fixture]
+    fn endpoint(fixture_api_base_url: Arc<ApiBaseUrl>) -> MediaRequestEndpoint {
+        MediaRequestEndpoint::new(fixture_api_base_url)
+    }
+}

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -55,7 +55,7 @@ mod tests {
     use crate::{
         generate,
         media::{MediaId, MediaStatus, MediaTypeParam},
-        posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+        posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
         request::endpoint::{
             tests::{fixture_api_base_url, validate_wp_v2_endpoint},
             ApiBaseUrl,
@@ -91,8 +91,8 @@ mod tests {
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Relevance))), "orderby=relevance")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Slug))), "orderby=slug")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Title))), "orderby=title")]
-    #[case(generate!(MediaListParams, (parent, vec![MediaId(44444), MediaId(44445)])), "parent=44444%2C44445")]
-    #[case(generate!(MediaListParams, (parent_exclude, vec![MediaId(55555), MediaId(55556)])), "parent_exclude=55555%2C55556")]
+    #[case(generate!(MediaListParams, (parent, vec![PostId(44444), PostId(44445)])), "parent=44444%2C44445")]
+    #[case(generate!(MediaListParams, (parent_exclude, vec![PostId(55555), PostId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
     #[case(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
@@ -201,8 +201,8 @@ mod tests {
             offset: Some(11111),
             order: Some(WpApiParamOrder::Desc),
             orderby: Some(WpApiParamPostsOrderBy::Slug),
-            parent: vec![MediaId(44444), MediaId(44445)],
-            parent_exclude: vec![MediaId(55555), MediaId(55556)],
+            parent: vec![PostId(44444), PostId(44445)],
+            parent_exclude: vec![PostId(55555), PostId(55556)],
             search_columns: vec![
                 WpApiParamPostsSearchColumn::PostContent,
                 WpApiParamPostsSearchColumn::PostExcerpt,

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 use wp_api::{
-    posts::{CategoryId, MediaId, PostId, TagId},
+    media::MediaId,
+    posts::{CategoryId, PostId, TagId},
     request::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },

--- a/wp_api_integration_tests/tests/test_media_immut.rs
+++ b/wp_api_integration_tests/tests/test_media_immut.rs
@@ -1,0 +1,133 @@
+use rstest::*;
+use rstest_reuse::{self, apply, template};
+use serial_test::parallel;
+use wp_api::{
+    generate,
+    media::{
+        JsonValue, MediaListParams, SparseMediaFieldWithEditContext,
+        SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
+    },
+};
+use wp_api_integration_tests::{api_client, AssertResponse};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: MediaListParams) {
+    let media_list = api_client()
+        .media()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response()
+        .data;
+    // Temporary checks to see if JsonValue implementation is working
+    media_list.into_iter().for_each(|m| {
+        match m.media_details {
+            JsonValue::Object(hash_map) => {
+                //let w = hash_map.get("width").expect("All media in our test site seems to return a width, but this is probably not guaranteed.");
+                let w = hash_map.get("width");
+                if w.is_some() {
+                    let w = w.unwrap();
+                    match w {
+                        JsonValue::Number(json_number) => {
+                            println!("width: {:#?}", json_number);
+                        }
+                        _ => panic!("Width should be a number"),
+                    }
+                } else {
+                    println!("{:#?}", hash_map);
+                }
+            }
+            _ => panic!("Media details should be a JSON object"),
+        }
+    });
+}
+
+#[template]
+#[rstest]
+#[case::default(MediaListParams::default())]
+#[case::page(generate!(MediaListParams, (page, Some(1))))]
+pub fn list_cases(#[case] params: MediaListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_media_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_media_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_media_field_with_view_context_test_cases!();
+
+    #[apply(sparse_media_field_with_edit_context_test_cases)]
+    #[case(&[SparseMediaFieldWithEditContext::Id, SparseMediaFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_media_with_edit_context(
+        #[case] fields: &[SparseMediaFieldWithEditContext],
+        #[values(
+            MediaListParams::default(),
+            generate!(MediaListParams, (page, Some(2))),
+            generate!(MediaListParams, (search, Some("foo".to_string())))
+        )]
+        params: MediaListParams,
+    ) {
+        api_client()
+            .media()
+            .filter_list_with_edit_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|media| {
+                media.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_media_field_with_embed_context_test_cases)]
+    #[case(&[SparseMediaFieldWithEmbedContext::Id, SparseMediaFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_media_with_embed_context(
+        #[case] fields: &[SparseMediaFieldWithEmbedContext],
+        #[values(
+            MediaListParams::default(),
+            generate!(MediaListParams, (page, Some(2))),
+            generate!(MediaListParams, (search, Some("foo".to_string())))
+        )]
+        params: MediaListParams,
+    ) {
+        api_client()
+            .media()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|media| {
+                media.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_media_field_with_view_context_test_cases)]
+    #[case(&[SparseMediaFieldWithViewContext::Id, SparseMediaFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_media_with_view_context(
+        #[case] fields: &[SparseMediaFieldWithViewContext],
+        #[values(
+            MediaListParams::default(),
+            generate!(MediaListParams, (page, Some(2))),
+            generate!(MediaListParams, (search, Some("foo".to_string())))
+        )]
+        params: MediaListParams,
+    ) {
+        api_client()
+            .media()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|media| {
+                media.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+}

--- a/wp_api_integration_tests/tests/test_media_immut.rs
+++ b/wp_api_integration_tests/tests/test_media_immut.rs
@@ -4,9 +4,10 @@ use serial_test::parallel;
 use wp_api::{
     generate,
     media::{
-        JsonValue, MediaListParams, SparseMediaFieldWithEditContext,
-        SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
+        MediaListParams, SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
+        SparseMediaFieldWithViewContext,
     },
+    JsonValue,
 };
 use wp_api_integration_tests::{api_client, AssertResponse};
 
@@ -29,7 +30,7 @@ async fn list_with_edit_context(#[case] params: MediaListParams) {
                 if w.is_some() {
                     let w = w.unwrap();
                     match w {
-                        JsonValue::Number(json_number) => {
+                        JsonValue::Int(json_number) => {
                             println!("width: {:#?}", json_number);
                         }
                         _ => panic!("Width should be a number"),

--- a/wp_api_integration_tests/tests/test_media_immut.rs
+++ b/wp_api_integration_tests/tests/test_media_immut.rs
@@ -7,7 +7,7 @@ use wp_api::{
         MediaId, MediaListParams, MediaStatus, MediaTypeParam, SparseMediaFieldWithEditContext,
         SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
     },
-    posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+    posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
     WpApiParamOrder,
 };
 use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
@@ -91,8 +91,8 @@ async fn paginate_list_posts_with_edit_context(#[case] params: MediaListParams) 
 #[case::offset(generate!(MediaListParams, (offset, Some(2))))]
 #[case::order(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))))]
 #[case::orderby(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))))]
-#[case::parent(generate!(MediaListParams, (parent, vec![MediaId(1), MediaId(2)])))]
-#[case::parent_exclude(generate!(MediaListParams, (parent, vec![MediaId(1), MediaId(2)])))]
+#[case::parent(generate!(MediaListParams, (parent, vec![PostId(1), PostId(2)])))]
+#[case::parent_exclude(generate!(MediaListParams, (parent, vec![PostId(1), PostId(2)])))]
 #[case::search_columns(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt])))]
 #[case::slug(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
 #[case::status(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Private, MediaStatus::Trash])))]

--- a/wp_api_integration_tests/tests/test_media_immut.rs
+++ b/wp_api_integration_tests/tests/test_media_immut.rs
@@ -4,50 +4,100 @@ use serial_test::parallel;
 use wp_api::{
     generate,
     media::{
-        MediaListParams, SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
-        SparseMediaFieldWithViewContext,
+        MediaId, MediaListParams, MediaStatus, MediaTypeParam, SparseMediaFieldWithEditContext,
+        SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
     },
-    JsonValue,
+    posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+    WpApiParamOrder,
 };
-use wp_api_integration_tests::{api_client, AssertResponse};
+use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
 async fn list_with_edit_context(#[case] params: MediaListParams) {
-    let media_list = api_client()
+    api_client()
         .media()
         .list_with_edit_context(&params)
         .await
-        .assert_response()
-        .data;
-    // Temporary checks to see if JsonValue implementation is working
-    media_list.into_iter().for_each(|m| {
-        match m.media_details {
-            JsonValue::Object(hash_map) => {
-                //let w = hash_map.get("width").expect("All media in our test site seems to return a width, but this is probably not guaranteed.");
-                let w = hash_map.get("width");
-                if w.is_some() {
-                    let w = w.unwrap();
-                    match w {
-                        JsonValue::Int(json_number) => {
-                            println!("width: {:#?}", json_number);
-                        }
-                        _ => panic!("Width should be a number"),
-                    }
-                } else {
-                    println!("{:#?}", hash_map);
-                }
-            }
-            _ => panic!("Media details should be a JSON object"),
-        }
-    });
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: MediaListParams) {
+    api_client()
+        .media()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: MediaListParams) {
+    api_client()
+        .media()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+#[case(MediaListParams { per_page: Some(1), ..Default::default() })]
+#[case(MediaListParams { per_page: Some(1), order: Some(WpApiParamOrder::Desc), ..Default::default() })]
+#[case(MediaListParams { per_page: Some(1), orderby: Some(WpApiParamPostsOrderBy::Modified), ..Default::default() })]
+async fn paginate_list_posts_with_edit_context(#[case] params: MediaListParams) {
+    let first_page_response = api_client()
+        .media()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+    assert!(!first_page_response.data.is_empty());
+    let next_page_params = first_page_response.next_page_params.unwrap();
+    let next_page_response = api_client()
+        .media()
+        .list_with_edit_context(&next_page_params)
+        .await
+        .assert_response();
+    assert!(!next_page_response.data.is_empty());
+    let prev_page_params = next_page_response.prev_page_params.unwrap();
+    let prev_page_response = api_client()
+        .media()
+        .list_with_edit_context(&prev_page_params)
+        .await
+        .assert_response();
+    assert!(!prev_page_response.data.is_empty());
 }
 
 #[template]
 #[rstest]
 #[case::default(MediaListParams::default())]
 #[case::page(generate!(MediaListParams, (page, Some(1))))]
+#[case::per_page(generate!(MediaListParams, (per_page, Some(3))))]
+#[case::search(generate!(MediaListParams, (search, Some("foo".to_string()))))]
+#[case::after(generate!(MediaListParams, (after, Some("2020-08-14 17:00:00.000".to_string()))))]
+#[case::modified_after(generate!(MediaListParams, (modified_after, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::author(generate!(MediaListParams, (author, vec![FIRST_USER_ID, SECOND_USER_ID])))]
+#[case::author_exclude(generate!(MediaListParams, (author_exclude, vec![SECOND_USER_ID])))]
+#[case::before(generate!(MediaListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))))]
+#[case::modified_before(generate!(MediaListParams, (modified_before, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::exclude(generate!(MediaListParams, (exclude, vec![MediaId(1), MediaId(2)])))]
+#[case::include(generate!(MediaListParams, (include, vec![MediaId(1)])))]
+#[case::offset(generate!(MediaListParams, (offset, Some(2))))]
+#[case::order(generate!(MediaListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))))]
+#[case::parent(generate!(MediaListParams, (parent, vec![MediaId(1), MediaId(2)])))]
+#[case::parent_exclude(generate!(MediaListParams, (parent, vec![MediaId(1), MediaId(2)])))]
+#[case::search_columns(generate!(MediaListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt])))]
+#[case::slug(generate!(MediaListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+#[case::status(generate!(MediaListParams, (status, vec![MediaStatus::Inherit, MediaStatus::Private, MediaStatus::Trash])))]
+#[case::media_type(generate!(MediaListParams, (media_type, Some(MediaTypeParam::Image))))]
+#[case::mime_type(generate!(MediaListParams, (mime_type, Some("image/jpeg".to_string()))))]
 pub fn list_cases(#[case] params: MediaListParams) {}
 
 mod filter {


### PR DESCRIPTION
This PR implements list [`/media` endpoint](https://developer.wordpress.org/rest-api/reference/media/#list-media) by mostly following the established patterns. Here are a few things worth noting:

* 0b8b06c874953dfeb17d9b2c54be91e6fa05f10d implements `FromStr` for `PluginStatus`. I was planning to work on `/plugins` pagination and later realized that the endpoint doesn't support pagination. Since this is a useful addition, I didn't want to throw it away and decided to include in this PR.
* `MediaId` was temporarily implemented in `wp_api/src/posts.rs` but now moved to `wp_api/src/media.rs`.
* A new `JsonValue` type is introduced. The `media_details` field in `/media` has a dynamic type without a clear set of fields. This new `JsonValue` type will be used in such cases. @jkmassel mentioned that he had to implement something similar while working in #287 and we agreed that this generic version is a reasonable addition.
* The PR implements both `MediaType` & `MediaTypeParam` types. This is because the server accepts values such as `image, video, text, application, audio` to filter the media list, but it returns `image` or  `file`.
* There is likely an error in the `status` of [`/media` documentation](https://developer.wordpress.org/rest-api/reference/media/). The `Schema` section indicates `status` is `One of: publish, future, draft, pending, private`, however using `status=publish` will result in `InvalidParam` error saying `status[0] is not one of inherit, private, and trash.`. Our test site also returns `inherit` for every media object. That's why `MediaStatus` is only implemented to have `inherit, private, trash` variants - with the addition of `Custom(String)` variant for fallback.