### PR TITLE
Add `content_disposition` parameter to `WpDerivedRequest`

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
 pub use api_error::{ParsedRequestError, RequestExecutionError, WpApiError, WpError, WpErrorCode};
+use http::{header::InvalidHeaderValue, HeaderValue};
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use serde::{Deserialize, Serialize};
@@ -131,6 +132,25 @@ pub enum JsonValue {
     String(String),
     Array(Vec<JsonValue>),
     Object(HashMap<String, JsonValue>),
+}
+
+#[derive(Debug, uniffi::Enum)]
+pub enum WpContentDisposition {
+    AttachmentFilename(String),
+}
+
+pub trait AsContentDisposition {
+    fn header_value(self) -> Result<HeaderValue, InvalidHeaderValue>;
+}
+
+impl AsContentDisposition for WpContentDisposition {
+    fn header_value(self) -> Result<HeaderValue, InvalidHeaderValue> {
+        match self {
+            WpContentDisposition::AttachmentFilename(f) => {
+                HeaderValue::from_str(format!("attachment;filename=\"{}\"", f).as_str())
+            }
+        }
+    }
 }
 
 #[macro_export]

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -8,7 +8,7 @@ use url::Url;
 use crate::{
     api_error::{ParsedRequestError, RequestExecutionError, WpError},
     url_query::{FromUrlQueryPairs, UrlQueryPairsMap},
-    WpApiError, WpAuthentication,
+    AsContentDisposition, WpApiError, WpAuthentication,
 };
 
 use self::endpoint::WpEndpointUrl;
@@ -74,10 +74,41 @@ impl InnerRequestBuilder {
             method: RequestMethod::POST,
             url: url.into(),
             header_map: self.header_map_for_post_request().into(),
-            body: serde_json::to_vec(json_body)
-                .ok()
-                .map(|b| Arc::new(WpNetworkRequestBody::new(b))),
+            body: Self::post_body(json_body),
         }
