### PR TITLE
Add `/media` related errors and their integration tests

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -191,6 +191,10 @@ pub enum WpErrorCode {
     CannotAssignSticky,
     #[serde(rename = "rest_cannot_assign_term")]
     CannotAssignTerm,
+    #[serde(rename = "rest_cannot_edit_file_type")]
+    CannotEditFileType,
+    #[serde(rename = "rest_cannot_edit_image")]
+    CannotEditImage,
     #[serde(rename = "rest_cannot_edit_others")]
     CannotEditOthers,
     #[serde(rename = "rest_cannot_manage_application_passwords")]
@@ -201,12 +205,22 @@ pub enum WpErrorCode {
     CannotReadType,
     #[serde(rename = "rest_forbidden_status")]
     ForbiddenStatus,
+    #[serde(rename = "rest_image_not_edited")]
+    ImageNotEdited,
+    #[serde(rename = "rest_image_crop_failed")]
+    ImageCropFailed,
+    #[serde(rename = "rest_image_rotation_failed")]
+    ImageRotationFailed,
     #[serde(rename = "rest_invalid_featured_media")]
     InvalidFeaturedMedia,
     #[serde(rename = "rest_no_authenticated_app_password")]
     NoAuthenticatedAppPassword,
     #[serde(rename = "rest_user_cannot_delete_post")]
     UserCannotDeletePost, // See `rest_cannot_delete` instead
+    #[serde(rename = "rest_unknown_attachment")]
+    UnknownAttachment,
+    #[serde(rename = "rest_unknown_image_file_type")]
+    UnknownImageFileType,
     // ------------------------------------------------------------------------------------
     // Untested, because we believe these errors require multisite
     // ------------------------------------------------------------------------------------

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -1,0 +1,131 @@
+use serial_test::parallel;
+use wp_api::{
+    media::{MediaId, MediaListParams, MediaUpdateParams},
+    posts::WpApiParamPostsOrderBy,
+    users::UserId,
+    WpErrorCode,
+};
+use wp_api_integration_tests::{
+    api_client, api_client_as_author, api_client_as_subscriber, AssertWpError, MEDIA_ID_611,
+};
+
+#[tokio::test]
+#[parallel]
+async fn delete_media_err_cannot_delete() {
+    api_client_as_subscriber()
+        .media()
+        .delete(&MEDIA_ID_611)
+        .await
+        .assert_wp_error(WpErrorCode::CannotDelete);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_no_search_term_defined() {
+    api_client()
+        .media()
+        .list_with_edit_context(&MediaListParams {
+            orderby: Some(WpApiParamPostsOrderBy::Relevance),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::NoSearchTermDefined);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_order_by_include_missing_include() {
+    api_client()
+        .media()
+        .list_with_edit_context(&MediaListParams {
+            orderby: Some(WpApiParamPostsOrderBy::Include),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::OrderbyIncludeMissingInclude);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_media_invalid_page_number() {
+    api_client()
+        .media()
+        .list_with_edit_context(&MediaListParams {
+            page: Some(99999999),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidPageNumber);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_media_err_forbidden_context() {
+    api_client_as_subscriber()
+        .media()
+        .retrieve_with_edit_context(&MEDIA_ID_611)
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_media_err_media_invalid_id() {
+    api_client()
+        .media()
+        .retrieve_with_edit_context(&MediaId(99999999))
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_media_err_cannot_edit() {
+    api_client_as_author()
+        .media()
+        .update(&MEDIA_ID_611, &MediaUpdateParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotEdit);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_media_err_invalid_author() {
+    api_client()
+        .media()
+        .update(
+            &MEDIA_ID_611,
+            &MediaUpdateParams {
+                author: Some(UserId(99999999)),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidAuthor);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_media_err_invalid_template() {
+    api_client()
+        .media()
+        .update(
+            &MEDIA_ID_611,
+            &MediaUpdateParams {
+                template: Some("foo".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidParam);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_media_err_post_invalid_id() {
+    api_client_as_author()
+        .media()
+        .update(&MediaId(99999999), &MediaUpdateParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId);
+}

--- a/wp_api_integration_tests/tests/test_posts_err.rs
+++ b/wp_api_integration_tests/tests/test_posts_err.rs
@@ -146,12 +146,7 @@ async fn trash_post_err_already_trashed() {
 async fn update_post_err_cannot_edit() {
     api_client_as_author()
         .posts()
-        .update(
-            &FIRST_POST_ID,
-            &PostUpdateParams {
-                ..Default::default()
-            },
-        )
+        .update(&FIRST_POST_ID, &PostUpdateParams::default())
         .await
         .assert_wp_error(WpErrorCode::CannotEdit);
 }


### PR DESCRIPTION
Since create `/media` has not been merged yet, it doesn't include the errors related to creating/uploading media.