### PR TITLE
Add `/comments` related errors and their integration tests

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -143,16 +143,52 @@ pub enum WpErrorCode {
     CannotManagePlugins,
     #[serde(rename = "rest_cannot_read_application_password")]
     CannotReadApplicationPassword,
+    #[serde(rename = "rest_cannot_read")]
+    CannotRead,
+    #[serde(rename = "rest_cannot_read_post")]
+    CannotReadPost,
     #[serde(rename = "rest_cannot_view")]
     CannotView,
     #[serde(rename = "rest_cannot_view_plugin")]
     CannotViewPlugin,
     #[serde(rename = "rest_cannot_view_plugins")]
     CannotViewPlugins,
+    #[serde(rename = "comment_author_column_length")]
+    CommentAuthorColumnLength,
+    #[serde(rename = "rest_comment_author_data_required")]
+    CommentAuthorDataRequired,
+    #[serde(rename = "comment_author_email_column_length")]
+    CommentAuthorEmailColumnLength,
+    #[serde(rename = "rest_comment_author_invalid")]
+    CommentAuthorInvalid,
+    #[serde(rename = "comment_author_url_column_length")]
+    CommentAuthorUrlColumnLength,
+    #[serde(rename = "rest_comment_closed")]
+    CommentClosed,
+    #[serde(rename = "comment_content_column_length")]
+    ContentColumnLength,
+    #[serde(rename = "rest_comment_content_invalid")]
+    CommentContentInvalid,
+    #[serde(rename = "rest_comment_draft_post")]
+    CommentDraftPost,
+    #[serde(rename = "rest_comment_invalid_author")]
+    CommentInvalidAuthor,
+    #[serde(rename = "rest_comment_invalid_author_ip")]
+    CommentInvalidAuthorIp,
+    #[serde(rename = "rest_comment_invalid_id")]
+    CommentInvalidId,
+    #[serde(rename = "rest_comment_invalid_post_id")]
+    CommentInvalidPostId,
+    #[serde(rename = "rest_comment_invalid_status")]
+    CommentInvalidStatus,
+    #[serde(rename = "rest_comment_trash_post")]
+    CommentTrashPost,
     #[serde(rename = "empty_content")]
     EmptyContent,
     #[serde(rename = "rest_forbidden_context")]
     ForbiddenContext,
+    #[serde(rename = "rest_forbidden_param")]
+    ForbiddenParam,
     #[serde(rename = "rest_forbidden_orderby")]
     ForbiddenOrderBy,
     #[serde(rename = "rest_forbidden_who")]
@@ -218,6 +254,16 @@ pub enum WpErrorCode {
     CannotPublish,
     #[serde(rename = "rest_cannot_read_type")]
     CannotReadType,
+    #[serde(rename = "comment_duplicate")]
+    CommentDuplicate,
+    #[serde(rename = "rest_comment_failed_create")]
+    CommentFailedCreate,
+    #[serde(rename = "rest_comment_failed_edit")]
+    CommentFailedEdit,
+    #[serde(rename = "comment_flood")]
+    CommentFlood,
+    #[serde(rename = "rest_comment_login_required")]
+    CommentLoginRequired,
     #[serde(rename = "rest_forbidden_status")]
     ForbiddenStatus,
     #[serde(rename = "rest_image_not_edited")]
@@ -273,11 +319,17 @@ pub enum WpErrorCode {
     /// resulting in `CannotManagePlugins` error instead.
     #[serde(rename = "rest_cannot_activate_plugin")]
     CannotActivatePlugin,
+    // If the create comment request includes an id.
+    #[serde(rename = "rest_comment_exists")]
+    CommentExists,
     /// If a plugin is tried to be deactivated without the `deactivate_plugin` permission.
     /// However, in a default setup a prior check of `deactivate_plugin` will fail
     /// resulting in `CannotManagePlugins` error instead.
     #[serde(rename = "rest_cannot_deactivate_plugin")]
     CannotDeactivatePlugin,
+    // If a `comment_type` parameter is passed while creating / editing a comment.
+    #[serde(rename = "rest_invalid_comment_type")]
+    InvalidCommentType,
     // If the create post request includes an id.
     #[serde(rename = "rest_post_exists")]
     PostExists,

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -416,22 +416,70 @@ impl CommentCreateParams {
             status: None,
         }
     }
+}
 
-    pub fn with_status(post: PostId, content: String, status: CommentStatus) -> Self {
+#[derive(Debug)]
+pub struct CommentCreateParamsBuilder {
+    params: CommentCreateParams,
+}
+
+impl CommentCreateParamsBuilder {
+    pub fn new(post: PostId, content: String) -> Self {
         Self {
-            post,
-            author: None,
-            author_email: None,
-            author_ip: None,
-            author_name: None,
-            author_url: None,
-            author_user_agent: None,
-            content: Some(content),
-            date: None,
-            date_gmt: None,
-            parent: None,
-            status: Some(status),
+            params: CommentCreateParams::new(post, content),
         }
+    }
+
+    pub fn author(mut self, author: Option<UserId>) -> Self {
+        self.params.author = author;
+        self
+    }
+
+    pub fn author_email(mut self, author_email: Option<String>) -> Self {
+        self.params.author_email = author_email;
+        self
+    }
+
+    pub fn author_ip(mut self, author_ip: Option<String>) -> Self {
+        self.params.author_ip = author_ip;
+        self
+    }
+
+    pub fn author_name(mut self, author_name: Option<String>) -> Self {
+        self.params.author_name = author_name;
+        self
+    }
+    pub fn author_url(mut self, author_url: Option<String>) -> Self {
+        self.params.author_url = author_url;
+        self
+    }
+
+    pub fn author_user_agent(mut self, author_user_agent: Option<String>) -> Self {
+        self.params.author_user_agent = author_user_agent;
+        self
+    }
+    pub fn date(mut self, date: Option<String>) -> Self {
+        self.params.date = date;
+        self
+    }
+
+    pub fn date_gmt(mut self, date_gmt: Option<String>) -> Self {
+        self.params.date_gmt = date_gmt;
+        self
+    }
+
+    pub fn parent(mut self, parent: Option<CommentId>) -> Self {
+        self.params.parent = parent;
+        self
+    }
+
+    pub fn status(mut self, status: Option<CommentStatus>) -> Self {
+        self.params.status = status;
+        self
+    }
+
+    pub fn build(self) -> CommentCreateParams {
+        self.params
     }
 }
 

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -45,13 +45,17 @@ pub const FIRST_USER_EMAIL: &str = "test@example.com";
 pub const SECOND_USER_ID: UserId = UserId(2);
 pub const SECOND_USER_EMAIL: &str = "themeshaperwp+demos@gmail.com";
 pub const SECOND_USER_SLUG: &str = "themedemos";
+pub const USER_ID_INVALID: UserId = UserId(99999999);
 pub const HELLO_DOLLY_PLUGIN_SLUG: &str = "hello-dolly/hello";
 pub const CLASSIC_EDITOR_PLUGIN_SLUG: &str = "classic-editor/classic-editor";
 pub const WP_ORG_PLUGIN_SLUG_CLASSIC_WIDGETS: &str = "classic-widgets";
 pub const FIRST_COMMENT_ID: CommentId = CommentId(1);
 pub const SECOND_COMMENT_ID: CommentId = CommentId(2);
+pub const COMMENT_ID_INVALID: CommentId = CommentId(99999999);
 pub const FIRST_POST_ID: PostId = PostId(1);
 pub const POST_ID_555: PostId = PostId(555);
+pub const POST_ID_DRAFT: PostId = PostId(1164);
+pub const POST_ID_INVALID: PostId = PostId(99999999);
 pub const MEDIA_ID_611: MediaId = MediaId(611);
 pub const MEDIA_TEST_FILE_PATH: &str = "../test_media.jpg";
 pub const MEDIA_TEST_FILE_CONTENT_TYPE: &str = "image/jpeg";
@@ -128,7 +132,7 @@ impl<T: std::fmt::Debug> AssertWpError<T> for Result<T, WpApiError> {
                 expected_error_code, error_code, response
             );
         } else {
-            panic!("Unexpected wp_error '{:?}'", err);
+            panic!("Unexpected wp_error '{}'", err);
         }
     }
 }