+    }
+
+    pub fn post_with_content_disposition<T, CD>(
+        &self,
+        url: ApiEndpointUrl,
+        json_body: &T,
+        content_disposition: CD,
+    ) -> WpNetworkRequest
+    where
+        T: ?Sized + Serialize,
+        CD: AsContentDisposition,
+    {
+        let mut header_map = self.header_map_for_post_request();
+        header_map.inner.insert(
+            http::header::CONTENT_DISPOSITION,
+            // TODO: What should be the behaviour when the header value can't be created?
+            content_disposition.header_value().unwrap(),
+        );
+        WpNetworkRequest {
+            method: RequestMethod::POST,
+            url: url.into(),
+            header_map: header_map.into(),
+            body: Self::post_body(json_body),
+        }
+    }
+
+    fn post_body<T>(json_body: &T) -> Option<Arc<WpNetworkRequestBody>>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde_json::to_vec(json_body)
+            .ok()
+            .map(|b| Arc::new(WpNetworkRequestBody::new(b)))
     }
 
     pub fn delete(&self, url: ApiEndpointUrl) -> WpNetworkRequest {

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -45,6 +45,7 @@ fn generate_async_request_executor(
     let functions = parsed_enum.variants.iter().map(|variant| {
         let url_parts = variant.attr.url_parts.as_slice();
         let params_type = &variant.attr.params;
+        let content_disposition_type = &variant.attr.content_disposition;
 
         ContextAndFilterHandler::from_request_type(
             variant.attr.request_type,
@@ -64,6 +65,7 @@ fn generate_async_request_executor(
                 &variant.variant_ident,
                 url_parts,
                 params_type.as_ref(),
+                content_disposition_type.as_ref(),
                 variant.attr.request_type,
                 &context_and_filter_handler,
             );
@@ -213,6 +215,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
                 &variant.variant_ident,
                 url_parts,
                 params_type.as_ref(),
+                content_disposition_type.as_ref(),
                 variant.attr.request_type,
                 &context_and_filter_handler,
             );
@@ -260,6 +263,7 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
     let functions = parsed_enum.variants.iter().map(|variant| {
         let url_parts = variant.attr.url_parts.as_slice();
         let params_type = &variant.attr.params;
+        let content_disposition_type = &variant.attr.content_disposition;
         let request_type = variant.attr.request_type;
         let url_from_api_base_url =
             fn_body_get_url_from_api_base_url(&parsed_enum.enum_ident, url_parts);
@@ -276,6 +280,7 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
                     &variant.variant_ident,
                     url_parts,
                     params_type.as_ref(),
+                    content_disposition_type.as_ref(),
                     request_type,
                     &context_and_filter_handler,
                 );

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -193,6 +193,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
     let functions = parsed_enum.variants.iter().map(|variant| {
         let url_parts = variant.attr.url_parts.as_slice();
         let params_type = &variant.attr.params;
+        let content_disposition_type = &variant.attr.content_disposition;
 
         ContextAndFilterHandler::from_request_type(
             variant.attr.request_type,
@@ -215,8 +216,11 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
                 variant.attr.request_type,
                 &context_and_filter_handler,
             );
-            let fn_body_build_request_from_url =
-                fn_body_build_request_from_url(params_type.as_ref(), variant.attr.request_type);
+            let fn_body_build_request_from_url = fn_body_build_request_from_url(
+                params_type.as_ref(),
+                variant.attr.request_type,
+                content_disposition_type.as_ref(),
+            );
             quote! {
                 pub #fn_signature -> #static_wp_network_request_type {
                     #url_from_endpoint

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -57,6 +57,7 @@ fn generate_async_request_executor(
                 &variant.variant_ident,
                 url_parts,
                 params_type.as_ref(),
+                content_disposition_type.as_ref(),
                 variant.attr.request_type,
                 &context_and_filter_handler,
             );

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -74,14 +74,16 @@ pub fn fn_signature(
     variant_ident: &Ident,
     url_parts: &[UrlPart],
     params_type: Option<&ParamsType>,
+    content_disposition_type: Option<&ContentDispositionType>,
     request_type: RequestType,
     context_and_filter_handler: &ContextAndFilterHandler,
 ) -> TokenStream {
     let fn_name = fn_name(variant_ident, context_and_filter_handler);
     let url_params = fn_url_params(url_parts);
     let provided_param = fn_provided_param(part_of, params_type, request_type);
+    let content_disposition_param = fn_content_disposition_param(part_of, content_disposition_type);
     let fields_param = fn_fields_param(context_and_filter_handler);
-    quote! { fn #fn_name(&self, #url_params #provided_param #fields_param) }
+    quote! { fn #fn_name(&self, #url_params #provided_param #content_disposition_param #fields_param) }
 }
 
 pub fn fn_url_params(url_parts: &[UrlPart]) -> TokenStream {
@@ -117,6 +119,25 @@ pub fn fn_provided_param(
                 | RequestType::Get => tokens,
                 RequestType::Post => TokenStream::new(),
             },
+            PartOf::RequestBuilder | PartOf::RequestExecutor => tokens,
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
+pub fn fn_content_disposition_param(
+    part_of: PartOf,
+    content_disposition_type: Option<&ContentDispositionType>,
+) -> TokenStream {
+    if let Some(content_disposition_type) = content_disposition_type {
+        let tokens = {
+            let content_disposition_type_token_stream = &content_disposition_type.tokens;
+            quote! { content_disposition: #content_disposition_type_token_stream, }
+        };
+        match part_of {
+            // Endpoints don't need the content disposition type because it's not part of the url
+            PartOf::Endpoint => TokenStream::new(),
             PartOf::RequestBuilder | PartOf::RequestExecutor => tokens,
         }
     } else {
@@ -510,6 +531,34 @@ mod tests {
     }
 
     #[rstest]
+    #[case(PartOf::Endpoint, None, "")]
+    #[case(
+        PartOf::Endpoint,
+        referenced_content_disposition_type("FooContentDisposition"),
+        ""
+    )]
+    #[case(
+        PartOf::RequestBuilder,
+        referenced_content_disposition_type("FooContentDisposition"),
+        "content_disposition : & FooContentDisposition ,"
+    )]
+    #[case(
+        PartOf::RequestExecutor,
+        referenced_content_disposition_type("FooContentDisposition"),
+        "content_disposition : & FooContentDisposition ,"
+    )]
+    fn test_fn_content_disposition_param(
+        #[case] part_of: PartOf,
+        #[case] content_disposition_type: Option<ContentDispositionType>,
+        #[case] expected_str: &str,
+    ) {
+        assert_eq!(
+            fn_content_disposition_param(part_of, content_disposition_type.as_ref()).to_string(),
+            expected_str
+        );
+    }
+
+    #[rstest]
     #[case("List", ContextAndFilterHandler::None, "list")]
     #[case(
         "List",
@@ -681,6 +730,7 @@ mod tests {
         format_ident!("Create"),
         url_static_users(),
         None,
+        None,
         RequestType::Post,
         ContextAndFilterHandler::None,
         "fn create (& self ,)")]
@@ -689,6 +739,7 @@ mod tests {
         format_ident!("Create"),
         url_static_users(),
         referenced_params_type("UserCreateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
         RequestType::Post,
         filter_no_context(),
         "fn filter_create (& self , fields : & [crate :: SparseUserField])")]
@@ -697,22 +748,25 @@ mod tests {
         format_ident!("Create"),
         url_static_users(),
         referenced_params_type("UserCreateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
         RequestType::Post,
         filter_no_context(),
-        "fn filter_create (& self , params : & UserCreateParams , fields : & [crate :: SparseUserField])")]
+        "fn filter_create (& self , params : & UserCreateParams , content_disposition : & UserContentDisposition , fields : & [crate :: SparseUserField])")]
     #[case(
         PartOf::RequestExecutor,
         format_ident!("Create"),
         url_static_users(),
         referenced_params_type("UserCreateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
         RequestType::Post,
         filter_no_context(),
-        "fn filter_create (& self , params : & UserCreateParams , fields : & [crate :: SparseUserField])")]
+        "fn filter_create (& self , params : & UserCreateParams , content_disposition : & UserContentDisposition , fields : & [crate :: SparseUserField])")]
     #[case(
         PartOf::Endpoint,
         format_ident!("Delete"),
         url_users_with_user_id(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         ContextAndFilterHandler::None,
         "fn delete (& self , user_id : & UserId , params : & UserDeleteParams ,)")]
@@ -721,6 +775,7 @@ mod tests {
         format_ident!("Delete"),
         url_users_with_user_id(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         filter_no_context(),
         "fn filter_delete (& self , user_id : & UserId , params : & UserDeleteParams , fields : & [crate :: SparseUserField])")]
@@ -729,6 +784,7 @@ mod tests {
         format_ident!("DeleteMe"),
         url_static_users(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         ContextAndFilterHandler::None,
         "fn delete_me (& self , params : & UserDeleteParams ,)")]
@@ -737,6 +793,7 @@ mod tests {
         format_ident!("List"),
         url_static_users(),
         referenced_params_type("UserListParams"),
+        None,
         RequestType::ContextualGet,
         filter_take_context_as_argument(),
         "fn filter_list_with_edit_context (& self , params : & UserListParams , fields : & [crate :: SparseUserFieldWithEditContext])")]
