### PR TITLE
[Tooling] Nightly build notifications only when the build fails

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -11,3 +11,4 @@ notify:
       channels:
         - "#wordpress-rs"
       message: "Nightly build."
+    if: build.state == "failed"


### PR DESCRIPTION
Updates the Nightly build pipeline to send notifications only when the job fails.