### PR TITLE
Retrieve `/media` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -1,9 +1,14 @@
 package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import uniffi.wp_api.MediaListParams
+import uniffi.wp_api.SparseMediaFieldWithEditContext
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertNotNull
+
+private const val MEDIA_ID_611 = 611
 
 class MediaEndpointTest {
     private val testCredentials = TestCredentials.INSTANCE
@@ -19,5 +24,43 @@ class MediaEndpointTest {
             requestBuilder.media().listWithEditContext(params = MediaListParams())
         }.assertSuccessAndRetrieveData().data
         assert(mediaList.isNotEmpty())
+    }
+
+    @Test
+    fun testRetrieveMediaRequest() = runTest {
+        val media = client.request { requestBuilder ->
+            requestBuilder.media().retrieveWithEditContext(MEDIA_ID_611)
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(media)
+    }
+
+    @Test
+    fun testFilterMediaListRequest() = runTest {
+        val postList = client.request { requestBuilder ->
+            requestBuilder.media().filterListWithEditContext(
+                params = MediaListParams(),
+                fields = listOf(
+                    SparseMediaFieldWithEditContext.DATE,
+                    SparseMediaFieldWithEditContext.TITLE
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assert(postList.isNotEmpty())
+        assertNull(postList.first().slug)
+    }
+
+    @Test
+    fun testFilterRetrieveMediaRequest() = runTest {
+        val sparseMedia = client.request { requestBuilder ->
+            requestBuilder.media().filterRetrieveWithEditContext(
+                mediaId = MEDIA_ID_611,
+                fields = listOf(
+                    SparseMediaFieldWithEditContext.DATE,
+                    SparseMediaFieldWithEditContext.TITLE
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(sparseMedia)
+        assertNull(sparseMedia.slug)
     }
 }

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -1,8 +1,8 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::{
     media::{
-        MediaListParams, SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
-        SparseMediaFieldWithViewContext,
+        MediaId, MediaListParams, SparseMediaFieldWithEditContext,
+        SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
     },
     SparseField,
 };
@@ -12,6 +12,8 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum MediaRequest {
     #[contextual_paged(url = "/media", params = &MediaListParams, output = Vec<crate::media::SparseMedia>, filter_by = crate::media::SparseMediaField)]
     List,
+    #[contextual_get(url = "/media/<media_id>", output = crate::media::SparseMedia, filter_by = crate::media::SparseMediaField)]
+    Retrieve,
 }
 
 impl DerivedRequest for MediaRequest {
@@ -180,6 +182,58 @@ mod tests {
         validate_wp_v2_endpoint(
             endpoint.filter_list_with_view_context(&params, fields),
             expected_path,
+        );
+    }
+
+    #[rstest]
+    fn retrieve_media(endpoint: MediaRequestEndpoint) {
+        let media_id = MediaId(77);
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(&media_id),
+            "/media/77?context=edit",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(&media_id),
+            "/media/77?context=embed",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(&media_id),
+            "/media/77?context=view",
+        );
+    }
+
+    #[rstest]
+    fn filter_retrieve_media(endpoint: MediaRequestEndpoint) {
+        let media_id = MediaId(77);
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_edit_context(
+                &media_id,
+                &[
+                    SparseMediaFieldWithEditContext::Date,
+                    SparseMediaFieldWithEditContext::Guid,
+                ],
+            ),
+            "/media/77?context=edit&_fields=date%2Cguid",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_embed_context(
+                &media_id,
+                &[
+                    SparseMediaFieldWithEmbedContext::Link,
+                    SparseMediaFieldWithEmbedContext::PostType,
+                ],
+            ),
+            "/media/77?context=embed&_fields=link%2Ctype",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_view_context(
+                &media_id,
+                &[
+                    SparseMediaFieldWithViewContext::AltText,
+                    SparseMediaFieldWithViewContext::Template,
+                ],
+            ),
+            "/media/77?context=view&_fields=alt_text%2Ctemplate",
         );
     }
 

--- a/wp_api_integration_tests/tests/test_media_immut.rs
+++ b/wp_api_integration_tests/tests/test_media_immut.rs
@@ -10,7 +10,9 @@ use wp_api::{
     posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
     WpApiParamOrder,
 };
-use wp_api_integration_tests::{api_client, AssertResponse, FIRST_USER_ID, SECOND_USER_ID};
+use wp_api_integration_tests::{
+    api_client, AssertResponse, FIRST_USER_ID, MEDIA_ID_611, SECOND_USER_ID,
+};
 
 #[tokio::test]
 #[apply(list_cases)]
@@ -41,6 +43,36 @@ async fn list_with_view_context(#[case] params: MediaListParams) {
     api_client()
         .media()
         .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .media()
+        .retrieve_with_edit_context(&MEDIA_ID_611)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .media()
+        .retrieve_with_embed_context(&MEDIA_ID_611)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .media()
+        .retrieve_with_view_context(&MEDIA_ID_611)
         .await
         .assert_response();
 }
@@ -132,6 +164,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_media_field_with_edit_context_test_cases)]
+    #[case(&[SparseMediaFieldWithEditContext::Id, SparseMediaFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_media_with_edit_context(
+        #[case] fields: &[SparseMediaFieldWithEditContext],
+    ) {
+        let media = api_client()
+            .media()
+            .filter_retrieve_with_edit_context(&MEDIA_ID_611, fields)
+            .await
+            .assert_response()
+            .data;
+        media.assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
     #[apply(sparse_media_field_with_embed_context_test_cases)]
     #[case(&[SparseMediaFieldWithEmbedContext::Id, SparseMediaFieldWithEmbedContext::Author])]
     #[tokio::test]
@@ -157,6 +205,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_media_field_with_embed_context_test_cases)]
+    #[case(&[SparseMediaFieldWithEmbedContext::Id, SparseMediaFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_media_with_embed_context(
+        #[case] fields: &[SparseMediaFieldWithEmbedContext],
+    ) {
+        let media = api_client()
+            .media()
+            .filter_retrieve_with_embed_context(&MEDIA_ID_611, fields)
+            .await
+            .assert_response()
+            .data;
+        media.assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
     #[apply(sparse_media_field_with_view_context_test_cases)]
     #[case(&[SparseMediaFieldWithViewContext::Id, SparseMediaFieldWithViewContext::Author])]
     #[tokio::test]
@@ -180,5 +244,21 @@ mod filter {
             .for_each(|media| {
                 media.assert_that_instance_fields_nullability_match_provided_fields(fields)
             });
+    }
+
+    #[apply(sparse_media_field_with_view_context_test_cases)]
+    #[case(&[SparseMediaFieldWithViewContext::Id, SparseMediaFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_media_with_view_context(
+        #[case] fields: &[SparseMediaFieldWithViewContext],
+    ) {
+        let media = api_client()
+            .media()
+            .filter_retrieve_with_view_context(&MEDIA_ID_611, fields)
+            .await
+            .assert_response()
+            .data;
+        media.assert_that_instance_fields_nullability_match_provided_fields(fields);
     }
 }


### PR DESCRIPTION
Follows established patterns to implement [retrieve `/media` endpoint.](https://developer.wordpress.org/rest-api/reference/media/#retrieve-a-media-item)