--- a/wp_api_integration_tests/tests/test_comments_err.rs
+++ b/wp_api_integration_tests/tests/test_comments_err.rs
@@ -1,0 +1,376 @@
+use rstest::rstest;
+use serial_test::parallel;
+use wp_api::{
+    comments::{
+        CommentCreateParams, CommentCreateParamsBuilder, CommentDeleteParams, CommentListParams,
+        CommentRetrieveParams, CommentStatus, CommentType, CommentUpdateParams,
+    },
+    posts::PostId,
+    WpErrorCode,
+};
+use wp_api_integration_tests::{
+    api_client, api_client_as_author, api_client_as_subscriber, AssertWpError, TestCredentials,
+    COMMENT_ID_INVALID, FIRST_COMMENT_ID, FIRST_POST_ID, FIRST_USER_ID, POST_ID_555, POST_ID_DRAFT,
+    POST_ID_INVALID, USER_ID_INVALID,
+};
+
+const NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM: usize = 1000000;
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_author_column_length() {
+    api_client()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author_email(Some("foo@example.com".to_string()))
+                .author_name(Some("x".repeat(NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM)))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentAuthorColumnLength);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_author_data_required() {
+    api_client()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author_name(Some("x".repeat(NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM)))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentAuthorDataRequired);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_author_email_column_length() {
+    api_client()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author_email(Some(format!(
+                    "{}@example.com",
+                    "x".repeat(NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM)
+                )))
+                .author_name(Some("foo".to_string()))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentAuthorEmailColumnLength);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_author_invalid() {
+    api_client()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author(Some(USER_ID_INVALID))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentAuthorInvalid);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_author_url_column_length() {
+    api_client()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author_email(Some("foo@example.com".to_string()))
+                .author_name(Some("foo".to_string()))
+                .author_url(Some(format!(
+                    "{}.example.com",
+                    "x".repeat(NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM)
+                )))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentAuthorUrlColumnLength);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_closed() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(POST_ID_555, "foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::CommentClosed);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_content_column_length() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(
+            FIRST_POST_ID,
+            "x".repeat(NUMBER_OF_CHARS_FOR_TOO_LONG_PARAM),
+        ))
+        .await
+        .assert_wp_error(WpErrorCode::ContentColumnLength);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_content_invalid() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(FIRST_POST_ID, "".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::CommentContentInvalid);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_draft_post() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(POST_ID_DRAFT, "foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::CommentDraftPost);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_invalid_author() {
+    api_client_as_author()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                // A different user from the one making the request
+                .author(Some(FIRST_USER_ID))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidAuthor);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_invalid_author_ip() {
+    api_client_as_author()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .author_ip(Some("127.0.0.1".to_string()))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidAuthorIp);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_invalid_post_id() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(
+            POST_ID_INVALID,
+            "foo".to_string(),
+        ))
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidPostId);
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+async fn create_err_comment_invalid_status(
+    #[values(
+        CommentStatus::Approve,
+        CommentStatus::Hold,
+        CommentStatus::Spam,
+        CommentStatus::Trash
+    )]
+    status: CommentStatus,
+) {
+    api_client_as_author()
+        .comments()
+        .create(
+            &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+                .status(Some(status))
+                .build(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidStatus);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_comment_trash_post() {
+    api_client()
+        .comments()
+        .create(&CommentCreateParams::new(
+            PostId(TestCredentials::instance().trashed_post_id),
+            "foo".to_string(),
+        ))
+        .await
+        .assert_wp_error(WpErrorCode::CommentTrashPost);
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_err_cannot_delete() {
+    api_client_as_subscriber()
+        .comments()
+        .delete(&FIRST_COMMENT_ID, &CommentDeleteParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotDelete);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_cannot_read() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            post: vec![PostId(0)],
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::CannotRead);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_cannot_read_post() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            post: vec![PostId(
+                TestCredentials::instance().password_protected_post_id,
+            )],
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::CannotReadPost);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_forbidden_context() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_edit_context(&CommentListParams {
+            post: vec![FIRST_POST_ID],
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_forbidden_param_author() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            author: vec![FIRST_USER_ID],
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenParam);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_forbidden_param_author_email() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            author_email: Some("foo@example.com".to_string()),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenParam);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_forbidden_param_author_exclude() {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            author_exclude: vec![FIRST_USER_ID],
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenParam);
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+async fn list_err_forbidden_param_comment_type(
+    #[values(CommentType::Pingback, CommentType::Trackback)] comment_type: CommentType,
+) {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            comment_type: Some(comment_type),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenParam);
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+async fn list_err_forbidden_param_status(
+    #[values(CommentStatus::Hold, CommentStatus::Spam, CommentStatus::Trash)] status: CommentStatus,
+) {
+    api_client_as_subscriber()
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            status: Some(status),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenParam);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_comment_invalid_id() {
+    api_client()
+        .comments()
+        .retrieve_with_edit_context(&COMMENT_ID_INVALID, &CommentRetrieveParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidId);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_err_cannot_edit() {
+    api_client_as_subscriber()
+        .comments()
+        .update(&FIRST_COMMENT_ID, &CommentUpdateParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotEdit);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_err_comment_invalid_post_id() {
+    api_client()
+        .comments()
+        .update(
+            &FIRST_COMMENT_ID,
+            &CommentUpdateParams {
+                post: Some(POST_ID_INVALID),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CommentInvalidPostId);
+}

--- a/wp_api_integration_tests/tests/test_comments_mut.rs
+++ b/wp_api_integration_tests/tests/test_comments_mut.rs
@@ -1,8 +1,8 @@
 use macro_helper::generate_update_test;
 use serial_test::serial;
 use wp_api::comments::{
-    CommentCreateParams, CommentDeleteParams, CommentStatus, CommentUpdateParams,
-    CommentWithEditContext,
+    CommentCreateParams, CommentCreateParamsBuilder, CommentDeleteParams, CommentStatus,
+    CommentUpdateParams, CommentWithEditContext,
 };
 use wp_api_integration_tests::{
     api_client,
@@ -29,7 +29,9 @@ async fn create_comment_with_just_content() {
 #[serial]
 async fn create_comment_with_content_and_status() {
     test_create_comment(
-        &CommentCreateParams::with_status(FIRST_POST_ID, "foo".to_string(), CommentStatus::Hold),
+        &CommentCreateParamsBuilder::new(FIRST_POST_ID, "foo".to_string())
+            .status(Some(CommentStatus::Hold))
+            .build(),
         |created_comment, comment_from_wp_cli| {
             assert_eq!(created_comment.content.raw, "foo");
             assert_eq!(created_comment.status, CommentStatus::Hold);


### PR DESCRIPTION
Follows established patterns to implement error types for `/comments` and their integration tests. It also introduces `CommentCreateParamsBuilder` type to make it easier to build a `CommentCreateParams` type in Rust.

There is some [discussion](https://internals.rust-lang.org/t/default-for-a-subset-of-fields/20013/22) and pre-RFCs for using something like the `..Default::default()` syntax for all the remaining fields when the type itself doesn't implement `Default`, but the remaining fields do. If such a feature is ever implemented, we could drop these builders.

There are also proc macro crates that implement these, but the ones I tried before didn't work out the way I'd like. For example, most `build` functions will return a `Result<T, E>`, but that only makes sense when the build might fail. In this builder type, I make the mandatory fields for the params type also mandatory for the builder, so we don't require any error handling.

In any case, I think this setup will serve us well on the Rust side for now. In native wrappers, this problem doesn't exist because we can use the `#[uniffi(default = None)]` macro attribute and both Kotlin and Swift can take arbitrary number of arguments in their constructor.
