### PR TITLE
Export `parse_as_response_type` functions

### DIFF
--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -39,6 +39,7 @@ testing {
             dependencies {
                 implementation(project())
 
+                implementation(libs.okhttp)
                 implementation(rootProject.libs.kotlin.test)
                 implementation(rootProject.libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinx.serialization)

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ManualParserTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ManualParserTest.kt
@@ -1,0 +1,27 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.UniffiWpApiRequestBuilder
+import uniffi.wp_api.UserListParams
+import uniffi.wp_api.parseAsUsersRequestListWithEditContextResponse
+import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
+
+class ManualParserTest {
+    private val testCredentials = TestCredentials.INSTANCE
+    private val siteUrl = testCredentials.parsedSiteUrl
+    private val authentication = wpAuthenticationFromUsernameAndPassword(
+        username = testCredentials.adminUsername, password = testCredentials.adminPassword
+    )
+    private val requestExecutor by lazy { WpRequestExecutor() }
+
+    @Test
+    fun testUserListManualRequestAndParsing() = runTest {
+        val requestBuilder = UniffiWpApiRequestBuilder(siteUrl, authentication)
+        val userListRequest = requestBuilder.users().listWithEditContext(UserListParams())
+        val userListResponse = requestExecutor.execute(userListRequest)
+        val userList = parseAsUsersRequestListWithEditContextResponse(userListResponse).data
+        assertEquals(NUMBER_OF_USERS, userList.count())
+    }
+}

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -33,6 +33,7 @@ fn generate_async_request_executor(
     parsed_enum: &ParsedEnum,
     crate_config: &CrateConfig,
 ) -> TokenStream {
+    let crate_ident = &config.crate_ident;
     let static_api_base_url_type = &config.static_types.api_base_url;
     let static_wp_authentication_type = &config.static_types.wp_authentication;
     let static_request_executor_type = &crate_config.request_executor;
@@ -94,6 +95,7 @@ fn generate_async_request_executor(
                 &variant.variant_ident,
                 &context_and_filter_handler,
             );
+            let fn_parse_as_response_type_ident = ident_fn_parse_as_response_type(&response_type_ident);
             let response_params_type = response_params_type(variant.attr.params.as_ref(), variant.attr.request_type);
             let response_pagination_params_fields = response_params_type.as_ref().map(|p| {
                 quote! {
@@ -126,10 +128,10 @@ fn generate_async_request_executor(
                 pub struct #response_type_ident {
                     pub data: #output_type,
                     #[serde(skip)]
-                    pub header_map: std::sync::Arc<crate::request::WpNetworkHeaderMap>,
+                    pub header_map: std::sync::Arc<#crate_ident::request::WpNetworkHeaderMap>,
                     #response_pagination_params_fields
                 }
-                impl From<#response_type_ident> for crate::request::ParsedResponse<#output_type, #parsed_response_params_type> {
+                impl From<#response_type_ident> for #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type> {
                     fn from(value: #response_type_ident) -> Self {
                         Self {
                             data: value.data,
@@ -138,14 +140,19 @@ fn generate_async_request_executor(
                         }
                     }
                 }
-                impl From<crate::request::ParsedResponse<#output_type, #parsed_response_params_type>> for #response_type_ident {
-                    fn from(value: crate::request::ParsedResponse<#output_type, #parsed_response_params_type>) -> Self {
+                impl From<#crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type>> for #response_type_ident {
+                    fn from(value: #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type>) -> Self {
                         Self {
                             data: value.data,
                             header_map: value.header_map,
                             #from_parsed_response_impl_for_pagination_params
                         }
                     }
+                }
+
+                #[uniffi::export]
+                fn #fn_parse_as_response_type_ident(response: #crate_ident::request::WpNetworkResponse) -> Result<#response_type_ident, #error_type> {
+                    response.parse()
                 }
             }
         })

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -410,6 +410,13 @@ pub fn ident_response_type(
     )
 }
 
+pub fn ident_fn_parse_as_response_type(response_type_ident: &Ident) -> Ident {
+    format_ident!(
+        "parse_as_{}",
+        response_type_ident.to_string().to_case(Case::Snake)
+    )
+}
+
 pub fn response_params_type(
     params_type: Option<&ParamsType>,
     request_type: RequestType,


### PR DESCRIPTION
We allow two different ways to work with this library.

The main way is to use the `WpApiClient` type which exposes endpoint specific request executors which executes the request and parses the response as such:
```
let api_client = WpApiClient::new(/*_arguments_*/);
let result: Result<UsersRequestListWithEditContextResponse, WpApiError> = api_client
    .users()
    .list_with_edit_context(&UserListParams::default())
    .await;
```

We also provide an alternative way where building & executing the request as well as parsing it has to be done in individual steps. We always allowed building the request with the `WpApiRequestBuilder`, however one had to manually parse it. This is relatively easy to do in Rust by using the `WpNetworkResponse::parse` function, but native wrappers had to implement a parser of their own.

This PR generates these individual parsers, so native wrappers can use the Rust response parser. Here is how that looks in `Kotlin`:
```
val requestBuilder = UniffiWpApiRequestBuilder(siteUrl, authentication)
val userListRequest = requestBuilder.users().listWithEditContext(UserListParams())
val userListResponse = requestExecutor.execute(userListRequest)
val userList = parseAsUsersRequestListWithEditContextResponse(userListResponse).data
```

This looks very similar to the `WpApiClient` approach, but here we execute the given request ourselves and then pick the correct parser. Note that this approach isn't recommended unless you need the extra flexibility because it's both easier and safer to use the `WpApiClient` since it'll choose the correct parser for you.