@@ -744,6 +801,7 @@ mod tests {
         PartOf::Endpoint,
         format_ident!("Retrieve"),
         url_users_with_user_id(),
+        None,
         None,
         RequestType::ContextualGet,
         ContextAndFilterHandler::NoFilterTakeContextAsFunctionName(WpContext::Embed),
@@ -753,6 +811,7 @@ mod tests {
         format_ident!("Retrieve"),
         url_users_with_user_id(),
         None,
+        None,
         RequestType::ContextualGet,
         filter_take_context_as_argument(),
         "fn filter_retrieve_with_edit_context (& self , user_id : & UserId , fields : & [crate :: SparseUserFieldWithEditContext])")]
@@ -761,6 +820,7 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        None,
         RequestType::Post,
         ContextAndFilterHandler::None,
         "fn update (& self , user_id : & UserId ,)")]
@@ -769,6 +829,7 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        None,
         RequestType::Post,
         filter_no_context(),
         "fn filter_update (& self , user_id : & UserId , fields : & [crate :: SparseUserField])")]
@@ -777,14 +838,7 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
-        RequestType::Post,
-        ContextAndFilterHandler::None,
-        "fn update (& self , user_id : & UserId , params : & UserUpdateParams ,)")]
-    #[case(
-        PartOf::RequestExecutor,
-        format_ident!("Update"),
-        url_users_with_user_id(),
-        referenced_params_type("UserUpdateParams"),
+        None,
         RequestType::Post,
         ContextAndFilterHandler::None,
         "fn update (& self , user_id : & UserId , params : & UserUpdateParams ,)")]
@@ -793,22 +847,52 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
         RequestType::Post,
-        filter_no_context(),
-        "fn filter_update (& self , user_id : & UserId , params : & UserUpdateParams , fields : & [crate :: SparseUserField])")]
+        ContextAndFilterHandler::None,
+        "fn update (& self , user_id : & UserId , params : & UserUpdateParams , content_disposition : & UserContentDisposition ,)")]
     #[case(
         PartOf::RequestExecutor,
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        None,
+        RequestType::Post,
+        ContextAndFilterHandler::None,
+        "fn update (& self , user_id : & UserId , params : & UserUpdateParams ,)")]
+    #[case(
+        PartOf::RequestExecutor,
+        format_ident!("Update"),
+        url_users_with_user_id(),
+        referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        ContextAndFilterHandler::None,
+        "fn update (& self , user_id : & UserId , params : & UserUpdateParams , content_disposition : & UserContentDisposition ,)")]
+    #[case(
+        PartOf::RequestBuilder,
+        format_ident!("Update"),
+        url_users_with_user_id(),
+        referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
         RequestType::Post,
         filter_no_context(),
-        "fn filter_update (& self , user_id : & UserId , params : & UserUpdateParams , fields : & [crate :: SparseUserField])")]
+        "fn filter_update (& self , user_id : & UserId , params : & UserUpdateParams , content_disposition : & UserContentDisposition , fields : & [crate :: SparseUserField])")]
+    #[case(
+        PartOf::RequestExecutor,
+        format_ident!("Update"),
+        url_users_with_user_id(),
+        referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        filter_no_context(),
+        "fn filter_update (& self , user_id : & UserId , params : & UserUpdateParams , content_disposition : & UserContentDisposition , fields : & [crate :: SparseUserField])")]
     #[case(
         PartOf::RequestBuilder,
         format_ident!("List"),
         url_static_users(),
         referenced_params_type("UserListParams"),
