### PR TITLE
List & retrieve `/taxonomies` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TaxonomiesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TaxonomiesEndpointTest.kt
@@ -1,0 +1,34 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.TaxonomyListParams
+import uniffi.wp_api.TaxonomyType
+import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
+
+class TaxonomiesEndpointTest {
+    private val testCredentials = TestCredentials.INSTANCE
+    private val siteUrl = testCredentials.parsedSiteUrl
+    private val authentication = wpAuthenticationFromUsernameAndPassword(
+        username = testCredentials.adminUsername, password = testCredentials.adminPassword
+    )
+    private val client = WpApiClient(siteUrl, authentication)
+
+    @Test
+    fun testTaxonomyListRequest() = runTest {
+        val taxonomyList = client.request { requestBuilder ->
+            requestBuilder.taxonomies().listWithEditContext(params = TaxonomyListParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(taxonomyList.taxonomyTypes.isNotEmpty())
+    }
+
+    @Test
+    fun testRetrieveCategoryTaxonomyRequest() = runTest {
+        val taxonomy = client.request { requestBuilder ->
+            requestBuilder.taxonomies().retrieveWithEditContext(TaxonomyType.Category)
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("Categories", taxonomy.name)
+    }
+
+}

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -9,6 +9,7 @@ use crate::request::{
         post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
         posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
         site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
+        taxonomies_endpoint::{TaxonomiesRequestBuilder, TaxonomiesRequestExecutor},
         users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
         wp_site_health_tests_endpoint::{
             WpSiteHealthTestsRequestBuilder, WpSiteHealthTestsRequestExecutor,
@@ -47,6 +48,7 @@ pub struct WpApiRequestBuilder {
     post_types: Arc<PostTypesRequestBuilder>,
     posts: Arc<PostsRequestBuilder>,
     site_settings: Arc<SiteSettingsRequestBuilder>,
+    taxonomies: Arc<TaxonomiesRequestBuilder>,
     users: Arc<UsersRequestBuilder>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestBuilder>,
 }
@@ -63,6 +65,7 @@ impl WpApiRequestBuilder {
             plugins,
             post_types,
             posts,
+            taxonomies,
             users,
             site_settings,
             wp_site_health_tests
@@ -98,6 +101,7 @@ pub struct WpApiClient {
     post_types: Arc<PostTypesRequestExecutor>,
     posts: Arc<PostsRequestExecutor>,
     site_settings: Arc<SiteSettingsRequestExecutor>,
+    taxonomies: Arc<TaxonomiesRequestExecutor>,
     users: Arc<UsersRequestExecutor>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestExecutor>,
 }
@@ -121,6 +125,7 @@ impl WpApiClient {
             post_types,
             posts,
             site_settings,
+            taxonomies,
             users,
             wp_site_health_tests
         )
@@ -134,6 +139,7 @@ api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_types);
 api_client_generate_endpoint_impl!(WpApi, posts);
 api_client_generate_endpoint_impl!(WpApi, site_settings);
+api_client_generate_endpoint_impl!(WpApi, taxonomies);
 api_client_generate_endpoint_impl!(WpApi, users);
 api_client_generate_endpoint_impl!(WpApi, wp_site_health_tests);
 

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -211,6 +211,8 @@ pub enum WpErrorCode {
     PostInvalidId,
     #[serde(rename = "rest_post_invalid_page_number")]
     PostInvalidPageNumber,
+    #[serde(rename = "rest_taxonomy_invalid")]
+    TaxonomyInvalid,
     #[serde(rename = "rest_type_invalid")]
     TypeInvalid,
     #[serde(rename = "rest_not_logged_in")]

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, num::ParseIntError, str::FromStr};
+use std::{collections::HashMap, convert::Infallible, num::ParseIntError, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -117,7 +117,7 @@ impl CommentType {
 }
 
 impl FromStr for CommentType {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -632,7 +632,7 @@ impl CommentStatus {
 }
 
 impl FromStr for CommentStatus {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -27,6 +27,7 @@ pub mod post_types;
 pub mod posts;
 pub mod request;
 pub mod site_settings;
+pub mod taxonomies;
 pub mod url_query;
 pub mod users;
 pub mod wordpress_org;

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -8,10 +8,10 @@ use crate::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, JsonValue, UserId, WpApiParamOrder,
+    JsonValue, UserId, WpApiParamOrder,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, num::ParseIntError, str::FromStr};
+use std::{collections::HashMap, convert::Infallible, num::ParseIntError, str::FromStr};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
@@ -58,7 +58,7 @@ impl MediaType {
 }
 
 impl FromStr for MediaType {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -102,7 +102,7 @@ impl MediaTypeParam {
 }
 
 impl FromStr for MediaTypeParam {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -153,7 +153,7 @@ impl MediaStatus {
 }
 
 impl FromStr for MediaStatus {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,7 +1,8 @@
+use std::convert::Infallible;
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
+use crate::impl_as_query_value_from_as_str;
 use crate::url_query::AsQueryValue;
-use crate::{impl_as_query_value_from_as_str, EnumFromStrParsingError};
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
@@ -43,7 +44,7 @@ impl PostType {
 }
 
 impl FromStr for PostType {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -57,9 +57,7 @@ impl FromStr for PostType {
             "wp_navigation" => Ok(Self::WpNavigation),
             "wp_font_family" => Ok(Self::WpFontFamily),
             "wp_font_face" => Ok(Self::WpFontFace),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
+            value => Ok(Self::Custom(value.to_string())),
         }
     }
 }

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,5 +1,7 @@
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::HashMap, fmt::Display, str::FromStr};
 
+use crate::url_query::AsQueryValue;
+use crate::{impl_as_query_value_from_as_str, EnumFromStrParsingError};
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
@@ -22,9 +24,9 @@ pub enum PostType {
     Custom(String),
 }
 
-impl Display for PostType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
+impl PostType {
+    fn as_str(&self) -> &str {
+        match self {
             Self::Post => "post",
             Self::Page => "page",
             Self::Attachment => "attachment",
@@ -36,10 +38,39 @@ impl Display for PostType {
             Self::WpFontFamily => "wp_font_family",
             Self::WpFontFace => "wp_font_face",
             Self::Custom(name) => name.as_str(),
-        };
-        write!(f, "{}", s)
+        }
     }
 }
+
+impl FromStr for PostType {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "post" => Ok(Self::Post),
+            "page" => Ok(Self::Page),
+            "attachment" => Ok(Self::Attachment),
+            "nav_menu_item" => Ok(Self::NavMenuItem),
+            "wp_block" => Ok(Self::WpBlock),
+            "wp_template" => Ok(Self::WpTemplate),
+            "wp_template_part" => Ok(Self::WpTemplatePart),
+            "wp_navigation" => Ok(Self::WpNavigation),
+            "wp_font_family" => Ok(Self::WpFontFamily),
+            "wp_font_face" => Ok(Self::WpFontFace),
+            value => Err(EnumFromStrParsingError::UnknownVariant {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl Display for PostType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl_as_query_value_from_as_str!(PostType);
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 #[serde(transparent)]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,4 +1,4 @@
-use std::{num::ParseIntError, str::FromStr};
+use std::{convert::Infallible, num::ParseIntError, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -715,7 +715,7 @@ impl PostStatus {
 }
 
 impl FromStr for PostStatus {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -9,6 +9,7 @@ pub mod plugins_endpoint;
 pub mod post_types_endpoint;
 pub mod posts_endpoint;
 pub mod site_settings_endpoint;
+pub mod taxonomies_endpoint;
 pub mod users_endpoint;
 pub mod wp_site_health_tests_endpoint;
 

--- a/wp_api/src/request/endpoint/taxonomies_endpoint.rs
+++ b/wp_api/src/request/endpoint/taxonomies_endpoint.rs
@@ -1,0 +1,31 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::taxonomies::{
+    SparseTaxonomyTypeDetailsFieldWithEditContext, SparseTaxonomyTypeDetailsFieldWithEmbedContext,
+    SparseTaxonomyTypeDetailsFieldWithViewContext, TaxonomyListParams, TaxonomyType,
+};
+use crate::SparseField;
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum TaxonomiesRequest {
+    #[contextual_get(url = "/taxonomies", params = &TaxonomyListParams, output = crate::taxonomies::SparseTaxonomyTypesResponse)]
+    List,
+    #[contextual_get(url = "/taxonomies/<taxonomy_type>", output = crate::taxonomies::SparseTaxonomyTypeDetails, filter_by = crate::taxonomies::SparseTaxonomyTypeDetailsField)]
+    Retrieve,
+}
+
+impl DerivedRequest for TaxonomiesRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseTaxonomyTypeDetailsFieldWithEditContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseTaxonomyTypeDetailsFieldWithEmbedContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseTaxonomyTypeDetailsFieldWithViewContext
+);

--- a/wp_api/src/taxonomies.rs
+++ b/wp_api/src/taxonomies.rs
@@ -1,0 +1,170 @@
+use std::{collections::HashMap, fmt::Display};
+
+use serde::{Deserialize, Serialize};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+use crate::{
+    post_types::PostType,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+};
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TaxonomyType {
+    Category,
+    NavMenu,
+    PostTag,
+    WpPatternCategory,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl Display for TaxonomyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Category => "category",
+            Self::PostTag => "post_tag",
+            Self::NavMenu => "nav_menu",
+            Self::WpPatternCategory => "wp_pattern_category",
+            Self::Custom(name) => name.as_str(),
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TaxonomyTypeCapabilities {
+    AssignTerms,
+    DeleteTerms,
+    EditTerms,
+    ManageTerms,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TaxonomyTypeLabels {
+    AddNewItem,
+    AddOrRemoveItems,
+    AllItems,
+    BackToItems,
+    ChooseFromMostUsed,
+    DescFieldDescription,
+    EditItem,
+    FilterByItem,
+    ItemLink,
+    ItemLinkDescription,
+    ItemsList,
+    ItemsListNavigation,
+    MenuName,
+    MostUsed,
+    Name,
+    NameAdminBar,
+    NameFieldDescription,
+    NewItemName,
+    NoTerms,
+    NotFound,
+    ParentFieldDescription,
+    ParentItem,
+    ParentItemColon,
+    PopularItems,
+    SearchItems,
+    SeparateItemsWithCommas,
+    SingularName,
+    SlugFieldDescription,
+    TemplateName,
+    UpdateItem,
+    ViewItem,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+pub struct TaxonomyListParams {
+    /// Limit results to taxonomies associated with a specific post type.
+    #[uniffi(default = None)]
+    pub post_type: Option<PostType>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum TaxonomyListParamsField {
+    #[strum(serialize = "type")]
+    PostType,
+}
+
+impl AppendUrlQueryPairs for TaxonomyListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair(
+            TaxonomyListParamsField::PostType,
+            self.post_type.as_ref(),
+        );
+    }
+}
+
+impl FromUrlQueryPairs for TaxonomyListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            post_type: query_pairs.get(TaxonomyListParamsField::PostType),
+        })
+    }
+
+    fn supports_pagination() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+#[serde(transparent)]
+pub struct SparseTaxonomyTypesResponse {
+    #[serde(flatten)]
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub taxonomy_types: Option<HashMap<TaxonomyType, SparseTaxonomyTypeDetails>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseTaxonomyTypeDetails {
+    #[WpContext(edit)]
+    pub capabilities: Option<HashMap<TaxonomyTypeCapabilities, String>>,
+    #[WpContext(edit, view)]
+    pub description: Option<String>,
+    #[WpContext(edit, view)]
+    pub hierarchical: Option<bool>,
+    #[WpContext(edit)]
+    pub labels: Option<HashMap<TaxonomyTypeLabels, Option<String>>>,
+    #[WpContext(edit, embed, view)]
+    pub name: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit)]
+    pub show_cloud: Option<bool>,
+    #[WpContext(edit, view)]
+    pub types: Option<Vec<String>>,
+    #[WpContext(edit, embed, view)]
+    pub rest_base: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub rest_namespace: Option<String>,
+    #[WpContext(edit)]
+    pub visibility: Option<TaxonomyTypeVisibility>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]
+pub struct TaxonomyTypeVisibility {
+    pub public: bool,
+    pub publicly_queryable: bool,
+    pub show_admin_column: bool,
+    pub show_in_nav_menus: bool,
+    pub show_in_quick_edit: bool,
+    pub show_ui: bool,
+}

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, fmt::Display, num::ParseIntError, str::FromStr};
+use std::{
+    collections::HashMap, convert::Infallible, fmt::Display, num::ParseIntError, str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -102,7 +104,7 @@ pub enum WpApiParamUsersHasPublishedPosts {
 }
 
 impl FromStr for WpApiParamUsersHasPublishedPosts {
-    type Err = EnumFromStrParsingError;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {

--- a/wp_api_integration_tests/tests/test_post_types_immut.rs
+++ b/wp_api_integration_tests/tests/test_post_types_immut.rs
@@ -8,7 +8,6 @@ use wp_api::post_types::{
 
 use wp_api_integration_tests::{api_client, AssertResponse};
 
-#[rstest]
 #[tokio::test]
 #[parallel]
 async fn list_post_types_with_edit_context() {
@@ -28,7 +27,6 @@ async fn list_post_types_with_edit_context() {
     );
 }
 
-#[rstest]
 #[tokio::test]
 #[parallel]
 async fn list_post_types_with_embed_context() {

--- a/wp_api_integration_tests/tests/test_taxonomies_err.rs
+++ b/wp_api_integration_tests/tests/test_taxonomies_err.rs
@@ -1,0 +1,36 @@
+use serial_test::parallel;
+use wp_api::{
+    taxonomies::{TaxonomyListParams, TaxonomyType},
+    WpErrorCode,
+};
+use wp_api_integration_tests::{api_client_as_subscriber, AssertWpError};
+
+#[tokio::test]
+#[parallel]
+async fn list_err_cannot_view() {
+    api_client_as_subscriber()
+        .taxonomies()
+        .list_with_edit_context(&TaxonomyListParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotView);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_forbidden_context() {
+    api_client_as_subscriber()
+        .taxonomies()
+        .retrieve_with_edit_context(&TaxonomyType::PostTag)
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_taxonomy_invalid() {
+    api_client_as_subscriber()
+        .taxonomies()
+        .retrieve_with_edit_context(&TaxonomyType::Custom("foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::TaxonomyInvalid);
+}

--- a/wp_api_integration_tests/tests/test_taxonomies_immut.rs
+++ b/wp_api_integration_tests/tests/test_taxonomies_immut.rs
@@ -26,7 +26,7 @@ async fn list_taxonomies_with_edit_context(
         response
             .taxonomy_types
             .get(&expected_taxonomy_type)
-            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
+            .unwrap_or_else(|| panic!("Expected to find taxonomy type: {}", expected_taxonomy_type))
             .name,
         expected_taxonomy_type_name
     );
@@ -50,7 +50,7 @@ async fn list_taxonomies_with_embed_context(
         response
             .taxonomy_types
             .get(&expected_taxonomy_type)
-            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
+            .unwrap_or_else(|| panic!("Expected to find taxonomy type: {}", expected_taxonomy_type))
             .name,
         expected_taxonomy_type_name
     );
@@ -74,7 +74,7 @@ async fn list_taxonomies_with_view_context(
         response
             .taxonomy_types
             .get(&expected_taxonomy_type)
-            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
+            .unwrap_or_else(|| panic!("Expected to find taxonomy type: {}", expected_taxonomy_type))
             .name,
         expected_taxonomy_type_name
     );

--- a/wp_api_integration_tests/tests/test_taxonomies_immut.rs
+++ b/wp_api_integration_tests/tests/test_taxonomies_immut.rs
@@ -11,7 +11,11 @@ use wp_api_integration_tests::{api_client, AssertResponse};
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_taxonomies_with_edit_context(#[case] params: TaxonomyListParams) {
+async fn list_taxonomies_with_edit_context(
+    #[case] params: TaxonomyListParams,
+    #[case] expected_taxonomy_type: TaxonomyType,
+    #[case] expected_taxonomy_type_name: String,
+) {
     let response = api_client()
         .taxonomies()
         .list_with_edit_context(&params)
@@ -21,17 +25,21 @@ async fn list_taxonomies_with_edit_context(#[case] params: TaxonomyListParams) {
     assert_eq!(
         response
             .taxonomy_types
-            .get(&TaxonomyType::Category)
-            .expect("Our local WordPress test site has `category` taxonomy type")
+            .get(&expected_taxonomy_type)
+            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
             .name,
-        "Categories"
+        expected_taxonomy_type_name
     );
 }
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_taxonomies_with_embed_context(#[case] params: TaxonomyListParams) {
+async fn list_taxonomies_with_embed_context(
+    #[case] params: TaxonomyListParams,
+    #[case] expected_taxonomy_type: TaxonomyType,
+    #[case] expected_taxonomy_type_name: String,
+) {
     let response = api_client()
         .taxonomies()
         .list_with_embed_context(&params)
@@ -41,17 +49,21 @@ async fn list_taxonomies_with_embed_context(#[case] params: TaxonomyListParams) 
     assert_eq!(
         response
             .taxonomy_types
-            .get(&TaxonomyType::Category)
-            .expect("Our local WordPress test site has `category` taxonomy type")
+            .get(&expected_taxonomy_type)
+            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
             .name,
-        "Categories"
+        expected_taxonomy_type_name
     );
 }
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_taxonomies_with_view_context(#[case] params: TaxonomyListParams) {
+async fn list_taxonomies_with_view_context(
+    #[case] params: TaxonomyListParams,
+    #[case] expected_taxonomy_type: TaxonomyType,
+    #[case] expected_taxonomy_type_name: String,
+) {
     let response = api_client()
         .taxonomies()
         .list_with_view_context(&params)
@@ -61,10 +73,10 @@ async fn list_taxonomies_with_view_context(#[case] params: TaxonomyListParams) {
     assert_eq!(
         response
             .taxonomy_types
-            .get(&TaxonomyType::Category)
-            .expect("Our local WordPress test site has `category` taxonomy type")
+            .get(&expected_taxonomy_type)
+            .expect(format!("Expected to find taxonomy type: {}", expected_taxonomy_type).as_str())
             .name,
-        "Categories"
+        expected_taxonomy_type_name
     );
 }
 
@@ -103,22 +115,16 @@ async fn retrieve_taxonomies_with_view_context(#[case] taxonomy_type: TaxonomyTy
 
 #[template]
 #[rstest]
-#[case::default(TaxonomyListParams::default())]
-#[case::post(TaxonomyListParams { post_type: Some(PostType::Post) })]
-// TODO: These post types return:
-// ```
-// {"code":"rest_cannot_view","message":"Sorry, you are not allowed to manage terms in this taxonomy.","data":{"status":403}}
-// ```
-//#[case::page(TaxonomyListParams { post_type: Some(PostType::Page) })]
-//#[case::attachment(TaxonomyListParams { post_type: Some(PostType::Attachment) })]
-//#[case::nav_menu_item(TaxonomyListParams { post_type: Some(PostType::NavMenuItem) })]
-//#[case::wp_block(TaxonomyListParams { post_type: Some(PostType::WpBlock) })]
-//#[case::wp_template(TaxonomyListParams { post_type: Some(PostType::WpTemplate) })]
-//#[case::wp_template_part(TaxonomyListParams { post_type: Some(PostType::WpTemplatePart) })]
-//#[case::wp_navigation(TaxonomyListParams { post_type: Some(PostType::WpNavigation) })]
-//#[case::wp_font_family(TaxonomyListParams { post_type: Some(PostType::WpFontFamily) })]
-//#[case::wp_font_face(TaxonomyListParams { post_type: Some(PostType::WpFontFace) })]
-pub fn list_cases(#[case] params: TaxonomyListParams) {}
+#[case::default(TaxonomyListParams::default(), TaxonomyType::Category, "Categories")]
+#[case::post(TaxonomyListParams { post_type: Some(PostType::Post) }, TaxonomyType::Category, "Categories")]
+#[case::nav_menu_item(TaxonomyListParams { post_type: Some(PostType::NavMenuItem) }, TaxonomyType::NavMenu, "Navigation Menus")]
+#[case::wp_block(TaxonomyListParams { post_type: Some(PostType::WpBlock) }, TaxonomyType::WpPatternCategory, "Pattern Categories")]
+pub fn list_cases(
+    #[case] params: TaxonomyListParams,
+    #[case] expected_taxonomy_type: TaxonomyType,
+    #[case] expected_taxonomy_type_name: String,
+) {
+}
 
 #[template]
 #[rstest]

--- a/wp_api_integration_tests/tests/test_taxonomies_immut.rs
+++ b/wp_api_integration_tests/tests/test_taxonomies_immut.rs
@@ -1,0 +1,203 @@
+use rstest::rstest;
+use rstest_reuse::{self, apply, template};
+use serial_test::parallel;
+use wp_api::post_types::PostType;
+use wp_api::taxonomies::{
+    SparseTaxonomyTypeDetailsFieldWithEditContext, SparseTaxonomyTypeDetailsFieldWithEmbedContext,
+    SparseTaxonomyTypeDetailsFieldWithViewContext, TaxonomyListParams, TaxonomyType,
+};
+use wp_api_integration_tests::{api_client, AssertResponse};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_taxonomies_with_edit_context(#[case] params: TaxonomyListParams) {
+    let response = api_client()
+        .taxonomies()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        response
+            .taxonomy_types
+            .get(&TaxonomyType::Category)
+            .expect("Our local WordPress test site has `category` taxonomy type")
+            .name,
+        "Categories"
+    );
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_taxonomies_with_embed_context(#[case] params: TaxonomyListParams) {
+    let response = api_client()
+        .taxonomies()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        response
+            .taxonomy_types
+            .get(&TaxonomyType::Category)
+            .expect("Our local WordPress test site has `category` taxonomy type")
+            .name,
+        "Categories"
+    );
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_taxonomies_with_view_context(#[case] params: TaxonomyListParams) {
+    let response = api_client()
+        .taxonomies()
+        .list_with_view_context(&params)
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        response
+            .taxonomy_types
+            .get(&TaxonomyType::Category)
+            .expect("Our local WordPress test site has `category` taxonomy type")
+            .name,
+        "Categories"
+    );
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_taxonomies_with_edit_context(#[case] taxonomy_type: TaxonomyType) {
+    api_client()
+        .taxonomies()
+        .retrieve_with_edit_context(&taxonomy_type)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_taxonomies_with_embed_context(#[case] taxonomy_type: TaxonomyType) {
+    api_client()
+        .taxonomies()
+        .retrieve_with_embed_context(&taxonomy_type)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_taxonomies_with_view_context(#[case] taxonomy_type: TaxonomyType) {
+    api_client()
+        .taxonomies()
+        .retrieve_with_view_context(&taxonomy_type)
+        .await
+        .assert_response();
+}
+
+#[template]
+#[rstest]
+#[case::default(TaxonomyListParams::default())]
+#[case::post(TaxonomyListParams { post_type: Some(PostType::Post) })]
+// TODO: These post types return:
+// ```
+// {"code":"rest_cannot_view","message":"Sorry, you are not allowed to manage terms in this taxonomy.","data":{"status":403}}
+// ```
+//#[case::page(TaxonomyListParams { post_type: Some(PostType::Page) })]
+//#[case::attachment(TaxonomyListParams { post_type: Some(PostType::Attachment) })]
+//#[case::nav_menu_item(TaxonomyListParams { post_type: Some(PostType::NavMenuItem) })]
+//#[case::wp_block(TaxonomyListParams { post_type: Some(PostType::WpBlock) })]
+//#[case::wp_template(TaxonomyListParams { post_type: Some(PostType::WpTemplate) })]
+//#[case::wp_template_part(TaxonomyListParams { post_type: Some(PostType::WpTemplatePart) })]
+//#[case::wp_navigation(TaxonomyListParams { post_type: Some(PostType::WpNavigation) })]
+//#[case::wp_font_family(TaxonomyListParams { post_type: Some(PostType::WpFontFamily) })]
+//#[case::wp_font_face(TaxonomyListParams { post_type: Some(PostType::WpFontFace) })]
+pub fn list_cases(#[case] params: TaxonomyListParams) {}
+
+#[template]
+#[rstest]
+#[case::category(TaxonomyType::Category)]
+#[case::nav_menu(TaxonomyType::NavMenu)]
+#[case::post_tag(TaxonomyType::PostTag)]
+#[case::wp_pattern_category(TaxonomyType::WpPatternCategory)]
+pub fn retrieve_cases(#[case] taxonomy_type: TaxonomyType) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_taxonomy_type_details_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_taxonomy_type_details_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_taxonomy_type_details_field_with_view_context_test_cases!();
+
+    #[apply(sparse_taxonomy_type_details_field_with_edit_context_test_cases)]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_taxonomies_with_edit_context(
+        #[values(
+            TaxonomyType::Category,
+            TaxonomyType::NavMenu,
+            TaxonomyType::PostTag,
+            TaxonomyType::WpPatternCategory
+        )]
+        taxonomy_type: TaxonomyType,
+        #[case] fields: &[SparseTaxonomyTypeDetailsFieldWithEditContext],
+    ) {
+        let taxonomy = api_client()
+            .taxonomies()
+            .filter_retrieve_with_edit_context(&taxonomy_type, fields)
+            .await
+            .assert_response()
+            .data;
+        taxonomy.assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_taxonomy_type_details_field_with_embed_context_test_cases)]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_taxonomies_with_embed_context(
+        #[values(
+            TaxonomyType::Category,
+            TaxonomyType::NavMenu,
+            TaxonomyType::PostTag,
+            TaxonomyType::WpPatternCategory
+        )]
+        taxonomy_type: TaxonomyType,
+        #[case] fields: &[SparseTaxonomyTypeDetailsFieldWithEmbedContext],
+    ) {
+        let taxonomy = api_client()
+            .taxonomies()
+            .filter_retrieve_with_embed_context(&taxonomy_type, fields)
+            .await
+            .assert_response()
+            .data;
+        taxonomy.assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_taxonomy_type_details_field_with_view_context_test_cases)]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_taxonomies_with_view_context(
+        #[values(
+            TaxonomyType::Category,
+            TaxonomyType::NavMenu,
+            TaxonomyType::PostTag,
+            TaxonomyType::WpPatternCategory
+        )]
+        taxonomy_type: TaxonomyType,
+        #[case] fields: &[SparseTaxonomyTypeDetailsFieldWithViewContext],
+    ) {
+        let taxonomy = api_client()
+            .taxonomies()
+            .filter_retrieve_with_view_context(&taxonomy_type, fields)
+            .await
+            .assert_response()
+            .data;
+        taxonomy.assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+}


### PR DESCRIPTION
Follows established patterns to implement [`/taxonomies`](https://developer.wordpress.org/rest-api/reference/taxonomies/) endpoint.

[List `/taxonomies` endpoint](https://developer.wordpress.org/rest-api/reference/taxonomies/#retrieve-a-taxonomy) has the following argument:

> `type` 	Limit results to taxonomies associated with a specific post type.

However, I couldn't get this to work for any post types except for `post`. I believe this corresponds to the `$object_type` in [this source function](https://github.com/WordPress/WordPress/blob/1747403b13a6d20f52082237ab8b8b28d605a4a0/wp-includes/taxonomy.php#L311), but it's not clear to me what other values would be appropriate here.

This might mean that using `PostType` here might be incorrect, but for now I left the other test cases as a `TODO`.

@jkmassel @crazytonyli I'd appreciate your help with this one.

