### PR TITLE
Use 64-bit integer instead of 32-bit integer as data modal id

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -8,7 +8,7 @@ import uniffi.wp_api.SparseMediaFieldWithEditContext
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
 import kotlin.test.assertNotNull
 
-private const val MEDIA_ID_611 = 611
+private const val MEDIA_ID_611: Long = 611
 
 class MediaEndpointTest {
     private val testCredentials = TestCredentials.INSTANCE

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -16,9 +16,9 @@ use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 impl_as_query_value_for_new_type!(MediaId);
-uniffi::custom_newtype!(MediaId, i32);
+uniffi::custom_newtype!(MediaId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MediaId(pub i32);
+pub struct MediaId(pub i64);
 
 impl FromStr for MediaId {
     type Err = ParseIntError;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -518,9 +518,9 @@ pub struct PostUpdateParams {
 }
 
 impl_as_query_value_for_new_type!(PostId);
-uniffi::custom_newtype!(PostId, i32);
+uniffi::custom_newtype!(PostId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PostId(pub i32);
+pub struct PostId(pub i64);
 
 impl FromStr for PostId {
     type Err = ParseIntError;
@@ -531,9 +531,9 @@ impl FromStr for PostId {
 }
 
 impl_as_query_value_for_new_type!(TagId);
-uniffi::custom_newtype!(TagId, i32);
+uniffi::custom_newtype!(TagId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TagId(pub i32);
+pub struct TagId(pub i64);
 
 impl FromStr for TagId {
     type Err = ParseIntError;
@@ -544,9 +544,9 @@ impl FromStr for TagId {
 }
 
 impl_as_query_value_for_new_type!(CategoryId);
-uniffi::custom_newtype!(CategoryId, i32);
+uniffi::custom_newtype!(CategoryId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CategoryId(pub i32);
+pub struct CategoryId(pub i64);
 
 impl FromStr for CategoryId {
     type Err = ParseIntError;

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -78,7 +78,9 @@ pub(crate) trait AsQueryValue {
 }
 
 impl_as_query_value_from_to_string!(u32);
+impl_as_query_value_from_to_string!(u64);
 impl_as_query_value_from_to_string!(i32);
+impl_as_query_value_from_to_string!(i64);
 impl_as_query_value_from_to_string!(bool);
 
 impl AsQueryValue for &str {

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -415,9 +415,9 @@ pub struct UserDeleteResponse {
 }
 
 impl_as_query_value_for_new_type!(UserId);
-uniffi::custom_newtype!(UserId, i32);
+uniffi::custom_newtype!(UserId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct UserId(pub i32);
+pub struct UserId(pub i64);
 
 impl FromStr for UserId {
     type Err = ParseIntError;

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -24,10 +24,10 @@ pub struct TestCredentials {
     pub subscriber_password_uuid: &'static str,
     pub author_username: &'static str,
     pub author_password: &'static str,
-    pub password_protected_post_id: i32,
+    pub password_protected_post_id: i64,
     pub password_protected_post_password: &'static str,
     pub password_protected_post_title: &'static str,
-    pub trashed_post_id: i32,
+    pub trashed_post_id: i64,
 }
 
 pub mod backend;

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -121,7 +121,7 @@ async fn delete_post() {
         !Backend::posts(None)
             .await
             .into_iter()
-            .any(|u| u.id == FIRST_POST_ID.0 as i64),
+            .any(|u| u.id == FIRST_POST_ID.0),
         "Post wasn't deleted"
     );
 
@@ -139,7 +139,7 @@ async fn trash_post() {
     let trashed_post = Backend::posts(Some("trash"))
         .await
         .into_iter()
-        .find(|u| u.id == FIRST_POST_ID.0 as i64);
+        .find(|u| u.id == FIRST_POST_ID.0);
     assert!(trashed_post.is_some(), "Can't find the trashed post");
     assert_eq!(
         trashed_post.unwrap().post_status,
@@ -216,7 +216,7 @@ generate_update_test!(
     SECOND_USER_ID,
     |updated_post, updated_post_from_wp_cli| {
         assert_eq!(updated_post.author, SECOND_USER_ID);
-        assert_eq!(updated_post_from_wp_cli.author, SECOND_USER_ID.0 as i64);
+        assert_eq!(updated_post_from_wp_cli.author, SECOND_USER_ID.0);
     }
 );
 

--- a/wp_api_integration_tests/tests/test_users_mut.rs
+++ b/wp_api_integration_tests/tests/test_users_mut.rs
@@ -53,7 +53,7 @@ async fn delete_user() {
         !Backend::users()
             .await
             .into_iter()
-            .any(|u| u.id == SECOND_USER_ID.0 as i64),
+            .any(|u| u.id == SECOND_USER_ID.0),
         "User wasn't deleted"
     );
 
@@ -81,7 +81,7 @@ async fn delete_current_user() {
         !Backend::users()
             .await
             .into_iter()
-            .any(|u| u.id == FIRST_USER_ID.0 as i64),
+            .any(|u| u.id == FIRST_USER_ID.0),
         "User wasn't deleted"
     );
 
@@ -221,7 +221,7 @@ async fn update_user_roles() {
     let updated_user = Backend::users()
         .await
         .into_iter()
-        .find(|u| u.id == SECOND_USER_ID.0 as i64)
+        .find(|u| u.id == SECOND_USER_ID.0)
         .expect("Failed to find the updated user");
     assert_eq!(updated_user.roles, new_role);
 

--- a/wp_cli/src/wp_cli_users.rs
+++ b/wp_cli/src/wp_cli_users.rs
@@ -29,7 +29,7 @@ pub struct WpCliUser {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WpCliUserMeta {
-    pub user_id: i32,
+    pub user_id: i64,
     pub meta_key: String,
     pub meta_value: String,
 }


### PR DESCRIPTION
WordPress uses BIGINT (64-bit) in all id column. https://codex.wordpress.org/Database_Description