### PR TITLE
Use strum to replace manual implementation of `as_str` and `FromStr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,6 +3317,7 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_json",
+ "strum",
  "strum_macros",
  "thiserror",
  "uniffi",

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -22,6 +22,7 @@ paste = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
+strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 uniffi = { workspace = true }

--- a/wp_api/src/categories.rs
+++ b/wp_api/src/categories.rs
@@ -286,6 +286,6 @@ mod tests {
     #[case(WpApiParamCategoriesOrderBy::Description)]
     #[case(WpApiParamCategoriesOrderBy::Count)]
     fn test_orderby_string_conversion(#[case] orderby: WpApiParamCategoriesOrderBy) {
-        assert_eq!(orderby, orderby.to_string().parse().unwrap(),);
+        assert_eq!(orderby, orderby.to_string().parse().unwrap());
     }
 }

--- a/wp_api/src/categories.rs
+++ b/wp_api/src/categories.rs
@@ -5,14 +5,14 @@ use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 use crate::{
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     taxonomies::TaxonomyType,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, WpApiParamOrder,
+    WpApiParamOrder,
 };
 
 impl_as_query_value_for_new_type!(CategoryId);
@@ -34,7 +34,18 @@ impl std::fmt::Display for CategoryId {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamCategoriesOrderBy {
     Id,
     Include,
@@ -47,42 +58,7 @@ pub enum WpApiParamCategoriesOrderBy {
     Count,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamCategoriesOrderBy);
-
-impl WpApiParamCategoriesOrderBy {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Id => "id",
-            Self::Include => "include",
-            Self::Name => "name",
-            Self::Slug => "slug",
-            Self::IncludeSlugs => "include_slugs",
-            Self::TermGroup => "term_group",
-            Self::Description => "description",
-            Self::Count => "count",
-        }
-    }
-}
-
-impl FromStr for WpApiParamCategoriesOrderBy {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "id" => Ok(Self::Id),
-            "include" => Ok(Self::Include),
-            "name" => Ok(Self::Name),
-            "slug" => Ok(Self::Slug),
-            "include_slugs" => Ok(Self::IncludeSlugs),
-            "term_group" => Ok(Self::TermGroup),
-            "description" => Ok(Self::Description),
-            "count" => Ok(Self::Count),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamCategoriesOrderBy);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct CategoryListParams {
@@ -270,4 +246,46 @@ pub struct SparseCategory {
     #[WpContext(edit, view)]
     pub parent: Option<CategoryId>,
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/470
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+    use url::Url;
+
+    #[rstest]
+    #[case(WpApiParamCategoriesOrderBy::Id, "id")]
+    #[case(WpApiParamCategoriesOrderBy::Include, "include")]
+    #[case(WpApiParamCategoriesOrderBy::Name, "name")]
+    #[case(WpApiParamCategoriesOrderBy::Slug, "slug")]
+    #[case(WpApiParamCategoriesOrderBy::IncludeSlugs, "include_slugs")]
+    #[case(WpApiParamCategoriesOrderBy::TermGroup, "term_group")]
+    #[case(WpApiParamCategoriesOrderBy::Description, "description")]
+    #[case(WpApiParamCategoriesOrderBy::Count, "count")]
+    fn test_orderby_url_query(
+        #[case] orderby: WpApiParamCategoriesOrderBy,
+        #[case] expected: &str,
+    ) {
+        let mut url = Url::parse("https://example.com").unwrap();
+        url.query_pairs_mut()
+            .append_query_value_pair("orderby", &orderby);
+        assert_eq!(
+            url.query().map(|x| x.to_string()),
+            Some(format!("orderby={}", expected))
+        );
+    }
+
+    #[rstest]
+    #[case(WpApiParamCategoriesOrderBy::Id)]
+    #[case(WpApiParamCategoriesOrderBy::Include)]
+    #[case(WpApiParamCategoriesOrderBy::Name)]
+    #[case(WpApiParamCategoriesOrderBy::Slug)]
+    #[case(WpApiParamCategoriesOrderBy::IncludeSlugs)]
+    #[case(WpApiParamCategoriesOrderBy::TermGroup)]
+    #[case(WpApiParamCategoriesOrderBy::Description)]
+    #[case(WpApiParamCategoriesOrderBy::Count)]
+    fn test_orderby_string_conversion(#[case] orderby: WpApiParamCategoriesOrderBy) {
+        assert_eq!(orderby, orderby.to_string().parse().unwrap(),);
+    }
 }

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -1,20 +1,31 @@
-use std::{collections::HashMap, convert::Infallible, num::ParseIntError, str::FromStr};
+use std::{collections::HashMap, num::ParseIntError, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 use crate::{
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
+    UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
 };
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamCommentsOrderBy {
     Date,
     #[default]
@@ -26,40 +37,7 @@ pub enum WpApiParamCommentsOrderBy {
     Type,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamCommentsOrderBy);
-
-impl WpApiParamCommentsOrderBy {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Date => "date",
-            Self::DateGmt => "date_gmt",
-            Self::Id => "id",
-            Self::Include => "include",
-            Self::Post => "post",
-            Self::Parent => "parent",
-            Self::Type => "type",
-        }
-    }
-}
-
-impl FromStr for WpApiParamCommentsOrderBy {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "date" => Ok(Self::Date),
-            "date_gmt" => Ok(Self::DateGmt),
-            "id" => Ok(Self::Id),
-            "include" => Ok(Self::Include),
-            "post" => Ok(Self::Post),
-            "parent" => Ok(Self::Parent),
-            "type" => Ok(Self::Type),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamCommentsOrderBy);
 
 impl_as_query_value_for_new_type!(CommentId);
 uniffi::custom_newtype!(CommentId, i64);
@@ -92,42 +70,22 @@ impl std::fmt::Display for CommentId {
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum CommentType {
     #[default]
     Comment,
     Pingback,
     Trackback,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(CommentType);
-
-impl CommentType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Comment => "comment",
-            Self::Pingback => "pingback",
-            Self::Trackback => "trackback",
-            Self::Custom(comment_type) => comment_type,
-        }
-    }
-}
-
-impl FromStr for CommentType {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "comment" => Ok(Self::Comment),
-            "pingback" => Ok(Self::Pingback),
-            "trackback" => Ok(Self::Trackback),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(CommentType);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct CommentListParams {
@@ -605,8 +563,11 @@ pub enum CommentAuthorAvatarUrlSize {
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum CommentStatus {
     Hold,
     #[default]
@@ -614,36 +575,11 @@ pub enum CommentStatus {
     Spam,
     Trash,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(CommentStatus);
-
-impl CommentStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Hold => "hold",
-            Self::Approve => "approve",
-            Self::Spam => "spam",
-            Self::Trash => "trash",
-            Self::Custom(status) => status,
-        }
-    }
-}
-
-impl FromStr for CommentStatus {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "hold" => Ok(Self::Hold),
-            "approve" => Ok(Self::Approve),
-            "spam" => Ok(Self::Spam),
-            "trash" => Ok(Self::Trash),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(CommentStatus);
 
 #[cfg(test)]
 mod tests {

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -8,7 +8,7 @@ pub use api_error::{
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 use url_query::AsQueryValue;
 use users::*;
 pub use uuid::{WpUuid, WpUuidParseError};
@@ -81,37 +81,25 @@ fn wp_authentication_from_username_and_password(
     WpAuthentication::from_username_and_password(username, password)
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamOrder {
     #[default]
     Asc,
     Desc,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamOrder);
-
-impl WpApiParamOrder {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Asc => "asc",
-            Self::Desc => "desc",
-        }
-    }
-}
-
-impl FromStr for WpApiParamOrder {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "asc" => Ok(Self::Asc),
-            "desc" => Ok(Self::Desc),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamOrder);
 
 trait SparseField {
     fn as_str(&self) -> &str;
@@ -218,3 +206,31 @@ macro_rules! generate {
 }
 
 uniffi::setup_scaffolding!();
+
+#[cfg(test)]
+mod lib_tests {
+    use super::*;
+    use rstest::*;
+    use url::Url;
+    use url_query::QueryPairsExtension;
+
+    #[rstest]
+    #[case(WpApiParamOrder::Asc, "asc")]
+    #[case(WpApiParamOrder::Desc, "desc")]
+    fn test_order_url_query(#[case] orderby: WpApiParamOrder, #[case] expected: &str) {
+        let mut url = Url::parse("https://example.com").unwrap();
+        url.query_pairs_mut()
+            .append_query_value_pair("orderby", &orderby);
+        assert_eq!(
+            url.query().map(|x| x.to_string()),
+            Some(format!("orderby={}", expected))
+        );
+    }
+
+    #[rstest]
+    #[case(WpApiParamOrder::Asc)]
+    #[case(WpApiParamOrder::Desc)]
+    fn test_orderby_string_conversion(#[case] orderby: WpApiParamOrder) {
+        assert_eq!(orderby, orderby.to_string().parse().unwrap(),);
+    }
+}

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -208,7 +208,7 @@ macro_rules! generate {
 uniffi::setup_scaffolding!();
 
 #[cfg(test)]
-mod lib_tests {
+mod tests {
     use super::*;
     use rstest::*;
     use url::Url;

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -231,6 +231,6 @@ mod lib_tests {
     #[case(WpApiParamOrder::Asc)]
     #[case(WpApiParamOrder::Desc)]
     fn test_orderby_string_conversion(#[case] orderby: WpApiParamOrder) {
-        assert_eq!(orderby, orderby.to_string().parse().unwrap(),);
+        assert_eq!(orderby, orderby.to_string().parse().unwrap());
     }
 }

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::{
         PostCommentStatus, PostId, PostPingStatus, PostStatus, WpApiParamPostsOrderBy,
         WpApiParamPostsSearchColumn,
@@ -11,7 +11,7 @@ use crate::{
     JsonValue, UserId, WpApiParamOrder,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::Infallible, num::ParseIntError, str::FromStr};
+use std::{collections::HashMap, num::ParseIntError, str::FromStr};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
@@ -35,47 +35,50 @@ impl std::fmt::Display for MediaId {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum MediaType {
     File,
     Image,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(MediaType);
-
-impl MediaType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::File => "file",
-            Self::Image => "image",
-            Self::Custom(media_type) => media_type,
-        }
-    }
-}
-
-impl FromStr for MediaType {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "file" => Ok(Self::File),
-            "image" => Ok(Self::Image),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(MediaType);
 
 // A separate param type is implemented for `MediaType` because the API will accept types such as
 // "audio" & "application" as a parameter, but it'll return "file" for the value of `media_type`
 // field for these media types.
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum MediaTypeParam {
     Image,
     Video,
@@ -83,38 +86,11 @@ pub enum MediaTypeParam {
     Application,
     Audio,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(MediaTypeParam);
-
-impl MediaTypeParam {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Image => "image",
-            Self::Video => "video",
-            Self::Text => "text",
-            Self::Application => "application",
-            Self::Audio => "audio",
-            Self::Custom(media_type) => media_type,
-        }
-    }
-}
-
-impl FromStr for MediaTypeParam {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "image" => Ok(Self::Image),
-            "video" => Ok(Self::Video),
-            "text" => Ok(Self::Text),
-            "application" => Ok(Self::Application),
-            "audio" => Ok(Self::Audio),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(MediaTypeParam);
 
 #[derive(
     Debug,
@@ -128,42 +104,22 @@ impl FromStr for MediaTypeParam {
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum MediaStatus {
     #[default]
     Inherit,
     Private,
     Trash,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(MediaStatus);
-
-impl MediaStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Inherit => "inherit",
-            Self::Private => "private",
-            Self::Trash => "trash",
-            Self::Custom(status) => status,
-        }
-    }
-}
-
-impl FromStr for MediaStatus {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "inherit" => Ok(Self::Inherit),
-            "private" => Ok(Self::Private),
-            "trash" => Ok(Self::Trash),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(MediaStatus);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct MediaListParams {
@@ -499,17 +455,14 @@ impl From<MediaCreateParams> for HashMap<String, String> {
         add("date", params.date);
         add("date_gmt", params.date_gmt);
         add("slug", params.slug);
-        add("status", params.status.map(|x| x.as_str().to_string()));
+        add("status", params.status.map(|x| x.to_string()));
         add("title", params.title);
         add("author", params.author.map(|x| x.to_string()));
         add(
             "comment_status",
-            params.comment_status.map(|x| x.as_str().to_string()),
+            params.comment_status.map(|x| x.to_string()),
         );
-        add(
-            "ping_status",
-            params.ping_status.map(|x| x.as_str().to_string()),
-        );
+        add("ping_status", params.ping_status.map(|x| x.to_string()));
         add("template", params.template);
         add("alt_text", params.alt_text);
         add("caption", params.caption);

--- a/wp_api/src/parsed_url.rs
+++ b/wp_api/src/parsed_url.rs
@@ -96,7 +96,7 @@ mod tests {
     #[case("http://example.com")]
     fn parse_url_success(#[case] input: &str) {
         let parsed_url = ParsedUrl::parse(input).unwrap();
-        assert_eq!(parsed_url.url(), "http://example.com/",);
+        assert_eq!(parsed_url.url(), "http://example.com/");
         assert_eq!(parsed_url, Url::parse("http://example.com").unwrap().into());
     }
 

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -1,12 +1,11 @@
-use std::{fmt::Display, str::FromStr};
+use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
 use crate::{
-    impl_as_query_value_from_as_str,
+    impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
-    EnumFromStrParsingError,
 };
 
 #[derive(Debug, Default, uniffi::Record)]
@@ -119,42 +118,31 @@ impl From<&str> for PluginWpOrgDirectorySlug {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, uniffi::Enum)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
 pub enum PluginStatus {
     #[serde(rename = "active")]
+    #[strum(serialize = "active")]
     Active,
     #[serde(rename = "inactive")]
+    #[strum(serialize = "inactive")]
     Inactive,
     #[serde(rename = "network-active")]
+    #[strum(serialize = "network-active")]
     NetworkActive,
 }
 
-impl_as_query_value_from_as_str!(PluginStatus);
-
-impl PluginStatus {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Active => "active",
-            Self::Inactive => "inactive",
-            Self::NetworkActive => "network-active",
-        }
-    }
-}
-
-impl FromStr for PluginStatus {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "active" => Ok(Self::Active),
-            "inactive" => Ok(Self::Inactive),
-            "network-active" => Ok(Self::NetworkActive),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(PluginStatus);
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct PluginDescription {

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,15 +1,26 @@
-use std::convert::Infallible;
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::collections::HashMap;
 
-use crate::impl_as_query_value_from_as_str;
+use crate::impl_as_query_value_from_to_string;
 use crate::url_query::AsQueryValue;
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PostType {
     Post,
     Page,
@@ -22,54 +33,11 @@ pub enum PostType {
     WpFontFamily,
     WpFontFace,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl PostType {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Post => "post",
-            Self::Page => "page",
-            Self::Attachment => "attachment",
-            Self::NavMenuItem => "nav_menu_item",
-            Self::WpBlock => "wp_block",
-            Self::WpTemplate => "wp_template",
-            Self::WpTemplatePart => "wp_template_part",
-            Self::WpNavigation => "wp_navigation",
-            Self::WpFontFamily => "wp_font_family",
-            Self::WpFontFace => "wp_font_face",
-            Self::Custom(name) => name.as_str(),
-        }
-    }
-}
-
-impl FromStr for PostType {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "post" => Ok(Self::Post),
-            "page" => Ok(Self::Page),
-            "attachment" => Ok(Self::Attachment),
-            "nav_menu_item" => Ok(Self::NavMenuItem),
-            "wp_block" => Ok(Self::WpBlock),
-            "wp_template" => Ok(Self::WpTemplate),
-            "wp_template_part" => Ok(Self::WpTemplatePart),
-            "wp_navigation" => Ok(Self::WpNavigation),
-            "wp_font_family" => Ok(Self::WpFontFamily),
-            "wp_font_face" => Ok(Self::WpFontFace),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
-
-impl Display for PostType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl_as_query_value_from_as_str!(PostType);
+impl_as_query_value_from_to_string!(PostType);
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 #[serde(transparent)]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, num::ParseIntError, str::FromStr};
+use std::{num::ParseIntError, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -7,17 +7,28 @@ use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_s
 
 use crate::{
     categories::CategoryId,
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     media::MediaId,
     tags::TagId,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, UserId, WpApiParamOrder,
+    UserId, WpApiParamOrder,
 };
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamPostsOrderBy {
     Author,
     #[default]
@@ -32,111 +43,31 @@ pub enum WpApiParamPostsOrderBy {
     Title,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamPostsOrderBy);
+impl_as_query_value_from_to_string!(WpApiParamPostsOrderBy);
 
-impl WpApiParamPostsOrderBy {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Author => "author",
-            Self::Date => "date",
-            Self::Id => "id",
-            Self::Include => "include",
-            Self::IncludeSlugs => "include_slugs",
-            Self::Modified => "modified",
-            Self::Parent => "parent",
-            Self::Relevance => "relevance",
-            Self::Slug => "slug",
-            Self::Title => "title",
-        }
-    }
-}
-
-impl FromStr for WpApiParamPostsOrderBy {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "author" => Ok(Self::Author),
-            "date" => Ok(Self::Date),
-            "id" => Ok(Self::Id),
-            "include" => Ok(Self::Include),
-            "include_slugs" => Ok(Self::IncludeSlugs),
-            "modified" => Ok(Self::Modified),
-            "parent" => Ok(Self::Parent),
-            "relevance" => Ok(Self::Relevance),
-            "slug" => Ok(Self::Slug),
-            "title" => Ok(Self::Title),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display,
+)]
 pub enum WpApiParamPostsTaxRelation {
+    #[strum(serialize = "AND")]
     And,
+    #[strum(serialize = "OR")]
     Or,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamPostsTaxRelation);
+impl_as_query_value_from_to_string!(WpApiParamPostsTaxRelation);
 
-impl WpApiParamPostsTaxRelation {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::And => "AND",
-            Self::Or => "OR",
-        }
-    }
-}
-
-impl FromStr for WpApiParamPostsTaxRelation {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "AND" => Ok(Self::And),
-            "OR" => Ok(Self::Or),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamPostsSearchColumn {
     PostContent,
     PostExcerpt,
     PostTitle,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamPostsSearchColumn);
-
-impl WpApiParamPostsSearchColumn {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostContent => "post_content",
-            Self::PostExcerpt => "post_excerpt",
-            Self::PostTitle => "post_title",
-        }
-    }
-}
-
-impl FromStr for WpApiParamPostsSearchColumn {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "post_content" => Ok(Self::PostContent),
-            "post_excerpt" => Ok(Self::PostExcerpt),
-            "post_title" => Ok(Self::PostTitle),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamPostsSearchColumn);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct PostListParams {
@@ -662,8 +593,11 @@ pub struct PostFootnote {
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PostStatus {
     Draft,
     Future,
@@ -672,85 +606,76 @@ pub enum PostStatus {
     #[default]
     Publish,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(PostStatus);
-
-impl PostStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Draft => "draft",
-            Self::Future => "future",
-            Self::Pending => "pending",
-            Self::Private => "private",
-            Self::Publish => "publish",
-            Self::Custom(status) => status,
-        }
-    }
-}
-
-impl FromStr for PostStatus {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "draft" => Ok(Self::Draft),
-            "future" => Ok(Self::Future),
-            "pending" => Ok(Self::Pending),
-            "private" => Ok(Self::Private),
-            "publish" => Ok(Self::Publish),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(PostStatus);
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PostCommentStatus {
     Open,
     Closed,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl PostCommentStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Open => "open",
-            Self::Closed => "closed",
-            Self::Custom(comment_status) => comment_status,
-        }
-    }
-}
-
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PostPingStatus {
     Open,
     Closed,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl PostPingStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Open => "open",
-            Self::Closed => "closed",
-            Self::Custom(ping_status) => ping_status,
-        }
-    }
-}
-
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PostFormat {
     Standard,
     Aside,
@@ -763,6 +688,7 @@ pub enum PostFormat {
     Video,
     Audio,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
@@ -827,6 +753,9 @@ mod tests {
     #[case(generate!(PostListParams, (status, vec![PostStatus::Private])), "status=private")]
     #[case(generate!(PostListParams, (status, vec![PostStatus::Publish])), "status=publish")]
     #[case(generate!(PostListParams, (status, vec![PostStatus::Custom("foo".to_string())])), "status=foo")]
+    #[case(generate!(PostListParams, (status, vec![PostStatus::Custom("foo-bar".to_string())])), "status=foo-bar")]
+    #[case(generate!(PostListParams, (status, vec![PostStatus::Custom("foo_bar".to_string())])), "status=foo_bar")]
+    #[case(generate!(PostListParams, (status, vec![PostStatus::Custom("FooBar".to_string())])), "status=FooBar")]
     #[case(generate!(PostListParams, (status, vec![PostStatus::Draft, PostStatus::Future, PostStatus::Pending, PostStatus::Private, PostStatus::Publish, PostStatus::Custom("foo".to_string())])), "status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
     #[case(generate!(PostListParams, (tax_relation, Some(WpApiParamPostsTaxRelation::And))), "tax_relation=AND")]
     #[case(generate!(PostListParams, (tax_relation, Some(WpApiParamPostsTaxRelation::Or))), "tax_relation=OR")]

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -1,12 +1,11 @@
 use crate::{
-    impl_as_query_value_from_as_str,
+    impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
-    AsQueryValue, EnumFromStrParsingError, IntegerOrString,
+    AsQueryValue, IntegerOrString,
 };
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
@@ -22,88 +21,54 @@ use wp_contextual::WpContextual;
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 pub enum SearchResultType {
     #[default]
     #[serde(rename = "post")]
+    #[strum(serialize = "post")]
     Post,
     #[serde(rename = "term")]
+    #[strum(serialize = "term")]
     Term,
     #[serde(rename = "post-format")]
+    #[strum(serialize = "post-format")]
     PostFormat,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(SearchResultType);
-
-impl SearchResultType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Post => "post",
-            Self::Term => "term",
-            Self::PostFormat => "post-format",
-            Self::Custom(result_type) => result_type,
-        }
-    }
-}
-
-impl FromStr for SearchResultType {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "post" => Ok(Self::Post),
-            "term" => Ok(Self::Term),
-            "post-format" => Ok(Self::PostFormat),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(SearchResultType);
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum SearchResultSubtype {
-    #[serde(rename = "post")]
     Post,
-    #[serde(rename = "page")]
     Page,
-    #[serde(rename = "category")]
     Category,
-    #[serde(rename = "post_tag")]
     PostTag,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(SearchResultSubtype);
-
-impl SearchResultSubtype {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Post => "post",
-            Self::Page => "page",
-            Self::Category => "category",
-            Self::PostTag => "post_tag",
-            Self::Custom(result_type) => result_type,
-        }
-    }
-}
-
-impl FromStr for SearchResultSubtype {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "post" => Ok(Self::Post),
-            "page" => Ok(Self::Page),
-            "category" => Ok(Self::Category),
-            "post_tag" => Ok(Self::PostTag),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(SearchResultSubtype);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct SearchListParams {

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -171,3 +171,19 @@ pub struct SparseSearchResult {
     #[WpContextualOption]
     pub object_subtype: Option<SearchResultSubtype>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    #[case(SearchResultType::Post)]
+    #[case(SearchResultType::Term)]
+    #[case(SearchResultType::PostFormat)]
+    #[case(SearchResultType::Custom("foo_bar".to_string()))]
+    #[case(SearchResultType::Custom("foo-bar".to_string()))]
+    fn test_search_result_type_string_conversion(#[case] value: SearchResultType) {
+        assert_eq!(value, value.to_string().parse().unwrap());
+    }
+}

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -5,14 +5,14 @@ use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 use crate::{
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     taxonomies::TaxonomyType,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, WpApiParamOrder,
+    WpApiParamOrder,
 };
 
 impl_as_query_value_for_new_type!(TagId);
@@ -34,7 +34,18 @@ impl std::fmt::Display for TagId {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamTagsOrderBy {
     Id,
     Include,
@@ -47,42 +58,7 @@ pub enum WpApiParamTagsOrderBy {
     Count,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamTagsOrderBy);
-
-impl WpApiParamTagsOrderBy {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Id => "id",
-            Self::Include => "include",
-            Self::Name => "name",
-            Self::Slug => "slug",
-            Self::IncludeSlugs => "include_slugs",
-            Self::TermGroup => "term_group",
-            Self::Description => "description",
-            Self::Count => "count",
-        }
-    }
-}
-
-impl FromStr for WpApiParamTagsOrderBy {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "id" => Ok(Self::Id),
-            "include" => Ok(Self::Include),
-            "name" => Ok(Self::Name),
-            "slug" => Ok(Self::Slug),
-            "include_slugs" => Ok(Self::IncludeSlugs),
-            "term_group" => Ok(Self::TermGroup),
-            "description" => Ok(Self::Description),
-            "count" => Ok(Self::Count),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamTagsOrderBy);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct TagListParams {

--- a/wp_api/src/themes.rs
+++ b/wp_api/src/themes.rs
@@ -1,49 +1,40 @@
 use crate::{
-    impl_as_query_value_from_as_str,
+    impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
-    AsQueryValue, BoolOrVecString, EnumFromStrParsingError,
+    AsQueryValue, BoolOrVecString,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::{collections::HashMap, fmt::Display};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ThemeStatus {
     Active,
     Inactive,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(ThemeStatus);
-
-impl ThemeStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Active => "active",
-            Self::Inactive => "inactive",
-            Self::Custom(status) => status,
-        }
-    }
-}
-
-impl FromStr for ThemeStatus {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "active" => Ok(Self::Active),
-            "inactive" => Ok(Self::Inactive),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(ThemeStatus);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct ThemeListParams {

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -7,8 +7,7 @@ use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
 use crate::{
-    impl_as_query_value_for_new_type, impl_as_query_value_from_as_str,
-    impl_as_query_value_from_to_string,
+    impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
@@ -16,7 +15,18 @@ use crate::{
     EnumFromStrParsingError, OptionFromStr, WpApiParamOrder, WpResponseString,
 };
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
 pub enum WpApiParamUsersOrderBy {
     Id,
     Include,
@@ -29,42 +39,7 @@ pub enum WpApiParamUsersOrderBy {
     Url,
 }
 
-impl_as_query_value_from_as_str!(WpApiParamUsersOrderBy);
-
-impl WpApiParamUsersOrderBy {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Id => "id",
-            Self::Include => "include",
-            Self::Name => "name",
-            Self::RegisteredDate => "registered_date",
-            Self::Slug => "slug",
-            Self::IncludeSlugs => "include_slugs",
-            Self::Email => "email",
-            Self::Url => "url",
-        }
-    }
-}
-
-impl FromStr for WpApiParamUsersOrderBy {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "id" => Ok(Self::Id),
-            "include" => Ok(Self::Include),
-            "name" => Ok(Self::Name),
-            "registered_date" => Ok(Self::RegisteredDate),
-            "slug" => Ok(Self::Slug),
-            "include_slugs" => Ok(Self::IncludeSlugs),
-            "email" => Ok(Self::Email),
-            "url" => Ok(Self::Url),
-            value => Err(EnumFromStrParsingError::UnknownVariant {
-                value: value.to_string(),
-            }),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WpApiParamUsersOrderBy);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WpApiParamUsersWho {

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -248,7 +248,7 @@ generate_update_test!(
         assert_eq!(updated_post.comment_status, PostCommentStatus::Open);
         assert_eq!(
             updated_post_from_wp_cli.comment_status,
-            PostCommentStatus::Open.as_str()
+            PostCommentStatus::Open.to_string()
         );
     }
 );
@@ -261,7 +261,7 @@ generate_update_test!(
         assert_eq!(updated_post.comment_status, PostCommentStatus::Closed);
         assert_eq!(
             updated_post_from_wp_cli.comment_status,
-            PostCommentStatus::Closed.as_str()
+            PostCommentStatus::Closed.to_string()
         );
     }
 );
@@ -274,7 +274,7 @@ generate_update_test!(
         assert_eq!(updated_post.ping_status, PostPingStatus::Open);
         assert_eq!(
             updated_post_from_wp_cli.ping_status,
-            PostPingStatus::Open.as_str()
+            PostPingStatus::Open.to_string()
         );
     }
 );
@@ -287,7 +287,7 @@ generate_update_test!(
         assert_eq!(updated_post.ping_status, PostPingStatus::Closed);
         assert_eq!(
             updated_post_from_wp_cli.ping_status,
-            PostPingStatus::Closed.as_str()
+            PostPingStatus::Closed.to_string()
         );
     }
 );
@@ -393,7 +393,7 @@ async fn update_status_to_future() {
             assert_eq!(updated_post.status, PostStatus::Future);
             assert_eq!(
                 updated_post_from_wp_cli.post_status,
-                PostStatus::Future.as_str()
+                PostStatus::Future.to_string()
             );
         },
     )
@@ -481,7 +481,7 @@ mod macro_helper {
                             assert_eq!(updated_post.status, PostStatus::$status);
                             assert_eq!(
                                 updated_post_from_wp_cli.post_status,
-                                PostStatus::$status.as_str()
+                                PostStatus::$status.to_string()
                             );
                         }
                     ).await;


### PR DESCRIPTION
Here are the two core changes:
1. Use `strum_macros::EnumString` derive macro to replace our own `FromStr` implementation.
2. Use `strum_macros::Display` derive macro to replace our own `as_str` implementation. The macro adds `std::fmt::Display` implementation to the attached enums.

### Breaking change

The enums now no longer have the `as_str` function. Instead, they have `to_string`.

### Do not use `strum_macros::AsRefStr`

strum also has a derive macro `AsRefStr` to add `fn as_ref() -> AsRef<str>` to the attached enums. However, the function does not match the `to_string` implementation generated by `strum_macros::Display` macro. The `Custom(String)` variant returns `"Custom"`, instead of the `String` value in the tuple.