### PR TITLE
Pretty print JSON responses for `WpApiError::ResponseParsingError`

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -25,7 +25,11 @@ pub enum WpApiError {
     },
     #[error("Media file not found at file path: {}", file_path)]
     MediaFileNotFound { file_path: String },
-    #[error("Error while parsing. \nReason: {}\nResponse: {}", reason, response)]
+    #[error(
+        "Error while parsing. \nReason: {}\nResponse: {}",
+        reason,
+        maybe_json_response(response)
+    )]
     ResponseParsingError { reason: String, response: String },
     #[error("Error while parsing site url: {}", reason)]
     SiteUrlParsingError { reason: String },
@@ -48,6 +52,13 @@ pub enum WpApiError {
         status_code: u16,
         response: String,
     },
+}
+
+// Pretty print the response as JSON if it can be parsed as such, return as is otherwise
+fn maybe_json_response(response: &String) -> String {
+    serde_json::from_str::<serde_json::Value>(response.as_str())
+        .and_then(|value| serde_json::to_string_pretty(&value))
+        .unwrap_or(response.to_string())
 }
 
 impl ParsedRequestError for WpApiError {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -253,11 +253,7 @@ impl<T: std::fmt::Debug, E: std::error::Error> AssertResponse for Result<T, E> {
     type Item = T;
 
     fn assert_response(self) -> T {
-        assert!(
-            self.is_ok(),
-            "Request failed with: {:#?}",
-            self.unwrap_err()
-        );
+        assert!(self.is_ok(), "Request failed with: {}", self.unwrap_err());
         self.unwrap()
     }
 }


### PR DESCRIPTION
This is a simple PR that adds JSON formatting to `WpApiError::ResponseParsingError` response strings.

Whenever there is an integration test failure, we print out the error and for parsing errors, that includes the response string. However, this string is not formatted and can't even be copy-pasted to format in an editor, because it includes escape characters. That makes it very hard to find the root of the issue quickly.

This change should help with that and as a bonus it should also work in native wrappers.

---

Note that I am not sure about the `maybe_json_response` function name, so if you have suggestions, I'd be happy to rename it.