### PR TITLE
Refactor generating Swift binding files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,25 +19,9 @@ swift_package_platform_tvos = $(call swift_package_platform_version,tvos)
 # Required for supporting tvOS and watchOS. We can update the nightly toolchain version if needed.
 rust_nightly_toolchain := nightly-2024-04-30
 
-uname := $(shell uname | tr A-Z a-z)
-ifeq ($(uname), linux)
-	dylib_ext := so
-endif
-ifeq ($(uname), darwin)
-	dylib_ext := dylib
-endif
-
 clean:
 	@# Help: Remove untracked files from the project via Git.
 	git clean -ffXd
-
-bindings:
-	rm -rf target/swift-bindings
-	cargo build --release
-
-	#wp_api
-	cargo run --release --bin wp_uniffi_bindgen generate --library ./target/release/libwp_api.$(dylib_ext) --out-dir ./target/swift-bindings --language swift
-	cp target/swift-bindings/wp_api.swift native/swift/Sources/wordpress-api-wrapper/wp_api.swift
 
 .PHONY: docs # Rebuild docs each time we run this command
 docs:
@@ -77,14 +61,6 @@ release-on-ci:
 	@echo "Swift package will be released by https://buildkite.com/automattic/wordpress-rs/builds/$$(jq -r '.number' .build/buildkite_release_job_response.json)"
 	@echo "Once that job finishes, Android libraries will be release by https://buildkite.com/automattic/wordpress-rs/builds?branch=$(WORDPRESS_RS_NEW_VERSION)"
 
-# An XCFramework relies on the .h file and the modulemap to interact with the precompiled binary
-xcframework-headers: bindings
-	rm -rvf target/swift-bindings/headers
-	mkdir -p target/swift-bindings/headers
-
-	cp target/swift-bindings/*.h target/swift-bindings/headers
-	cp target/swift-bindings/libwordpressFFI.modulemap target/swift-bindings/headers/module.modulemap
-
 apple-platform-targets-macos := x86_64-apple-darwin aarch64-apple-darwin
 apple-platform-targets-ios := aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 apple-platform-targets-tvos := aarch64-apple-tvos aarch64-apple-tvos-sim
@@ -97,8 +73,10 @@ apple-platform-targets := \
 
 ifeq ($(BUILDKITE), true)
 CARGO_PROFILE ?= release
+CARGO_PROFILE_DIRNAME := release
 else
 CARGO_PROFILE ?= dev
+CARGO_PROFILE_DIRNAME := debug
 endif
 
 cargo_config_library = --config profile.$(CARGO_PROFILE).debug=true --config 'profile.$(CARGO_PROFILE).panic="abort"'
@@ -114,8 +92,9 @@ _build-apple-%-tvos _build-apple-%-tvos-sim _build-apple-%-watchos _build-apple-
 	CARGO_OPTS = +$(rust_nightly_toolchain) -Z build-std=panic_abort,std
 
 # Build the library for a specific target
-_build-apple-%: xcframework-headers
+_build-apple-%:
 	cargo $(CARGO_OPTS) $(cargo_config_library) build --target $* --package wp_api --profile $(CARGO_PROFILE)
+	./scripts/swift-bindings.sh target/$*/$(CARGO_PROFILE_DIRNAME)/libwp_api.a
 
 # Build the library for one single platform, including real device and simulator.
 build-apple-platform-macos := $(addprefix _build-apple-,$(apple-platform-targets-macos))
@@ -153,11 +132,12 @@ xcframework-package-checksum:
 docker-image-swift:
 	docker build -t wordpress-rs-swift -f Dockerfile.swift .
 
