### PR TITLE
`/categories` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/CategoriesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/CategoriesEndpointTest.kt
@@ -1,0 +1,131 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.PostListParams
+import uniffi.wp_api.SparseCategoryFieldWithEditContext
+import uniffi.wp_api.CategoryCreateParams
+import uniffi.wp_api.CategoryListParams
+import uniffi.wp_api.CategoryUpdateParams
+import uniffi.wp_api.WpErrorCode
+import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private const val CATEGORY_ID_48: Long = 48
+private const val CATEGORY_ID_59: Long = 59
+
+class CategoriesEndpointTest {
+    private val testCredentials = TestCredentials.INSTANCE
+    private val siteUrl = testCredentials.parsedSiteUrl
+    private val authentication = wpAuthenticationFromUsernameAndPassword(
+        username = testCredentials.adminUsername, password = testCredentials.adminPassword
+    )
+    private val client = WpApiClient(siteUrl, authentication)
+
+    @Test
+    fun testCategoryListRequest() = runTest {
+        val categoryList = client.request { requestBuilder ->
+            requestBuilder.categories().listWithEditContext(params = CategoryListParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(categoryList.isNotEmpty())
+    }
+
+    @Test
+    fun testFilterCategoryListRequest() = runTest {
+        val categoryList = client.request { requestBuilder ->
+            requestBuilder.categories().filterListWithEditContext(
+                params = CategoryListParams(),
+                fields = listOf(
+                    SparseCategoryFieldWithEditContext.NAME,
+                    SparseCategoryFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assert(categoryList.isNotEmpty())
+        assertNull(categoryList.first().description)
+    }
+
+    @Test
+    fun testRetrieveMediaRequest() = runTest {
+        val category = client.request { requestBuilder ->
+            requestBuilder.categories().retrieveWithEditContext(CATEGORY_ID_59)
+        }.assertSuccessAndRetrieveData().data
+        assertNotNull(category)
+    }
+
+    @Test
+    fun testFilterRetrieveCategoryRequest() = runTest {
+        val category = client.request { requestBuilder ->
+            requestBuilder.categories().filterRetrieveWithEditContext(
+                CATEGORY_ID_59,
+                fields = listOf(
+                    SparseCategoryFieldWithEditContext.NAME,
+                    SparseCategoryFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assertNull(category.description)
+    }
+
+    @Test
+    fun createCategoryRequest() = runTest {
+        val createdCategory = client.request { requestBuilder ->
+            requestBuilder.categories()
+                .create(CategoryCreateParams(name = "foo", description = "bar"))
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("foo", createdCategory.name)
+        assertEquals("bar", createdCategory.description)
+        restoreTestServer()
+    }
+
+    @Test
+    fun deleteCategoryRequest() = runTest {
+        val deletedCategory = client.request { requestBuilder ->
+            requestBuilder.categories().delete(categoryId = CATEGORY_ID_59)
+        }.assertSuccessAndRetrieveData().data
+        assert(deletedCategory.deleted)
+        restoreTestServer()
+    }
+
+    @Test
+    fun updateCategoryRequest() = runTest {
+        val updatedCategory = client.request { requestBuilder ->
+            requestBuilder.categories()
+                .update(
+                    categoryId = CATEGORY_ID_59,
+                    CategoryUpdateParams(
+                        name = "new_name",
+                        description = "new_description",
+                        slug = "new_slug",
+                        parent = CATEGORY_ID_48
+                    )
+                )
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("new_name", updatedCategory.name)
+        assertEquals("new_description", updatedCategory.description)
+        assertEquals("new_slug", updatedCategory.slug)
+        assertEquals(CATEGORY_ID_48, updatedCategory.parent)
+        restoreTestServer()
+    }
+
+    @Test
+    fun testErrorTermInvalid() = runTest {
+        val result =
+            client.request { requestBuilder ->
+                requestBuilder.categories().retrieveWithEditContext(9999999)
+            }
+        assert(result.wpErrorCode() is WpErrorCode.TermInvalid)
+    }
+
+    @Test
+    fun testErrorParentTermInvalid() = runTest {
+        val result =
+            client.request { requestBuilder ->
+                requestBuilder.categories()
+                    .create(CategoryCreateParams(name = "foo", parent = 9999999))
+            }
+        assert(result.wpErrorCode() is WpErrorCode.TermInvalid)
+    }
+}

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -3,6 +3,7 @@ use crate::request::{
         application_passwords_endpoint::{
             ApplicationPasswordsRequestBuilder, ApplicationPasswordsRequestExecutor,
         },
+        categories_endpoint::{CategoriesRequestBuilder, CategoriesRequestExecutor},
         comments_endpoint::{CommentsRequestBuilder, CommentsRequestExecutor},
         media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
         plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
@@ -43,6 +44,7 @@ impl UniffiWpApiRequestBuilder {
 #[derive(Debug)]
 pub struct WpApiRequestBuilder {
     application_passwords: Arc<ApplicationPasswordsRequestBuilder>,
+    categories: Arc<CategoriesRequestBuilder>,
     comments: Arc<CommentsRequestBuilder>,
     media: Arc<MediaRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
@@ -62,6 +64,7 @@ impl WpApiRequestBuilder {
             api_base_url,
             authentication;
             application_passwords,
+            categories,
             comments,
             media,
             plugins,
@@ -98,6 +101,7 @@ impl UniffiWpApiClient {
 #[derive(Debug)]
 pub struct WpApiClient {
     application_passwords: Arc<ApplicationPasswordsRequestExecutor>,
+    categories: Arc<CategoriesRequestExecutor>,
     comments: Arc<CommentsRequestExecutor>,
     media: Arc<MediaRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
@@ -123,6 +127,7 @@ impl WpApiClient {
             authentication,
             request_executor;
             application_passwords,
+            categories,
             comments,
             media,
             plugins,
@@ -138,6 +143,7 @@ impl WpApiClient {
 }
 
 api_client_generate_endpoint_impl!(WpApi, application_passwords);
+api_client_generate_endpoint_impl!(WpApi, categories);
 api_client_generate_endpoint_impl!(WpApi, comments);
 api_client_generate_endpoint_impl!(WpApi, media);
 api_client_generate_endpoint_impl!(WpApi, plugins);

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -339,6 +339,10 @@ pub enum WpErrorCode {
     // If the create post request includes an id.
     #[serde(rename = "rest_post_exists")]
     PostExists,
+    // If a create/update request to a non-hierarchical endpoint, such as `/tags`, include
+    // `parent` argument
+    #[serde(rename = "rest_taxonomy_not_hierarchical")]
+    TaxonomyNotHierarchical,
     // If `force=true` is missing from delete user request.
     // If trash is not supported for the post type: https://github.com/WordPress/WordPress/blob/6.6.2/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1011-L1029
     #[serde(rename = "rest_trash_not_supported")]

--- a/wp_api/src/categories.rs
+++ b/wp_api/src/categories.rs
@@ -1,0 +1,273 @@
+use std::{num::ParseIntError, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+use crate::{
+    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    posts::PostId,
+    taxonomies::TaxonomyType,
+    url_query::{
+        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
+        UrlQueryPairsMap,
+    },
+    EnumFromStrParsingError, WpApiParamOrder,
+};
+
+impl_as_query_value_for_new_type!(CategoryId);
+uniffi::custom_newtype!(CategoryId, i64);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CategoryId(pub i64);
+
+impl FromStr for CategoryId {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl std::fmt::Display for CategoryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum WpApiParamCategoriesOrderBy {
+    Id,
+    Include,
+    #[default]
+    Name,
+    Slug,
+    IncludeSlugs,
+    TermGroup,
+    Description,
+    Count,
+}
+
+impl_as_query_value_from_as_str!(WpApiParamCategoriesOrderBy);
+
+impl WpApiParamCategoriesOrderBy {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Id => "id",
+            Self::Include => "include",
+            Self::Name => "name",
+            Self::Slug => "slug",
+            Self::IncludeSlugs => "include_slugs",
+            Self::TermGroup => "term_group",
+            Self::Description => "description",
+            Self::Count => "count",
+        }
+    }
+}
+
+impl FromStr for WpApiParamCategoriesOrderBy {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "id" => Ok(Self::Id),
+            "include" => Ok(Self::Include),
+            "name" => Ok(Self::Name),
+            "slug" => Ok(Self::Slug),
+            "include_slugs" => Ok(Self::IncludeSlugs),
+            "term_group" => Ok(Self::TermGroup),
+            "description" => Ok(Self::Description),
+            "count" => Ok(Self::Count),
+            value => Err(EnumFromStrParsingError::UnknownVariant {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+pub struct CategoryListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    /// Default: `10`
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = [])]
+    pub exclude: Vec<CategoryId>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = [])]
+    pub include: Vec<CategoryId>,
+    /// Offset the result set by a specific number of items.
+    #[uniffi(default = None)]
+    pub offset: Option<u32>,
+    /// Order sort attribute ascending or descending.
+    /// Default: `asc`
+    /// One of: `asc`, `desc`
+    #[uniffi(default = None)]
+    pub order: Option<WpApiParamOrder>,
+    /// Sort collection by user attribute.
+    /// Default: `name`
+    /// One of: `id`, `include`, `name`, `slug`, `include_slugs`, `term_group`, `description`, `count`
+    #[uniffi(default = None)]
+    pub orderby: Option<WpApiParamCategoriesOrderBy>,
+    /// Whether to hide terms not assigned to any posts.
+    #[uniffi(default = None)]
+    pub hide_empty: Option<bool>,
+    /// Limit result set to terms assigned to a specific parent.
+    #[uniffi(default = None)]
+    pub parent: Option<CategoryId>,
+    /// Limit result set to terms assigned to a specific post.
+    #[uniffi(default = None)]
+    pub post: Option<PostId>,
+    /// Limit result set to users with one or more specific slugs.
+    #[uniffi(default = [])]
+    pub slug: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum CategoryListParamsField {
+    #[strum(serialize = "page")]
+    Page,
+    #[strum(serialize = "per_page")]
+    PerPage,
+    #[strum(serialize = "search")]
+    Search,
+    #[strum(serialize = "exclude")]
+    Exclude,
+    #[strum(serialize = "include")]
+    Include,
+    #[strum(serialize = "offset")]
+    Offset,
+    #[strum(serialize = "order")]
+    Order,
+    #[strum(serialize = "orderby")]
+    Orderby,
+    #[strum(serialize = "hide_empty")]
+    HideEmpty,
+    #[strum(serialize = "parent")]
+    Parent,
+    #[strum(serialize = "post")]
+    Post,
+    #[strum(serialize = "slug")]
+    Slug,
+}
+
+impl AppendUrlQueryPairs for CategoryListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair(CategoryListParamsField::Page, self.page.as_ref())
+            .append_option_query_value_pair(
+                CategoryListParamsField::PerPage,
+                self.per_page.as_ref(),
+            )
+            .append_option_query_value_pair(CategoryListParamsField::Search, self.search.as_ref())
+            .append_vec_query_value_pair(CategoryListParamsField::Exclude, &self.exclude)
+            .append_vec_query_value_pair(CategoryListParamsField::Include, &self.include)
+            .append_option_query_value_pair(CategoryListParamsField::Offset, self.offset.as_ref())
+            .append_option_query_value_pair(CategoryListParamsField::Order, self.order.as_ref())
+            .append_option_query_value_pair(CategoryListParamsField::Orderby, self.orderby.as_ref())
+            .append_option_query_value_pair(
+                CategoryListParamsField::HideEmpty,
+                self.hide_empty.as_ref(),
+            )
+            .append_option_query_value_pair(CategoryListParamsField::Parent, self.parent.as_ref())
+            .append_option_query_value_pair(CategoryListParamsField::Post, self.post.as_ref())
+            .append_vec_query_value_pair(CategoryListParamsField::Slug, &self.slug);
+    }
+}
+
+impl FromUrlQueryPairs for CategoryListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            page: query_pairs.get(CategoryListParamsField::Page),
+            per_page: query_pairs.get(CategoryListParamsField::PerPage),
+            search: query_pairs.get(CategoryListParamsField::Search),
+            exclude: query_pairs.get_csv(CategoryListParamsField::Exclude),
+            include: query_pairs.get_csv(CategoryListParamsField::Include),
+            offset: query_pairs.get(CategoryListParamsField::Offset),
+            order: query_pairs.get(CategoryListParamsField::Order),
+            orderby: query_pairs.get(CategoryListParamsField::Orderby),
+            hide_empty: query_pairs.get(CategoryListParamsField::HideEmpty),
+            parent: query_pairs.get(CategoryListParamsField::Parent),
+            post: query_pairs.get(CategoryListParamsField::Post),
+            slug: query_pairs.get_csv(CategoryListParamsField::Slug),
+        })
+    }
+
+    fn supports_pagination() -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct CategoryDeleteResponse {
+    pub deleted: bool,
+    pub previous: CategoryWithEditContext,
+}
+
+#[derive(Debug, Serialize, uniffi::Record)]
+pub struct CategoryCreateParams {
+    /// HTML title for the term.
+    pub name: String,
+    /// HTML description of the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// An alphanumeric identifier for the term unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    /// The parent term ID.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<CategoryId>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/470
+}
+
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct CategoryUpdateParams {
+    /// HTML title for the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// HTML description of the term.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// An alphanumeric identifier for the term unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    /// The parent term ID.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<CategoryId>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/470
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseCategory {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<CategoryId>,
+    #[WpContext(edit, view)]
+    pub count: Option<i64>,
+    #[WpContext(edit, view)]
+    pub description: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub link: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub name: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub taxonomy: Option<TaxonomyType>,
+    #[WpContext(edit, view)]
+    pub parent: Option<CategoryId>,
+    // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/470
+}

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -19,6 +19,7 @@ mod parsed_url; // re-exported relevant types
 mod uuid; // re-exported relevant types
 
 pub mod application_passwords;
+pub mod categories;
 pub mod comments;
 pub mod login;
 pub mod media;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -6,6 +6,7 @@ use wp_contextual::WpContextual;
 use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 use crate::{
+    categories::CategoryId,
     impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
     media::MediaId,
     tags::TagId,
@@ -534,19 +535,6 @@ impl FromStr for PostId {
 impl std::fmt::Display for PostId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl_as_query_value_for_new_type!(CategoryId);
-uniffi::custom_newtype!(CategoryId, i64);
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CategoryId(pub i64);
-
-impl FromStr for CategoryId {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(Self)
     }
 }
 

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -3,6 +3,7 @@ use url::Url;
 use crate::SparseField;
 
 pub mod application_passwords_endpoint;
+pub mod categories_endpoint;
 pub mod comments_endpoint;
 pub mod media_endpoint;
 pub mod plugins_endpoint;

--- a/wp_api/src/request/endpoint/categories_endpoint.rs
+++ b/wp_api/src/request/endpoint/categories_endpoint.rs
@@ -1,0 +1,283 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    categories::{
+        CategoryId, CategoryListParams, SparseCategoryFieldWithEditContext,
+        SparseCategoryFieldWithEmbedContext, SparseCategoryFieldWithViewContext,
+    },
+    SparseField,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum CategoriesRequest {
+    #[contextual_paged(url = "/categories", params = &CategoryListParams, output = Vec<crate::categories::SparseCategory>, filter_by = crate::categories::SparseCategoryField)]
+    List,
+    #[contextual_get(url = "/categories/<category_id>", output = crate::categories::SparseCategory, filter_by = crate::categories::SparseCategoryField)]
+    Retrieve,
+    #[post(url = "/categories", params = &crate::categories::CategoryCreateParams, output = crate::categories::CategoryWithEditContext)]
+    Create,
+    #[delete(url = "/categories/<category_id>", output = crate::categories::CategoryDeleteResponse)]
+    Delete,
+    #[post(url = "/categories/<category_id>", params = &crate::categories::CategoryUpdateParams, output = crate::categories::CategoryWithEditContext)]
+    Update,
+}
+
+impl DerivedRequest for CategoriesRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            // The server always returns an error when `force=false`, so a separate `Trash` action
+            // is not implemented.
+            Self::Delete => vec![("force", true.to_string())],
+            _ => vec![],
+        }
+    }
+
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseCategoryFieldWithEditContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseCategoryFieldWithEmbedContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseCategoryFieldWithViewContext
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        categories::{CategoryId, WpApiParamCategoriesOrderBy},
+        generate,
+        posts::PostId,
+        request::endpoint::{
+            tests::{fixture_api_base_url, validate_wp_v2_endpoint},
+            ApiBaseUrl,
+        },
+        WpApiParamOrder,
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[case(CategoryListParams::default(), "")]
+    #[case(generate!(CategoryListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(CategoryListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(CategoryListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(CategoryListParams, (exclude, vec![CategoryId(1), CategoryId(2)])), "exclude=1%2C2")]
+    #[case(generate!(CategoryListParams, (include, vec![CategoryId(1), CategoryId(2)])), "include=1%2C2")]
+    #[case(generate!(CategoryListParams, (offset, Some(2))), "offset=2")]
+    #[case(generate!(CategoryListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(CategoryListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))), "orderby=id")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Include))), "orderby=include")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Name))), "orderby=name")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Slug))), "orderby=slug")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::IncludeSlugs))), "orderby=include_slugs")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::TermGroup))), "orderby=term_group")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Description))), "orderby=description")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Count))), "orderby=count")]
+    #[case(generate!(CategoryListParams, (hide_empty, Some(true))), "hide_empty=true")]
+    #[case(generate!(CategoryListParams, (parent, Some(CategoryId(3)))), "parent=3")]
+    #[case(generate!(CategoryListParams, (post, Some(PostId(3)))), "post=3")]
+    #[case(generate!(CategoryListParams, (slug, vec!["slug_1".to_string(), "slug_2".to_string()])), "slug=slug_1%2Cslug_2")]
+    // TODO
+    #[case(
+        category_list_params_with_all_fields(),
+        EXPECTED_QUERY_PAIRS_FOR_CATEGORY_LIST_PARAMS_WITH_ALL_FIELDS
+    )]
+    fn list_categories(
+        endpoint: CategoriesRequestEndpoint,
+        #[case] params: CategoryListParams,
+        #[case] expected_additional_params: &str,
+    ) {
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/categories?context={}", context)
+            } else {
+                format!(
+                    "/categories?context={}&{}",
+                    context, expected_additional_params
+                )
+            }
+        };
+        validate_wp_v2_endpoint(
+            endpoint.list_with_edit_context(&params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(&params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(&params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(CategoryListParams::default(), &[], "/categories?context=edit&_fields=")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))), &[SparseCategoryFieldWithEditContext::Count], "/categories?context=edit&orderby=id&_fields=count")]
+    #[case(category_list_params_with_all_fields(), ALL_SPARSE_CATEGORY_FIELDS_WITH_EDIT_CONTEXT, &format!("/categories?context=edit&{}&{}", EXPECTED_QUERY_PAIRS_FOR_CATEGORY_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_EDIT_CONTEXT))]
+    fn filter_list_categories_with_edit_context(
+        endpoint: CategoriesRequestEndpoint,
+        #[case] params: CategoryListParams,
+        #[case] fields: &[SparseCategoryFieldWithEditContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_edit_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(CategoryListParams::default(), &[], "/categories?context=embed&_fields=")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Slug))), &[SparseCategoryFieldWithEmbedContext::Link], "/categories?context=embed&orderby=slug&_fields=link")]
+    #[case(category_list_params_with_all_fields(), ALL_SPARSE_CATEGORY_FIELDS_WITH_EMBED_CONTEXT, &format!("/categories?context=embed&{}&{}", EXPECTED_QUERY_PAIRS_FOR_CATEGORY_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_EMBED_CONTEXT))]
+    fn filter_list_categories_with_embed_context(
+        endpoint: CategoriesRequestEndpoint,
+        #[case] params: CategoryListParams,
+        #[case] fields: &[SparseCategoryFieldWithEmbedContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_embed_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(CategoryListParams::default(), &[], "/categories?context=view&_fields=")]
+    #[case(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Include))), &[SparseCategoryFieldWithViewContext::Description], "/categories?context=view&orderby=include&_fields=description")]
+    #[case(category_list_params_with_all_fields(), ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT, &format!("/categories?context=view&{}&{}", EXPECTED_QUERY_PAIRS_FOR_CATEGORY_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_list_categories_with_view_context(
+        endpoint: CategoriesRequestEndpoint,
+        #[case] params: CategoryListParams,
+        #[case] fields: &[SparseCategoryFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_view_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_CATEGORY_LIST_PARAMS_WITH_ALL_FIELDS: &str = "page=11&per_page=22&search=s_q&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&hide_empty=true&parent=33333&post=44444&slug=slug_1%2Cslug_2";
+    fn category_list_params_with_all_fields() -> CategoryListParams {
+        CategoryListParams {
+            page: Some(11),
+            per_page: Some(22),
+            search: Some("s_q".to_string()),
+            exclude: vec![CategoryId(1111), CategoryId(1112)],
+            include: vec![CategoryId(2111), CategoryId(2112)],
+            offset: Some(11111),
+            order: Some(WpApiParamOrder::Desc),
+            orderby: Some(WpApiParamCategoriesOrderBy::Slug),
+            hide_empty: Some(true),
+            parent: Some(CategoryId(33333)),
+            post: Some(PostId(44444)),
+            slug: vec!["slug_1".to_string(), "slug_2".to_string()],
+        }
+    }
+
+    #[rstest]
+    fn retrieve_category(endpoint: CategoriesRequestEndpoint) {
+        let category_id = CategoryId(54);
+        let expected_path = |context: &str| format!("/categories/54?context={}", context);
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(&category_id),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(&category_id),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(&category_id),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(None, &[], "/categories/54?context=view&_fields=")]
+    #[case(Some("foo"), &[SparseCategoryFieldWithViewContext::Count], "/categories/54?context=view&_fields=count")]
+    #[case(Some("foo"), ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT, &format!("/categories/54?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_retrieve_category_with_view_context(
+        endpoint: CategoriesRequestEndpoint,
+        #[case] password: Option<&str>,
+        #[case] fields: &[SparseCategoryFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_view_context(&CategoryId(54), fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    fn create_category(endpoint: CategoriesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.create(), "/categories");
+    }
+
+    #[rstest]
+    fn delete_category(endpoint: CategoriesRequestEndpoint) {
+        validate_wp_v2_endpoint(
+            endpoint.delete(&CategoryId(54)),
+            "/categories/54?force=true",
+        );
+    }
+
+    #[rstest]
+    fn update_category(endpoint: CategoriesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.update(&CategoryId(54)), "/categories/54");
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_EDIT_CONTEXT: &str =
+        "_fields=id%2Ccount%2Cdescription%2Clink%2Cname%2Cslug%2Ctaxonomy%2Cparent";
+    const ALL_SPARSE_CATEGORY_FIELDS_WITH_EDIT_CONTEXT: &[SparseCategoryFieldWithEditContext; 8] =
+        &[
+            SparseCategoryFieldWithEditContext::Id,
+            SparseCategoryFieldWithEditContext::Count,
+            SparseCategoryFieldWithEditContext::Description,
+            SparseCategoryFieldWithEditContext::Link,
+            SparseCategoryFieldWithEditContext::Name,
+            SparseCategoryFieldWithEditContext::Slug,
+            SparseCategoryFieldWithEditContext::Taxonomy,
+            SparseCategoryFieldWithEditContext::Parent,
+        ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_EMBED_CONTEXT: &str =
+        "_fields=id%2Clink%2Cname%2Cslug%2Ctaxonomy";
+    const ALL_SPARSE_CATEGORY_FIELDS_WITH_EMBED_CONTEXT: &[SparseCategoryFieldWithEmbedContext; 5] =
+        &[
+            SparseCategoryFieldWithEmbedContext::Id,
+            SparseCategoryFieldWithEmbedContext::Link,
+            SparseCategoryFieldWithEmbedContext::Name,
+            SparseCategoryFieldWithEmbedContext::Slug,
+            SparseCategoryFieldWithEmbedContext::Taxonomy,
+        ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT: &str =
+        "_fields=id%2Ccount%2Cdescription%2Clink%2Cname%2Cslug%2Ctaxonomy%2Cparent";
+    const ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT: &[SparseCategoryFieldWithViewContext; 8] =
+        &[
+            SparseCategoryFieldWithViewContext::Id,
+            SparseCategoryFieldWithViewContext::Count,
+            SparseCategoryFieldWithViewContext::Description,
+            SparseCategoryFieldWithViewContext::Link,
+            SparseCategoryFieldWithViewContext::Name,
+            SparseCategoryFieldWithViewContext::Slug,
+            SparseCategoryFieldWithViewContext::Taxonomy,
+            SparseCategoryFieldWithViewContext::Parent,
+        ];
+
+    #[fixture]
+    fn endpoint(fixture_api_base_url: Arc<ApiBaseUrl>) -> CategoriesRequestEndpoint {
+        CategoriesRequestEndpoint::new(fixture_api_base_url)
+    }
+}

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -71,10 +71,11 @@ impl SparseField for SparsePostFieldWithViewContext {
 mod tests {
     use super::*;
     use crate::{
+        categories::CategoryId,
         generate,
         posts::{
-            CategoryId, PostRetrieveParams, PostStatus, WpApiParamPostsOrderBy,
-            WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+            PostRetrieveParams, PostStatus, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn,
+            WpApiParamPostsTaxRelation,
         },
         request::endpoint::{
             tests::{fixture_api_base_url, validate_wp_v2_endpoint},

--- a/wp_api_integration_tests/src/backend.rs
+++ b/wp_api_integration_tests/src/backend.rs
@@ -1,9 +1,15 @@
 use serde::{de::DeserializeOwned, Serialize};
-use wp_api::{comments::CommentId, posts::PostId, tags::TagId, users::UserId};
-use wp_cli::{WpCliComment, WpCliPost, WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta};
+use wp_api::{
+    categories::CategoryId, comments::CommentId, posts::PostId, tags::TagId, users::UserId,
+};
+use wp_cli::{
+    WpCliCategory, WpCliComment, WpCliPost, WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta,
+};
 
 const BACKEND_ADDRESS: &str = "http://127.0.0.1:4000";
 const BACKEND_PATH_RESTORE: &str = "/restore";
+const BACKEND_PATH_CATEGORY: &str = "/wp-cli/category";
+const BACKEND_PATH_CATEGORIES: &str = "/wp-cli/categories";
 const BACKEND_PATH_COMMENT: &str = "/wp-cli/comment";
 const BACKEND_PATH_COMMENTS: &str = "/wp-cli/comments";
 const BACKEND_PATH_SITE_SETTINGS: &str = "/wp-cli/site-settings";
@@ -22,6 +28,19 @@ impl Backend {
     async fn get<T: DeserializeOwned>(path: impl AsRef<str>) -> Result<T, reqwest::Error> {
         let url = format!("{}{}", BACKEND_ADDRESS, path.as_ref());
         reqwest::get(url).await?.json().await
+    }
+    pub async fn category(category_id: &CategoryId) -> WpCliCategory {
+        Self::get(format!(
+            "{}?category_id={}",
+            BACKEND_PATH_CATEGORY, category_id
+        ))
+        .await
+        .expect("Failed to parse fetched category from wp_cli")
+    }
+    pub async fn categories() -> Vec<WpCliCategory> {
+        Self::get(BACKEND_PATH_CATEGORIES)
+            .await
+            .expect("Failed to parse fetched categories from wp_cli")
     }
     pub async fn comment(comment_id: &CommentId) -> WpCliComment {
         Self::get(format!(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -3,9 +3,10 @@ use http::{HeaderMap, HeaderValue};
 use reqwest::multipart::Part;
 use std::sync::Arc;
 use wp_api::{
+    categories::CategoryId,
     comments::CommentId,
     media::MediaId,
-    posts::{CategoryId, PostId},
+    posts::PostId,
     request::{
         endpoint::media_endpoint::MediaUploadRequest, RequestExecutor, RequestMethod,
         WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
@@ -60,7 +61,9 @@ pub const POST_ID_INVALID: PostId = PostId(99999999);
 pub const MEDIA_ID_611: MediaId = MediaId(611);
 pub const MEDIA_TEST_FILE_PATH: &str = "../test_media.jpg";
 pub const MEDIA_TEST_FILE_CONTENT_TYPE: &str = "image/jpeg";
-pub const CATEGORY_ID_1: CategoryId = CategoryId(1);
+pub const CATEGORY_ID_48: CategoryId = CategoryId(48);
+pub const CATEGORY_ID_59: CategoryId = CategoryId(59);
+pub const CATEGORY_ID_INVALID: CategoryId = CategoryId(99999999);
 pub const TAG_ID_100: TagId = TagId(100);
 pub const TAG_ID_INVALID: TagId = TagId(99999999);
 pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";

--- a/wp_api_integration_tests/tests/test_categories_err.rs
+++ b/wp_api_integration_tests/tests/test_categories_err.rs
@@ -1,0 +1,108 @@
+use serial_test::parallel;
+use wp_api::{
+    categories::{CategoryCreateParams, CategoryListParams, CategoryUpdateParams},
+    WpErrorCode,
+};
+use wp_api_integration_tests::{
+    api_client, api_client_as_subscriber, AssertWpError, CATEGORY_ID_59, CATEGORY_ID_INVALID,
+    POST_ID_INVALID,
+};
+
+#[tokio::test]
+#[parallel]
+async fn create_err_cannot_create() {
+    api_client_as_subscriber()
+        .categories()
+        .create(&CategoryCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: None,
+            parent: None,
+        })
+        .await
+        .assert_wp_error(WpErrorCode::CannotCreate);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_term_invalid() {
+    api_client()
+        .categories()
+        .create(&CategoryCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: None,
+            parent: Some(CATEGORY_ID_INVALID),
+        })
+        .await
+        .assert_wp_error(WpErrorCode::TermInvalid);
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_err_cannot_delete() {
+    api_client_as_subscriber()
+        .categories()
+        .delete(&CATEGORY_ID_59)
+        .await
+        .assert_wp_error(WpErrorCode::CannotDelete);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_forbidden_context() {
+    api_client_as_subscriber()
+        .categories()
+        .list_with_edit_context(&CategoryListParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_post_invalid_id() {
+    api_client()
+        .categories()
+        .list_with_edit_context(&CategoryListParams {
+            post: Some(POST_ID_INVALID),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_term_invalid() {
+    api_client()
+        .categories()
+        .retrieve_with_edit_context(&CATEGORY_ID_INVALID)
+        .await
+        .assert_wp_error(WpErrorCode::TermInvalid);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_err_cannot_update() {
+    api_client_as_subscriber()
+        .categories()
+        .update(&CATEGORY_ID_59, &CategoryUpdateParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotUpdate);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_err_term_invalid() {
+    api_client()
+        .categories()
+        .update(
+            &CATEGORY_ID_59,
+            &CategoryUpdateParams {
+                parent: Some(CATEGORY_ID_INVALID),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::TermInvalid);
+}

--- a/wp_api_integration_tests/tests/test_categories_immut.rs
+++ b/wp_api_integration_tests/tests/test_categories_immut.rs
@@ -1,0 +1,221 @@
+use rstest::*;
+use rstest_reuse::{self, apply, template};
+use serial_test::parallel;
+use wp_api::categories::{
+    CategoryListParams, SparseCategoryFieldWithEditContext, SparseCategoryFieldWithEmbedContext,
+    SparseCategoryFieldWithViewContext, WpApiParamCategoriesOrderBy,
+};
+use wp_api::{generate, WpApiParamOrder};
+use wp_api_integration_tests::{api_client, AssertResponse, CATEGORY_ID_59, FIRST_POST_ID};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: CategoryListParams) {
+    api_client()
+        .categories()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: CategoryListParams) {
+    api_client()
+        .categories()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: CategoryListParams) {
+    api_client()
+        .categories()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .categories()
+        .retrieve_with_edit_context(&CATEGORY_ID_59)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .categories()
+        .retrieve_with_embed_context(&CATEGORY_ID_59)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .categories()
+        .retrieve_with_view_context(&CATEGORY_ID_59)
+        .await
+        .assert_response();
+}
+
+#[template]
+#[rstest]
+#[case::default(CategoryListParams::default())]
+#[case::page(generate!(CategoryListParams, (page, Some(1))))]
+#[case::per_page(generate!(CategoryListParams, (per_page, Some(3))))]
+#[case::search(generate!(CategoryListParams, (search, Some("foo".to_string()))))]
+#[case::exclude(generate!(CategoryListParams, (exclude, vec![CATEGORY_ID_59])))]
+#[case::include(generate!(CategoryListParams, (include, vec![CATEGORY_ID_59])))]
+#[case::offset(generate!(CategoryListParams, (offset, Some(2))))]
+#[case::order(generate!(CategoryListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))))]
+#[case::hide_empty_false(generate!(CategoryListParams, (hide_empty, Some(false))))]
+#[case::hide_empty_true(generate!(CategoryListParams, (hide_empty, Some(true))))]
+#[case::post(generate!(CategoryListParams, (parent, Some(CATEGORY_ID_59))))]
+#[case::post(generate!(CategoryListParams, (post, Some(FIRST_POST_ID))))]
+#[case::slug(generate!(CategoryListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+pub fn list_cases(#[case] params: CategoryListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_category_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_category_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_category_field_with_view_context_test_cases!();
+
+    #[apply(sparse_category_field_with_edit_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithEditContext::Name, SparseCategoryFieldWithEditContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_edit_context(
+        #[case] fields: &[SparseCategoryFieldWithEditContext],
+        #[values(
+            CategoryListParams::default(),
+            generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))),
+            generate!(CategoryListParams, (search, Some("foo".to_string())))
+        )]
+        params: CategoryListParams,
+    ) {
+        api_client()
+            .categories()
+            .filter_list_with_edit_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|category| {
+                category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_category_field_with_edit_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithEditContext::Name, SparseCategoryFieldWithEditContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_edit_context(
+        #[case] fields: &[SparseCategoryFieldWithEditContext],
+    ) {
+        let category = api_client()
+            .categories()
+            .filter_retrieve_with_edit_context(&CATEGORY_ID_59, fields)
+            .await
+            .assert_response()
+            .data;
+        category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_category_field_with_embed_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithEmbedContext::Name, SparseCategoryFieldWithEmbedContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseCategoryFieldWithEmbedContext],
+        #[values(
+            CategoryListParams::default(),
+            generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))),
+            generate!(CategoryListParams, (search, Some("foo".to_string())))
+        )]
+        params: CategoryListParams,
+    ) {
+        api_client()
+            .categories()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|category| {
+                category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_category_field_with_embed_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithEmbedContext::Name, SparseCategoryFieldWithEmbedContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_embed_context(
+        #[case] fields: &[SparseCategoryFieldWithEmbedContext],
+    ) {
+        let category = api_client()
+            .categories()
+            .filter_retrieve_with_embed_context(&CATEGORY_ID_59, fields)
+            .await
+            .assert_response()
+            .data;
+        category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_category_field_with_view_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithViewContext::Name, SparseCategoryFieldWithViewContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseCategoryFieldWithViewContext],
+        #[values(
+            CategoryListParams::default(),
+            generate!(CategoryListParams, (orderby, Some(WpApiParamCategoriesOrderBy::Id))),
+            generate!(CategoryListParams, (search, Some("foo".to_string())))
+        )]
+        params: CategoryListParams,
+    ) {
+        api_client()
+            .categories()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|category| {
+                category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_category_field_with_view_context_test_cases)]
+    #[case(&[SparseCategoryFieldWithViewContext::Name, SparseCategoryFieldWithViewContext::Slug])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_view_context(
+        #[case] fields: &[SparseCategoryFieldWithViewContext],
+    ) {
+        let category = api_client()
+            .categories()
+            .filter_retrieve_with_view_context(&CATEGORY_ID_59, fields)
+            .await
+            .assert_response()
+            .data;
+        category.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+}

--- a/wp_api_integration_tests/tests/test_categories_mut.rs
+++ b/wp_api_integration_tests/tests/test_categories_mut.rs
@@ -1,0 +1,218 @@
+use macro_helper::generate_update_test;
+use serial_test::serial;
+use wp_api::categories::{CategoryCreateParams, CategoryUpdateParams, CategoryWithEditContext};
+use wp_api_integration_tests::backend::{Backend, RestoreServer};
+use wp_api_integration_tests::{api_client, AssertResponse, CATEGORY_ID_48, CATEGORY_ID_59};
+use wp_cli::WpCliCategory;
+
+#[tokio::test]
+#[serial]
+async fn create_category_with_just_name() {
+    test_create_category(
+        &CategoryCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: None,
+            parent: None,
+        },
+        |created_category, category_from_wp_cli| {
+            assert_eq!(created_category.name, "foo");
+            assert_eq!(category_from_wp_cli.name, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_category_with_name_and_description() {
+    test_create_category(
+        &CategoryCreateParams {
+            name: "foo".to_string(),
+            description: Some("bar".to_string()),
+            slug: None,
+            parent: None,
+        },
+        |created_category, category_from_wp_cli| {
+            assert_eq!(created_category.name, "foo");
+            assert_eq!(created_category.description, "bar");
+            assert_eq!(category_from_wp_cli.description, "bar");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_category_with_name_and_slug() {
+    test_create_category(
+        &CategoryCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: Some("bar".to_string()),
+            parent: None,
+        },
+        |created_category, category_from_wp_cli| {
+            assert_eq!(created_category.name, "foo");
+            assert_eq!(created_category.slug, "bar");
+            assert_eq!(category_from_wp_cli.slug, "bar");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_category_with_name_and_parent() {
+    test_create_category(
+        &CategoryCreateParams {
+            name: "foo".to_string(),
+            description: None,
+            slug: None,
+            parent: Some(CATEGORY_ID_48),
+        },
+        |created_category, category_from_wp_cli| {
+            assert_eq!(created_category.name, "foo");
+            assert_eq!(created_category.parent, CATEGORY_ID_48);
+            assert_eq!(category_from_wp_cli.parent, CATEGORY_ID_48.0);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_category_with_name_description_and_slug() {
+    test_create_category(
+        &CategoryCreateParams {
+            name: "foo".to_string(),
+            description: Some("bar".to_string()),
+            slug: Some("quox".to_string()),
+            parent: None,
+        },
+        |created_category, category_from_wp_cli| {
+            assert_eq!(created_category.name, "foo");
+            assert_eq!(created_category.description, "bar");
+            assert_eq!(category_from_wp_cli.description, "bar");
+            assert_eq!(created_category.slug, "quox");
+            assert_eq!(category_from_wp_cli.slug, "quox");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn delete_category() {
+    // Delete the category using the API and ensure it's successful
+    let category_delete_response = api_client().categories().delete(&CATEGORY_ID_59).await;
+    assert!(
+        category_delete_response.is_ok(),
+        "{:#?}",
+        category_delete_response
+    );
+    assert!(category_delete_response.unwrap().data.deleted);
+
+    // Assert that the category was deleted
+    assert!(
+        !Backend::categories()
+            .await
+            .into_iter()
+            .any(|u| u.id == CATEGORY_ID_59.0),
+        "Category wasn't deleted"
+    );
+
+    RestoreServer::db().await;
+}
+
+generate_update_test!(
+    update_description,
+    description,
+    "new_description".to_string(),
+    |updated_category, updated_category_from_wp_cli| {
+        assert_eq!(updated_category.description, "new_description");
+        assert_eq!(updated_category_from_wp_cli.description, "new_description");
+    }
+);
+
+generate_update_test!(
+    update_name,
+    name,
+    "new_name".to_string(),
+    |updated_category, updated_category_from_wp_cli| {
+        assert_eq!(updated_category.name, "new_name");
+        assert_eq!(updated_category_from_wp_cli.name, "new_name");
+    }
+);
+
+generate_update_test!(
+    update_slug,
+    slug,
+    "new_slug".to_string(),
+    |updated_category, updated_category_from_wp_cli| {
+        assert_eq!(updated_category.slug, "new_slug");
+        assert_eq!(updated_category_from_wp_cli.slug, "new_slug");
+    }
+);
+
+generate_update_test!(
+    update_parent,
+    parent,
+    CATEGORY_ID_48,
+    |updated_category, updated_category_from_wp_cli| {
+        assert_eq!(updated_category.parent, CATEGORY_ID_48);
+        assert_eq!(updated_category_from_wp_cli.parent, CATEGORY_ID_48.0);
+    }
+);
+
+async fn test_create_category<F>(params: &CategoryCreateParams, assert: F)
+where
+    F: Fn(CategoryWithEditContext, WpCliCategory),
+{
+    let created_category = api_client()
+        .categories()
+        .create(params)
+        .await
+        .assert_response()
+        .data;
+    let created_category_from_wp_cli = Backend::category(&created_category.id).await;
+    assert(created_category, created_category_from_wp_cli);
+    RestoreServer::db().await;
+}
+
+async fn test_update_category<F>(params: &CategoryUpdateParams, assert: F)
+where
+    F: Fn(CategoryWithEditContext, WpCliCategory),
+{
+    let updated_category = api_client()
+        .categories()
+        .update(&CATEGORY_ID_59, params)
+        .await
+        .assert_response()
+        .data;
+    let updated_category_from_wp_cli = Backend::category(&CATEGORY_ID_59).await;
+    assert(updated_category, updated_category_from_wp_cli);
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_category(
+                        &CategoryUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
+}

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,11 +1,11 @@
 use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
+use wp_api::categories::CategoryId;
 use wp_api::posts::{
-    CategoryId, PostId, PostListParams, PostRetrieveParams, PostStatus,
-    SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
-    SparsePostFieldWithViewContext, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn,
-    WpApiParamPostsTaxRelation,
+    PostId, PostListParams, PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
+    SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
+    WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
 };
 use wp_api::tags::TagId;
 use wp_api::{generate, WpApiParamOrder};

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -9,7 +9,7 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_1, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
+    AssertResponse, CATEGORY_ID_59, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
     SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
@@ -350,7 +350,7 @@ async fn update_sticky_to_false() {
 #[tokio::test]
 #[serial]
 async fn update_categories() {
-    let updated_value = vec![CATEGORY_ID_1];
+    let updated_value = vec![CATEGORY_ID_59];
     test_update_post(
         &PostUpdateParams {
             categories: updated_value.clone(),

--- a/wp_api_integration_tests/tests/test_tags_immut.rs
+++ b/wp_api_integration_tests/tests/test_tags_immut.rs
@@ -99,7 +99,7 @@ mod filter {
     #[case(&[SparseTagFieldWithEditContext::Name, SparseTagFieldWithEditContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_tags_with_edit_context(
+    async fn filter_list_with_edit_context(
         #[case] fields: &[SparseTagFieldWithEditContext],
         #[values(
             TagListParams::default(),
@@ -124,9 +124,7 @@ mod filter {
     #[case(&[SparseTagFieldWithEditContext::Name, SparseTagFieldWithEditContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_retrieve_posts_with_edit_context(
-        #[case] fields: &[SparseTagFieldWithEditContext],
-    ) {
+    async fn filter_retrieve_with_edit_context(#[case] fields: &[SparseTagFieldWithEditContext]) {
         let tag = api_client()
             .tags()
             .filter_retrieve_with_edit_context(&TAG_ID_100, fields)
@@ -140,7 +138,7 @@ mod filter {
     #[case(&[SparseTagFieldWithEmbedContext::Name, SparseTagFieldWithEmbedContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_tags_with_embed_context(
+    async fn filter_list_with_embed_context(
         #[case] fields: &[SparseTagFieldWithEmbedContext],
         #[values(
             TagListParams::default(),
@@ -165,9 +163,7 @@ mod filter {
     #[case(&[SparseTagFieldWithEmbedContext::Name, SparseTagFieldWithEmbedContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_retrieve_posts_with_embed_context(
-        #[case] fields: &[SparseTagFieldWithEmbedContext],
-    ) {
+    async fn filter_retrieve_with_embed_context(#[case] fields: &[SparseTagFieldWithEmbedContext]) {
         let tag = api_client()
             .tags()
             .filter_retrieve_with_embed_context(&TAG_ID_100, fields)
@@ -181,7 +177,7 @@ mod filter {
     #[case(&[SparseTagFieldWithViewContext::Name, SparseTagFieldWithViewContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_tags_with_view_context(
+    async fn filter_list_with_view_context(
         #[case] fields: &[SparseTagFieldWithViewContext],
         #[values(
             TagListParams::default(),
@@ -206,9 +202,7 @@ mod filter {
     #[case(&[SparseTagFieldWithViewContext::Name, SparseTagFieldWithViewContext::Slug])]
     #[tokio::test]
     #[parallel]
-    async fn filter_retrieve_posts_with_view_context(
-        #[case] fields: &[SparseTagFieldWithViewContext],
-    ) {
+    async fn filter_retrieve_with_view_context(#[case] fields: &[SparseTagFieldWithViewContext]) {
         let tag = api_client()
             .tags()
             .filter_retrieve_with_view_context(&TAG_ID_100, fields)

--- a/wp_api_integration_tests_backend/src/main.rs
+++ b/wp_api_integration_tests_backend/src/main.rs
@@ -6,8 +6,8 @@ use std::fs::metadata;
 use std::io;
 use std::path::Path;
 use wp_cli::{
-    WpCliComment, WpCliCommentListArguments, WpCliPost, WpCliPostListArguments, WpCliSiteSettings,
-    WpCliTag, WpCliUser, WpCliUserMeta,
+    WpCliCategory, WpCliComment, WpCliCommentListArguments, WpCliPost, WpCliPostListArguments,
+    WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta,
 };
 
 pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
@@ -16,6 +16,20 @@ pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
 enum Error {
     #[response(status = 500)]
     AsString(String),
+}
+
+#[get("/category?<category_id>")]
+fn wp_cli_category(category_id: i64) -> Result<Json<WpCliCategory>, Error> {
+    WpCliCategory::get(category_id)
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
+}
+
+#[get("/categories")]
+fn wp_cli_categories() -> Result<Json<Vec<WpCliCategory>>, Error> {
+    WpCliCategory::list()
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
 }
 
 #[get("/comment?<comment_id>")]
@@ -109,6 +123,8 @@ async fn restore_wp_server(db: bool, plugins: bool) -> Result<Status, Error> {
 fn rocket() -> _ {
     rocket::build()
         .mount("/", routes![restore_wp_server])
+        .mount("/wp-cli/", routes![wp_cli_category])
+        .mount("/wp-cli/", routes![wp_cli_categories])
         .mount("/wp-cli/", routes![wp_cli_comment])
         .mount("/wp-cli/", routes![wp_cli_comments])
         .mount("/wp-cli/", routes![wp_cli_site_settings])

--- a/wp_cli/src/lib.rs
+++ b/wp_cli/src/lib.rs
@@ -1,11 +1,13 @@
 use std::{collections::HashMap, ffi::OsStr, process::Command};
 
+mod wp_cli_categories;
 mod wp_cli_comments;
 mod wp_cli_posts;
 mod wp_cli_settings;
 mod wp_cli_tags;
 mod wp_cli_users;
 
+pub use wp_cli_categories::*;
 pub use wp_cli_comments::*;
 pub use wp_cli_posts::*;
 pub use wp_cli_settings::*;

--- a/wp_cli/src/wp_cli_categories.rs
+++ b/wp_cli/src/wp_cli_categories.rs
@@ -1,0 +1,43 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use wp_serde_helper::deserialize_i64_or_string;
+
+use crate::run_wp_cli_command;
+
+const CATEGORIES_FIELDS_ARG: &str = "--fields=term_id,count,description,name,slug,taxonomy,parent";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpCliCategory {
+    #[serde(rename = "term_id")]
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub id: i64,
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub count: i64,
+    pub description: String,
+    pub name: String,
+    pub slug: String,
+    pub taxonomy: String,
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub parent: i64,
+}
+
+impl WpCliCategory {
+    pub fn get(category_id: i64) -> Result<Self> {
+        let output = run_wp_cli_command([
+            "term",
+            "get",
+            "category",
+            category_id.to_string().as_str(),
+            CATEGORIES_FIELDS_ARG,
+        ]);
+        serde_json::from_slice::<Self>(&output.stdout).with_context(|| {
+            "Failed to parse `wp term get category {category_id} {CATEGORIES_FIELDS_ARG} --format=json` into `WpCliCategory`"
+        })
+    }
+    pub fn list() -> Result<Vec<Self>> {
+        let output = run_wp_cli_command(["term", "list", "category", CATEGORIES_FIELDS_ARG]);
+        serde_json::from_slice::<Vec<Self>>(&output.stdout).with_context(|| {
+            "Failed to parse `wp term list category --format=json` into Vec<WpCliCategory>"
+        })
+    }
+}


### PR DESCRIPTION
Follows established patterns to implement the entirety of [`/categories` endpoint.](https://developer.wordpress.org/rest-api/reference/categories/)

`/categories` and `/tags` are very similar, the difference being `/categories` can have a `parent` whereas `/tags` can't. In order to save us time, I implemented the entirety of `/categories` in a single PR. The reviewer can mainly focus on the `parent` related changes and that will probably be enough.

---

I've thought a little about whether we want to combine `/tags` and `/categories` somehow. However, I believe that'll not only make the code more complicated and harder to maintain, it'll also make it more likely we introduce bugs due to the extra complication.

If we need to treat both taxonomy types in a similar manner, we can introduce new traits to establish "is a" relationship. That way we can still avoid duplicating code that includes logic. Whereas the code that's "duplicated" right now is the type information and wouldn't benefit from a DRY approach.

I'd be happy to discuss this further as I'd like to establish this as a pattern going forward where we'll implement other endpoints that are similar to existing ones - such as `/pages` being similar to `/posts`.