### PR TITLE
Update `/tags` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TagsEndpointTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uniffi.wp_api.SparseTagFieldWithEditContext
 import uniffi.wp_api.TagCreateParams
 import uniffi.wp_api.TagListParams
+import uniffi.wp_api.TagUpdateParams
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -71,8 +72,8 @@ class TagsEndpointTest {
             requestBuilder.tags()
                 .create(TagCreateParams(name = "foo", description = "bar"))
         }.assertSuccessAndRetrieveData().data
-        assertEquals(createdTag.name, "foo")
-        assertEquals(createdTag.description, "bar")
+        assertEquals("foo", createdTag.name)
+        assertEquals("bar", createdTag.description)
         restoreTestServer()
     }
 
@@ -82,6 +83,25 @@ class TagsEndpointTest {
             requestBuilder.tags().delete(tagId = TAG_ID_100)
         }.assertSuccessAndRetrieveData().data
         assert(deletedTag.deleted)
+        restoreTestServer()
+    }
+
+    @Test
+    fun updateTagRequest() = runTest {
+        val updatedTag = client.request { requestBuilder ->
+            requestBuilder.tags()
+                .update(
+                    tagId = TAG_ID_100,
+                    TagUpdateParams(
+                        name = "new_name",
+                        description = "new_description",
+                        slug = "new_slug"
+                    )
+                )
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("new_name", updatedTag.name)
+        assertEquals("new_description", updatedTag.description)
+        assertEquals("new_slug", updatedTag.slug)
         restoreTestServer()
     }
 }

--- a/wp_api/src/request/endpoint/tags_endpoint.rs
+++ b/wp_api/src/request/endpoint/tags_endpoint.rs
@@ -18,6 +18,8 @@ enum TagsRequest {
     Create,
     #[delete(url = "/tags/<tag_id>", output = crate::tags::TagDeleteResponse)]
     Delete,
+    #[post(url = "/tags/<tag_id>", params = &crate::tags::TagUpdateParams, output = crate::tags::TagWithEditContext)]
+    Update,
 }
 
 impl DerivedRequest for TagsRequest {

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -213,6 +213,23 @@ pub struct TagCreateParams {
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/463
 }
 
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct TagUpdateParams {
+    /// HTML title for the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// HTML description of the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// An alphanumeric identifier for the term unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/463
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseTag {
     #[WpContext(edit, embed, view)]

--- a/wp_api_integration_tests/tests/test_tags_mut.rs
+++ b/wp_api_integration_tests/tests/test_tags_mut.rs
@@ -1,5 +1,6 @@
+use macro_helper::generate_update_test;
 use serial_test::serial;
-use wp_api::tags::{TagCreateParams, TagWithEditContext};
+use wp_api::tags::{TagCreateParams, TagUpdateParams, TagWithEditContext};
 use wp_api_integration_tests::backend::{Backend, RestoreServer};
 use wp_api_integration_tests::{api_client, AssertResponse, TAG_ID_100};
 use wp_cli::WpCliTag;
@@ -97,6 +98,36 @@ async fn delete_tag() {
     RestoreServer::db().await;
 }
 
+generate_update_test!(
+    update_description,
+    description,
+    "new_description".to_string(),
+    |updated_tag, updated_tag_from_wp_cli| {
+        assert_eq!(updated_tag.description, "new_description");
+        assert_eq!(updated_tag_from_wp_cli.description, "new_description");
+    }
+);
+
+generate_update_test!(
+    update_name,
+    name,
+    "new_name".to_string(),
+    |updated_tag, updated_tag_from_wp_cli| {
+        assert_eq!(updated_tag.name, "new_name");
+        assert_eq!(updated_tag_from_wp_cli.name, "new_name");
+    }
+);
+
+generate_update_test!(
+    update_slug,
+    slug,
+    "new_slug".to_string(),
+    |updated_tag, updated_tag_from_wp_cli| {
+        assert_eq!(updated_tag.slug, "new_slug");
+        assert_eq!(updated_tag_from_wp_cli.slug, "new_slug");
+    }
+);
+
 async fn test_create_tag<F>(params: &TagCreateParams, assert: F)
 where
     F: Fn(TagWithEditContext, WpCliTag),
@@ -110,4 +141,41 @@ where
     let created_tag_from_wp_cli = Backend::tag(&created_tag.id).await;
     assert(created_tag, created_tag_from_wp_cli);
     RestoreServer::db().await;
+}
+
+async fn test_update_tag<F>(params: &TagUpdateParams, assert: F)
+where
+    F: Fn(TagWithEditContext, WpCliTag),
+{
+    let updated_tag = api_client()
+        .tags()
+        .update(&TAG_ID_100, params)
+        .await
+        .assert_response()
+        .data;
+    let updated_tag_from_wp_cli = Backend::tag(&TAG_ID_100).await;
+    assert(updated_tag, updated_tag_from_wp_cli);
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_tag(
+                        &TagUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
 }


### PR DESCRIPTION
Follows established patterns to implement [update `/tags` endpoint.](https://developer.wordpress.org/rest-api/reference/tags/#update-a-tag)