### PR TITLE
[Tooling] Call `use-bot-for-git` in the release script 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,13 +68,13 @@ steps:
           - target/libwordpressFFI.xcframework.zip
           - native/swift/Sources/wordpress-api-wrapper/wp_api.swift
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
       - label: ":swift: :darwin: Build + Test on Simulators"
         command: .buildkite/swift-test.sh run_tests
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
@@ -82,7 +82,7 @@ steps:
       - label: ":swift: :darwin: Build for Real Devices"
         command: .buildkite/swift-test.sh build_for_real_device
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
@@ -90,7 +90,7 @@ steps:
       - label: ":swift: :cocoapods: Validate CocoaPods Support"
         command: .buildkite/validate-cocoapods.sh
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
@@ -106,7 +106,7 @@ steps:
           make lint-swift
         depends_on: xcframework
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
       - label: ":swift: Example Apps"
@@ -124,7 +124,7 @@ steps:
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         env:
-          IMAGE_ID: xcode-16.0-v7
+          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
   #
@@ -228,7 +228,7 @@ steps:
     depends_on: swift
     plugins: [$CI_TOOLKIT]
     env:
-      IMAGE_ID: xcode-16.0-v7
+      IMAGE_ID: $IMAGE_ID
     agents:
       queue: mac
     if: build.env("NEW_VERSION") != null

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  IMAGE_ID: $IMAGE_ID
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   matrix: &wordpress_version_matrix
@@ -67,30 +70,22 @@ steps:
         artifact_paths:
           - target/libwordpressFFI.xcframework.zip
           - native/swift/Sources/wordpress-api-wrapper/wp_api.swift
-        env:
-          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
       - label: ":swift: :darwin: Build + Test on Simulators"
         command: .buildkite/swift-test.sh run_tests
-        env:
-          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
           queue: mac
       - label: ":swift: :darwin: Build for Real Devices"
         command: .buildkite/swift-test.sh build_for_real_device
-        env:
-          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
           queue: mac
       - label: ":swift: :cocoapods: Validate CocoaPods Support"
         command: .buildkite/validate-cocoapods.sh
-        env:
-          IMAGE_ID: $IMAGE_ID
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
         agents:
@@ -105,8 +100,6 @@ steps:
           echo "--- :swift: Swiftlint"
           make lint-swift
         depends_on: xcframework
-        env:
-          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
       - label: ":swift: Example Apps"
@@ -123,8 +116,6 @@ steps:
           make swift-example-app-ios
         depends_on: xcframework
         plugins: [$CI_TOOLKIT]
-        env:
-          IMAGE_ID: $IMAGE_ID
         agents:
           queue: mac
   #
@@ -227,8 +218,6 @@ steps:
     command: .buildkite/release.sh $NEW_VERSION
     depends_on: swift
     plugins: [$CI_TOOLKIT]
-    env:
-      IMAGE_ID: $IMAGE_ID
     agents:
       queue: mac
     if: build.env("NEW_VERSION") != null

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -7,6 +7,9 @@ fi
 
 set -euo pipefail
 
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
 echo "--- :rust: Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
 

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,7 +1,12 @@
 #!/bin/sh
 
- # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
- # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"
- export TEST_COLLECTOR="test-collector#v1.10.2"
+XCODE_VERSION="16.0-v7"
+CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
+TEST_COLLECTOR_VERSION="v1.10.2"
+
+export IMAGE_ID="xcode-$XCODE_VERSION"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"
+export TEST_COLLECTOR="test-collector#$TEST_COLLECTOR_VERSION"


### PR DESCRIPTION
I've noticed we're using a SSH deploy key with write permission so that we can [`git push` during the release process](https://github.com/Automattic/wordpress-rs/blob/b54a394bb4cc2155f9d136f6658a35252589585d/fastlane/Fastfile#L77).

This PR adds a call to `use-bot-for-git` in the beginning of the release script so that we can perform the `git push` operation in our trusted environment and revert this repo's key to read-only.
While at it, I've also moved the Xcode version to `shared-pipeline-vars` (I considered using `16.1` already but I'll let that to the team).

See also:
- 554-gh-Automattic/buildkite-ci (⚠️ **needs to be merged + deployed before merging the present PR**)
- 39-gh-Automattic/apps-infra-plans
- paaHJt-6EP-p2
