### PR TITLE
Retrieve `/comments` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
@@ -1,10 +1,13 @@
 package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import uniffi.wp_api.CommentListParams
+import uniffi.wp_api.CommentRetrieveParams
 import uniffi.wp_api.SparseCommentFieldWithEditContext
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class CommentsEndpointTest {
@@ -24,8 +27,16 @@ class CommentsEndpointTest {
     }
 
     @Test
+    fun testRetrieveCommentRequest() = runTest {
+        val comment = client.request { requestBuilder ->
+            requestBuilder.comments().retrieveWithEditContext(1, CommentRetrieveParams())
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(comment)
+    }
+
+    @Test
     fun testFilterCommentListRequest() = runTest {
-        val postList = client.request { requestBuilder ->
+        val commentList = client.request { requestBuilder ->
             requestBuilder.comments().filterListWithEditContext(
                 params = CommentListParams(),
                 fields = listOf(
@@ -34,7 +45,23 @@ class CommentsEndpointTest {
                 )
             )
         }.assertSuccessAndRetrieveData().data
-        assert(postList.isNotEmpty())
-        assertNull(postList.first().authorEmail)
+        assert(commentList.isNotEmpty())
+        assertNull(commentList.first().authorEmail)
+    }
+
+    @Test
+    fun testFilterRetrieveCommentRequest() = runTest {
+        val sparseComment = client.request { requestBuilder ->
+            requestBuilder.comments().filterRetrieveWithEditContext(
+                commentId = 1,
+                params = CommentRetrieveParams(),
+                fields = listOf(
+                    SparseCommentFieldWithEditContext.AUTHOR,
+                    SparseCommentFieldWithEditContext.CONTENT
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(sparseComment)
+        Assertions.assertNull(sparseComment.id)
     }
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostsEndpointTest.kt
@@ -29,7 +29,7 @@ class PostsEndpointTest {
     @Test
     fun testRetrievePostRequest() = runTest {
         val post = client.request { requestBuilder ->
-            requestBuilder.posts().retrieveWithEditContext(1, PostRetrieveParams(null))
+            requestBuilder.posts().retrieveWithEditContext(1, PostRetrieveParams())
         }.assertSuccessAndRetrieveData().data
         assertNotNull(post)
     }
@@ -54,7 +54,7 @@ class PostsEndpointTest {
         val sparsePost = client.request { requestBuilder ->
             requestBuilder.posts().filterRetrieveWithEditContext(
                 postId = 1,
-                params = PostRetrieveParams(null),
+                params = PostRetrieveParams(),
                 fields = listOf(
                     SparsePostFieldWithEditContext.TITLE,
                     SparsePostFieldWithEditContext.CONTENT

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -88,6 +88,8 @@ create_test_credentials () {
   local SUBSCRIBER_PASSWORD_UUID
   local TRASHED_POST_ID
   local PASSWORD_PROTECTED_POST_ID
+  local PASSWORD_PROTECTED_COMMENT_ID
+  local PASSWORD_PROTECTED_COMMENT_AUTHOR
   SITE_URL="http://localhost"
   ADMIN_USERNAME="test@example.com"
   ADMIN_PASSWORD="$(wp user application-password create test@example.com test --porcelain)"
@@ -100,6 +102,9 @@ create_test_credentials () {
 
   PASSWORD_PROTECTED_POST_ID="$(wp post create --post_type=post --post_password=INTEGRATION_TEST --post_title=Password_Protected --porcelain)"
   TRASHED_POST_ID="$(wp post create --post_type=post --post_title=Trashed_Post --porcelain)"
+
+  PASSWORD_PROTECTED_COMMENT_AUTHOR="setup-test-site.sh"
+  PASSWORD_PROTECTED_COMMENT_ID="$(wp comment create --comment_post_ID="$PASSWORD_PROTECTED_POST_ID" --comment_content="test_comment_for_password_protected_post" --comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" --porcelain)"
 
   # Trash the post
   wp post delete "$TRASHED_POST_ID"
@@ -118,6 +123,8 @@ create_test_credentials () {
     password_protected_post_id="$PASSWORD_PROTECTED_POST_ID" \
     password_protected_post_password="INTEGRATION_TEST" \
     password_protected_post_title="Password_Protected" \
+    password_protected_comment_id="$PASSWORD_PROTECTED_COMMENT_ID" \
+    password_protected_comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" \
     trashed_post_id="$TRASHED_POST_ID" \
     > /app/test_credentials.json
 }

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -74,6 +74,12 @@ impl FromStr for CommentId {
     }
 }
 
+impl std::fmt::Display for CommentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(
     Debug,
     Default,
@@ -301,6 +307,19 @@ impl FromUrlQueryPairs for CommentListParams {
 
     fn supports_pagination() -> bool {
         true
+    }
+}
+
+#[derive(Debug, Default, uniffi::Record)]
+pub struct CommentRetrieveParams {
+    /// The password for the parent post of the comment (if the post is password protected).
+    #[uniffi(default = None)]
+    pub password: Option<String>,
+}
+
+impl AppendUrlQueryPairs for CommentRetrieveParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair("password", self.password.as_ref());
     }
 }
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -530,6 +530,12 @@ impl FromStr for PostId {
     }
 }
 
+impl std::fmt::Display for PostId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl_as_query_value_for_new_type!(TagId);
 uniffi::custom_newtype!(TagId, i64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -553,12 +559,6 @@ impl FromStr for CategoryId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse().map(Self)
-    }
-}
-
-impl std::fmt::Display for PostId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
     }
 }
 

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -1,6 +1,6 @@
 use crate::comments::{
-    CommentListParams, SparseCommentFieldWithEditContext, SparseCommentFieldWithEmbedContext,
-    SparseCommentFieldWithViewContext,
+    CommentId, CommentListParams, SparseCommentFieldWithEditContext,
+    SparseCommentFieldWithEmbedContext, SparseCommentFieldWithViewContext,
 };
 use crate::SparseField;
 use wp_derive_request_builder::WpDerivedRequest;
@@ -10,6 +10,8 @@ use super::{AsNamespace, DerivedRequest, WpNamespace};
 enum CommentsRequest {
     #[contextual_paged(url = "/comments", params = &CommentListParams, output = Vec<crate::comments::SparseComment>, filter_by = crate::comments::SparseCommentField)]
     List,
+    #[contextual_get(url = "/comments/<comment_id>", params = &crate::comments::CommentRetrieveParams, output = crate::comments::SparseComment, filter_by = crate::comments::SparseCommentField)]
+    Retrieve,
 }
 
 impl DerivedRequest for CommentsRequest {
@@ -49,7 +51,9 @@ impl SparseField for SparseCommentFieldWithViewContext {
 mod tests {
     use super::*;
     use crate::{
-        comments::{CommentId, CommentStatus, CommentType, WpApiParamCommentsOrderBy},
+        comments::{
+            CommentId, CommentRetrieveParams, CommentStatus, CommentType, WpApiParamCommentsOrderBy,
+        },
         generate,
         posts::PostId,
         request::endpoint::{
@@ -200,6 +204,64 @@ mod tests {
             comment_type: Some(CommentType::Pingback),
             password: Some("p_q".to_string()),
         }
+    }
+
+    #[rstest]
+    #[case(None, "")]
+    #[case(Some("foo"), "password=foo")]
+    fn retrieve_comment(
+        endpoint: CommentsRequestEndpoint,
+        #[case] password: Option<&str>,
+        #[case] expected_additional_params: &str,
+    ) {
+        let comment_id = CommentId(54);
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/comments/54?context={}", context)
+            } else {
+                format!(
+                    "/comments/54?context={}&{}",
+                    context, expected_additional_params
+                )
+            }
+        };
+        let params = CommentRetrieveParams {
+            password: password.map(|p| p.to_string()),
+        };
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(&comment_id, &params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(&comment_id, &params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(&comment_id, &params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(None, &[], "/comments/54?context=view&_fields=")]
+    #[case(Some("foo"), &[SparseCommentFieldWithViewContext::Author], "/comments/54?context=view&password=foo&_fields=author")]
+    #[case(Some("foo"), ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT, &format!("/comments/54?context=view&password=foo&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_retrieve_comment_with_view_context(
+        endpoint: CommentsRequestEndpoint,
+        #[case] password: Option<&str>,
+        #[case] fields: &[SparseCommentFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_view_context(
+                &CommentId(54),
+                &CommentRetrieveParams {
+                    password: password.map(|p| p.to_string()),
+                },
+                fields,
+            ),
+            expected_path,
+        );
     }
 
     const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_EDIT_CONTEXT: &str = "_fields=id%2Cauthor%2Cauthor_email%2Cauthor_ip%2Cauthor_name%2Cauthor_url%2Cauthor_user_agent%2Ccontent%2Cdate%2Cdate_gmt%2Clink%2Cparent%2Cpost%2Cstatus%2Ctype%2Cauthor_avatar_urls";

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -3,6 +3,7 @@ use http::{HeaderMap, HeaderValue};
 use reqwest::multipart::Part;
 use std::sync::Arc;
 use wp_api::{
+    comments::CommentId,
     media::MediaId,
     posts::{CategoryId, PostId, TagId},
     request::{
@@ -31,6 +32,8 @@ pub struct TestCredentials {
     pub password_protected_post_id: i64,
     pub password_protected_post_password: &'static str,
     pub password_protected_post_title: &'static str,
+    pub password_protected_comment_id: i64,
+    pub password_protected_comment_author: &'static str,
     pub trashed_post_id: i64,
 }
 
@@ -45,6 +48,7 @@ pub const SECOND_USER_SLUG: &str = "themedemos";
 pub const HELLO_DOLLY_PLUGIN_SLUG: &str = "hello-dolly/hello";
 pub const CLASSIC_EDITOR_PLUGIN_SLUG: &str = "classic-editor/classic-editor";
 pub const WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS: &str = "classic-widgets";
+pub const FIRST_COMMENT_ID: CommentId = CommentId(1);
 pub const FIRST_POST_ID: PostId = PostId(1);
 pub const MEDIA_ID_611: MediaId = MediaId(611);
 pub const MEDIA_TEST_FILE_PATH: &str = "../test_media.jpg";

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -252,7 +252,7 @@ mod filter {
     #[case(&[SparseCommentFieldWithEditContext::Id, SparseCommentFieldWithEditContext::Author])]
     #[tokio::test]
     #[parallel]
-    async fn filter_comment_with_edit_context(
+    async fn filter_comments_with_edit_context(
         #[case] fields: &[SparseCommentFieldWithEditContext],
         #[values(
             CommentListParams::default(),
@@ -273,11 +273,31 @@ mod filter {
             });
     }
 
+    #[apply(sparse_comment_field_with_edit_context_test_cases)]
+    #[case(&[SparseCommentFieldWithEditContext::Id, SparseCommentFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_comments_with_edit_context(
+        #[case] fields: &[SparseCommentFieldWithEditContext],
+    ) {
+        let comment = api_client()
+            .comments()
+            .filter_retrieve_with_edit_context(
+                &FIRST_COMMENT_ID,
+                &CommentRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        comment.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_comment_field_with_embed_context_test_cases)]
     #[case(&[SparseCommentFieldWithEmbedContext::Id, SparseCommentFieldWithEmbedContext::Author])]
     #[tokio::test]
     #[parallel]
-    async fn filter_comment_with_embed_context(
+    async fn filter_comments_with_embed_context(
         #[case] fields: &[SparseCommentFieldWithEmbedContext],
         #[values(
             CommentListParams::default(),
@@ -298,11 +318,31 @@ mod filter {
             });
     }
 
+    #[apply(sparse_comment_field_with_embed_context_test_cases)]
+    #[case(&[SparseCommentFieldWithEmbedContext::Id, SparseCommentFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_comments_with_embed_context(
+        #[case] fields: &[SparseCommentFieldWithEmbedContext],
+    ) {
+        let comment = api_client()
+            .comments()
+            .filter_retrieve_with_embed_context(
+                &FIRST_COMMENT_ID,
+                &CommentRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        comment.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_comment_field_with_view_context_test_cases)]
     #[case(&[SparseCommentFieldWithViewContext::Id, SparseCommentFieldWithViewContext::Author])]
     #[tokio::test]
     #[parallel]
-    async fn filter_comment_with_view_context(
+    async fn filter_comments_with_view_context(
         #[case] fields: &[SparseCommentFieldWithViewContext],
         #[values(
             CommentListParams::default(),
@@ -321,5 +361,25 @@ mod filter {
             .for_each(|comment| {
                 comment.assert_that_instance_fields_nullability_match_provided_fields(fields)
             });
+    }
+
+    #[apply(sparse_comment_field_with_view_context_test_cases)]
+    #[case(&[SparseCommentFieldWithViewContext::Id, SparseCommentFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_comments_with_view_context(
+        #[case] fields: &[SparseCommentFieldWithViewContext],
+    ) {
+        let comment = api_client()
+            .comments()
+            .filter_retrieve_with_view_context(
+                &FIRST_COMMENT_ID,
+                &CommentRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        comment.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
 }

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -2,15 +2,16 @@ use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
 use wp_api::comments::{
-    CommentId, CommentListParams, CommentStatus, CommentType, SparseCommentFieldWithEditContext,
-    SparseCommentFieldWithEmbedContext, SparseCommentFieldWithViewContext,
-    WpApiParamCommentsOrderBy,
+    CommentId, CommentListParams, CommentRetrieveParams, CommentStatus, CommentType,
+    SparseCommentFieldWithEditContext, SparseCommentFieldWithEmbedContext,
+    SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy,
 };
 use wp_api::posts::PostId;
 use wp_api::users::UserAvatarSize;
 use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
-    api_client, AssertResponse, FIRST_USER_EMAIL, FIRST_USER_ID, SECOND_USER_ID,
+    api_client, AssertResponse, TestCredentials, FIRST_COMMENT_ID, FIRST_USER_EMAIL, FIRST_USER_ID,
+    SECOND_USER_ID,
 };
 
 #[tokio::test]
@@ -44,6 +45,111 @@ async fn list_with_view_context(#[case] params: CommentListParams) {
         .list_with_view_context(&params)
         .await
         .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .comments()
+        .retrieve_with_edit_context(&FIRST_COMMENT_ID, &CommentRetrieveParams::default())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context(#[case] params: CommentRetrieveParams) {
+    api_client()
+        .comments()
+        .retrieve_with_embed_context(&FIRST_COMMENT_ID, &CommentRetrieveParams::default())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context(#[case] params: CommentRetrieveParams) {
+    api_client()
+        .comments()
+        .retrieve_with_view_context(&FIRST_COMMENT_ID, &CommentRetrieveParams::default())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_edit_context() {
+    let test_credentials = TestCredentials::instance();
+    let comment = api_client()
+        .comments()
+        .retrieve_with_edit_context(
+            &CommentId(test_credentials.password_protected_comment_id),
+            &CommentRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_post_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        comment.author_name,
+        test_credentials.password_protected_comment_author
+    );
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_embed_context() {
+    let test_credentials = TestCredentials::instance();
+    let comment = api_client()
+        .comments()
+        .retrieve_with_embed_context(
+            &CommentId(test_credentials.password_protected_comment_id),
+            &CommentRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_post_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        comment.author_name,
+        test_credentials.password_protected_comment_author
+    );
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_view_context() {
+    let test_credentials = TestCredentials::instance();
+    let comment = api_client()
+        .comments()
+        .retrieve_with_view_context(
+            &CommentId(test_credentials.password_protected_comment_id),
+            &CommentRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_post_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        comment.author_name,
+        test_credentials.password_protected_comment_author
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follows established patterns to implement [retrieve `comments` endpoint.](https://developer.wordpress.org/rest-api/reference/comments/#retrieve-a-comment)