### PR TITLE
Add explicit Sendable conformance to WordPressAPI

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-swiftlint_version: 0.55.1
+swiftlint_version: 0.57.1
 strict: true
 included:
   - native/swift

--- a/Package.resolved
+++ b/Package.resolved
@@ -40,10 +40,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",
       "state" : {
-        "revision" : "b515723b16eba33f15c4677ee65f3fef2ce8c255",
-        "version" : "0.55.1"
+        "revision" : "25f2776977e663305bee71309ea1e34d435065f1",
+        "version" : "0.57.1"
       }
     },
     {

--- a/native/swift/Example/Example.xcodeproj/project.pbxproj
+++ b/native/swift/Example/Example.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		2479BF842B621CB70014A01D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2479BF882B621CB70014A01D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2479BF922B621E9B0014A01D /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		247E00B82CF94FD900FE3FFB /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		24A3C32E2BA8F96F00162AD1 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		24A3C3342BAA45B800162AD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24A3C3352BAA874C00162AD1 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
@@ -90,6 +91,7 @@
 		2479BF7F2B621CB60014A01D /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				247E00B82CF94FD900FE3FFB /* Example.entitlements */,
 				242D64972C363960007CA96C /* UI */,
 				242D64982C363996007CA96C /* Resources */,
 				2479BF802B621CB60014A01D /* ExampleApp.swift */,
@@ -324,9 +326,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Example/UI/Preview Content\"";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Example/Resources/Info.plist;
@@ -361,9 +365,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Example/Example.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Example/UI/Preview Content\"";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Example/Resources/Info.plist;

--- a/native/swift/Example/Example.xcodeproj/project.pbxproj
+++ b/native/swift/Example/Example.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1520;
-				LastUpgradeCheck = 1520;
+				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					2479BF7C2B621CB60014A01D = {
 						CreatedOnToolsVersion = 15.2;
@@ -235,6 +235,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -259,6 +260,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -296,6 +298,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -312,6 +315,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -348,7 +352,6 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Debug;
@@ -386,7 +389,6 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Release;

--- a/native/swift/Example/Example/Example.entitlements
+++ b/native/swift/Example/Example/Example.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -19,7 +19,7 @@ struct ExampleApp: App {
                 .map { $0.asListViewData }
         }),
         RootListData(name: "Users", sequence: {
-            let sequence = try WordPressAPI.globalInstance.users.sequenceWithEditContext(params: userListParams)
+            let sequence = try await WordPressAPI.globalInstance.users.sequenceWithEditContext(params: userListParams)
             return ListViewSequence(underlyingSequence: sequence)
         }),
         RootListData(name: "Plugins", callback: {
@@ -33,11 +33,11 @@ struct ExampleApp: App {
             }
         }),
         RootListData(name: "Posts", sequence: {
-            let sequence = try WordPressAPI.globalInstance.posts.sequenceWithEditContext(params: postListParams)
+            let sequence = try await WordPressAPI.globalInstance.posts.sequenceWithEditContext(params: postListParams)
             return ListViewSequence(underlyingSequence: sequence)
         }),
         RootListData(name: "Media", sequence: {
-            let sequence = try WordPressAPI.globalInstance.media.sequenceWithEditContext(params: mediaListParams)
+            let sequence = try await WordPressAPI.globalInstance.media.sequenceWithEditContext(params: mediaListParams)
             return ListViewSequence(underlyingSequence: sequence)
         }),
         RootListData(name: "Site Health Tests", callback: {

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -13,11 +13,10 @@ struct ListViewData: Identifiable, Comparable, Hashable {
     }
 }
 
-protocol ListViewDataConvertable: Identifiable {
+protocol ListViewDataConvertable {
     var asListViewData: ListViewData { get }
 }
 
-extension UserWithEditContext: @retroactive Identifiable {}
 extension UserWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.email, fields: [
@@ -28,7 +27,6 @@ extension UserWithEditContext: ListViewDataConvertable {
     }
 }
 
-extension UserWithViewContext: @retroactive Identifiable {}
 extension UserWithViewContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.slug, fields: [
@@ -37,7 +35,6 @@ extension UserWithViewContext: ListViewDataConvertable {
     }
 }
 
-extension UserWithEmbedContext: @retroactive Identifiable {}
 extension UserWithEmbedContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.slug, fields: [
@@ -46,12 +43,7 @@ extension UserWithEmbedContext: ListViewDataConvertable {
     }
 }
 
-extension PluginWithEditContext: @retroactive Identifiable {}
 extension PluginWithEditContext: ListViewDataConvertable {
-    public var id: String {
-        self.plugin.slug
-    }
-
     var asListViewData: ListViewData {
         ListViewData(id: self.plugin.slug, title: self.name, subtitle: self.version, fields: [
             "Author": self.author,
@@ -60,12 +52,7 @@ extension PluginWithEditContext: ListViewDataConvertable {
     }
 }
 
-extension ApplicationPasswordWithEditContext: @retroactive Identifiable {}
 extension ApplicationPasswordWithEditContext: ListViewDataConvertable {
-    public var id: String {
-        self.uuid.uuid
-    }
-
     var creationDateString: String {
         guard let date = Date.fromWordPressDate(self.created) else {
             return self.created
@@ -81,18 +68,12 @@ extension ApplicationPasswordWithEditContext: ListViewDataConvertable {
     }
 }
 
-extension WpSiteHealthTest: @retroactive Identifiable {}
 extension SiteHealthTest: ListViewDataConvertable {
-    public var id: String {
-        self.label
-    }
-
     var asListViewData: ListViewData {
         ListViewData(id: self.label, title: self.label, subtitle: self.status, fields: [:])
     }
 }
 
-extension WpSiteHealthDirectorySizes: @retroactive Identifiable {}
 extension SiteHealthDirectorySizes: ListViewDataConvertable {
     public var id: String {
         [
@@ -124,14 +105,9 @@ extension SiteHealthDirectorySizes: ListViewDataConvertable {
     }
 }
 
-extension PostTypeDetailsWithViewContext: @retroactive Identifiable {}
 extension PostTypeDetailsWithViewContext: ListViewDataConvertable {
-    public var id: String {
-        self.slug
-    }
-
     var asListViewData: ListViewData {
-        ListViewData(id: self.id, title: self.name, subtitle: self.slug, fields: [:])
+        ListViewData(id: self.slug, title: self.name, subtitle: self.slug, fields: [:])
     }
 }
 
@@ -155,24 +131,15 @@ extension SiteSettingsWithEditContext {
     }
 }
 
-extension PostWithEditContext: @retroactive Identifiable {}
 extension PostWithEditContext: ListViewDataConvertable {
-    public var id: String {
-        self.slug
-    }
-
     var asListViewData: ListViewData {
-        ListViewData(id: self.id, title: self.title.raw, subtitle: self.slug, fields: [:])
+        ListViewData(id: self.slug, title: self.title.raw, subtitle: self.slug, fields: [:])
     }
 }
 
-extension MediaWithEditContext: @retroactive Identifiable, ListViewDataConvertable {
-    public var id: String {
-        self.slug
-    }
-
+extension MediaWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
-        ListViewData(id: self.id, title: self.title.raw, subtitle: String(describing: self.mediaDetails), fields: [:])
+        ListViewData(id: self.slug, title: self.title.raw, subtitle: String(describing: self.mediaDetails), fields: [:])
     }
 }
 

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -17,6 +17,7 @@ protocol ListViewDataConvertable: Identifiable {
     var asListViewData: ListViewData { get }
 }
 
+extension UserWithEditContext: @retroactive Identifiable {}
 extension UserWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.email, fields: [
@@ -27,6 +28,7 @@ extension UserWithEditContext: ListViewDataConvertable {
     }
 }
 
+extension UserWithViewContext: @retroactive Identifiable {}
 extension UserWithViewContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.slug, fields: [
@@ -35,6 +37,7 @@ extension UserWithViewContext: ListViewDataConvertable {
     }
 }
 
+extension UserWithEmbedContext: @retroactive Identifiable {}
 extension UserWithEmbedContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         ListViewData(id: "user-\(self.id)", title: self.name, subtitle: self.slug, fields: [
@@ -43,6 +46,7 @@ extension UserWithEmbedContext: ListViewDataConvertable {
     }
 }
 
+extension PluginWithEditContext: @retroactive Identifiable {}
 extension PluginWithEditContext: ListViewDataConvertable {
     public var id: String {
         self.plugin.slug
@@ -56,6 +60,7 @@ extension PluginWithEditContext: ListViewDataConvertable {
     }
 }
 
+extension ApplicationPasswordWithEditContext: @retroactive Identifiable {}
 extension ApplicationPasswordWithEditContext: ListViewDataConvertable {
     public var id: String {
         self.uuid.uuid
@@ -76,6 +81,7 @@ extension ApplicationPasswordWithEditContext: ListViewDataConvertable {
     }
 }
 
+extension WpSiteHealthTest: @retroactive Identifiable {}
 extension SiteHealthTest: ListViewDataConvertable {
     public var id: String {
         self.label
@@ -86,6 +92,7 @@ extension SiteHealthTest: ListViewDataConvertable {
     }
 }
 
+extension WpSiteHealthDirectorySizes: @retroactive Identifiable {}
 extension SiteHealthDirectorySizes: ListViewDataConvertable {
     public var id: String {
         [
@@ -117,6 +124,7 @@ extension SiteHealthDirectorySizes: ListViewDataConvertable {
     }
 }
 
+extension PostTypeDetailsWithViewContext: @retroactive Identifiable {}
 extension PostTypeDetailsWithViewContext: ListViewDataConvertable {
     public var id: String {
         self.slug
@@ -147,6 +155,7 @@ extension SiteSettingsWithEditContext {
     }
 }
 
+extension PostWithEditContext: @retroactive Identifiable {}
 extension PostWithEditContext: ListViewDataConvertable {
     public var id: String {
         self.slug

--- a/native/swift/Example/Example/ListViewModel.swift
+++ b/native/swift/Example/Example/ListViewModel.swift
@@ -18,7 +18,7 @@ protocol ListViewModel {
 @Observable class SequenceListViewModel: ListViewModel {
     var listItems: [String: ListViewData] = [String: ListViewData](minimumCapacity: 250)
 
-    typealias SequenceProvider = () throws -> ListViewSequence
+    typealias SequenceProvider = @Sendable () async throws -> ListViewSequence
 
     private let sequenceProvider: SequenceProvider
 
@@ -34,7 +34,7 @@ protocol ListViewModel {
 
     func task() async {
         do {
-            for try await page in try self.sequenceProvider() {
+            for try await page in try await self.sequenceProvider() {
                 for item in page {
                     self.listItems[item.id] = item
                 }
@@ -52,7 +52,7 @@ protocol ListViewModel {
 
 @Observable class TaskListViewModel: ListViewModel {
 
-    typealias FetchDataTask = () async throws -> [ListViewData]
+    typealias FetchDataTask = @Sendable () async throws -> [ListViewData]
 
     var listItems: [String: ListViewData] = [:]
     private var dataCallback: FetchDataTask
@@ -101,9 +101,9 @@ struct MyError: LocalizedError {
 struct ListViewSequence: AsyncSequence {
     typealias Element = [ListViewData]
 
-    private let underlyingSequence: any AsyncSequence
+    private let underlyingSequence: any (AsyncSequence & Sendable)
 
-    init(underlyingSequence: any AsyncSequence) {
+    init(underlyingSequence: any (AsyncSequence & Sendable)) {
         self.underlyingSequence = underlyingSequence
     }
 

--- a/native/swift/Example/Example/LoginManager.swift
+++ b/native/swift/Example/Example/LoginManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressAPI
 
+@MainActor
 class LoginManager: NSObject, ObservableObject {
 
     @Published
@@ -39,9 +40,7 @@ class LoginManager: NSObject, ObservableObject {
         setDefaultSiteUrl(to: newValue.siteUrl)
         try Keychain.store(username: newValue.userLogin, password: newValue.password, for: newValue.siteUrl)
 
-        await MainActor.run {
-            isLoggedIn = true
-        }
+        isLoggedIn = true
     }
 
     public func getLoginCredentials() throws -> WpAuthentication? {

--- a/native/swift/Example/Example/UI/LoginView.swift
+++ b/native/swift/Example/Example/UI/LoginView.swift
@@ -20,6 +20,8 @@ struct LoginView: View {
     @Environment(\.webAuthenticationSession)
     private var webAuthenticationSession
 
+    private let authenticationHelper = AuthenticationHelper()
+
     @EnvironmentObject
     var loginManager: LoginManager
 
@@ -66,9 +68,8 @@ struct LoginView: View {
                 let loginDetails = try await loginClient.login(
                     site: url,
                     appName: "WordPress SDK Example App",
-                    appId: nil,
-                    contextProvider: AuthenticationHelper()
-                ).get()
+                    appId: nil
+                )
                 debugPrint(loginDetails)
                 try await loginManager.setLoginCredentials(to: loginDetails)
             } catch let err {
@@ -84,19 +85,7 @@ struct LoginView: View {
 }
 
 class AuthenticationHelper: NSObject, ASWebAuthenticationPresentationContextProviding {
-    // swiftlint:disable force_cast
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        #if os(macOS)
-        ASPresentationAnchor(contentViewController: NSApp.windows.first!.contentViewController!)
-        #elseif os(iOS)
-        ASPresentationAnchor(windowScene: UIApplication.shared.connectedScenes.first as! UIWindowScene)
-        #endif
+        ASPresentationAnchor()
     }
-    // swiftlint:enable force_cast
 }
-
-// Stuff that should be Rust code
-
-// func findApiEndpoint(in bytes: Data) -> URL {
-//
-// }

--- a/native/swift/Example/Example/UI/RootListView.swift
+++ b/native/swift/Example/Example/UI/RootListView.swift
@@ -43,7 +43,7 @@ struct RootListViewItem: View {
     }
 }
 
-enum RootListData: Identifiable {
+enum RootListData: Identifiable, Sendable {
 
     case callback(String, TaskListViewModel.FetchDataTask)
     case sequence(String, SequenceListViewModel.SequenceProvider)

--- a/native/swift/Example/Example/WordPressAPI+Extensions.swift
+++ b/native/swift/Example/Example/WordPressAPI+Extensions.swift
@@ -2,19 +2,26 @@ import Foundation
 import WordPressAPI
 
 extension WordPressAPI {
-    @MainActor
+
     static var globalInstance: WordPressAPI {
-        get throws {
-            let loginManager = LoginManager()
+        get async throws {
+            let loginManager = await LoginManager()
 
-            let parsedUrl = try ParsedUrl.parse(input: loginManager.getDefaultSiteUrl()!)
+            guard let defaultSiteUrl = await loginManager.getDefaultSiteUrl() else {
+                throw CocoaError(.validationMissingMandatoryProperty)
+            }
 
-            return try WordPressAPI(
+            let parsedUrl = try ParsedUrl.parse(input: defaultSiteUrl)
+
+            guard let loginCredentials = try await loginManager.getLoginCredentials() else {
+                throw CocoaError(.xpcConnectionInvalid)
+            }
+
+            return WordPressAPI(
                urlSession: .shared,
                baseUrl: parsedUrl,
-               authenticationStategy: loginManager.getLoginCredentials()!
+               authenticationStategy: loginCredentials
            )
         }
     }
-
 }

--- a/native/swift/Example/Example/WordPressAPI+Extensions.swift
+++ b/native/swift/Example/Example/WordPressAPI+Extensions.swift
@@ -2,6 +2,7 @@ import Foundation
 import WordPressAPI
 
 extension WordPressAPI {
+    @MainActor
     static var globalInstance: WordPressAPI {
         get throws {
             let loginManager = LoginManager()

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -36,6 +36,7 @@ public typealias UserCreateParams = WordPressAPIInternal.UserCreateParams
 public typealias UserDeleteParams = WordPressAPIInternal.UserDeleteParams
 public typealias UserDeleteResponse = WordPressAPIInternal.UserDeleteResponse
 public typealias UsersRequestExecutor = WordPressAPIInternal.UsersRequestExecutor
+extension UsersRequestExecutor: @unchecked Sendable {}
 
 public typealias UsersRequestListWithEditContextResponse = WordPressAPIInternal.UsersRequestListWithEditContextResponse
 public typealias UsersRequestListWithViewContextResponse = WordPressAPIInternal.UsersRequestListWithViewContextResponse
@@ -61,6 +62,8 @@ public typealias SparseApplicationPassword = WordPressAPIInternal.SparseApplicat
 public typealias ApplicationPasswordWithEditContext = WordPressAPIInternal.ApplicationPasswordWithEditContext
 public typealias ApplicationPasswordWithViewContext = WordPressAPIInternal.ApplicationPasswordWithViewContext
 public typealias ApplicationPasswordWithEmbedContext = WordPressAPIInternal.ApplicationPasswordWithEmbedContext
+public typealias ApplicationPasswordsRequestExecutor = WordPressAPIInternal.ApplicationPasswordsRequestExecutor
+extension ApplicationPasswordsRequestExecutor: @unchecked Sendable {}
 
 // MARK: - Site Health Checks
 public typealias SiteHealthTest = WordPressAPIInternal.WpSiteHealthTest
@@ -75,6 +78,8 @@ public typealias PostTypeWithEmbedContext = WordPressAPIInternal.PostTypeDetails
 public typealias PostTypeDetailsWithEditContext = WordPressAPIInternal.PostTypeDetailsWithEditContext
 public typealias PostTypeDetailsWithViewContext = WordPressAPIInternal.PostTypeDetailsWithViewContext
 public typealias PostTypeDetailsWithEmbedContext = WordPressAPIInternal.PostTypeDetailsWithEmbedContext
+public typealias PostTypesRequestExecutor = WordPressAPIInternal.PostTypesRequestExecutor
+extension PostTypesRequestExecutor: @unchecked Sendable {}
 
 // MARK: - Posts
 public typealias SparsePost = WordPressAPIInternal.SparsePost
@@ -83,6 +88,7 @@ public typealias PostWithViewContext = WordPressAPIInternal.PostWithViewContext
 public typealias PostWithEmbedContext = WordPressAPIInternal.PostWithEmbedContext
 public typealias PostListParams = WordPressAPIInternal.PostListParams
 public typealias PostsRequestExecutor = WordPressAPIInternal.PostsRequestExecutor
+extension PostsRequestExecutor: @unchecked Sendable {}
 
 public typealias PostsRequestListWithEditContextResponse = WordPressAPIInternal.PostsRequestListWithEditContextResponse
 public typealias PostsRequestListWithViewContextResponse = WordPressAPIInternal.PostsRequestListWithViewContextResponse
@@ -96,6 +102,7 @@ public typealias MediaWithViewContext = WordPressAPIInternal.MediaWithViewContex
 public typealias MediaWithEmbedContext = WordPressAPIInternal.MediaWithEmbedContext
 public typealias MediaListParams = WordPressAPIInternal.MediaListParams
 public typealias MediaRequestExecutor = WordPressAPIInternal.MediaRequestExecutor
+extension MediaRequestExecutor: @unchecked Sendable {}
 
 public typealias MediaRequestListWithEditContextResponse = WordPressAPIInternal.MediaRequestListWithEditContextResponse
 public typealias MediaRequestListWithViewContextResponse = WordPressAPIInternal.MediaRequestListWithViewContextResponse
@@ -107,6 +114,13 @@ public typealias SiteSettingsWithEditContext = WordPressAPIInternal.SiteSettings
 public typealias SiteSettingsWithViewContext = WordPressAPIInternal.SiteSettingsWithViewContext
 public typealias SiteSettingsWithEmbedContext = WordPressAPIInternal.SiteSettingsWithEmbedContext
 
+// MARK: – Site Settings
+public typealias SiteSettingsRequestExecutor = WordPressAPIInternal.SiteSettingsRequestExecutor
+extension SiteSettingsRequestExecutor: @unchecked Sendable {}
+
+// MARK: – Site Health Tests
+public typealias WpSiteHealthTestsRequestExecutor = WordPressAPIInternal.WpSiteHealthTestsRequestExecutor
+extension WpSiteHealthTestsRequestExecutor: @unchecked Sendable {}
 // swiftlint:enable line_length
 
 #endif

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -55,6 +55,7 @@ public typealias PluginUpdateParams = WordPressAPIInternal.PluginUpdateParams
 public typealias PluginCreateParams = WordPressAPIInternal.PluginCreateParams
 public typealias PluginDeleteResponse = WordPressAPIInternal.PluginDeleteResponse
 public typealias PluginsRequestExecutor = WordPressAPIInternal.PluginsRequestExecutor
+extension PluginsRequestExecutor: @unchecked Sendable {}
 
 // MARK: – Application Passwords
 

--- a/native/swift/Sources/wordpress-api/LoginAPI.swift
+++ b/native/swift/Sources/wordpress-api/LoginAPI.swift
@@ -10,81 +10,14 @@ import FoundationNetworking
 
 public final class WordPressLoginClient {
 
-    public protocol Authenticator {
-        func authenticate(url: URL, callbackURL: URL) async -> Result<URL, Error>
+    public protocol AuthenticatorProtocol {
+        func authenticate(url: URL, callbackURL: URL) async throws(WordPressLoginClientError) -> URL
     }
 
     private static let callbackURL = URL(string: "x-wordpress-app://login-callback")!
 
-    public enum Error: Swift.Error {
-        case invalidSiteAddress(UrlDiscoveryError)
-        case missingLoginUrl
-        case authenticationError(OAuthResponseUrlError)
-        case invalidApplicationPasswordCallback
-        case cancelled
-        case unknown(Swift.Error)
-
-        func isAutodiscoveryError() -> Bool {
-            guard case let .invalidSiteAddress(urlDiscoveryError) = self else {
-                return false
-            }
-
-            guard case .UrlDiscoveryFailed = urlDiscoveryError else {
-                return false
-            }
-
-            return true
-        }
-
-        var isFailedToFetchApiDetails: Bool {
-            guard
-                case let .invalidSiteAddress(urlDiscoveryError) = self,
-                case .UrlDiscoveryFailed(let attempts) = urlDiscoveryError
-            else {
-                return false
-            }
-
-            return attempts.values.contains { state in
-                return switch state {
-                case .failure(let error): urlDiscoverErrorIsFetchApiDetailsFailed(error)
-                default: false
-                }
-            }
-        }
-
-        var isFailedToFetchApiRoot: Bool {
-            guard
-                case let .invalidSiteAddress(urlDiscoveryError) = self,
-                case .UrlDiscoveryFailed(let attempts) = urlDiscoveryError
-            else {
-                return false
-            }
-
-            return attempts.values.contains { state in
-                if case let .failure(error) = state {
-                    return isFetchRootUrlFailedError(error)
-                }
-
-                return false
-            }
-        }
-
-        private func urlDiscoverErrorIsFetchApiDetailsFailed(_ error: UrlDiscoveryAttemptError) -> Bool {
-            return switch error {
-            case .fetchApiDetailsFailed: true
-            default: false
-            }
-        }
-
-        private func isFetchRootUrlFailedError(_ error: UrlDiscoveryAttemptError) -> Bool {
-            return switch error {
-            case .fetchApiRootUrlFailed: true
-            default: false
-            }
-        }
-    }
-
     private let requestExecutor: SafeRequestExecutor
+    private let client: UniffiWpLoginClient
 
     public convenience init(urlSession: URLSession) {
         self.init(requestExecutor: urlSession)
@@ -92,69 +25,65 @@ public final class WordPressLoginClient {
 
     init(requestExecutor: SafeRequestExecutor) {
         self.requestExecutor = requestExecutor
+        self.client = UniffiWpLoginClient(requestExecutor: requestExecutor)
     }
 
     public func login(
         site: String,
         appName: String,
         appId: WpUuid?,
-        authenticator: Authenticator
-    ) async -> Result<WpApiApplicationPasswordDetails, Error> {
-        let loginURL = await self.loginURL(forSite: site)
-        let authURL = loginURL
-            .map { loginURL in
-                createApplicationPasswordAuthenticationUrl(
-                    loginUrl: loginURL,
-                    appName: appName,
-                    appId: appId,
-                    successUrl: Self.callbackURL.absoluteString,
-                    rejectUrl: Self.callbackURL.absoluteString
-                )
-                .asURL()
-            }
+        authenticator: AuthenticatorProtocol
+    ) async throws -> WpApiApplicationPasswordDetails {
+        let loginURL = try await self.loginURL(forSite: site)
+        let authURL = createApplicationPasswordAuthenticationUrl(
+            loginUrl: loginURL,
+            appName: appName,
+            appId: appId,
+            successUrl: Self.callbackURL.absoluteString,
+            rejectUrl: Self.callbackURL.absoluteString
+        )
+        .asURL()
 
-        switch authURL {
-        case let .failure(error):
-            return .failure(error)
-        case let .success(authURL):
-            return await authenticator.authenticate(url: authURL, callbackURL: Self.callbackURL)
-                .flatMap(handleAuthenticationCallback(_:))
-        }
+        let urlWithToken = try await authenticator.authenticate(url: authURL, callbackURL: Self.callbackURL)
+        return try handleAuthenticationCallback(urlWithToken)
     }
 
-    private func loginURL(forSite proposedSiteUrl: String) async -> Result<ParsedUrl, Error> {
-        let result: UrlDiscoverySuccess
+    private func loginURL(forSite proposedSiteUrl: String) async throws(WordPressLoginClientError) -> ParsedUrl {
+
         do {
             let client = UniffiWpLoginClient(requestExecutor: self.requestExecutor)
-            result = try await client.apiDiscovery(siteUrl: proposedSiteUrl)
+            let discoveryResult = try await client.apiDiscovery(siteUrl: proposedSiteUrl)
+
+            // All sites should have some form of authentication we can use
+            guard
+                let passwordAuthenticationUrl = discoveryResult.apiDetails.findApplicationPasswordsAuthenticationUrl(),
+                let parsedLoginUrl = try? ParsedUrl.parse(input: passwordAuthenticationUrl)
+            else {
+                throw WordPressLoginClientError.missingLoginUrl
+            }
+
+            return parsedLoginUrl
+
         } catch let error as UrlDiscoveryError {
-            return .failure(.invalidSiteAddress(error))
+            throw WordPressLoginClientError.invalidSiteAddress(error)
         } catch {
-            return .failure(.unknown(error))
+            throw WordPressLoginClientError.unknown(error)
         }
-
-        // All sites should have some form of authentication we can use
-        guard let passwordAuthenticationUrl = result.apiDetails.findApplicationPasswordsAuthenticationUrl(),
-              let parsedLoginUrl = try? ParsedUrl.parse(input: passwordAuthenticationUrl) else {
-            return .failure(.missingLoginUrl)
-        }
-
-        return .success(parsedLoginUrl)
     }
 
     private func handleAuthenticationCallback(
         _ urlWithToken: URL
-    ) -> Result<WpApiApplicationPasswordDetails, Error> {
+    ) throws(WordPressLoginClientError) -> WpApiApplicationPasswordDetails {
         guard let parsed = try? ParsedUrl.from(url: urlWithToken) else {
-            return .failure(.invalidApplicationPasswordCallback)
+            throw .invalidApplicationPasswordCallback
         }
 
         do {
-            return try .success(extractLoginDetailsFromUrl(url: parsed))
+            return try extractLoginDetailsFromUrl(url: parsed)
         } catch let error as OAuthResponseUrlError {
-            return .failure(.authenticationError(error))
+            throw .authenticationError(error)
         } catch {
-            return .failure(.unknown(error))
+            throw .unknown(error)
         }
     }
 }
@@ -165,38 +94,42 @@ import AuthenticationServices
 
 extension WordPressLoginClient {
 
-    class AuthenticationServiceAuthenticator: Authenticator {
-        let contextProvider: ASWebAuthenticationPresentationContextProviding
-
-        init(contextProvider: ASWebAuthenticationPresentationContextProviding) {
-            self.contextProvider = contextProvider
+    class AuthenticationServiceAuthenticator: NSObject, AuthenticatorProtocol,
+                                                ASWebAuthenticationPresentationContextProviding {
+        func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+            ASPresentationAnchor()
         }
 
         @MainActor
-        func authenticate(url: URL, callbackURL: URL) async -> Result<URL, WordPressLoginClient.Error> {
-            await withCheckedContinuation { continuation in
-                let session = ASWebAuthenticationSession(
-                    url: url,
-                    callbackURLScheme: callbackURL.scheme!
-                ) { url, error in
-                    if let url {
-                        continuation.resume(returning: .success(url))
-                    } else if let error = error as? ASWebAuthenticationSessionError {
-                        switch error.code {
-                        case .canceledLogin:
-                            continuation.resume(returning: .failure(.cancelled))
-                        case .presentationContextInvalid, .presentationContextNotProvided:
-                            assertionFailure("An unexpected error received: \(error)")
-                            continuation.resume(returning: .failure(.cancelled))
-                        @unknown default:
-                            continuation.resume(returning: .failure(.cancelled))
+        func authenticate(url: URL, callbackURL: URL) async throws(WordPressLoginClientError) -> URL {
+            do {
+                return try await withCheckedThrowingContinuation { continuation in
+                    let session = ASWebAuthenticationSession(
+                        url: url,
+                        callbackURLScheme: callbackURL.scheme!
+                    ) { url, error in
+                        if let url {
+                            continuation.resume(returning: url)
+                        } else if let error = error as? ASWebAuthenticationSessionError {
+                            switch error.code {
+                            case .canceledLogin:
+                                continuation.resume(throwing: WordPressLoginClientError.cancelled)
+                            case .presentationContextInvalid, .presentationContextNotProvided:
+                                assertionFailure("An unexpected error received: \(error)")
+                                continuation.resume(throwing: WordPressLoginClientError.cancelled)
+                            @unknown default:
+                                continuation.resume(throwing: WordPressLoginClientError.cancelled)
+                            }
+                        } else {
+                            continuation.resume(throwing: WordPressLoginClientError.invalidApplicationPasswordCallback)
                         }
-                    } else {
-                        continuation.resume(returning: .failure(.invalidApplicationPasswordCallback))
                     }
+                    session.presentationContextProvider = self
+                    session.start()
                 }
-                session.presentationContextProvider = contextProvider
-                session.start()
+            } catch {
+                // swiftlint:disable:next force_cast
+                throw error as! WordPressLoginClientError
             }
         }
     }
@@ -204,17 +137,16 @@ extension WordPressLoginClient {
     public func login(
         site: String,
         appName: String,
-        appId: WpUuid?,
-        contextProvider: ASWebAuthenticationPresentationContextProviding
-    ) async -> Result<WpApiApplicationPasswordDetails, Error> {
-        await login(
+        appId: WpUuid?
+    ) async throws -> WpApiApplicationPasswordDetails {
+        let provider = await AuthenticationServiceAuthenticator()
+        return try await login(
             site: site,
             appName: appName,
             appId: appId,
-            authenticator: AuthenticationServiceAuthenticator(contextProvider: contextProvider)
+            authenticator: provider
         )
     }
-
 }
 
 #endif

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -1,8 +1,12 @@
 import Foundation
 
+#if canImport(WordPressAPIInternal)
+import WordPressAPIInternal
+#endif
+
 public protocol PaginatableResponse: Sendable {
-    associatedtype ParamsType
-    associatedtype DataType
+    associatedtype ParamsType: Sendable
+    associatedtype DataType: Sendable
 
     var nextPageParams: ParamsType? { get }
     var prevPageParams: ParamsType? { get }
@@ -12,7 +16,7 @@ public protocol PaginatableResponse: Sendable {
     init(data: [DataType], headerMap: WpNetworkHeaderMap, nextPageParams: ParamsType?, prevPageParams: ParamsType?)
 }
 
-public protocol PaginationAwareExecutor {
+public protocol PaginationAwareExecutor: Sendable {
     associatedtype EditContextResponseType: PaginatableResponse
     associatedtype ViewContextResponseType: PaginatableResponse
     associatedtype EmbedContextResponseType: PaginatableResponse
@@ -146,8 +150,8 @@ extension PaginationAwareExecutor {
     }
 }
 
-public struct PaginationSequence<ResponseType: PaginatableResponse>: AsyncSequence {
-    public typealias Transformer = (ResponseType.ParamsType) async throws -> ResponseType
+public struct PaginationSequence<ResponseType: PaginatableResponse>: AsyncSequence, Sendable {
+    public typealias Transformer = @Sendable (ResponseType.ParamsType) async throws -> ResponseType
 
     private let params: ResponseType.ParamsType
     private let transform: Transformer

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -1,13 +1,13 @@
 import Foundation
 #if canImport(WordPressAPIInternal)
-import WordPressAPIInternal
+@preconcurrency import WordPressAPIInternal
 #endif
 
 #if os(Linux)
 import FoundationNetworking
 #endif
 
-public struct WordPressAPI {
+public struct WordPressAPI: Sendable {
 
     enum Errors: Error {
         case unableToParseResponse

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -7,7 +7,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public struct WordPressAPI: Sendable {
+public actor WordPressAPI {
 
     enum Errors: Error {
         case unableToParseResponse

--- a/native/swift/Sources/wordpress-api/WordPressLoginClientError.swift
+++ b/native/swift/Sources/wordpress-api/WordPressLoginClientError.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+#if canImport(WordPressAPIInternal)
+import WordPressAPIInternal
+#endif
+
+#if os(Linux)
+import FoundationNetworking
+#endif
+
+public enum WordPressLoginClientError: Swift.Error {
+    case invalidSiteAddress(UrlDiscoveryError)
+    case missingLoginUrl
+    case authenticationError(OAuthResponseUrlError)
+    case invalidApplicationPasswordCallback
+    case cancelled
+    case unknown(Swift.Error)
+
+    func isAutodiscoveryError() -> Bool {
+        guard case let .invalidSiteAddress(urlDiscoveryError) = self else {
+            return false
+        }
+
+        guard case .UrlDiscoveryFailed = urlDiscoveryError else {
+            return false
+        }
+
+        return true
+    }
+
+    var isFailedToFetchApiDetails: Bool {
+        guard
+            case let .invalidSiteAddress(urlDiscoveryError) = self,
+            case .UrlDiscoveryFailed(let attempts) = urlDiscoveryError
+        else {
+            return false
+        }
+
+        return attempts.values.contains { state in
+            return switch state {
+            case .failure(let error): urlDiscoverErrorIsFetchApiDetailsFailed(error)
+            default: false
+            }
+        }
+    }
+
+    var isFailedToFetchApiRoot: Bool {
+        guard
+            case let .invalidSiteAddress(urlDiscoveryError) = self,
+            case .UrlDiscoveryFailed(let attempts) = urlDiscoveryError
+        else {
+            return false
+        }
+
+        return attempts.values.contains { state in
+            if case let .failure(error) = state {
+                return isFetchRootUrlFailedError(error)
+            }
+
+            return false
+        }
+    }
+
+    private func urlDiscoverErrorIsFetchApiDetailsFailed(_ error: UrlDiscoveryAttemptError) -> Bool {
+        return switch error {
+        case .fetchApiDetailsFailed: true
+        default: false
+        }
+    }
+
+    private func isFetchRootUrlFailedError(_ error: UrlDiscoveryAttemptError) -> Bool {
+        return switch error {
+        case .fetchApiRootUrlFailed: true
+        default: false
+        }
+    }
+}

--- a/native/swift/Tests/wordpress-api/LoginTests.swift
+++ b/native/swift/Tests/wordpress-api/LoginTests.swift
@@ -20,10 +20,10 @@ class LoginTests {
                 site: "invalid url",
                 appName: "foo",
                 appId: appId,
-                authenticator: Authenticator()
-            ).get()
+                authenticator: MockAuthenticator()
+            )
         }, throws: { error in
-            guard let loginError = error as? WordPressLoginClient.Error, case .invalidSiteAddress = loginError else {
+            guard let loginError = error as? WordPressLoginClientError, case .invalidSiteAddress = loginError else {
                 return false
             }
 
@@ -47,10 +47,10 @@ class LoginTests {
                 site: "https://example.com/blog",
                 appName: "foo",
                 appId: appId,
-                authenticator: Authenticator()
-            ).get()
+                authenticator: MockAuthenticator()
+            )
         }, throws: { error in
-            guard let loginError = error as? WordPressLoginClient.Error, case .invalidSiteAddress = loginError else {
+            guard let loginError = error as? WordPressLoginClientError, case .invalidSiteAddress = loginError else {
                 return false
             }
 
@@ -89,10 +89,10 @@ class LoginTests {
                 site: "https://example.com",
                 appName: "foo",
                 appId: appId,
-                authenticator: Authenticator()
-            ).get()
+                authenticator: MockAuthenticator()
+            )
         }, throws: { error in
-            guard let loginError = error as? WordPressLoginClient.Error else {
+            guard let loginError = error as? WordPressLoginClientError else {
                 return false
             }
 
@@ -134,10 +134,10 @@ class LoginTests {
                 site: "https://example.com",
                 appName: "foo",
                 appId: appId,
-                authenticator: Authenticator()
-            ).get()
+                authenticator: MockAuthenticator()
+            )
         }, throws: { error in
-            error as? WordPressLoginClient.Error == .missingLoginUrl
+            error as? WordPressLoginClientError == .missingLoginUrl
         })
     }
 
@@ -174,10 +174,10 @@ class LoginTests {
                 site: "https://example.com",
                 appName: "foo",
                 appId: appId,
-                authenticator: Authenticator().returning(.success(rejectedURL))
-            ).get()
+                authenticator: MockAuthenticator().returning(rejectedURL)
+            )
         }, throws: { error in
-            error as? WordPressLoginClient.Error == .authenticationError(.UnsuccessfulLogin)
+            error as? WordPressLoginClientError == .authenticationError(.UnsuccessfulLogin)
         })
     }
 
@@ -210,29 +210,38 @@ class LoginTests {
         // swiftlint:disable:next line_length
         let successfulURL = URL(string: "x-wordpress-app://login-callback?site_url=https%3A%2F%2Fexample.com&user_login=admin&password=123456")!
 
-        let result = await client.login(
+        let result = try await client.login(
             site: "https://example.com",
             appName: "foo",
             appId: appId,
-            authenticator: Authenticator().returning(.success(successfulURL))
+            authenticator: MockAuthenticator().returning(successfulURL)
         )
-        let success = try result.get()
 
-        #expect(success.siteUrl == "https://example.com")
-        #expect(success.userLogin == "admin")
-        #expect(success.password == "123456")
+        #expect(result.siteUrl == "https://example.com")
+        #expect(result.userLogin == "admin")
+        #expect(result.password == "123456")
     }
 }
 
-private class Authenticator: WordPressLoginClient.Authenticator {
-    var result: Result<URL, WordPressLoginClient.Error>?
+private class MockAuthenticator: WordPressLoginClient.AuthenticatorProtocol {
+    var result: URL!
+    var error: WordPressLoginClientError?
 
-    func returning(_ result: Result<URL, WordPressLoginClient.Error>) -> Self {
-        self.result = result
+    func returning(_ url: URL) -> Self {
+        self.result = url
         return self
     }
 
-    func authenticate(url: URL, callbackURL: URL) async -> Result<URL, WordPressLoginClient.Error> {
-        result ?? .failure(.unknown(NSError(domain: "authenticator-test", code: 1)))
+    func throwing(_ error: WordPressLoginClientError) -> Self {
+        self.error = error
+        return self
+    }
+
+    func authenticate(url: URL, callbackURL: URL) async throws(WordPressLoginClientError) -> URL {
+        if let error = self.error {
+            throw error
+        }
+
+        return result
     }
 }

--- a/native/swift/Tests/wordpress-api/SendableTests.swift
+++ b/native/swift/Tests/wordpress-api/SendableTests.swift
@@ -1,9 +1,12 @@
+import Foundation
 import Testing
 import WordPressAPI
 
 struct SendableTests {
 
     private static let sendables: [Sendable] = [
+        WordPressAPI(urlSession: URLSession(configuration: .ephemeral), baseUrl: try! ParsedUrl.parse(input: "https://example.com"), authenticationStategy: .none),
+
         MediaRequestListWithEditContextResponse.empty,
         MediaRequestListWithViewContextResponse.empty,
         MediaRequestListWithEmbedContextResponse.empty,

--- a/native/swift/Tests/wordpress-api/SendableTests.swift
+++ b/native/swift/Tests/wordpress-api/SendableTests.swift
@@ -5,7 +5,12 @@ import WordPressAPI
 struct SendableTests {
 
     private static let sendables: [Sendable] = [
-        WordPressAPI(urlSession: URLSession(configuration: .ephemeral), baseUrl: try! ParsedUrl.parse(input: "https://example.com"), authenticationStategy: .none),
+        WordPressAPI(
+            urlSession: URLSession(configuration: .ephemeral),
+            // swiftlint:disable:next force_try
+            baseUrl: try! ParsedUrl.parse(input: "https://example.com"),
+            authenticationStategy: .none
+        ),
 
         MediaRequestListWithEditContextResponse.empty,
         MediaRequestListWithViewContextResponse.empty,

--- a/native/swift/Tests/wordpress-api/SendableTests.swift
+++ b/native/swift/Tests/wordpress-api/SendableTests.swift
@@ -2,6 +2,10 @@ import Foundation
 import Testing
 import WordPressAPI
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 struct SendableTests {
 
     private static let sendables: [Sendable] = [

--- a/native/swift/Tests/wordpress-api/SendableTests.swift
+++ b/native/swift/Tests/wordpress-api/SendableTests.swift
@@ -9,13 +9,6 @@ import FoundationNetworking
 struct SendableTests {
 
     private static let sendables: [Sendable] = [
-        WordPressAPI(
-            urlSession: URLSession(configuration: .ephemeral),
-            // swiftlint:disable:next force_try
-            baseUrl: try! ParsedUrl.parse(input: "https://example.com"),
-            authenticationStategy: .none
-        ),
-
         MediaRequestListWithEditContextResponse.empty,
         MediaRequestListWithViewContextResponse.empty,
         MediaRequestListWithEmbedContextResponse.empty,

--- a/native/swift/Tests/wordpress-api/Support/Extensions.swift
+++ b/native/swift/Tests/wordpress-api/Support/Extensions.swift
@@ -28,8 +28,8 @@ extension WpNetworkRequest: @unchecked Sendable {}
 extension WpNetworkResponse: @unchecked Sendable {}
 
 // This is only for testing – it's not production-ready
-extension WordPressLoginClient.Error: Equatable {
-    public static func == (lhs: WordPressLoginClient.Error, rhs: WordPressLoginClient.Error) -> Bool {
+extension WordPressLoginClientError: Equatable {
+    public static func == (lhs: WordPressLoginClientError, rhs: WordPressLoginClientError) -> Bool {
         lhs.localizedDescription == rhs.localizedDescription
     }
 }

--- a/wp_api/uniffi.toml
+++ b/wp_api/uniffi.toml
@@ -8,3 +8,4 @@ generate_immutable_records = true
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "libwordpressFFI"
 generate_immutable_records = true
+experimental_sendable_value_types = true


### PR DESCRIPTION
To address warnings like

> Non-sendable type 'WordPressAPI' in implicitly asynchronous access to actor-isolated property 'api' cannot cross actor boundary; this is an error in the Swift 6 language mode