### PR TITLE
Retrieve `/tags` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
@@ -2,8 +2,13 @@ package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import uniffi.wp_api.SparseTagFieldWithEditContext
 import uniffi.wp_api.TagListParams
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private const val TAG_ID_100: Long = 100
 
 class TagsEndpointTest {
     private val testCredentials = TestCredentials.INSTANCE
@@ -19,5 +24,42 @@ class TagsEndpointTest {
             requestBuilder.tags().listWithEditContext(params = TagListParams())
         }.assertSuccessAndRetrieveData().data
         assert(tagList.isNotEmpty())
+    }
+
+    @Test
+    fun testFilterTagListRequest() = runTest {
+        val tagList = client.request { requestBuilder ->
+            requestBuilder.tags().filterListWithEditContext(
+                params = TagListParams(),
+                fields = listOf(
+                    SparseTagFieldWithEditContext.NAME,
+                    SparseTagFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assert(tagList.isNotEmpty())
+        assertNull(tagList.first().description)
+    }
+
+    @Test
+    fun testRetrieveMediaRequest() = runTest {
+        val tag = client.request { requestBuilder ->
+            requestBuilder.tags().retrieveWithEditContext(TAG_ID_100)
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(tag)
+    }
+
+    @Test
+    fun testFilterRetrieveTagRequest() = runTest {
+        val tag = client.request { requestBuilder ->
+            requestBuilder.tags().filterRetrieveWithEditContext(
+                TAG_ID_100,
+                fields = listOf(
+                    SparseTagFieldWithEditContext.NAME,
+                    SparseTagFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assertNull(tag.description)
     }
 }

--- a/wp_api/src/request/endpoint/tags_endpoint.rs
+++ b/wp_api/src/request/endpoint/tags_endpoint.rs
@@ -2,7 +2,7 @@ use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::{
     tags::{
         SparseTagFieldWithEditContext, SparseTagFieldWithEmbedContext,
-        SparseTagFieldWithViewContext, TagListParams,
+        SparseTagFieldWithViewContext, TagId, TagListParams,
     },
     SparseField,
 };
@@ -12,6 +12,8 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum TagsRequest {
     #[contextual_paged(url = "/tags", params = &TagListParams, output = Vec<crate::tags::SparseTag>, filter_by = crate::tags::SparseTagField)]
     List,
+    #[contextual_get(url = "/tags/<tag_id>", output = crate::tags::SparseTag, filter_by = crate::tags::SparseTagField)]
+    Retrieve,
 }
 
 impl DerivedRequest for TagsRequest {

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -28,6 +28,12 @@ impl FromStr for TagId {
     }
 }
 
+impl std::fmt::Display for TagId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WpApiParamTagsOrderBy {
     Id,

--- a/wp_api_integration_tests/tests/test_tags_immut.rs
+++ b/wp_api_integration_tests/tests/test_tags_immut.rs
@@ -41,6 +41,36 @@ async fn list_with_view_context(#[case] params: TagListParams) {
         .assert_response();
 }
 
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .tags()
+        .retrieve_with_edit_context(&TAG_ID_100)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .tags()
+        .retrieve_with_embed_context(&TAG_ID_100)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .tags()
+        .retrieve_with_view_context(&TAG_ID_100)
+        .await
+        .assert_response();
+}
+
 #[template]
 #[rstest]
 #[case::default(TagListParams::default())]
@@ -90,6 +120,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_tag_field_with_edit_context_test_cases)]
+    #[case(&[SparseTagFieldWithEditContext::Name, SparseTagFieldWithEditContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_posts_with_edit_context(
+        #[case] fields: &[SparseTagFieldWithEditContext],
+    ) {
+        let tag = api_client()
+            .tags()
+            .filter_retrieve_with_edit_context(&TAG_ID_100, fields)
+            .await
+            .assert_response()
+            .data;
+        tag.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_tag_field_with_embed_context_test_cases)]
     #[case(&[SparseTagFieldWithEmbedContext::Name, SparseTagFieldWithEmbedContext::Slug])]
     #[tokio::test]
@@ -115,6 +161,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_tag_field_with_embed_context_test_cases)]
+    #[case(&[SparseTagFieldWithEmbedContext::Name, SparseTagFieldWithEmbedContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_posts_with_embed_context(
+        #[case] fields: &[SparseTagFieldWithEmbedContext],
+    ) {
+        let tag = api_client()
+            .tags()
+            .filter_retrieve_with_embed_context(&TAG_ID_100, fields)
+            .await
+            .assert_response()
+            .data;
+        tag.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_tag_field_with_view_context_test_cases)]
     #[case(&[SparseTagFieldWithViewContext::Name, SparseTagFieldWithViewContext::Slug])]
     #[tokio::test]
@@ -138,5 +200,21 @@ mod filter {
             .for_each(|tag| {
                 tag.assert_that_instance_fields_nullability_match_provided_fields(fields)
             });
+    }
+
+    #[apply(sparse_tag_field_with_view_context_test_cases)]
+    #[case(&[SparseTagFieldWithViewContext::Name, SparseTagFieldWithViewContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_posts_with_view_context(
+        #[case] fields: &[SparseTagFieldWithViewContext],
+    ) {
+        let tag = api_client()
+            .tags()
+            .filter_retrieve_with_view_context(&TAG_ID_100, fields)
+            .await
+            .assert_response()
+            .data;
+        tag.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
 }


### PR DESCRIPTION
Follows established patterns to implement [retrieve `/tags` endpoint.](https://developer.wordpress.org/rest-api/reference/tags/#retrieve-a-tag)