-swift-linux-library: bindings
-	mkdir -p target/swift-bindings/libwordpressFFI-linux
-	cp target/swift-bindings/*.h target/swift-bindings/libwordpressFFI-linux/
-	cp target/swift-bindings/libwordpressFFI.modulemap target/swift-bindings/libwordpressFFI-linux/module.modulemap
-	cp target/release/libwp_api.a target/swift-bindings/libwordpressFFI-linux/
+swift-linux-library:
+	cargo build --release --package wp_api
+	./scripts/swift-bindings.sh target/release/libwp_api.a
+	mkdir -p target/release/libwordpressFFI-linux
+	cp target/release/swift-bindings/Headers/* target/release/libwordpressFFI-linux/
+	cp target/release/libwp_api.a target/release/libwordpressFFI-linux/
 
 swift-example-app: swift-example-app-mac swift-example-app-ios
 
@@ -174,7 +154,7 @@ test-swift-linux: docker-image-swift
 	docker run $(docker_opts_shared) -it wordpress-rs-swift make test-swift-linux-in-docker
 
 test-swift-linux-in-docker: swift-linux-library
-	swift test -Xlinker -Ltarget/swift-bindings/libwordpressFFI-linux -Xlinker -lwp_api
+	swift test -Xlinker -Ltarget/release/libwordpressFFI-linux -Xlinker -lwp_api
 
 test-swift-darwin: xcframework
 	swift test
@@ -255,10 +235,6 @@ fmt-rust:
 
 fmt-check-rust:
 	$(rust_docker_run) /bin/bash -c "rustup component add rustfmt && cargo fmt --all -- --check"
-
-build-in-docker:
-	$(call bindings)
-	$(docker_build_and_run)
 
 setup-rust:
 	@# Help: Install the necessary Rust toolchains on your development computer (for macOS).

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9aafa5656d7a6c49905ab42cb52d23fe8b7cefe1a04a14e537053255e511790a",
+  "originHash" : "4c30bcea863fdb29514c7daf20b8911f79465cc6626c1c7fdc311c43d9a8367a",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let libwordpressFFIVersion: WordPressRSVersion = .local
 #if os(Linux)
 let libwordpressFFI: Target = .systemLibrary(
         name: "libwordpressFFI",
-        path: "target/swift-bindings/libwordpressFFI-linux/"
+        path: "target/release/libwordpressFFI-linux/"
     )
 #elseif os(macOS)
 let libwordpressFFI: Target = libwordpressFFIVersion.target

--- a/scripts/swift-bindings.sh
+++ b/scripts/swift-bindings.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 /path/to/library"
+  exit 1
+fi
+
+module_name="libwordpressFFI"
+library_path=$1
+output_dir="$(dirname "$library_path")/swift-bindings"
+rm -rf "$output_dir" && mkdir "$output_dir"
+
+cargo run --release --quiet --bin wp_uniffi_bindgen generate \
+    --library "$library_path" \
+    --out-dir "$output_dir" \
+    --language swift
+
+# The search-and-replace below can be removed after updating to a uniffi-rs
+# version that includes this PR https://github.com/mozilla/uniffi-rs/pull/2341
+for swift_binding in "$output_dir"/*.swift; do
+    options=("-i")
+    if [[ $(uname) == "Darwin" ]]; then
+        options+=("")
+    fi
+    sed "${options[@]}" 's/^protocol UniffiForeignFutureTask /fileprivate protocol UniffiForeignFutureTask /' "$swift_binding"
+done
+
+mv "$output_dir"/*.swift native/swift/Sources/wordpress-api-wrapper/
+
+header_dir="$output_dir/Headers"
+mkdir -p "$header_dir"
+
+{
+    for header_file in "$output_dir"/*.h; do
+        echo "#include \"$(basename "$header_file")\""
+    done
+} > "$header_dir/$module_name.h"
+mv "$output_dir"/*.h "$header_dir/"
+
+cat <<EOF > "$header_dir/module.modulemap"
+module $module_name {
+    header "$module_name.h"
+    export *
+}
+EOF

--- a/wp_api/uniffi.toml
+++ b/wp_api/uniffi.toml
@@ -6,5 +6,6 @@ generate_immutable_records = true
 
 [bindings.swift]
 ffi_module_name = "libwordpressFFI"
-ffi_module_filename = "libwordpressFFI"
+ffi_module_filename = "wp_api_uniffi"
+generate_module_map = false
 generate_immutable_records = true

--- a/xcframework/src/main.rs
+++ b/xcframework/src/main.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const XCFRAMEWORK_OUTPUT_PATH: &str = "target/libwordpressFFI.xcframework";
-const SWIFT_BINDINGS_HEADER_DIR: &str = "target/swift-bindings/headers";
 const LIBRARY_FILENAME: &str = "libwordpress.a";
 
 fn main() -> Result<()> {
@@ -50,7 +49,6 @@ impl CreateXCFramework {
 // work together to make it easier to create a xcframework.
 struct XCFramework {
     libraries: Vec<LibraryGroup>,
-    headers: PathBuf,
 }
 
 // Represent a group of static libraries that are built for the same platform.
@@ -67,11 +65,6 @@ struct Slice {
 
 impl XCFramework {
     fn new(targets: &Vec<String>, profile: &str) -> Result<Self> {
-        let headers = PathBuf::from(SWIFT_BINDINGS_HEADER_DIR);
-        if !headers.exists() {
-            anyhow::bail!("Headers not found: {}", headers.display())
-        }
-
         let mut groups = HashMap::<LibraryGroupId, LibraryGroup>::new();
         for target in targets {
             let id = LibraryGroupId::from_target(target)?;
@@ -91,15 +84,13 @@ impl XCFramework {
 
         Ok(Self {
             libraries: groups.into_values().collect(),
-            headers,
         })
     }
 
     fn create(&self, temp_dir: &Path) -> Result<PathBuf> {
         self.preview();
 
-        let libraries = self.combine_libraries(temp_dir)?;
-        let temp_dest = self.create_xcframework(&libraries, temp_dir)?;
+        let temp_dest = self.create_xcframework(temp_dir)?;
         self.patch_xcframework(&temp_dest)?;
 
         let dest = PathBuf::from(XCFRAMEWORK_OUTPUT_PATH);
@@ -120,23 +111,27 @@ impl XCFramework {
         }
     }
 
-    fn combine_libraries(&self, temp_dir: &Path) -> Result<Vec<PathBuf>> {
-        self.libraries
-            .iter()
-            .map(|lib| lib.create(temp_dir))
-            .collect()
-    }
-
-    fn create_xcframework(&self, libraries: &[PathBuf], temp_dir: &Path) -> Result<PathBuf> {
+    fn create_xcframework(&self, temp_dir: &Path) -> Result<PathBuf> {
         let temp_dest = temp_dir.join("libwordpressFFI.xcframework");
         std::fs::remove_dir_all(&temp_dest).ok();
 
-        let library_args = libraries.iter().flat_map(|lib| {
+        let library_args: Result<Vec<(PathBuf, PathBuf)>> = self
+            .libraries
+            .iter()
+            .map(|library| {
+                let lib = library.create(temp_dir)?;
+                let header = library.headers_dir()?;
+                Ok((lib, header))
+            })
+            .collect();
+        let library_args = library_args?;
+
+        let library_args = library_args.iter().flat_map(|(lib, headers)| {
             [
                 "-library".as_ref(),
                 lib.as_os_str(),
                 "-headers".as_ref(),
-                self.headers.as_os_str(),
+                headers.as_os_str(),
             ]
         });
         Command::new("xcodebuild")
@@ -157,29 +152,23 @@ impl XCFramework {
             let path = dir_entry.expect("Invalid Path").path();
             if path.is_dir() {
                 let headers_dir = temp_dir.join(&path).join("Headers");
-                let header_path = headers_dir.join("libwordpressFFI.h");
-                let module_path = headers_dir.join("module.modulemap");
+                let non_lib_files: Vec<PathBuf> = std::fs::read_dir(&headers_dir)?
+                    .flat_map(|f| f.ok())
+                    .filter_map(|f| {
+                        if f.path().ends_with(".a") {
+                            None
+                        } else {
+                            Some(f.path())
+                        }
+                    })
+                    .collect();
 
-                let new_headers_dir = temp_dir.join(&path).join("Headers").join("libwordpressFFI");
-
+                let new_headers_dir = headers_dir.join("libwordpressFFI");
                 recreate_directory(&new_headers_dir)?;
 
-                let new_header_path = new_headers_dir.join("libwordpressFFI.h");
-                let new_module_path = new_headers_dir.join("module.modulemap");
-
-                println!(
-                    "Moving: {} -> {}",
-                    header_path.display(),
-                    new_header_path.display()
-                );
-                println!(
-                    "Moving: {} -> {}",
-                    module_path.display(),
-                    new_module_path.display()
-                );
-
-                std::fs::rename(header_path, new_header_path)?;
-                std::fs::rename(module_path, new_module_path)?;
+                for file in non_lib_files {
+                    std::fs::rename(&file, new_headers_dir.join(file.file_name().unwrap()))?;
+                }
             }
         }
 
@@ -207,6 +196,18 @@ impl LibraryGroup {
             .successful_output()?;
 
         Ok(dest)
+    }
+
+    fn headers_dir(&self) -> Result<PathBuf> {
+        let slice = self
+            .slices
+            .first()
+            .with_context(|| "No slices in library group")?;
+        let path = slice.built_product_dir().join("swift-bindings/headers");
+        if !path.exists() {
+            anyhow::bail!("Headers not found: {}", path.display())
+        }
+        Ok(path)
     }
 }
 
@@ -237,7 +238,8 @@ impl Slice {
         Ok(dest)
     }
 
-    fn built_libraries(&self) -> Vec<PathBuf> {
+    /// Returns the directory where the built static libraries are located.
+    fn built_product_dir(&self) -> PathBuf {
         let mut target_dir: PathBuf = ["target", &self.target].iter().collect();
         if self.profile == "dev" {
             target_dir.push("debug");
@@ -245,7 +247,11 @@ impl Slice {
             target_dir.push(&self.profile);
         }
 
-        vec![target_dir.join("libwp_api.a")]
+        target_dir
+    }
+
+    fn built_libraries(&self) -> Vec<PathBuf> {
+        vec![self.built_product_dir().join("libwp_api.a")]
     }
 }
 


### PR DESCRIPTION
It's more technically correct to generate uniffi binding files with Rust library built for each platform. Because the Rust crate that exposes API via uniffi may have different APIs on different platforms (for example, it could have some API for iOS but not for tvOS), and uniffi-rs itself could have different implementations for each platform (for example, there could be subtle differences in the generated code for certain CPU arch).

However, in the reality of this project and the current state of uniffi-rs, there is no difference in the generated bindings on each Apple platform.

This PR updates the build pipeline to use a more "technically correct" approach, even though the result is no different than what we currently have.

### Details

At the moment, `make bindings` builds the wp_api library for macOS(*1), generates bindings using the built library, and uses them on all Apple platforms.

This PR removes the `make bindings` and uses a shell script to generate bindings. Please note the `cargo build` run in the step marked as *1 is skipped because it's unnecessary. We already built libraries for each Apple platform. We should use them to generate bindings.

This PR does run the `wp_uniffi_bindgen` multiple times, one for each platform. Their result will be used in the creating xcframework command: `xcodebuild -create-xcframework -library library-for-ios -headers headers-for-ios --library library-for-macos -headers headers-for-macos ...`. Again, even though we are now passing different header directories, they don't really make any practical difference from what we have right now because the header directories' content is exactly the same.