### PR TITLE
Create `/tags` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
@@ -3,8 +3,10 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import uniffi.wp_api.SparseTagFieldWithEditContext
+import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -61,6 +63,17 @@ class TagsEndpointTest {
             )
         }.assertSuccessAndRetrieveData().data
         assertNull(tag.description)
+    }
+
+    @Test
+    fun createTagRequest() = runTest {
+        val createdTag = client.request { requestBuilder ->
+            requestBuilder.tags()
+                .create(TagCreateParams(name = "foo", description = "bar"))
+        }.assertSuccessAndRetrieveData().data
+        assertEquals(createdTag.name, "foo")
+        assertEquals(createdTag.description, "bar")
+        restoreTestServer()
     }
 
     @Test

--- a/wp_api/src/request/endpoint/tags_endpoint.rs
+++ b/wp_api/src/request/endpoint/tags_endpoint.rs
@@ -14,6 +14,8 @@ enum TagsRequest {
     List,
     #[contextual_get(url = "/tags/<tag_id>", output = crate::tags::SparseTag, filter_by = crate::tags::SparseTagField)]
     Retrieve,
+    #[post(url = "/tags", params = &crate::tags::TagCreateParams, output = crate::tags::TagWithEditContext)]
+    Create,
     #[delete(url = "/tags/<tag_id>", output = crate::tags::TagDeleteResponse)]
     Delete,
 }

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -198,6 +198,21 @@ pub struct TagDeleteResponse {
     pub previous: TagWithEditContext,
 }
 
+#[derive(Debug, Serialize, uniffi::Record)]
+pub struct TagCreateParams {
+    /// HTML title for the term.
+    pub name: String,
+    /// HTML description of the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// An alphanumeric identifier for the term unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/463
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseTag {
     #[WpContext(edit, embed, view)]

--- a/wp_api_integration_tests/tests/test_tags_mut.rs
+++ b/wp_api_integration_tests/tests/test_tags_mut.rs
@@ -1,6 +1,81 @@
 use serial_test::serial;
+use wp_api::tags::{TagCreateParams, TagWithEditContext};
 use wp_api_integration_tests::backend::{Backend, RestoreServer};
-use wp_api_integration_tests::{api_client, TAG_ID_100};
+use wp_api_integration_tests::{api_client, AssertResponse, TAG_ID_100};
+use wp_cli::WpCliTag;
+
+#[tokio::test]
+#[serial]
+async fn create_tag_with_just_name() {
+    test_create_tag(
+        &TagCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: None,
+        },
+        |created_tag, tag_from_wp_cli| {
+            assert_eq!(created_tag.name, "foo");
+            assert_eq!(tag_from_wp_cli.name, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_tag_with_name_and_description() {
+    test_create_tag(
+        &TagCreateParams {
+            name: "foo".to_string(),
+            description: Some("bar".to_string()),
+            slug: None,
+        },
+        |created_tag, tag_from_wp_cli| {
+            assert_eq!(created_tag.name, "foo");
+            assert_eq!(created_tag.description, "bar");
+            assert_eq!(tag_from_wp_cli.description, "bar");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_tag_with_name_and_slug() {
+    test_create_tag(
+        &TagCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: Some("bar".to_string()),
+        },
+        |created_tag, tag_from_wp_cli| {
+            assert_eq!(created_tag.name, "foo");
+            assert_eq!(created_tag.slug, "bar");
+            assert_eq!(tag_from_wp_cli.slug, "bar");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_tag_with_name_description_and_slug() {
+    test_create_tag(
+        &TagCreateParams {
+            name: "foo".to_string(),
+            description: Some("bar".to_string()),
+            slug: Some("quox".to_string()),
+        },
+        |created_tag, tag_from_wp_cli| {
+            assert_eq!(created_tag.name, "foo");
+            assert_eq!(created_tag.description, "bar");
+            assert_eq!(tag_from_wp_cli.description, "bar");
+            assert_eq!(created_tag.slug, "quox");
+            assert_eq!(tag_from_wp_cli.slug, "quox");
+        },
+    )
+    .await;
+}
 
 #[tokio::test]
 #[serial]
@@ -19,5 +94,20 @@ async fn delete_tag() {
         "Tag wasn't deleted"
     );
 
+    RestoreServer::db().await;
+}
+
+async fn test_create_tag<F>(params: &TagCreateParams, assert: F)
+where
+    F: Fn(TagWithEditContext, WpCliTag),
+{
+    let created_tag = api_client()
+        .tags()
+        .create(params)
+        .await
+        .assert_response()
+        .data;
+    let created_tag_from_wp_cli = Backend::tag(&created_tag.id).await;
+    assert(created_tag, created_tag_from_wp_cli);
     RestoreServer::db().await;
 }


### PR DESCRIPTION
Follows established patterns to implement [create `/tags` endpoint.](https://developer.wordpress.org/rest-api/reference/tags/#create-a-tag)