### PR TITLE
Let uniffi add `Sendable` conformation to endpoint response types

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -29,7 +29,7 @@ class WpRequestExecutor(
                 request.method().toString(),
                 request.body()?.contents()?.toRequestBody()
             )
-            request.headerMap().toMap().forEach { (key, values) ->
+            request.headerMap().toMultiMap().forEach { (key, values) ->
                 values.forEach { value ->
                     requestBuilder.addHeader(key, value)
                 }
@@ -68,7 +68,7 @@ class WpRequestExecutor(
                 method = mediaUploadRequest.method().toString(),
                 body = multipartBodyBuilder.build()
             )
-            mediaUploadRequest.headerMap().toMap().forEach { (key, values) ->
+            mediaUploadRequest.headerMap().toMultiMap().forEach { (key, values) ->
                 values.forEach { value ->
                     requestBuilder.addHeader(key, value)
                 }

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -13,7 +13,7 @@ public protocol PaginatableResponse: Sendable {
 
     var data: [DataType] { get }
 
-    init(data: [DataType], headerMap: WpNetworkHeaderMap, nextPageParams: ParamsType?, prevPageParams: ParamsType?)
+    init(data: [DataType], headerMap: [String: [String]], nextPageParams: ParamsType?, prevPageParams: ParamsType?)
 }
 
 public protocol PaginationAwareExecutor: Sendable {
@@ -187,17 +187,17 @@ public struct PaginationSequence<ResponseType: PaginatableResponse>: AsyncSequen
 }
 
 // MARK: - Posts
-extension PostsRequestListWithEditContextResponse: PaginatableResponse, @unchecked Sendable {
+extension PostsRequestListWithEditContextResponse: PaginatableResponse {
     public typealias ParamsType = PostListParams
     public typealias DataType = PostWithEditContext
 }
 
-extension PostsRequestListWithViewContextResponse: PaginatableResponse, @unchecked Sendable {
+extension PostsRequestListWithViewContextResponse: PaginatableResponse {
     public typealias ParamsType = PostListParams
     public typealias DataType = PostWithViewContext
 }
 
-extension PostsRequestListWithEmbedContextResponse: PaginatableResponse, @unchecked Sendable {
+extension PostsRequestListWithEmbedContextResponse: PaginatableResponse {
     public typealias ParamsType = PostListParams
     public typealias DataType = PostWithEmbedContext
 }
@@ -209,17 +209,17 @@ extension PostsRequestExecutor: PaginationAwareExecutor {
 }
 
 // MARK: - Media
-extension MediaRequestListWithEditContextResponse: PaginatableResponse, @unchecked Sendable {
+extension MediaRequestListWithEditContextResponse: PaginatableResponse {
     public typealias ParamsType = MediaListParams
     public typealias DataType = MediaWithEditContext
 }
 
-extension MediaRequestListWithViewContextResponse: PaginatableResponse, @unchecked Sendable {
+extension MediaRequestListWithViewContextResponse: PaginatableResponse {
     public typealias ParamsType = MediaListParams
     public typealias DataType = MediaWithViewContext
 }
 
-extension MediaRequestListWithEmbedContextResponse: PaginatableResponse, @unchecked Sendable {
+extension MediaRequestListWithEmbedContextResponse: PaginatableResponse {
     public typealias ParamsType = MediaListParams
     public typealias DataType = MediaWithEmbedContext
 }
@@ -231,17 +231,17 @@ extension MediaRequestExecutor: PaginationAwareExecutor {
 }
 
 // MARK: - Users
-extension UsersRequestListWithEditContextResponse: PaginatableResponse, @unchecked Sendable {
+extension UsersRequestListWithEditContextResponse: PaginatableResponse {
     public typealias ParamsType = UserListParams
     public typealias DataType = UserWithEditContext
 }
 
-extension UsersRequestListWithViewContextResponse: PaginatableResponse, @unchecked Sendable {
+extension UsersRequestListWithViewContextResponse: PaginatableResponse {
     public typealias ParamsType = UserListParams
     public typealias DataType = UserWithViewContext
 }
 
-extension UsersRequestListWithEmbedContextResponse: PaginatableResponse, @unchecked Sendable {
+extension UsersRequestListWithEmbedContextResponse: PaginatableResponse {
     public typealias ParamsType = UserListParams
     public typealias DataType = UserWithEmbedContext
 }

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -121,7 +121,7 @@ public actor WordPressAPI {
 
 public extension WpNetworkHeaderMap {
     func toFlatMap() -> [String: String] {
-        self.toMap().mapValues { $0.joined(separator: ",") }
+        self.toMultiMap().mapValues { $0.joined(separator: ",") }
     }
 }
 
@@ -138,7 +138,7 @@ public extension WpNetworkRequest {
     #if DEBUG
     func debugPrint() {
         print("\(method().rawValue) \(self.url())")
-        for (name, value) in self.headerMap().toMap() {
+        for (name, value) in self.headerMap().toMultiMap() {
             print("\(name): \(value)")
         }
 

--- a/native/swift/Tests/wordpress-api/Support/Extensions.swift
+++ b/native/swift/Tests/wordpress-api/Support/Extensions.swift
@@ -15,7 +15,7 @@ extension WpNetworkHeaderMap {
 
 extension PaginatableResponse {
     static var empty: Self {
-        Self(data: [], headerMap: .empty, nextPageParams: nil, prevPageParams: nil)
+        Self(data: [], headerMap: [:], nextPageParams: nil, prevPageParams: nil)
     }
 }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -314,7 +314,7 @@ impl WpNetworkHeaderMap {
         Ok(Self { inner })
     }
 
-    fn to_map(&self) -> HashMap<String, Vec<String>> {
+    pub fn to_multi_map(&self) -> HashMap<String, Vec<String>> {
         let mut header_hashmap = HashMap::new();
         self.inner.iter().for_each(|(k, v)| {
             let v = String::from_utf8_lossy(v.as_bytes()).into_owned();

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -252,8 +252,8 @@ impl WpNetworkHeaderMap {
 
     // Splits the `header_value` by `,` then parses name & values into `HeaderName` & `HeaderValue`
     fn build_header_name_value(
-        header_name: String,
-        header_value: String,
+        header_name: &str,
+        header_value: &str,
     ) -> Vec<Result<(HeaderName, HeaderValue), WpNetworkHeaderMapError>> {
         header_value
             .split(',')
@@ -274,7 +274,7 @@ impl WpNetworkHeaderMap {
                     }
                 } else {
                     Err(WpNetworkHeaderMapError::InvalidHeaderName {
-                        header_name: header_name.clone(),
+                        header_name: header_name.to_string(),
                     })
                 }
             })
@@ -296,7 +296,7 @@ impl WpNetworkHeaderMap {
             .into_iter()
             .flat_map(|(header_name, values)| {
                 values.into_iter().flat_map(move |header_value| {
-                    Self::build_header_name_value(header_name.clone(), header_value)
+                    Self::build_header_name_value(&header_name, &header_value)
                 })
             })
             .collect::<Result<HeaderMap, WpNetworkHeaderMapError>>()?;
@@ -308,7 +308,7 @@ impl WpNetworkHeaderMap {
         let inner = hash_map
             .into_iter()
             .flat_map(|(header_name, header_value)| {
-                Self::build_header_name_value(header_name, header_value)
+                Self::build_header_name_value(&header_name, &header_value)
             })
             .collect::<Result<HeaderMap, WpNetworkHeaderMapError>>()?;
         Ok(Self { inner })

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -289,7 +289,7 @@ impl WpNetworkHeaderMap {
 #[uniffi::export]
 impl WpNetworkHeaderMap {
     #[uniffi::constructor]
-    fn from_multi_map(
+    pub fn from_multi_map(
         hash_map: HashMap<String, Vec<String>>,
     ) -> Result<Self, WpNetworkHeaderMapError> {
         let inner = hash_map

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -7,6 +7,7 @@ use wp_api::posts::{
     SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
     WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
 };
+use wp_api::request::WpNetworkHeaderMap;
 use wp_api::tags::TagId;
 use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
@@ -21,8 +22,9 @@ async fn list_with_edit_context_number_of_pages() {
         .list_with_edit_context(&PostListParams::default())
         .await
         .assert_response();
-    assert_eq!(p.header_map.wp_total(), Some(57));
-    assert_eq!(p.header_map.wp_total_pages(), Some(6));
+    let header_map = WpNetworkHeaderMap::from_multi_map(p.header_map).unwrap();
+    assert_eq!(header_map.wp_total(), Some(57));
+    assert_eq!(header_map.wp_total_pages(), Some(6));
 }
 
 #[tokio::test]

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -128,14 +128,14 @@ fn generate_async_request_executor(
                 pub struct #response_type_ident {
                     pub data: #output_type,
                     #[serde(skip)]
-                    pub header_map: std::sync::Arc<#crate_ident::request::WpNetworkHeaderMap>,
+                    pub header_map: std::collections::HashMap<std::string::String, std::vec::Vec<std::string::String>>,
                     #response_pagination_params_fields
                 }
                 impl From<#response_type_ident> for #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type> {
                     fn from(value: #response_type_ident) -> Self {
                         Self {
                             data: value.data,
-                            header_map: value.header_map,
+                            header_map: crate::request::WpNetworkHeaderMap::from_multi_map(value.header_map).unwrap().into(),
                             #from_concrete_response_impl_for_pagination_params
                         }
                     }
@@ -144,7 +144,7 @@ fn generate_async_request_executor(
                     fn from(value: #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type>) -> Self {
                         Self {
                             data: value.data,
-                            header_map: value.header_map,
+                            header_map: value.header_map.to_multi_map(),
                             #from_parsed_response_impl_for_pagination_params
                         }
                     }


### PR DESCRIPTION
See internal discussion in p1737332574514769-slack-C06S1QS55K9.