### PR TITLE
Update `/media` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -95,6 +95,7 @@ val generateUniFFIBindingsTask = tasks.register<Exec>("generateUniFFIBindings") 
         "--bin",
         "wp_uniffi_bindgen",
         "generate",
+        "--no-format",
         "--library",
         nativeLibraryPath,
         "--out-dir",

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -74,6 +74,10 @@ wp plugin delete wordpress-importer
 # We need an `author` user for some of the integration tests
 wp user create test_author test_author@example.com --role=author
 
+# Switch to `twentytwentyfour` which supports post templates
+# This is used in `/posts` integration tests that updates the `template` field
+wp theme activate twentytwentyfour
+
 create_test_credentials () {
   local SITE_URL
   local ADMIN_USERNAME

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,6 +1,9 @@
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
-    posts::{WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
+    posts::{
+        PostCommentStatus, PostId, PostPingStatus, PostStatus, WpApiParamPostsOrderBy,
+        WpApiParamPostsSearchColumn,
+    },
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
@@ -214,10 +217,10 @@ pub struct MediaListParams {
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Limit result set to items with particular parent IDs.
     #[uniffi(default = [])]
-    pub parent: Vec<crate::posts::PostId>,
+    pub parent: Vec<PostId>,
     /// Limit result set to all items except those of a particular parent ID.
     #[uniffi(default = [])]
-    pub parent_exclude: Vec<crate::posts::PostId>,
+    pub parent_exclude: Vec<PostId>,
     /// Array of column names to be searched.
     #[uniffi(default = [])]
     pub search_columns: Vec<WpApiParamPostsSearchColumn>,
@@ -357,6 +360,67 @@ impl FromUrlQueryPairs for MediaListParams {
     }
 }
 
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct MediaUpdateParams {
+    /// The date the post was published, in the site's timezone.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    /// The date the post was published, as GMT.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_gmt: Option<String>,
+    /// An alphanumeric identifier for the post unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    /// A named status for the post.
+    /// One of: publish, future, draft, pending, private
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PostStatus>,
+    /// The title for the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// The ID for the author of the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    /// Whether or not comments are open on the post.
+    /// One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_status: Option<PostCommentStatus>,
+    /// Whether or not the post can be pinged.
+    /// One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ping_status: Option<PostPingStatus>,
+    /// The theme file to use to display the post.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+    /// Alternative text to display when attachment is not displayed.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt_text: Option<String>,
+    /// The attachment caption.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+    /// The attachment description.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The ID for the associated post of the attachment.
+    #[serde(rename = "post")]
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_id: Option<PostId>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/381
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseMedia {
     #[WpContext(edit, embed, view)]
@@ -394,9 +458,9 @@ pub struct SparseMedia {
     #[WpContext(edit, embed, view)]
     pub author: Option<crate::UserId>,
     #[WpContext(edit, view)]
-    pub comment_status: Option<crate::posts::PostCommentStatus>,
+    pub comment_status: Option<PostCommentStatus>,
     #[WpContext(edit, view)]
-    pub ping_status: Option<crate::posts::PostPingStatus>,
+    pub ping_status: Option<PostPingStatus>,
     #[WpContext(edit, view)]
     pub template: Option<String>,
     #[WpContext(edit, embed, view)]
@@ -416,7 +480,7 @@ pub struct SparseMedia {
     #[serde(rename = "post")]
     #[WpContext(edit, view)]
     #[WpContextualOption]
-    pub post_id: Option<crate::posts::PostId>,
+    pub post_id: Option<PostId>,
     #[WpContext(edit, embed, view)]
     pub source_url: Option<String>,
     #[WpContext(edit)]

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -1,8 +1,9 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::{
     media::{
-        MediaId, MediaListParams, SparseMediaFieldWithEditContext,
-        SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
+        MediaId, MediaListParams, MediaUpdateParams, MediaWithEditContext,
+        SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
+        SparseMediaFieldWithViewContext,
     },
     SparseField,
 };
@@ -14,6 +15,8 @@ enum MediaRequest {
     List,
     #[contextual_get(url = "/media/<media_id>", output = crate::media::SparseMedia, filter_by = crate::media::SparseMediaField)]
     Retrieve,
+    #[post(url = "/media/<media_id>", params = &MediaUpdateParams, output = MediaWithEditContext)]
+    Update,
 }
 
 impl DerivedRequest for MediaRequest {

--- a/wp_api_integration_tests/tests/test_media_mut.rs
+++ b/wp_api_integration_tests/tests/test_media_mut.rs
@@ -1,0 +1,97 @@
+use macro_helper::generate_update_test;
+use serial_test::serial;
+use wp_api::{
+    media::MediaUpdateParams,
+    posts::{PostCommentStatus, PostPingStatus, PostStatus},
+};
+use wp_api_integration_tests::{
+    api_client, backend::RestoreServer, AssertResponse, FIRST_POST_ID, MEDIA_ID_611,
+};
+
+generate_update_test!(update_date, date, "2024-09-09T12:00:00".to_string());
+
+generate_update_test!(update_date_gmt, date_gmt, "2024-09-09T12:00:00".to_string());
+
+generate_update_test!(update_slug, slug, "new_slug".to_string());
+
+generate_update_test!(update_status_to_draft, status, PostStatus::Draft);
+generate_update_test!(update_status_to_future, status, PostStatus::Future);
+generate_update_test!(update_status_to_pending, status, PostStatus::Pending);
+generate_update_test!(update_status_to_private, status, PostStatus::Private);
+generate_update_test!(update_status_to_publish, status, PostStatus::Publish);
+
+generate_update_test!(update_title, title, "new_title".to_string());
+
+generate_update_test!(
+    update_comment_status_to_open,
+    comment_status,
+    PostCommentStatus::Open
+);
+
+generate_update_test!(
+    update_comment_status_to_closed,
+    comment_status,
+    PostCommentStatus::Closed
+);
+
+generate_update_test!(
+    update_ping_status_to_open,
+    ping_status,
+    PostPingStatus::Open
+);
+
+generate_update_test!(
+    update_ping_status_to_closed,
+    ping_status,
+    PostPingStatus::Closed
+);
+
+// TODO: `POST_TEMPLATE_SINGLE_WITH_SIDEBAR` doesn't work for `/media`.
+//generate_update_test!(
+//    update_template,
+//    template,
+//    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string()
+//);
+
+generate_update_test!(update_alt_text, alt_text, "new_alt_text".to_string());
+
+generate_update_test!(update_caption, caption, "new_caption".to_string());
+
+generate_update_test!(
+    update_description,
+    description,
+    "new_description".to_string()
+);
+
+generate_update_test!(update_post_id, post_id, FIRST_POST_ID);
+
+async fn test_update_media(params: &MediaUpdateParams) {
+    api_client()
+        .media()
+        .update(&MEDIA_ID_611, params)
+        .await
+        .assert_response();
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_media(
+                        &MediaUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        })
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
+}

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -9,7 +9,8 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, SECOND_USER_ID, TAG_ID_100,
+    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
+    SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
 
@@ -290,20 +291,14 @@ generate_update_test!(
     }
 );
 
-// TODO: This test started to intermittently fail without any changes in the codebase. The
-// intermittent failure was observed using the following command as well:
-//
-// ```
-// curl --user test@example.com:$(jq .admin_password test_credentials.json) -H "Content-Type: application/json" -d '{"template":"single-with-sidebar"}' http://localhost/wp-json/wp/v2/posts/1
-// ```
-//generate_update_test!(
-//    update_template,
-//    template,
-//    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string(),
-//    |updated_post, _| {
-//        assert_eq!(updated_post.template, POST_TEMPLATE_SINGLE_WITH_SIDEBAR);
-//    }
-//);
+generate_update_test!(
+    update_template,
+    template,
+    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string(),
+    |updated_post, _| {
+        assert_eq!(updated_post.template, POST_TEMPLATE_SINGLE_WITH_SIDEBAR);
+    }
+);
 
 generate_update_test!(
     update_meta_to_add_footnote,

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -9,8 +9,7 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
-    SECOND_USER_ID, TAG_ID_100,
+    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
 
@@ -291,14 +290,20 @@ generate_update_test!(
     }
 );
 
-generate_update_test!(
-    update_template,
-    template,
-    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string(),
-    |updated_post, _| {
-        assert_eq!(updated_post.template, POST_TEMPLATE_SINGLE_WITH_SIDEBAR);
-    }
-);
+// TODO: This test started to intermittently fail without any changes in the codebase. The
+// intermittent failure was observed using the following command as well:
+//
+// ```
+// curl --user test@example.com:$(jq .admin_password test_credentials.json) -H "Content-Type: application/json" -d '{"template":"single-with-sidebar"}' http://localhost/wp-json/wp/v2/posts/1
+// ```
+//generate_update_test!(
+//    update_template,
+//    template,
+//    POST_TEMPLATE_SINGLE_WITH_SIDEBAR.to_string(),
+//    |updated_post, _| {
+//        assert_eq!(updated_post.template, POST_TEMPLATE_SINGLE_WITH_SIDEBAR);
+//    }
+//);
 
 generate_update_test!(
     update_meta_to_add_footnote,


### PR DESCRIPTION
Implements update `/media` endpoint following the established patterns. There are a few things worth noting:

* [`wp media`](https://developer.wordpress.org/cli/commands/media/) doesn't support retrieving or listing the media, so the integration tests don't validate whether the value was actually updated. It'll only ensure that the request was successful.
* Switches the test site theme to `twentytwentyfour` which should fix the failing integration test that updates the post `template` field
* Adds `--no-format` argument to Kotlin bindings generation Gradle task. This will significantly speed up the Kotlin bindings generation when `ktlint` is installed - somewhere from ~10 minutes to under a second.