+        None,
         RequestType::ContextualGet,
         ContextAndFilterHandler::NoFilterTakeContextAsFunctionName(WpContext::Edit),
         "fn list_with_edit_context (& self , params : & UserListParams ,)")]
@@ -817,6 +901,7 @@ mod tests {
         format_ident!("List"),
         url_static_users(),
         referenced_params_type("UserListParams"),
+        None,
         RequestType::ContextualGet,
         ContextAndFilterHandler::NoFilterTakeContextAsFunctionName(WpContext::Edit),
         "fn list_with_edit_context (& self , params : & UserListParams ,)")]
@@ -825,6 +910,7 @@ mod tests {
         #[case] variant_ident: Ident,
         #[case] url_parts: Vec<UrlPart>,
         #[case] params_type: Option<ParamsType>,
+        #[case] content_disposition_type: Option<ContentDispositionType>,
         #[case] request_type: RequestType,
         #[case] context_and_filter_handler: ContextAndFilterHandler,
         #[case] expected_str: &str,
@@ -835,6 +921,7 @@ mod tests {
                 &variant_ident,
                 &url_parts,
                 params_type.as_ref(),
+                content_disposition_type.as_ref(),
                 request_type,
                 &context_and_filter_handler,
             )

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -6,7 +6,7 @@ use syn::Ident;
 use super::{ContextAndFilterHandler, PartOf, WpContext};
 use crate::{
     parse::RequestType,
-    variant_attr::{ParamsType, UrlPart},
+    variant_attr::{ContentDispositionType, ParamsType, UrlPart},
 };
 
 const SPARSE_IDENT_PREFIX: &str = "Sparse";
@@ -371,9 +371,9 @@ pub fn fn_body_build_request_from_url(
                     self.inner.post(url, params)
                 }
             } else {
-                quote! {
-                    self.inner.post(url)
-                }
+                panic!(
+                    "During parsing we ensure that RequestType::Post always has a `params` type"
+                );
             }
         }
     }

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -357,6 +357,7 @@ pub fn fn_body_context_query_pairs(
 pub fn fn_body_build_request_from_url(
     params_type: Option<&ParamsType>,
     request_type: RequestType,
+    content_disposition_type: Option<&ContentDispositionType>,
 ) -> TokenStream {
     match request_type {
         RequestType::ContextualGet | RequestType::ContextualPaged | RequestType::Get => quote! {
@@ -367,8 +368,14 @@ pub fn fn_body_build_request_from_url(
         },
         RequestType::Post => {
             if params_type.is_some() {
-                quote! {
-                    self.inner.post(url, params)
+                if content_disposition_type.is_some() {
+                    quote! {
+                        self.inner.post(url, params, content_disposition)
+                    }
+                } else {
+                    quote! {
+                        self.inner.post(url, params)
+                    }
                 }
             } else {
                 panic!(
@@ -1039,33 +1046,55 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, RequestType::ContextualGet, "self . inner . get (url)")]
+    #[case(None, RequestType::ContextualGet, None, "self . inner . get (url)")]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::ContextualGet,
+        None,
         "self . inner . get (url)"
     )]
-    #[case(None, RequestType::Delete, "self . inner . delete (url)")]
+    #[case(None, RequestType::Delete, None, "self . inner . delete (url)")]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::Delete,
+        None,
         "self . inner . delete (url)"
     )]
-    #[case(None, RequestType::Post, "self . inner . post (url)")]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::Post,
+        None,
         "self . inner . post (url , params)"
+    )]
+    #[case(
+        referenced_params_type("UserListParams"),
+        RequestType::Post,
+        referenced_content_disposition_type("MediaContentDisposition"),
+        "self . inner . post (url , params , content_disposition)"
     )]
     fn test_fn_body_build_request_from_url(
         #[case] params: Option<ParamsType>,
         #[case] request_type: RequestType,
+        #[case] content_disposition_type: Option<ContentDispositionType>,
         #[case] expected_str: &str,
     ) {
         assert_eq!(
-            fn_body_build_request_from_url(params.as_ref(), request_type).to_string(),
+            fn_body_build_request_from_url(
+                params.as_ref(),
+                request_type,
+                content_disposition_type.as_ref()
+            )
+            .to_string(),
             expected_str
         );
+    }
+
+    #[test]
+    fn test_fn_body_build_request_from_url_panic() {
+        let result = std::panic::catch_unwind(|| {
+            fn_body_build_request_from_url(None, RequestType::Post, None)
+        });
+        assert!(result.is_err());
     }
 
     #[rstest]
