### PR TITLE
Rename `as_header_map` to `to_header_map`

### DIFF
--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -281,7 +281,7 @@ impl WpNetworkHeaderMap {
             .collect()
     }
 
-    pub fn as_header_map(&self) -> HeaderMap {
+    pub fn to_header_map(&self) -> HeaderMap {
         self.inner.clone()
     }
 }

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -169,7 +169,7 @@ impl AsyncWpNetworking {
                 Self::request_method(wp_request.method()),
                 wp_request.url().0.as_str(),
             )
-            .headers(wp_request.header_map().as_header_map());
+            .headers(wp_request.header_map().to_header_map());
         if let Some(body) = wp_request.body() {
             request = request.body(body.contents());
         }
@@ -193,7 +193,7 @@ impl AsyncWpNetworking {
                 Self::request_method(media_upload_request.method()),
                 media_upload_request.url().0.as_str(),
             )
-            .headers(media_upload_request.header_map().as_header_map());
+            .headers(media_upload_request.header_map().to_header_map());
         let file_path = media_upload_request.file_path();
         let mut file_header_map = HeaderMap::new();
         file_header_map.insert(

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -222,7 +222,7 @@ impl RequestExecutor for MediaErrNetworking {
                 AsyncWpNetworking::request_method(media_upload_request.method()),
                 media_upload_request.url().0.as_str(),
             )
-            .headers(media_upload_request.header_map().as_header_map());
+            .headers(media_upload_request.header_map().to_header_map());
         let mut file_header_map = HeaderMap::new();
         file_header_map.insert(
             http::header::CONTENT_TYPE,


### PR DESCRIPTION
Using `to_xxx` because the function clones.