### PR TITLE
Delete `/comments` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
@@ -3,10 +3,12 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import uniffi.wp_api.CommentDeleteParams
 import uniffi.wp_api.CommentListParams
 import uniffi.wp_api.CommentRetrieveParams
 import uniffi.wp_api.SparseCommentFieldWithEditContext
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -63,5 +65,23 @@ class CommentsEndpointTest {
         }.assertSuccessAndRetrieveData().data
         assertNotNull(sparseComment)
         Assertions.assertNull(sparseComment.id)
+    }
+
+    @Test
+    fun deleteCommentRequest() = runTest {
+        val deletedComment = client.request { requestBuilder ->
+            requestBuilder.comments().delete(commentId = 1, CommentDeleteParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(deletedComment.deleted)
+        restoreTestServer()
+    }
+
+    @Test
+    fun trashCommentRequest() = runTest {
+        val trashedComment = client.request { requestBuilder ->
+            requestBuilder.comments().trash(commentId = 1, CommentDeleteParams())
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("trash", trashedComment.status)
+        restoreTestServer()
     }
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uniffi.wp_api.CommentDeleteParams
 import uniffi.wp_api.CommentListParams
 import uniffi.wp_api.CommentRetrieveParams
+import uniffi.wp_api.CommentStatus
 import uniffi.wp_api.SparseCommentFieldWithEditContext
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
 import kotlin.test.assertEquals
@@ -81,7 +82,7 @@ class CommentsEndpointTest {
         val trashedComment = client.request { requestBuilder ->
             requestBuilder.comments().trash(commentId = 1, CommentDeleteParams())
         }.assertSuccessAndRetrieveData().data
-        assertEquals("trash", trashedComment.status)
+        assertEquals(CommentStatus.Trash, trashedComment.status)
         restoreTestServer()
     }
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
@@ -20,7 +20,9 @@ fun <T> WpRequestResult<T>.assertSuccess() {
 }
 
 fun <T> WpRequestResult<T>.assertSuccessAndRetrieveData(): T {
-    assert(this is WpRequestResult.WpRequestSuccess)
+    assert(this is WpRequestResult.WpRequestSuccess) {
+        "Request wasn't successful: $this"
+    }
     return (this as WpRequestResult.WpRequestSuccess).data
 }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -3,37 +3,37 @@ package rs.wordpress.api.kotlin
 import uniffi.wp_api.WpErrorCode
 
 sealed class WpRequestResult<T> {
-    class WpRequestSuccess<T>(val data: T) : WpRequestResult<T>()
-    class WpError<T>(
+    data class WpRequestSuccess<T>(val data: T) : WpRequestResult<T>()
+    data class WpError<T>(
         val errorCode: WpErrorCode,
         val errorMessage: String,
         val statusCode: UShort,
         val response: String,
     ) : WpRequestResult<T>()
 
-    class InvalidHttpStatusCode<T>(
+    data class InvalidHttpStatusCode<T>(
         val statusCode: UShort
     ) : WpRequestResult<T>()
 
-    class RequestExecutionFailed<T>(
+    data class RequestExecutionFailed<T>(
         val statusCode: UShort?,
         val reason: String,
     ) : WpRequestResult<T>()
 
-    class MediaFileNotFound<T>(
+    data class MediaFileNotFound<T>(
         val filePath: String
     ) : WpRequestResult<T>()
 
-    class SiteUrlParsingError<T>(
+    data class SiteUrlParsingError<T>(
         val reason: String,
     ) : WpRequestResult<T>()
 
-    class ResponseParsingError<T>(
+    data class ResponseParsingError<T>(
         val reason: String,
         val response: String,
     ) : WpRequestResult<T>()
 
-    class UnknownError<T>(
+    data class UnknownError<T>(
         val statusCode: UShort,
         val response: String,
     ) : WpRequestResult<T>()

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -378,7 +378,7 @@ pub struct SparseComment {
     #[WpContext(edit, view)]
     pub post: Option<PostId>,
     #[WpContext(edit, view)]
-    pub status: Option<String>,
+    pub status: Option<CommentStatus>,
     #[serde(rename = "type")]
     #[WpContext(edit, embed, view)]
     pub comment_type: Option<CommentType>,

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -323,7 +323,7 @@ impl AppendUrlQueryPairs for CommentRetrieveParams {
     }
 }
 
-#[derive(Debug, uniffi::Record)]
+#[derive(Debug, Default, uniffi::Record)]
 pub struct CommentDeleteParams {
     /// The password for the parent post of the comment (if the post is password protected).
     #[uniffi(default = None)]

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -323,6 +323,31 @@ impl AppendUrlQueryPairs for CommentRetrieveParams {
     }
 }
 
+#[derive(Debug, uniffi::Record)]
+pub struct CommentDeleteParams {
+    /// The password for the parent post of the comment (if the post is password protected).
+    #[uniffi(default = None)]
+    pub password: Option<String>,
+}
+
+impl CommentDeleteParams {
+    pub fn new(password: Option<String>) -> Self {
+        Self { password }
+    }
+}
+
+impl AppendUrlQueryPairs for CommentDeleteParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair("password", self.password.as_ref());
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct CommentDeleteResponse {
+    pub deleted: bool,
+    pub previous: CommentWithEditContext,
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseComment {
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -12,9 +12,21 @@ enum CommentsRequest {
     List,
     #[contextual_get(url = "/comments/<comment_id>", params = &crate::comments::CommentRetrieveParams, output = crate::comments::SparseComment, filter_by = crate::comments::SparseCommentField)]
     Retrieve,
+    #[delete(url = "/comments/<comment_id>", params = &crate::comments::CommentDeleteParams, output = crate::comments::CommentDeleteResponse)]
+    Delete,
+    #[delete(url = "/comments/<comment_id>", params = &crate::comments::CommentDeleteParams, output = crate::comments::CommentWithEditContext)]
+    Trash,
 }
 
 impl DerivedRequest for CommentsRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            CommentsRequest::Delete => vec![("force", true.to_string())],
+            CommentsRequest::Trash => vec![("force", false.to_string())],
+            _ => vec![],
+        }
+    }
+
     fn namespace() -> impl AsNamespace {
         WpNamespace::WpV2
     }
@@ -52,7 +64,8 @@ mod tests {
     use super::*;
     use crate::{
         comments::{
-            CommentId, CommentRetrieveParams, CommentStatus, CommentType, WpApiParamCommentsOrderBy,
+            CommentDeleteParams, CommentId, CommentRetrieveParams, CommentStatus, CommentType,
+            WpApiParamCommentsOrderBy,
         },
         generate,
         posts::PostId,
@@ -260,6 +273,34 @@ mod tests {
                 },
                 fields,
             ),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(None, "/comments/54?force=true")]
+    #[case(Some("foo".to_string()), "/comments/54?password=foo&force=true")]
+    fn delete_comment(
+        endpoint: CommentsRequestEndpoint,
+        #[case] password: Option<String>,
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.delete(&CommentId(54), &CommentDeleteParams::new(password)),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(None, "/comments/54?force=false")]
+    #[case(Some("foo".to_string()), "/comments/54?password=foo&force=false")]
+    fn trash_comment(
+        endpoint: CommentsRequestEndpoint,
+        #[case] password: Option<String>,
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.trash(&CommentId(54), &CommentDeleteParams::new(password)),
             expected_path,
         );
     }

--- a/wp_api_integration_tests/src/backend.rs
+++ b/wp_api_integration_tests/src/backend.rs
@@ -27,12 +27,20 @@ impl Backend {
             BACKEND_PATH_COMMENT, comment_id
         ))
         .await
-        .expect("Failed to parse fetched post from wp_cli")
+        .expect("Failed to parse fetched comment from wp_cli")
     }
-    pub async fn comments() -> Vec<WpCliComment> {
-        Self::get(BACKEND_PATH_COMMENTS)
+    pub async fn comments(comment_status: Option<&str>) -> Vec<WpCliComment> {
+        let url = if let Some(comment_status) = comment_status {
+            format!(
+                "{}?comment_status={}",
+                BACKEND_PATH_COMMENTS, comment_status
+            )
+        } else {
+            BACKEND_PATH_COMMENTS.to_string()
+        };
+        Self::get(url)
             .await
-            .expect("Failed to parse fetched users from wp_cli")
+            .expect("Failed to parse fetched comments from wp_cli")
     }
     pub async fn site_settings() -> Result<WpCliSiteSettings, reqwest::Error> {
         Self::get(BACKEND_PATH_SITE_SETTINGS).await

--- a/wp_api_integration_tests/src/backend.rs
+++ b/wp_api_integration_tests/src/backend.rs
@@ -1,9 +1,11 @@
 use serde::{de::DeserializeOwned, Serialize};
-use wp_api::{posts::PostId, users::UserId};
-use wp_cli::{WpCliPost, WpCliSiteSettings, WpCliUser, WpCliUserMeta};
+use wp_api::{comments::CommentId, posts::PostId, users::UserId};
+use wp_cli::{WpCliComment, WpCliPost, WpCliSiteSettings, WpCliUser, WpCliUserMeta};
 
 const BACKEND_ADDRESS: &str = "http://127.0.0.1:4000";
 const BACKEND_PATH_RESTORE: &str = "/restore";
+const BACKEND_PATH_COMMENT: &str = "/wp-cli/comment";
+const BACKEND_PATH_COMMENTS: &str = "/wp-cli/comments";
 const BACKEND_PATH_SITE_SETTINGS: &str = "/wp-cli/site-settings";
 const BACKEND_PATH_POST: &str = "/wp-cli/post";
 const BACKEND_PATH_POSTS: &str = "/wp-cli/posts";
@@ -18,6 +20,19 @@ impl Backend {
     async fn get<T: DeserializeOwned>(path: impl AsRef<str>) -> Result<T, reqwest::Error> {
         let url = format!("{}{}", BACKEND_ADDRESS, path.as_ref());
         reqwest::get(url).await?.json().await
+    }
+    pub async fn comment(comment_id: &CommentId) -> WpCliComment {
+        Self::get(format!(
+            "{}?comment_id={}",
+            BACKEND_PATH_COMMENT, comment_id
+        ))
+        .await
+        .expect("Failed to parse fetched post from wp_cli")
+    }
+    pub async fn comments() -> Vec<WpCliComment> {
+        Self::get(BACKEND_PATH_COMMENTS)
+            .await
+            .expect("Failed to parse fetched users from wp_cli")
     }
     pub async fn site_settings() -> Result<WpCliSiteSettings, reqwest::Error> {
         Self::get(BACKEND_PATH_SITE_SETTINGS).await

--- a/wp_api_integration_tests/tests/test_comments_mut.rs
+++ b/wp_api_integration_tests/tests/test_comments_mut.rs
@@ -1,0 +1,34 @@
+use serial_test::serial;
+use wp_api::comments::CommentDeleteParams;
+use wp_api_integration_tests::{
+    api_client,
+    backend::{Backend, RestoreServer},
+    FIRST_COMMENT_ID,
+};
+
+#[tokio::test]
+#[serial]
+async fn delete_comment() {
+    // Delete the comment using the API and ensure it's successful
+    let comment_delete_response = api_client()
+        .comments()
+        .delete(&FIRST_COMMENT_ID, &CommentDeleteParams::default())
+        .await;
+    assert!(
+        comment_delete_response.is_ok(),
+        "{:#?}",
+        comment_delete_response
+    );
+    assert!(comment_delete_response.unwrap().data.deleted);
+
+    // Assert that the comment was deleted
+    assert!(
+        !Backend::comments()
+            .await
+            .into_iter()
+            .any(|c| c.comment_id == FIRST_COMMENT_ID.0),
+        "Comment wasn't deleted"
+    );
+
+    RestoreServer::db().await;
+}

--- a/wp_api_integration_tests/tests/test_comments_mut.rs
+++ b/wp_api_integration_tests/tests/test_comments_mut.rs
@@ -23,12 +23,36 @@ async fn delete_comment() {
 
     // Assert that the comment was deleted
     assert!(
-        !Backend::comments()
+        !Backend::comments(None)
             .await
             .into_iter()
             .any(|c| c.comment_id == FIRST_COMMENT_ID.0),
         "Comment wasn't deleted"
     );
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn trash_comment() {
+    // Trash the comment using the API and ensure it's successful
+    let comment_trash_response = api_client()
+        .comments()
+        .trash(&FIRST_COMMENT_ID, &CommentDeleteParams::default())
+        .await;
+    assert!(
+        comment_trash_response.is_ok(),
+        "{:#?}",
+        comment_trash_response
+    );
+
+    // Assert that the comment was trashed
+    let trashed_comment = Backend::comments(Some("trash"))
+        .await
+        .into_iter()
+        .find(|c| c.comment_id == FIRST_COMMENT_ID.0);
+    assert!(trashed_comment.is_some(), "Can't find the trashed comment");
 
     RestoreServer::db().await;
 }

--- a/wp_api_integration_tests_backend/src/main.rs
+++ b/wp_api_integration_tests_backend/src/main.rs
@@ -5,7 +5,9 @@ use std::fs;
 use std::fs::metadata;
 use std::io;
 use std::path::Path;
-use wp_cli::{WpCliPost, WpCliPostListArguments, WpCliSiteSettings, WpCliUser, WpCliUserMeta};
+use wp_cli::{
+    WpCliComment, WpCliPost, WpCliPostListArguments, WpCliSiteSettings, WpCliUser, WpCliUserMeta,
+};
 
 pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
 
@@ -13,6 +15,20 @@ pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
 enum Error {
     #[response(status = 500)]
     AsString(String),
+}
+
+#[get("/comment?<comment_id>")]
+fn wp_cli_comment(comment_id: i64) -> Result<Json<WpCliComment>, Error> {
+    WpCliComment::get(comment_id)
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
+}
+
+#[get("/comments")]
+fn wp_cli_comments() -> Result<Json<Vec<WpCliComment>>, Error> {
+    WpCliComment::list()
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
 }
 
 #[get("/site-settings")]
@@ -78,6 +94,8 @@ async fn restore_wp_server(db: bool, plugins: bool) -> Result<Status, Error> {
 fn rocket() -> _ {
     rocket::build()
         .mount("/", routes![restore_wp_server])
+        .mount("/wp-cli/", routes![wp_cli_comment])
+        .mount("/wp-cli/", routes![wp_cli_comments])
         .mount("/wp-cli/", routes![wp_cli_site_settings])
         .mount("/wp-cli/", routes![wp_cli_post])
         .mount("/wp-cli/", routes![wp_cli_posts])

--- a/wp_api_integration_tests_backend/src/main.rs
+++ b/wp_api_integration_tests_backend/src/main.rs
@@ -6,7 +6,8 @@ use std::fs::metadata;
 use std::io;
 use std::path::Path;
 use wp_cli::{
-    WpCliComment, WpCliPost, WpCliPostListArguments, WpCliSiteSettings, WpCliUser, WpCliUserMeta,
+    WpCliComment, WpCliCommentListArguments, WpCliPost, WpCliPostListArguments, WpCliSiteSettings,
+    WpCliUser, WpCliUserMeta,
 };
 
 pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
@@ -24,9 +25,9 @@ fn wp_cli_comment(comment_id: i64) -> Result<Json<WpCliComment>, Error> {
         .map_err(|e| Error::AsString(e.to_string()))
 }
 
-#[get("/comments")]
-fn wp_cli_comments() -> Result<Json<Vec<WpCliComment>>, Error> {
-    WpCliComment::list()
+#[get("/comments?<comment_status>")]
+fn wp_cli_comments(comment_status: Option<String>) -> Result<Json<Vec<WpCliComment>>, Error> {
+    WpCliComment::list(Some(WpCliCommentListArguments { comment_status }))
         .map(Json)
         .map_err(|e| Error::AsString(e.to_string()))
 }

--- a/wp_cli/src/lib.rs
+++ b/wp_cli/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, process::Command};
+use std::{collections::HashMap, ffi::OsStr, process::Command};
 
 mod wp_cli_comments;
 mod wp_cli_posts;
@@ -29,4 +29,22 @@ where
         .args(args);
     println!("Running wp_cli command: {:#?}", c);
     c.output().expect("Failed to run wp-cli command")
+}
+
+pub(crate) trait AsWpCliArguments {
+    fn as_wp_cli_arguments(&self) -> Option<String>;
+}
+
+impl AsWpCliArguments for HashMap<&'static str, &String> {
+    fn as_wp_cli_arguments(&self) -> Option<String> {
+        let mut s = String::new();
+        self.iter().for_each(|(k, v)| {
+            s.push_str(format!("--{}={}", k, v).as_str());
+        });
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
 }

--- a/wp_cli/src/lib.rs
+++ b/wp_cli/src/lib.rs
@@ -1,9 +1,11 @@
 use std::{ffi::OsStr, process::Command};
 
+mod wp_cli_comments;
 mod wp_cli_posts;
 mod wp_cli_settings;
 mod wp_cli_users;
 
+pub use wp_cli_comments::*;
 pub use wp_cli_posts::*;
 pub use wp_cli_settings::*;
 pub use wp_cli_users::*;

--- a/wp_cli/src/wp_cli_comments.rs
+++ b/wp_cli/src/wp_cli_comments.rs
@@ -1,0 +1,51 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use wp_serde_helper::deserialize_i64_or_string;
+
+use crate::run_wp_cli_command;
+
+const COMMENT_FIELDS_ARG: &str = "--fields=comment_ID,comment_post_ID,comment_author,comment_author_email,comment_author_url,comment_author_IP,comment_date,comment_date_gmt,comment_content,comment_karma,comment_approved,comment_agent,comment_type,comment_parent,user_id";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpCliComment {
+    #[serde(rename = "comment_ID")]
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub comment_id: i64,
+    #[serde(rename = "comment_post_ID")]
+    pub comment_post_id: String,
+    pub comment_author: String,
+    pub comment_author_email: String,
+    pub comment_author_url: String,
+    #[serde(rename = "comment_author_IP")]
+    pub comment_author_ip: String,
+    pub comment_date: String,
+    pub comment_date_gmt: String,
+    pub comment_content: String,
+    pub comment_karma: String,
+    pub comment_approved: String,
+    pub comment_agent: String,
+    pub comment_type: String,
+    pub comment_parent: String,
+    pub user_id: String,
+}
+
+impl WpCliComment {
+    pub fn get(comment_id: i64) -> Result<Self> {
+        let output = run_wp_cli_command([
+            "comment",
+            "get",
+            comment_id.to_string().as_str(),
+            COMMENT_FIELDS_ARG,
+        ]);
+        serde_json::from_slice::<Self>(&output.stdout).with_context(|| {
+            "Failed to parse `wp get {comment_id} --format=json` into WpCliComment"
+        })
+    }
+    pub fn list() -> Result<Vec<Self>> {
+        let output = run_wp_cli_command(["comment", "list", COMMENT_FIELDS_ARG]);
+        serde_json::from_slice::<Vec<Self>>(&output.stdout).with_context(|| {
+            "Failed to parse `wp comment list --format=json` into
+            Vec<WpCliComment>"
+        })
+    }
+}

--- a/wp_cli/src/wp_cli_comments.rs
+++ b/wp_cli/src/wp_cli_comments.rs
@@ -6,6 +6,29 @@ use crate::run_wp_cli_command;
 
 const COMMENT_FIELDS_ARG: &str = "--fields=comment_ID,comment_post_ID,comment_author,comment_author_email,comment_author_url,comment_author_IP,comment_date,comment_date_gmt,comment_content,comment_karma,comment_approved,comment_agent,comment_type,comment_parent,user_id";
 
+#[derive(Debug, Default)]
+pub struct WpCliCommentListArguments {
+    pub comment_status: Option<String>,
+}
+
+impl WpCliCommentListArguments {
+    fn as_wp_cli_arguments(&self) -> Option<String> {
+        let mut s = String::new();
+        Self::add_field_arg(&mut s, "status", self.comment_status.as_ref());
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+
+    fn add_field_arg(args: &mut String, field_name: &str, field: Option<&String>) {
+        if let Some(f) = field {
+            args.push_str(format!("--{}={}", field_name, f).as_str());
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WpCliComment {
     #[serde(rename = "comment_ID")]
@@ -41,8 +64,17 @@ impl WpCliComment {
             "Failed to parse `wp get {comment_id} --format=json` into WpCliComment"
         })
     }
-    pub fn list() -> Result<Vec<Self>> {
-        let output = run_wp_cli_command(["comment", "list", COMMENT_FIELDS_ARG]);
+    pub fn list(arguments: Option<WpCliCommentListArguments>) -> Result<Vec<Self>> {
+        let output = if let Some(cli_arguments) = arguments.and_then(|a| a.as_wp_cli_arguments()) {
+            run_wp_cli_command([
+                "comment",
+                "list",
+                COMMENT_FIELDS_ARG,
+                cli_arguments.as_str(),
+            ])
+        } else {
+            run_wp_cli_command(["comment", "list", COMMENT_FIELDS_ARG])
+        };
         serde_json::from_slice::<Vec<Self>>(&output.stdout).with_context(|| {
             "Failed to parse `wp comment list --format=json` into
             Vec<WpCliComment>"

--- a/wp_cli/src/wp_cli_comments.rs
+++ b/wp_cli/src/wp_cli_comments.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use wp_serde_helper::deserialize_i64_or_string;
 
-use crate::run_wp_cli_command;
+use crate::{run_wp_cli_command, AsWpCliArguments};
 
 const COMMENT_FIELDS_ARG: &str = "--fields=comment_ID,comment_post_ID,comment_author,comment_author_email,comment_author_url,comment_author_IP,comment_date,comment_date_gmt,comment_content,comment_karma,comment_approved,comment_agent,comment_type,comment_parent,user_id";
 
@@ -11,21 +13,13 @@ pub struct WpCliCommentListArguments {
     pub comment_status: Option<String>,
 }
 
-impl WpCliCommentListArguments {
+impl AsWpCliArguments for WpCliCommentListArguments {
     fn as_wp_cli_arguments(&self) -> Option<String> {
-        let mut s = String::new();
-        Self::add_field_arg(&mut s, "status", self.comment_status.as_ref());
-        if s.is_empty() {
-            None
-        } else {
-            Some(s)
+        let mut map = HashMap::new();
+        if let Some(comment_status) = &self.comment_status {
+            map.insert("status", comment_status);
         }
-    }
-
-    fn add_field_arg(args: &mut String, field_name: &str, field: Option<&String>) {
-        if let Some(f) = field {
-            args.push_str(format!("--{}={}", field_name, f).as_str());
-        }
+        map.as_wp_cli_arguments()
     }
 }
 

--- a/wp_cli/src/wp_cli_posts.rs
+++ b/wp_cli/src/wp_cli_posts.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use wp_serde_helper::deserialize_i64_or_string;
 
-use crate::run_wp_cli_command;
+use crate::{run_wp_cli_command, AsWpCliArguments};
 
 const POST_FIELDS_ARG: &str = "--fields=ID,post_name,post_title,post_date,post_status,post_author,post_date_gmt,post_content,post_excerpt,comment_status,ping_status,post_password,post_modified,post_modified_gmt,guid,post_type";
 
@@ -11,21 +13,13 @@ pub struct WpCliPostListArguments {
     pub post_status: Option<String>,
 }
 
-impl WpCliPostListArguments {
+impl AsWpCliArguments for WpCliPostListArguments {
     fn as_wp_cli_arguments(&self) -> Option<String> {
-        let mut s = String::new();
-        Self::add_field_arg(&mut s, "post_status", self.post_status.as_ref());
-        if s.is_empty() {
-            None
-        } else {
-            Some(s)
+        let mut map = HashMap::new();
+        if let Some(post_status) = &self.post_status {
+            map.insert("post_status", post_status);
         }
-    }
-
-    fn add_field_arg(args: &mut String, field_name: &str, field: Option<&String>) {
-        if let Some(f) = field {
-            args.push_str(format!("--{}={}", field_name, f).as_str());
-        }
+        map.as_wp_cli_arguments()
     }
 }
 


### PR DESCRIPTION
Follows established patterns to implement [delete comments endpoint.](https://developer.wordpress.org/rest-api/reference/comments/#delete-a-comment)

It introduces a new trait `AsWpCliArguments` which is used to share logic for building wp cli arguments from types such as `AsWpCliArguments` & `WpCliPostListArguments`.

While adding Kotlin integration tests, I realized that the subclasses for `WpRequestResult` weren't set as `data` classes which I've addressed in this PR. I've added a more helpful assertion message for when a Kotlin integration test request fails.

I also ended up fixing the `status` field for `SparseComment` in 1de556860dd04cab5c8fde13777998dacc4b9c05.