@@ -1201,6 +1230,13 @@ mod tests {
     fn referenced_params_type(str: &str) -> Option<ParamsType> {
         let ident = format_ident!("{}", str);
         Some(ParamsType {
+            tokens: quote! { & #ident },
+        })
+    }
+
+    fn referenced_content_disposition_type(str: &str) -> Option<ContentDispositionType> {
+        let ident = format_ident!("{}", str);
+        Some(ContentDispositionType {
             tokens: quote! { & #ident },
         })
     }

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -239,6 +239,21 @@ fn fn_arg_provided_params(
     }
 }
 
+fn fn_arg_content_disposition(
+    part_of: PartOf,
+    content_disposition_type: Option<&ContentDispositionType>,
+) -> TokenStream {
+    if content_disposition_type.is_some() {
+        match part_of {
+            // Endpoints don't need the content disposition type because it's not part of the url
+            PartOf::Endpoint => TokenStream::new(),
+            PartOf::RequestBuilder | PartOf::RequestExecutor => quote! { content_disposition, },
+        }
+    } else {
+        TokenStream::new()
+    }
+}
+
 fn fn_arg_fields(context_and_filter_handler: &ContextAndFilterHandler) -> TokenStream {
     match context_and_filter_handler {
         ContextAndFilterHandler::None
@@ -391,7 +406,7 @@ pub fn fn_body_build_request_from_url(
             if params_type.is_some() {
                 if content_disposition_type.is_some() {
                     quote! {
-                        self.inner.post(url, params, content_disposition)
+                        self.inner.post_with_content_disposition(url, params, content_disposition)
                     }
                 } else {
                     quote! {
@@ -411,6 +426,7 @@ pub fn fn_body_get_request_from_request_builder(
     variant_ident: &Ident,
     url_parts: &[UrlPart],
     params_type: Option<&ParamsType>,
+    content_disposition_type: Option<&ContentDispositionType>,
     request_type: RequestType,
     context_and_filter_handler: &ContextAndFilterHandler,
 ) -> TokenStream {
@@ -418,10 +434,12 @@ pub fn fn_body_get_request_from_request_builder(
     let fn_arg_url_parts = fn_arg_url_parts(url_parts);
     let fn_arg_provided_params =
         fn_arg_provided_params(PartOf::RequestExecutor, params_type, request_type);
+    let fn_arg_content_disposition =
+        fn_arg_content_disposition(PartOf::RequestExecutor, content_disposition_type);
     let fn_arg_fields = fn_arg_fields(context_and_filter_handler);
 
     quote! {
-        let request = self.request_builder.#fn_name(#fn_arg_url_parts #fn_arg_provided_params #fn_arg_fields);
+        let request = self.request_builder.#fn_name(#fn_arg_url_parts #fn_arg_provided_params #fn_arg_content_disposition #fn_arg_fields);
     }
 }
 
@@ -667,6 +685,36 @@ mod tests {
     ) {
         assert_eq!(
             fn_arg_provided_params(part_of, params_type.as_ref(), request_type).to_string(),
+            expected_str
+        );
+    }
+
+    #[rstest]
+    #[case(PartOf::Endpoint, None, "")]
+    #[case(
+        PartOf::Endpoint,
+        referenced_content_disposition_type("FooContentDisposition"),
+        ""
+    )]
+    #[case(PartOf::RequestBuilder, None, "")]
+    #[case(
+        PartOf::RequestBuilder,
+        referenced_content_disposition_type("FooContentDisposition"),
+        "content_disposition ,"
+    )]
+    #[case(PartOf::RequestExecutor, None, "")]
+    #[case(
+        PartOf::RequestExecutor,
+        referenced_content_disposition_type("FooContentDisposition"),
+        "content_disposition ,"
+    )]
+    fn test_fn_arg_content_disposition(
+        #[case] part_of: PartOf,
+        #[case] content_disposition_type: Option<ContentDispositionType>,
+        #[case] expected_str: &str,
+    ) {
+        assert_eq!(
+            fn_arg_content_disposition(part_of, content_disposition_type.as_ref()).to_string(),
             expected_str
         );
     }
@@ -1157,7 +1205,7 @@ mod tests {
         referenced_params_type("UserListParams"),
         RequestType::Post,
         referenced_content_disposition_type("MediaContentDisposition"),
-        "self . inner . post (url , params , content_disposition)"
+        "self . inner . post_with_content_disposition (url , params , content_disposition)"
     )]
     fn test_fn_body_build_request_from_url(
         #[case] params: Option<ParamsType>,
@@ -1189,6 +1237,7 @@ mod tests {
         format_ident!("Create"),
         url_static_users(),
         referenced_params_type("UserCreateParams"),
+        None,
         RequestType::Post,
         ContextAndFilterHandler::None,
         "let request = self . request_builder . create (params ,) ;")]
@@ -1196,13 +1245,31 @@ mod tests {
         format_ident!("Create"),
         url_static_users(),
         referenced_params_type("UserCreateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        ContextAndFilterHandler::None,
+        "let request = self . request_builder . create (params , content_disposition ,) ;")]
+    #[case(
+        format_ident!("Create"),
+        url_static_users(),
+        referenced_params_type("UserCreateParams"),
+        None,
         RequestType::Post,
         filter_no_context(),
         "let request = self . request_builder . filter_create (params , fields ,) ;")]
     #[case(
