### PR TITLE
Create `/comments` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/CommentsEndpointTest.kt
@@ -3,6 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import uniffi.wp_api.CommentCreateParams
 import uniffi.wp_api.CommentDeleteParams
 import uniffi.wp_api.CommentListParams
 import uniffi.wp_api.CommentRetrieveParams
@@ -66,6 +67,17 @@ class CommentsEndpointTest {
         }.assertSuccessAndRetrieveData().data
         assertNotNull(sparseComment)
         Assertions.assertNull(sparseComment.id)
+    }
+
+    @Test
+    fun createCommentRequest() = runTest {
+        val createdComment = client.request { requestBuilder ->
+            requestBuilder.comments()
+                .create(CommentCreateParams(post = 1, content = "foo", status = CommentStatus.Hold))
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("foo", createdComment.content.raw)
+        assertEquals(CommentStatus.Hold, createdComment.status)
+        restoreTestServer()
     }
 
     @Test

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -348,6 +348,93 @@ pub struct CommentDeleteResponse {
     pub previous: CommentWithEditContext,
 }
 
+#[derive(Debug, Serialize, uniffi::Record)]
+pub struct CommentCreateParams {
+    /// The ID of the associated post object.
+    pub post: PostId,
+    /// The ID of the user object, if author was a user.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    /// Email address for the comment author.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_email: Option<String>,
+    /// IP address for the comment author.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_ip: Option<String>,
+    /// Display name for the comment author.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_name: Option<String>,
+    /// URL for the comment author.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_url: Option<String>,
+    /// User agent for the comment author.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_user_agent: Option<String>,
+    /// The content for the comment.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// The date the comment was published, in the site's timezone.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    /// The date the comment was published, as GMT.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_gmt: Option<String>,
+    /// The ID for the parent of the comment.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<CommentId>,
+    /// State of the comment.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<CommentStatus>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/422
+}
+
+impl CommentCreateParams {
+    pub fn new(post: PostId, content: String) -> Self {
+        Self {
+            post,
+            author: None,
+            author_email: None,
+            author_ip: None,
+            author_name: None,
+            author_url: None,
+            author_user_agent: None,
+            content: Some(content),
+            date: None,
+            date_gmt: None,
+            parent: None,
+            status: None,
+        }
+    }
+
+    pub fn with_status(post: PostId, content: String, status: CommentStatus) -> Self {
+        Self {
+            post,
+            author: None,
+            author_email: None,
+            author_ip: None,
+            author_name: None,
+            author_url: None,
+            author_user_agent: None,
+            content: Some(content),
+            date: None,
+            date_gmt: None,
+            parent: None,
+            status: Some(status),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseComment {
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -12,6 +12,8 @@ enum CommentsRequest {
     List,
     #[contextual_get(url = "/comments/<comment_id>", params = &crate::comments::CommentRetrieveParams, output = crate::comments::SparseComment, filter_by = crate::comments::SparseCommentField)]
     Retrieve,
+    #[post(url = "/comments", params = &crate::comments::CommentCreateParams, output = crate::comments::CommentWithEditContext)]
+    Create,
     #[delete(url = "/comments/<comment_id>", params = &crate::comments::CommentDeleteParams, output = crate::comments::CommentDeleteResponse)]
     Delete,
     #[delete(url = "/comments/<comment_id>", params = &crate::comments::CommentDeleteParams, output = crate::comments::CommentWithEditContext)]
@@ -275,6 +277,11 @@ mod tests {
             ),
             expected_path,
         );
+    }
+
+    #[rstest]
+    fn create_comment(endpoint: CommentsRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.create(), "/comments");
     }
 
     #[rstest]

--- a/wp_api_integration_tests/tests/test_comments_mut.rs
+++ b/wp_api_integration_tests/tests/test_comments_mut.rs
@@ -1,10 +1,40 @@
 use serial_test::serial;
-use wp_api::comments::CommentDeleteParams;
+use wp_api::comments::{
+    CommentCreateParams, CommentDeleteParams, CommentStatus, CommentWithEditContext,
+};
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    FIRST_COMMENT_ID,
+    AssertResponse, FIRST_COMMENT_ID, FIRST_POST_ID,
 };
+use wp_cli::WpCliComment;
+
+#[tokio::test]
+#[serial]
+async fn create_comment_with_just_content() {
+    test_create_comment(
+        &CommentCreateParams::new(FIRST_POST_ID, "foo".to_string()),
+        |created_comment, comment_from_wp_cli| {
+            assert_eq!(created_comment.content.raw, "foo");
+            assert_eq!(comment_from_wp_cli.comment_content, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_comment_with_content_and_status() {
+    test_create_comment(
+        &CommentCreateParams::with_status(FIRST_POST_ID, "foo".to_string(), CommentStatus::Hold),
+        |created_comment, comment_from_wp_cli| {
+            assert_eq!(created_comment.content.raw, "foo");
+            assert_eq!(created_comment.status, CommentStatus::Hold);
+            assert_eq!(comment_from_wp_cli.comment_content, "foo");
+        },
+    )
+    .await;
+}
 
 #[tokio::test]
 #[serial]
@@ -54,5 +84,20 @@ async fn trash_comment() {
         .find(|c| c.comment_id == FIRST_COMMENT_ID.0);
     assert!(trashed_comment.is_some(), "Can't find the trashed comment");
 
+    RestoreServer::db().await;
+}
+
+async fn test_create_comment<F>(params: &CommentCreateParams, assert: F)
+where
+    F: Fn(CommentWithEditContext, WpCliComment),
+{
+    let created_comment = api_client()
+        .comments()
+        .create(params)
+        .await
+        .assert_response()
+        .data;
+    let created_comment_from_wp_cli = Backend::comment(&created_comment.id).await;
+    assert(created_comment, created_comment_from_wp_cli);
     RestoreServer::db().await;
 }


### PR DESCRIPTION
Follows established patterns to implement [create `/comments` endpoint.](https://developer.wordpress.org/rest-api/reference/comments/#create-a-comment)