### PR TITLE
Add `WpDateTime` to parse UTC/GMT time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "chrono",
  "futures",
  "http 1.2.0",
  "indoc",

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -90,6 +90,9 @@ public typealias PostWithEmbedContext = WordPressAPIInternal.PostWithEmbedContex
 public typealias PostListParams = WordPressAPIInternal.PostListParams
 public typealias PostsRequestExecutor = WordPressAPIInternal.PostsRequestExecutor
 extension PostsRequestExecutor: @unchecked Sendable {}
+extension PostWithEditContext: @unchecked Sendable {}
+extension PostWithViewContext: @unchecked Sendable {}
+extension PostWithEmbedContext: @unchecked Sendable {}
 
 public typealias PostsRequestListWithEditContextResponse = WordPressAPIInternal.PostsRequestListWithEditContextResponse
 public typealias PostsRequestListWithViewContextResponse = WordPressAPIInternal.PostsRequestListWithViewContextResponse

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -13,10 +13,10 @@ name = "wp_api"
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 indoc = { workspace = true }
-url = { workspace = true }
 parse_link_header = { workspace = true }
 paste = { workspace = true }
 regex = { workspace = true }
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 uniffi = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true, features = [ "v4" ] }
 wp_contextual = { path = "../wp_contextual" }
 wp_derive_request_builder = { path = "../wp_derive_request_builder", features = [ "generate_request_builder" ] }

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -1,0 +1,111 @@
+use std::fmt::Display;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use chrono::DateTime;
+use chrono::NaiveDateTime;
+use chrono::TimeZone;
+use chrono::Utc;
+use serde::Deserializer;
+use serde::Serializer;
+use serde::{Deserialize, Serialize};
+
+pub const REST_API_DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct WpDateTime {
+    gmt: Arc<GMTDateTime>,
+}
+
+impl WpDateTime {
+    pub fn date_time(&self) -> &DateTime<Utc> {
+        &self.gmt.date_time
+    }
+}
+
+// This is an intermediate struct to allow the public `WpDateTime` to be exported as a
+// uniffi Record type. This struct itself is exported as a uniffi Object type.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+struct GMTDateTime {
+    date_time: DateTime<Utc>,
+}
+
+impl<'de> Deserialize<'de> for WpDateTime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let str = String::deserialize(deserializer)?;
+        str.parse::<WpDateTime>().map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for WpDateTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl From<DateTime<Utc>> for WpDateTime {
+    fn from(value: DateTime<Utc>) -> Self {
+        Self {
+            gmt: GMTDateTime { date_time: value }.into(),
+        }
+    }
+}
+
+impl From<WpDateTime> for DateTime<Utc> {
+    fn from(value: WpDateTime) -> Self {
+        value.gmt.date_time
+    }
+}
+
+impl FromStr for WpDateTime {
+    type Err = chrono::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        NaiveDateTime::parse_from_str(s, REST_API_DATE_FORMAT)
+            .map(|v| Utc.from_utc_datetime(&v).into())
+    }
+}
+
+impl Display for WpDateTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.gmt.date_time.format(REST_API_DATE_FORMAT))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Dummy {
+        value: WpDateTime,
+    }
+
+    #[test]
+    fn test_string_round_trip() {
+        let original = "2025-01-02T03:04:05";
+        let value = original.parse::<WpDateTime>().unwrap();
+        let str = value.to_string();
+        assert_eq!(&str, original);
+    }
+
+    #[test]
+    fn test_serialization_round_trip() {
+        let original = r#""2025-01-02T03:04:05""#;
+        let value = serde_json::from_str::<WpDateTime>(original).unwrap();
+        let str = serde_json::to_string(&value).unwrap();
+        assert_eq!(&str, original);
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let result = "not-a-date".parse::<WpDateTime>();
+        assert!(result.is_err());
+    }
+}

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -20,6 +20,7 @@ mod uuid; // re-exported relevant types
 
 pub mod application_passwords;
 pub mod comments;
+pub mod date;
 pub mod login;
 pub mod media;
 pub mod plugins;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -6,6 +6,7 @@ use wp_contextual::WpContextual;
 use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 use crate::{
+    date::WpDateTime,
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
     media::MediaId,
     url_query::{
@@ -370,7 +371,7 @@ pub struct PostCreateParams {
     // The date the post was published, as GMT.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_gmt: Option<String>,
+    pub date_gmt: Option<WpDateTime>,
     // An alphanumeric identifier for the post unique to its type.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -448,7 +449,7 @@ pub struct PostUpdateParams {
     // The date the post was published, as GMT.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_gmt: Option<String>,
+    pub date_gmt: Option<WpDateTime>,
     // An alphanumeric identifier for the post unique to its type.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -569,7 +570,7 @@ pub struct SparsePost {
     #[WpContext(edit, embed, view)]
     pub date: Option<String>,
     #[WpContext(edit, view)]
-    pub date_gmt: Option<String>,
+    pub date_gmt: Option<WpDateTime>,
     #[WpContext(edit, view)]
     #[WpContextualField]
     pub guid: Option<SparsePostGuid>,

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -164,9 +164,9 @@ generate_update_test!(
 generate_update_test!(
     update_date_gmt,
     date_gmt,
-    "2024-09-09T12:00:00".to_string(),
+    "2024-09-09T12:00:00".parse().expect("Can't fail"),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.date_gmt, "2024-09-09T12:00:00");
+        assert_eq!(updated_post.date_gmt.to_string(), "2024-09-09T12:00:00");
         assert_eq!(updated_post_from_wp_cli.date_gmt, "2024-09-09 12:00:00");
     }
 );


### PR DESCRIPTION
Relate to #262.

The new `WpDateTime` type is used on posts. If the solution looks good, I can make further changes to use it on other endpoints.