+        format_ident!("Create"),
+        url_static_users(),
+        referenced_params_type("UserCreateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        filter_no_context(),
+        "let request = self . request_builder . filter_create (params , content_disposition , fields ,) ;")]
+    #[case(
         format_ident!("Delete"),
         url_users_with_user_id(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         ContextAndFilterHandler::None,
         "let request = self . request_builder . delete (user_id , params ,) ;")]
@@ -1210,6 +1277,7 @@ mod tests {
         format_ident!("Delete"),
         url_users_with_user_id(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         filter_no_context(),
         "let request = self . request_builder . filter_delete (user_id , params , fields ,) ;")]
@@ -1217,6 +1285,7 @@ mod tests {
         format_ident!("DeleteMe"),
         url_static_users(),
         referenced_params_type("UserDeleteParams"),
+        None,
         RequestType::Delete,
         ContextAndFilterHandler::None,
         "let request = self . request_builder . delete_me (params ,) ;")]
@@ -1224,6 +1293,7 @@ mod tests {
         format_ident!("List"),
         url_static_users(),
         referenced_params_type("UserListParams"),
+        None,
         RequestType::ContextualGet,
         ContextAndFilterHandler::NoFilterTakeContextAsFunctionName(WpContext::Edit),
         "let request = self . request_builder . list_with_edit_context (params ,) ;")]
@@ -1231,12 +1301,14 @@ mod tests {
         format_ident!("List"),
         url_static_users(),
         referenced_params_type("UserListParams"),
+        None,
         RequestType::ContextualGet,
         filter_take_context_as_argument(),
         "let request = self . request_builder . filter_list_with_edit_context (params , fields ,) ;")]
     #[case(
         format_ident!("Retrieve"),
         url_users_with_user_id(),
+        None,
         None,
         RequestType::ContextualGet,
         ContextAndFilterHandler::NoFilterTakeContextAsFunctionName(WpContext::Embed),
@@ -1245,6 +1317,7 @@ mod tests {
         format_ident!("Retrieve"),
         url_users_with_user_id(),
         None,
+        None,
         RequestType::ContextualGet,
         filter_take_context_as_argument(),
         "let request = self . request_builder . filter_retrieve_with_edit_context (user_id , fields ,) ;")]
@@ -1252,6 +1325,7 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        None,
         RequestType::Post,
         ContextAndFilterHandler::None,
         "let request = self . request_builder . update (user_id , params ,) ;")]
@@ -1259,13 +1333,31 @@ mod tests {
         format_ident!("Update"),
         url_users_with_user_id(),
         referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        ContextAndFilterHandler::None,
+        "let request = self . request_builder . update (user_id , params , content_disposition ,) ;")]
+    #[case(
+        format_ident!("Update"),
+        url_users_with_user_id(),
+        referenced_params_type("UserUpdateParams"),
+        None,
         RequestType::Post,
         filter_no_context(),
         "let request = self . request_builder . filter_update (user_id , params , fields ,) ;")]
+    #[case(
+        format_ident!("Update"),
+        url_users_with_user_id(),
+        referenced_params_type("UserUpdateParams"),
+        referenced_content_disposition_type("UserContentDisposition"),
+        RequestType::Post,
+        filter_no_context(),
+        "let request = self . request_builder . filter_update (user_id , params , content_disposition , fields ,) ;")]
     fn test_fn_body_get_request_from_request_builder(
         #[case] variant_ident: Ident,
         #[case] url_parts: Vec<UrlPart>,
         #[case] params_type: Option<ParamsType>,
+        #[case] content_disposition_type: Option<ContentDispositionType>,
         #[case] request_type: RequestType,
         #[case] context_and_filter_handler: ContextAndFilterHandler,
         #[case] expected_str: &str,
@@ -1275,6 +1367,7 @@ mod tests {
                 &variant_ident,
                 &url_parts,
                 params_type.as_ref(),
+                content_disposition_type.as_ref(),
                 request_type,
                 &context_and_filter_handler
             )

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -70,6 +70,22 @@ impl ParsedVariantAttribute {
             }
         }
 
+        let content_disposition_type =
+            non_empty_token_tree_or_none(content_disposition).map(|tokens| {
+                ContentDispositionType {
+                    tokens: TokenStream::from_iter(tokens),
+                }
+            });
+
+        if content_disposition_type.is_some() {
+            match request_type {
+                RequestType::Post => (),
+                _ => {
+                    return Err(ItemVariantAttributeParseError::ContentDispositionTypeIsOnlySupportedForPostRequests);
+                }
+            }
+        }
+
         Ok(Self {
             request_type,
             url_parts,
@@ -78,11 +94,7 @@ impl ParsedVariantAttribute {
             filter_by: non_empty_token_tree_or_none(filter_by).map(|tokens| FilterByType {
                 tokens: TokenStream::from_iter(tokens),
             }),
-            content_disposition: non_empty_token_tree_or_none(content_disposition).map(|tokens| {
-                ContentDispositionType {
-                    tokens: TokenStream::from_iter(tokens),
-                }
-            }),
+            content_disposition: content_disposition_type,
         })
     }
 
