### PR TITLE
`/search` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/SearchEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/SearchEndpointTest.kt
@@ -1,0 +1,40 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.SearchListParams
+import uniffi.wp_api.SparseSearchResultFieldWithViewContext
+import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertNull
+
+class SearchEndpointTest {
+    private val testCredentials = TestCredentials.INSTANCE
+    private val siteUrl = testCredentials.parsedSiteUrl
+    private val authentication = wpAuthenticationFromUsernameAndPassword(
+        username = testCredentials.adminUsername, password = testCredentials.adminPassword
+    )
+    private val client = WpApiClient(siteUrl, authentication)
+
+    @Test
+    fun testSearchListRequest() = runTest {
+        val list = client.request { requestBuilder ->
+            requestBuilder.search().listWithViewContext(params = SearchListParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(list.isNotEmpty())
+    }
+
+    @Test
+    fun testFilterSearchListRequest() = runTest {
+        val list = client.request { requestBuilder ->
+            requestBuilder.search().filterListWithViewContext(
+                params = SearchListParams(),
+                fields = listOf(
+                    SparseSearchResultFieldWithViewContext.ID,
+                    SparseSearchResultFieldWithViewContext.OBJECT_TYPE
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assert(list.isNotEmpty())
+        assertNull(list.first().objectSubtype)
+    }
+}

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -9,6 +9,7 @@ use crate::request::{
         plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
         post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
         posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
+        search_endpoint::{SearchRequestBuilder, SearchRequestExecutor},
         site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
         tags_endpoint::{TagsRequestBuilder, TagsRequestExecutor},
         taxonomies_endpoint::{TaxonomiesRequestBuilder, TaxonomiesRequestExecutor},
@@ -51,6 +52,7 @@ pub struct WpApiRequestBuilder {
     plugins: Arc<PluginsRequestBuilder>,
     post_types: Arc<PostTypesRequestBuilder>,
     posts: Arc<PostsRequestBuilder>,
+    search: Arc<SearchRequestBuilder>,
     site_settings: Arc<SiteSettingsRequestBuilder>,
     tags: Arc<TagsRequestBuilder>,
     taxonomies: Arc<TaxonomiesRequestBuilder>,
@@ -72,6 +74,7 @@ impl WpApiRequestBuilder {
             plugins,
             post_types,
             posts,
+            search,
             site_settings,
             tags,
             taxonomies,
@@ -110,6 +113,7 @@ pub struct WpApiClient {
     plugins: Arc<PluginsRequestExecutor>,
     post_types: Arc<PostTypesRequestExecutor>,
     posts: Arc<PostsRequestExecutor>,
+    search: Arc<SearchRequestExecutor>,
     site_settings: Arc<SiteSettingsRequestExecutor>,
     tags: Arc<TagsRequestExecutor>,
     taxonomies: Arc<TaxonomiesRequestExecutor>,
@@ -137,6 +141,7 @@ impl WpApiClient {
             plugins,
             post_types,
             posts,
+            search,
             site_settings,
             tags,
             taxonomies,
@@ -154,6 +159,7 @@ api_client_generate_endpoint_impl!(WpApi, media);
 api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_types);
 api_client_generate_endpoint_impl!(WpApi, posts);
+api_client_generate_endpoint_impl!(WpApi, search);
 api_client_generate_endpoint_impl!(WpApi, site_settings);
 api_client_generate_endpoint_impl!(WpApi, tags);
 api_client_generate_endpoint_impl!(WpApi, taxonomies);

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -290,6 +290,12 @@ pub enum WpErrorCode {
     NoAuthenticatedAppPassword,
     #[serde(rename = "rest_no_featured_media")]
     NoFeaturedMedia,
+    #[serde(rename = "rest_search_handler_error")]
+    SearchHandlerError,
+    #[serde(rename = "rest_search_invalid_page_number")]
+    SearchInvalidPageNumber,
+    #[serde(rename = "rest_search_invalid_type")]
+    SearchInvalidType,
     #[serde(rename = "rest_upload_file_error")]
     UploadFileError,
     #[serde(rename = "rest_upload_file_too_big")]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -27,6 +27,7 @@ pub mod plugins;
 pub mod post_types;
 pub mod posts;
 pub mod request;
+pub mod search_results;
 pub mod site_settings;
 pub mod tags;
 pub mod taxonomies;
@@ -183,18 +184,25 @@ impl TryFrom<BoolOrString> for WpResponseString {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
 #[serde(untagged)]
 pub enum BoolOrString {
     Bool(bool),
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
 #[serde(untagged)]
 pub enum BoolOrVecString {
     Bool(bool),
     VecString(Vec<String>),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
+#[serde(untagged)]
+pub enum IntegerOrString {
+    Integer(i64),
+    String(String),
 }
 
 #[macro_export]

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -9,6 +9,7 @@ pub mod media_endpoint;
 pub mod plugins_endpoint;
 pub mod post_types_endpoint;
 pub mod posts_endpoint;
+pub mod search_endpoint;
 pub mod site_settings_endpoint;
 pub mod tags_endpoint;
 pub mod taxonomies_endpoint;

--- a/wp_api/src/request/endpoint/search_endpoint.rs
+++ b/wp_api/src/request/endpoint/search_endpoint.rs
@@ -1,0 +1,165 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    search_results::{
+        SparseSearchResultFieldWithEmbedContext, SparseSearchResultFieldWithViewContext,
+    },
+    SparseField,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum SearchRequest {
+    #[contextual_paged(url = "/search", params = &crate::search_results::SearchListParams, output = Vec<crate::search_results::SparseSearchResult>, filter_by = crate::search_results::SparseSearchResultField, available_contexts = "embed,view")]
+    List,
+}
+
+impl DerivedRequest for SearchRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+impl SparseField for SparseSearchResultFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::ObjectType => "type",
+            Self::ObjectSubtype => "subtype",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseSearchResultFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::ObjectType => "type",
+            Self::ObjectSubtype => "subtype",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate,
+        request::endpoint::{
+            tests::{fixture_api_base_url, validate_wp_v2_endpoint},
+            ApiBaseUrl,
+        },
+        search_results::{SearchListParams, SearchResultSubtype, SearchResultType},
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[case(SearchListParams::default(), "")]
+    #[case(generate!(SearchListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(SearchListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(SearchListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(SearchListParams, (object_type, Some(SearchResultType::Post))), "type=post")]
+    #[case(generate!(SearchListParams, (object_type, Some(SearchResultType::Term))), "type=term")]
+    #[case(generate!(SearchListParams, (object_type, Some(SearchResultType::PostFormat))), "type=post-format")]
+    #[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Post))), "subtype=post")]
+    #[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Page))), "subtype=page")]
+    #[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Category))), "subtype=category")]
+    #[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::PostTag))), "subtype=post_tag")]
+    #[case(generate!(SearchListParams, (exclude, vec![1, 2])), "exclude=1%2C2")]
+    #[case(generate!(SearchListParams, (include, vec![1, 2])), "include=1%2C2")]
+    #[case(
+        search_list_params_with_all_fields(),
+        EXPECTED_QUERY_PAIRS_FOR_SEARCH_LIST_PARAMS_WITH_ALL_FIELDS
+    )]
+    fn list_search(
+        endpoint: SearchRequestEndpoint,
+        #[case] params: SearchListParams,
+        #[case] expected_additional_params: &str,
+    ) {
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/search?context={}", context)
+            } else {
+                format!("/search?context={}&{}", context, expected_additional_params)
+            }
+        };
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(&params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(&params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(SearchListParams::default(), &[], "/search?context=embed&_fields=")]
+    #[case(search_list_params_with_all_fields(), ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_EMBED_CONTEXT, &format!("/search?context=embed&{}&{}", EXPECTED_QUERY_PAIRS_FOR_SEARCH_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_EMBED_CONTEXT))]
+    fn filter_list_search_with_embed_context(
+        endpoint: SearchRequestEndpoint,
+        #[case] params: SearchListParams,
+        #[case] fields: &[SparseSearchResultFieldWithEmbedContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_embed_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(SearchListParams::default(), &[], "/search?context=view&_fields=")]
+    #[case(search_list_params_with_all_fields(), ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_VIEW_CONTEXT, &format!("/search?context=view&{}&{}", EXPECTED_QUERY_PAIRS_FOR_SEARCH_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_list_search_with_view_context(
+        endpoint: SearchRequestEndpoint,
+        #[case] params: SearchListParams,
+        #[case] fields: &[SparseSearchResultFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_view_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_SEARCH_LIST_PARAMS_WITH_ALL_FIELDS: &str = "page=11&per_page=22&search=s_q&type=term&subtype=category&exclude=1111%2C1112&include=2111%2C2112";
+    fn search_list_params_with_all_fields() -> SearchListParams {
+        SearchListParams {
+            page: Some(11),
+            per_page: Some(22),
+            search: Some("s_q".to_string()),
+            object_type: Some(SearchResultType::Term),
+            object_subtype: Some(SearchResultSubtype::Category),
+            exclude: vec![1111, 1112],
+            include: vec![2111, 2112],
+        }
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_EMBED_CONTEXT: &str =
+        "_fields=id%2Ctitle%2Curl%2Ctype%2Csubtype";
+    const ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_EMBED_CONTEXT: &[SparseSearchResultFieldWithEmbedContext;
+         5] = &[
+        SparseSearchResultFieldWithEmbedContext::Id,
+        SparseSearchResultFieldWithEmbedContext::Title,
+        SparseSearchResultFieldWithEmbedContext::Url,
+        SparseSearchResultFieldWithEmbedContext::ObjectType,
+        SparseSearchResultFieldWithEmbedContext::ObjectSubtype,
+    ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_VIEW_CONTEXT: &str =
+        "_fields=id%2Ctitle%2Curl%2Ctype%2Csubtype";
+    const ALL_SPARSE_SEARCH_RESULT_FIELDS_WITH_VIEW_CONTEXT: &[SparseSearchResultFieldWithViewContext;
+         5] = &[
+        SparseSearchResultFieldWithViewContext::Id,
+        SparseSearchResultFieldWithViewContext::Title,
+        SparseSearchResultFieldWithViewContext::Url,
+        SparseSearchResultFieldWithViewContext::ObjectType,
+        SparseSearchResultFieldWithViewContext::ObjectSubtype,
+    ];
+
+    #[fixture]
+    fn endpoint(fixture_api_base_url: Arc<ApiBaseUrl>) -> SearchRequestEndpoint {
+        SearchRequestEndpoint::new(fixture_api_base_url)
+    }
+}

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -1,0 +1,208 @@
+use crate::{
+    impl_as_query_value_from_as_str,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+    AsQueryValue, EnumFromStrParsingError, IntegerOrString,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+)]
+pub enum SearchResultType {
+    #[default]
+    #[serde(rename = "post")]
+    Post,
+    #[serde(rename = "term")]
+    Term,
+    #[serde(rename = "post-format")]
+    PostFormat,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(SearchResultType);
+
+impl SearchResultType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Post => "post",
+            Self::Term => "term",
+            Self::PostFormat => "post-format",
+            Self::Custom(result_type) => result_type,
+        }
+    }
+}
+
+impl FromStr for SearchResultType {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "post" => Ok(Self::Post),
+            "term" => Ok(Self::Term),
+            "post-format" => Ok(Self::PostFormat),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+pub enum SearchResultSubtype {
+    #[serde(rename = "post")]
+    Post,
+    #[serde(rename = "page")]
+    Page,
+    #[serde(rename = "category")]
+    Category,
+    #[serde(rename = "post_tag")]
+    PostTag,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(SearchResultSubtype);
+
+impl SearchResultSubtype {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Post => "post",
+            Self::Page => "page",
+            Self::Category => "category",
+            Self::PostTag => "post_tag",
+            Self::Custom(result_type) => result_type,
+        }
+    }
+}
+
+impl FromStr for SearchResultSubtype {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "post" => Ok(Self::Post),
+            "page" => Ok(Self::Page),
+            "category" => Ok(Self::Category),
+            "post_tag" => Ok(Self::PostTag),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+pub struct SearchListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    /// Default: `10`
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Limit results to items of an object type.
+    /// Default: `post`
+    /// One of: `post`, `term`, `post-format`
+    #[uniffi(default = None)]
+    pub object_type: Option<SearchResultType>,
+    /// Limit results to items of one or more object subtypes.
+    /// Default: `any`
+    #[uniffi(default = None)]
+    pub object_subtype: Option<SearchResultSubtype>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = [])]
+    pub exclude: Vec<i64>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = [])]
+    pub include: Vec<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum SearchListParamsField {
+    #[strum(serialize = "page")]
+    Page,
+    #[strum(serialize = "per_page")]
+    PerPage,
+    #[strum(serialize = "search")]
+    Search,
+    #[strum(serialize = "type")]
+    ObjectType,
+    #[strum(serialize = "subtype")]
+    ObjectSubtype,
+    #[strum(serialize = "exclude")]
+    Exclude,
+    #[strum(serialize = "include")]
+    Include,
+}
+
+impl AppendUrlQueryPairs for SearchListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair(SearchListParamsField::Page, self.page.as_ref())
+            .append_option_query_value_pair(SearchListParamsField::PerPage, self.per_page.as_ref())
+            .append_option_query_value_pair(SearchListParamsField::Search, self.search.as_ref())
+            .append_option_query_value_pair(
+                SearchListParamsField::ObjectType,
+                self.object_type.as_ref(),
+            )
+            .append_option_query_value_pair(
+                SearchListParamsField::ObjectSubtype,
+                self.object_subtype.as_ref(),
+            )
+            .append_vec_query_value_pair(SearchListParamsField::Exclude, &self.exclude)
+            .append_vec_query_value_pair(SearchListParamsField::Include, &self.include);
+    }
+}
+
+impl FromUrlQueryPairs for SearchListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            page: query_pairs.get(SearchListParamsField::Page),
+            per_page: query_pairs.get(SearchListParamsField::PerPage),
+            search: query_pairs.get(SearchListParamsField::Search),
+            object_type: query_pairs.get(SearchListParamsField::ObjectType),
+            object_subtype: query_pairs.get(SearchListParamsField::ObjectSubtype),
+            exclude: query_pairs.get_csv(SearchListParamsField::Exclude),
+            include: query_pairs.get_csv(SearchListParamsField::Include),
+        })
+    }
+
+    fn supports_pagination() -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseSearchResult {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<IntegerOrString>,
+    #[WpContext(edit, embed, view)]
+    pub title: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub url: Option<String>,
+    #[serde(rename = "type")]
+    #[WpContext(edit, embed, view)]
+    pub object_type: Option<SearchResultType>,
+    #[serde(rename = "subtype")]
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
+    pub object_subtype: Option<SearchResultSubtype>,
+}

--- a/wp_api_integration_tests/tests/test_search_err.rs
+++ b/wp_api_integration_tests/tests/test_search_err.rs
@@ -1,0 +1,32 @@
+use serial_test::parallel;
+use wp_api::{
+    search_results::{SearchListParams, SearchResultSubtype, SearchResultType},
+    WpErrorCode,
+};
+use wp_api_integration_tests::{api_client, AssertWpError};
+
+#[tokio::test]
+#[parallel]
+async fn list_err_object_type_invalid_param() {
+    api_client()
+        .search()
+        .list_with_view_context(&SearchListParams {
+            object_type: Some(SearchResultType::Custom("foo".to_string())),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::InvalidParam);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_object_subtype_invalid_param() {
+    api_client()
+        .search()
+        .list_with_view_context(&SearchListParams {
+            object_subtype: Some(SearchResultSubtype::Custom("foo".to_string())),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::InvalidParam);
+}

--- a/wp_api_integration_tests/tests/test_search_immut.rs
+++ b/wp_api_integration_tests/tests/test_search_immut.rs
@@ -1,0 +1,134 @@
+use rstest::*;
+use rstest_reuse::{self, apply, template};
+use serial_test::parallel;
+use wp_api::generate;
+use wp_api::search_results::{
+    SearchListParams, SearchResultSubtype, SearchResultType,
+    SparseSearchResultFieldWithEmbedContext, SparseSearchResultFieldWithViewContext,
+};
+use wp_api_integration_tests::{api_client, AssertResponse};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: SearchListParams) {
+    api_client()
+        .search()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: SearchListParams) {
+    api_client()
+        .search()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+#[case(SearchListParams { per_page: Some(1), ..Default::default() })]
+#[case(SearchListParams { per_page: Some(1), object_type: Some(SearchResultType::Post), ..Default::default() })]
+#[case(SearchListParams { per_page: Some(1), object_type: Some(SearchResultType::Term), object_subtype: Some(SearchResultSubtype::Category), ..Default::default() })]
+async fn paginate_list_search_with_view_context(#[case] params: SearchListParams) {
+    let first_page_response = api_client()
+        .search()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+    assert!(!first_page_response.data.is_empty());
+    let next_page_params = first_page_response.next_page_params.unwrap();
+    let next_page_response = api_client()
+        .search()
+        .list_with_view_context(&next_page_params)
+        .await
+        .assert_response();
+    assert!(!next_page_response.data.is_empty());
+    let prev_page_params = next_page_response.prev_page_params.unwrap();
+    let prev_page_response = api_client()
+        .search()
+        .list_with_view_context(&prev_page_params)
+        .await
+        .assert_response();
+    assert!(!prev_page_response.data.is_empty());
+}
+
+#[template]
+#[rstest]
+#[case::default(SearchListParams::default())]
+#[case(generate!(SearchListParams, (page, Some(2))))]
+#[case(generate!(SearchListParams, (per_page, Some(2))))]
+#[case(generate!(SearchListParams, (search, Some("foo".to_string()))))]
+#[case(generate!(SearchListParams, (object_type, Some(SearchResultType::Post))))]
+#[case(generate!(SearchListParams, (object_type, Some(SearchResultType::Term))))]
+#[case(generate!(SearchListParams, (object_type, Some(SearchResultType::PostFormat))))]
+#[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Post))))]
+#[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Page))))]
+#[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::Category))))]
+#[case(generate!(SearchListParams, (object_subtype, Some(SearchResultSubtype::PostTag))))]
+#[case(generate!(SearchListParams, (exclude, vec![1, 2])))]
+#[case(generate!(SearchListParams, (include, vec![1, 2])))]
+pub fn list_cases(#[case] params: SearchListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_search_result_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_search_result_field_with_view_context_test_cases!();
+
+    #[apply(sparse_search_result_field_with_embed_context_test_cases)]
+    #[case(&[SparseSearchResultFieldWithEmbedContext::Id, SparseSearchResultFieldWithEmbedContext::Title])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseSearchResultFieldWithEmbedContext],
+        #[values(
+            SearchListParams::default(),
+            generate!(SearchListParams, (page, Some(2))),
+            generate!(SearchListParams, (search, Some("foo".to_string())))
+        )]
+        params: SearchListParams,
+    ) {
+        api_client()
+            .search()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|search_result| {
+                search_result.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_search_result_field_with_view_context_test_cases)]
+    #[case(&[SparseSearchResultFieldWithViewContext::Id, SparseSearchResultFieldWithViewContext::ObjectType])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseSearchResultFieldWithViewContext],
+        #[values(
+            SearchListParams::default(),
+            generate!(SearchListParams, (page, Some(2))),
+            generate!(SearchListParams, (search, Some("foo".to_string())))
+        )]
+        params: SearchListParams,
+    ) {
+        api_client()
+            .search()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|search_result| {
+                search_result.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+}

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -5,8 +5,6 @@ use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::FoundCrate;
 use quote::{format_ident, quote};
 use serde::{de::Error, Deserialize, Deserializer};
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 use syn::Ident;
 
 use crate::{
@@ -49,6 +47,7 @@ fn generate_async_request_executor(
         ContextAndFilterHandler::from_request_type(
             variant.attr.request_type,
             variant.attr.filter_by.clone(),
+            &variant.attr.available_contexts,
         )
         .into_iter()
         .map(|context_and_filter_handler| {
@@ -86,6 +85,7 @@ fn generate_async_request_executor(
         ContextAndFilterHandler::from_request_type(
             variant.attr.request_type,
             variant.attr.filter_by.clone(),
+            &variant.attr.available_contexts
         )
         .into_iter()
         .map(|context_and_filter_handler| {
@@ -197,6 +197,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
         ContextAndFilterHandler::from_request_type(
             variant.attr.request_type,
             variant.attr.filter_by.clone(),
+            &variant.attr.available_contexts,
         )
         .into_iter()
         .map(|context_and_filter_handler| {
@@ -264,33 +265,37 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
         let additional_query_pairs =
             fn_body_additional_query_pairs(&parsed_enum.enum_ident, &variant.variant_ident);
 
-        ContextAndFilterHandler::from_request_type(request_type, variant.attr.filter_by.clone())
-            .into_iter()
-            .map(|context_and_filter_handler| {
-                let fn_signature = fn_signature(
-                    PartOf::Endpoint,
-                    &variant.variant_ident,
-                    url_parts,
-                    params_type.as_ref(),
-                    request_type,
-                    &context_and_filter_handler,
-                );
-                let context_query_pair =
-                    fn_body_context_query_pairs(&config.crate_ident, &context_and_filter_handler);
-                let fields_query_pairs =
-                    fn_body_fields_query_pairs(&config.crate_ident, &context_and_filter_handler);
-                quote! {
-                    pub #fn_signature -> #static_api_endpoint_url_type {
-                        #url_from_api_base_url
-                        #context_query_pair
-                        #query_pairs
-                        #additional_query_pairs
-                        #fields_query_pairs
-                        url.into()
-                    }
+        ContextAndFilterHandler::from_request_type(
+            request_type,
+            variant.attr.filter_by.clone(),
+            &variant.attr.available_contexts,
+        )
+        .into_iter()
+        .map(|context_and_filter_handler| {
+            let fn_signature = fn_signature(
+                PartOf::Endpoint,
+                &variant.variant_ident,
+                url_parts,
+                params_type.as_ref(),
+                request_type,
+                &context_and_filter_handler,
+            );
+            let context_query_pair =
+                fn_body_context_query_pairs(&config.crate_ident, &context_and_filter_handler);
+            let fields_query_pairs =
+                fn_body_fields_query_pairs(&config.crate_ident, &context_and_filter_handler);
+            quote! {
+                pub #fn_signature -> #static_api_endpoint_url_type {
+                    #url_from_api_base_url
+                    #context_query_pair
+                    #query_pairs
+                    #additional_query_pairs
+                    #fields_query_pairs
+                    url.into()
                 }
-            })
-            .collect::<TokenStream>()
+            }
+        })
+        .collect::<TokenStream>()
     });
 
     quote! {
@@ -328,6 +333,7 @@ impl ContextAndFilterHandler {
     fn from_request_type(
         request_type: RequestType,
         filter_by_type: Option<FilterByType>,
+        available_contexts: &[WpContext],
     ) -> Vec<Self> {
         match request_type {
             crate::parse::RequestType::Get => {
@@ -340,11 +346,11 @@ impl ContextAndFilterHandler {
             crate::parse::RequestType::ContextualGet
             | crate::parse::RequestType::ContextualPaged => {
                 let mut v = vec![];
-                WpContext::iter().for_each(|context| {
-                    v.push(Self::NoFilterTakeContextAsFunctionName(context));
+                available_contexts.iter().for_each(|context| {
+                    v.push(Self::NoFilterTakeContextAsFunctionName(*context));
                     if let Some(ref filter_by_type) = filter_by_type {
                         v.push(Self::FilterTakeContextAsFunctionName(
-                            context,
+                            *context,
                             filter_by_type.clone(),
                         ));
                     }
@@ -358,11 +364,17 @@ impl ContextAndFilterHandler {
     }
 }
 
-#[derive(Debug, Clone, Copy, EnumIter)]
+#[derive(Debug, Clone, Copy)]
 pub enum WpContext {
     Edit,
     Embed,
     View,
+}
+
+impl WpContext {
+    pub fn all() -> Vec<Self> {
+        vec![Self::Edit, Self::Embed, Self::View]
+    }
 }
 
 impl Display for WpContext {

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -5,7 +5,7 @@ use syn::{
     Attribute, Ident, MetaList,
 };
 
-use crate::parse::RequestType;
+use crate::{generate::WpContext, parse::RequestType};
 
 #[derive(Debug, Clone)]
 pub struct FilterByType {
@@ -24,6 +24,7 @@ pub struct ParsedVariantAttribute {
     pub params: Option<ParamsType>,
     pub output: Vec<TokenTree>,
     pub filter_by: Option<FilterByType>,
+    pub available_contexts: Vec<WpContext>,
 }
 
 impl ParsedVariantAttribute {
@@ -33,6 +34,7 @@ impl ParsedVariantAttribute {
         params: Option<Vec<TokenTree>>,
         output: Vec<TokenTree>,
         filter_by: Option<Vec<TokenTree>>,
+        available_contexts: Vec<WpContext>,
     ) -> Result<Self, ItemVariantAttributeParseError> {
         let non_empty_token_tree_or_none =
             |tokens: Option<Vec<TokenTree>>| -> Option<Vec<TokenTree>> {
@@ -60,6 +62,7 @@ impl ParsedVariantAttribute {
             filter_by: non_empty_token_tree_or_none(filter_by).map(|tokens| FilterByType {
                 tokens: TokenStream::from_iter(tokens),
             }),
+            available_contexts,
         })
     }
 
@@ -228,6 +231,65 @@ impl ParsedVariantAttribute {
             })
             .collect()
     }
+
+    fn available_contexts(
+        available_contexts_tokens: Option<&Vec<TokenTree>>,
+        error_span: Span,
+    ) -> syn::Result<Vec<WpContext>> {
+        if let Some(available_contexts_tokens) = available_contexts_tokens {
+            if available_contexts_tokens.len() != 1 {
+                return Err(
+                    ItemVariantAttributeParseError::AvailableContextsShouldBeASingleString
+                        .into_syn_error(error_span),
+                );
+            }
+            let first_token = available_contexts_tokens
+                .first()
+                .expect("Already verified that there is only one url token");
+
+            let mut contexts = vec![];
+            match first_token {
+                TokenTree::Literal(literal) => {
+                    let mut available_contexts_as_string = literal.to_string();
+                    if available_contexts_as_string.starts_with('"')
+                        && available_contexts_as_string.ends_with('"')
+                    {
+                        available_contexts_as_string.pop();
+                        available_contexts_as_string.remove(0);
+                    } else {
+                        return Err(
+                            ItemVariantAttributeParseError::AvailableContextShouldBeLiteral
+                                .into_syn_error(error_span),
+                        );
+                    }
+                    for possible_context in available_contexts_as_string.split(',') {
+                        match possible_context.to_lowercase().as_str() {
+                            "edit" => contexts.push(WpContext::Edit),
+                            "embed" => contexts.push(WpContext::Embed),
+                            "view" => contexts.push(WpContext::View),
+                            _ => {
+                                return Err(
+                    ItemVariantAttributeParseError::AvailableContextsUnexpectedContext{ unexpected_context: possible_context.to_string()}
+                        .into_syn_error(error_span)
+                );
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    return Err(
+                        ItemVariantAttributeParseError::AvailableContextsUnexpectedTokens
+                            .into_syn_error(error_span),
+                    )
+                }
+            }
+            Ok(contexts)
+        } else {
+            // `available_contexts` is an optional parameter and if not provided, we assume all
+            // contexts are available.
+            Ok(WpContext::all())
+        }
+    }
 }
 
 impl Parse for ParsedVariantAttribute {
@@ -242,6 +304,7 @@ impl Parse for ParsedVariantAttribute {
         let mut params_tokens = None;
         let mut output_tokens = None;
         let mut filter_by_tokens = None;
+        let mut available_contexts_tokens = None;
 
         for (ident, tokens) in pair_vec.into_iter() {
             match ident.to_string().as_str() {
@@ -249,6 +312,7 @@ impl Parse for ParsedVariantAttribute {
                 "params" => params_tokens = Some(tokens),
                 "output" => output_tokens = Some(tokens),
                 "filter_by" => filter_by_tokens = Some(tokens),
+                "available_contexts" => available_contexts_tokens = Some(tokens),
                 _ => {
                     return Err(ItemVariantAttributeParseError::ExpectingKeyValuePairs
                         .into_syn_error(meta_list_span));
@@ -283,6 +347,10 @@ impl Parse for ParsedVariantAttribute {
         })?;
 
         let url_parts = UrlPart::split(url_str.to_string(), &meta_list_span)?;
+        let available_contexts = ParsedVariantAttribute::available_contexts(
+            available_contexts_tokens.as_ref(),
+            input.span(),
+        )?;
 
         ParsedVariantAttribute::new(
             request_type,
@@ -290,6 +358,7 @@ impl Parse for ParsedVariantAttribute {
             params_tokens,
             output,
             filter_by_tokens,
+            available_contexts,
         )
         .map_err(|e| e.into_syn_error(meta_list_span))
     }
@@ -315,6 +384,17 @@ enum ItemVariantAttributeParseError {
     UrlShouldBeLiteral,
     #[error("Missing (output = crate::Foo)")]
     MissingOutput,
+    #[error("`available_contexts` contains unexpected tokens. It should be a comma separated string: \"edit,embed,view\"")]
+    AvailableContextsUnexpectedTokens,
+    #[error("`available_contexts` should be a single comma separated string: \"edit,embed,view\"")]
+    AvailableContextsShouldBeASingleString,
+    #[error(
+        "`available_contexts` contains unexpected context: '{}'",
+        unexpected_context
+    )]
+    AvailableContextsUnexpectedContext { unexpected_context: String },
+    #[error("`available_contexts` should be set as a String: (available_contexts = \"edit,embed,view\")")]
+    AvailableContextShouldBeLiteral,
     #[error("Only 'contextual_get', 'contextual_paged', 'get', 'post' & 'delete' are supported")]
     UnsupportedRequestType,
 }

--- a/wp_derive_request_builder/tests/fail/available_contexts_not_a_single_string.rs
+++ b/wp_derive_request_builder/tests/fail/available_contexts_not_a_single_string.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, filter_by = SparseUserField, available_contexts = &edit)]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/available_contexts_not_a_single_string.stderr
+++ b/wp_derive_request_builder/tests/fail/available_contexts_not_a_single_string.stderr
@@ -1,0 +1,5 @@
+error: `available_contexts` should be a single comma separated string: "edit,embed,view"
+ --> tests/fail/available_contexts_not_a_single_string.rs:4:5
+  |
+4 |     List,
+  |     ^^^^

--- a/wp_derive_request_builder/tests/fail/available_contexts_not_literal.rs
+++ b/wp_derive_request_builder/tests/fail/available_contexts_not_literal.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, filter_by = SparseUserField, available_contexts = edit)]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/available_contexts_not_literal.stderr
+++ b/wp_derive_request_builder/tests/fail/available_contexts_not_literal.stderr
@@ -1,0 +1,5 @@
+error: `available_contexts` contains unexpected tokens. It should be a comma separated string: "edit,embed,view"
+ --> tests/fail/available_contexts_not_literal.rs:4:5
+  |
+4 |     List,
+  |     ^^^^

--- a/wp_derive_request_builder/tests/fail/available_contexts_unexpected_context.rs
+++ b/wp_derive_request_builder/tests/fail/available_contexts_unexpected_context.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, filter_by = SparseUserField, available_contexts = "foo")]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/available_contexts_unexpected_context.stderr
+++ b/wp_derive_request_builder/tests/fail/available_contexts_unexpected_context.stderr
@@ -1,0 +1,5 @@
+error: `available_contexts` contains unexpected context: 'foo'
+ --> tests/fail/available_contexts_unexpected_context.rs:4:5
+  |
+4 |     List,
+  |     ^^^^

--- a/wp_derive_request_builder/tests/fail/available_contexts_unexpected_token.rs
+++ b/wp_derive_request_builder/tests/fail/available_contexts_unexpected_token.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum UsersRequest {
+    #[contextual_get(url = "/users", params = &UserListParams, output = Vec<SparseUser>, filter_by = SparseUserField, available_contexts = &)]
+    List,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/available_contexts_unexpected_token.stderr
+++ b/wp_derive_request_builder/tests/fail/available_contexts_unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: `available_contexts` contains unexpected tokens. It should be a comma separated string: "edit,embed,view"
+ --> tests/fail/available_contexts_unexpected_token.rs:4:5
+  |
+4 |     List,
+  |     ^^^^


### PR DESCRIPTION
Follows established patterns to implement the entirety of [`/search` endpoint.](https://developer.wordpress.org/rest-api/reference/search-results/)

Up until now every endpoint we implemented supported all 3 contexts, so we have been generating functions for all of them. However, `/search` only supports `view` & `embed` contexts. I've considered manually implementing this endpoint instead of using `#[derive(WpDerivedRequest)]`, but I figured there might be other endpoints that has a similar limitation. That's why this PR implements an optional `available_contexts` parameter, where we can provide which contexts we want to support as a comma separated list. Omitting this parameter will result in the previous behavior where all 3 contexts are supported.