@@ -327,6 +339,8 @@ enum ItemVariantAttributeParseError {
     ContextualPagedRequiresParamsType,
     #[error("#[post(params = ?)] is missing `params` type")]
     PostRequiresParamsType,
+    #[error("`contextual_disposition` is only supported for `post` request type")]
+    ContentDispositionTypeIsOnlySupportedForPostRequests,
     #[error("Missing variant attribute")]
     MissingAttr,
     #[error("Only a single attribute is supported")]

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -199,19 +199,22 @@ impl ParsedVariantAttribute {
     // #[derive(WpDerivedRequest)]
     // #[SparseField(crate::SparseUserField)]
     // enum UsersRequest {
-    //     #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>)]
+    //     #[contextual_get(url = "/users", params = &UserListParams, content_disposition =
+    //     &UserContentDisposition, output = Vec<SparseUser>)]
     //     List,
     // }
     // ```
     //
     // In the above example: (as pseudocode)
-    // * Input: `vec!["url = \"users\"", "params = &UserListParams", "output = Vec<SparseUser>"]`
-    // * Output: `vec![(url, "users"), (params, &UserListParams), (output, Vec<SparseUser>)]`
+    // * Input: `vec!["url = \"users\"", "params = &UserListParams", "content_disposition =
+    // &UserContentDisposition", "output = Vec<SparseUser>"]`
+    // * Output: `vec![(url, "users"), (params, &UserListParams),
+    // (content_disposition, &UserContentDisposition), (output, Vec<SparseUser>)]`
     //
     // How it works:
-    // * Since a specific set of keys is expected - "url", "params" or "output", it's certain that
-    // keys are `syn::Ident`s. Furthermore, the input is comma separated list, so it's certain that
-    // the first token is the key.
+    // * Since a specific set of keys is expected - "url", "params", "content_disposition" or
+    // "output", it's certain that keys are `syn::Ident`s. Furthermore, the input is comma
+    // separated list, so it's certain that the first token is the key.
     // * Since the first token is guaranteed to be a single `syn::Ident`, the second token is
     // guaranteed to be an `=` sign.
     // * The remaining tokens represent the "value". There needs to be at least one token.
@@ -233,7 +236,8 @@ impl ParsedVariantAttribute {
             .into_iter()
             .map(|tokens| {
                 let mut tokens_iter = tokens.into_iter();
-                // First token should be an Ident matching to "url", "params" or "output"
+                // First token should be an Ident matching to "url", "params",
+                // "content_disposition" or "output"
                 let first_token = tokens_iter.next();
                 let ident = if let Some(TokenTree::Ident(ident)) = first_token {
                     ident

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -18,12 +18,18 @@ pub struct ParamsType {
 }
 
 #[derive(Debug, Clone)]
+pub struct ContentDispositionType {
+    pub tokens: TokenStream,
+}
+
+#[derive(Debug, Clone)]
 pub struct ParsedVariantAttribute {
     pub request_type: RequestType,
     pub url_parts: Vec<UrlPart>,
     pub params: Option<ParamsType>,
     pub output: Vec<TokenTree>,
     pub filter_by: Option<FilterByType>,
+    pub content_disposition: Option<ContentDispositionType>,
 }
 
 impl ParsedVariantAttribute {
@@ -33,6 +39,7 @@ impl ParsedVariantAttribute {
         params: Option<Vec<TokenTree>>,
         output: Vec<TokenTree>,
         filter_by: Option<Vec<TokenTree>>,
+        content_disposition: Option<Vec<TokenTree>>,
     ) -> Result<Self, ItemVariantAttributeParseError> {
         let non_empty_token_tree_or_none =
             |tokens: Option<Vec<TokenTree>>| -> Option<Vec<TokenTree>> {
@@ -48,8 +55,19 @@ impl ParsedVariantAttribute {
             tokens: TokenStream::from_iter(tokens),
         });
 
-        if request_type == RequestType::ContextualPaged && params_type.is_none() {
-            return Err(ItemVariantAttributeParseError::ContextualPagedRequiresParamsType);
+        // Check if params type is required
+        if params_type.is_none() {
+            match request_type {
+                RequestType::ContextualPaged => {
+                    return Err(ItemVariantAttributeParseError::ContextualPagedRequiresParamsType);
+                }
+                RequestType::Post => {
+                    return Err(ItemVariantAttributeParseError::PostRequiresParamsType);
+                }
+                RequestType::ContextualGet => (),
+                RequestType::Delete => (),
+                RequestType::Get => (),
+            }
         }
 
         Ok(Self {
@@ -59,6 +77,11 @@ impl ParsedVariantAttribute {
             output,
             filter_by: non_empty_token_tree_or_none(filter_by).map(|tokens| FilterByType {
                 tokens: TokenStream::from_iter(tokens),
+            }),
+            content_disposition: non_empty_token_tree_or_none(content_disposition).map(|tokens| {
+                ContentDispositionType {
+                    tokens: TokenStream::from_iter(tokens),
+                }
             }),
         })
     }
@@ -242,6 +265,7 @@ impl Parse for ParsedVariantAttribute {
         let mut params_tokens = None;
         let mut output_tokens = None;
         let mut filter_by_tokens = None;
+        let mut content_disposition_tokens = None;
 
         for (ident, tokens) in pair_vec.into_iter() {
             match ident.to_string().as_str() {
@@ -249,6 +273,7 @@ impl Parse for ParsedVariantAttribute {
                 "params" => params_tokens = Some(tokens),
                 "output" => output_tokens = Some(tokens),
                 "filter_by" => filter_by_tokens = Some(tokens),
+                "content_disposition" => content_disposition_tokens = Some(tokens),
                 _ => {
                     return Err(ItemVariantAttributeParseError::ExpectingKeyValuePairs
                         .into_syn_error(meta_list_span));
@@ -290,6 +315,7 @@ impl Parse for ParsedVariantAttribute {
             params_tokens,
             output,
             filter_by_tokens,
+            content_disposition_tokens,
         )
         .map_err(|e| e.into_syn_error(meta_list_span))
     }
@@ -299,6 +325,8 @@ impl Parse for ParsedVariantAttribute {
 enum ItemVariantAttributeParseError {
     #[error("#[contextual_paged(params = ?)] is missing `params` type")]
     ContextualPagedRequiresParamsType,
+    #[error("#[post(params = ?)] is missing `params` type")]
+    PostRequiresParamsType,
     #[error("Missing variant attribute")]
     MissingAttr,
     #[error("Only a single attribute is supported")]

--- a/wp_derive_request_builder/tests/fail/content_disposition_is_only_supported_for_post_requests.rs
+++ b/wp_derive_request_builder/tests/fail/content_disposition_is_only_supported_for_post_requests.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, content_disposition = FooContentDisposition)]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/content_disposition_is_only_supported_for_post_requests.stderr
+++ b/wp_derive_request_builder/tests/fail/content_disposition_is_only_supported_for_post_requests.stderr
@@ -1,0 +1,5 @@
+error: `contextual_disposition` is only supported for `post` request type
+ --> tests/fail/content_disposition_is_only_supported_for_post_requests.rs:3:7
+  |
+3 |     #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, content_disposition = FooContentDisposition)]
+  |       ^^^^^^^^^^^^^^

--- a/wp_derive_request_builder/tests/fail/post_missing_params_type.rs
+++ b/wp_derive_request_builder/tests/fail/post_missing_params_type.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[post(url = "/users", output = Vec<SparseUser>)]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/post_missing_params_type.stderr
+++ b/wp_derive_request_builder/tests/fail/post_missing_params_type.stderr
@@ -1,0 +1,5 @@
+error: #[post(params = ?)] is missing `params` type
+ --> tests/fail/post_missing_params_type.rs:3:7
+  |
+3 |     #[post(url = "/users", output = Vec<SparseUser>)]
+  |       ^^^^

--- a/wp_derive_request_builder/tests/pass/basic_derived_request.rs
+++ b/wp_derive_request_builder/tests/pass/basic_derived_request.rs
@@ -2,6 +2,8 @@
 enum UsersRequest {
     #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, filter_by = SparseUserField)]
     List,
+    #[post(url = "/users/<user_id>", params = &UserUpdateParams, output = UserWithEditContext, content_disposition = &UserContentDisposition)]
+    Update,
 }
 
 fn main() {}


### PR DESCRIPTION
While working on create `/media` endpoint, I've implemented an optional `content_disposition` parameter for `POST` requests. The goal was to support creating a media object in WordPress DB when the file is already available in the server. However, I was unable to get this working. As far as I could tell, the only way to create a media object was to send a multipart request with the binary attached - which is implemented in an upcoming PR.

Since creating a media object without a media binary doesn't work, it doesn't make sense to merge these changes into `trunk`. Even though `content_disposition` is an optional parameter, it would add more code for us to maintain without any benefit. However, I also don't want this work to be completely removed because I think the implementation could be reused. Even if we don't need `content_disposition`, we might need to implement a different optional parameter in which case we can salvage most of this implementation. So, I'm opening this as a PR and closing it immediately after. That way, it's part of the repository and can be brought back at any point.

cc @crazytonyli & @jkmassel - just so you're aware of this in case you need it. No action is necessary.