### PR TITLE
Change `WpNetworkHeaderMap` to be a newtype for `HashMap<String, Vec<String>>`

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -12,7 +12,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import uniffi.wp_api.MediaUploadRequest
 import uniffi.wp_api.MediaUploadRequestExecutionException
 import uniffi.wp_api.RequestExecutor
-import uniffi.wp_api.WpNetworkHeaderMap
 import uniffi.wp_api.WpNetworkRequest
 import uniffi.wp_api.WpNetworkResponse
 import java.io.File
@@ -29,7 +28,7 @@ class WpRequestExecutor(
                 request.method().toString(),
                 request.body()?.contents()?.toRequestBody()
             )
-            request.headerMap().toMultiMap().forEach { (key, values) ->
+            request.headerMap().forEach { (key, values) ->
                 values.forEach { value ->
                     requestBuilder.addHeader(key, value)
                 }
@@ -39,7 +38,7 @@ class WpRequestExecutor(
                 return@withContext WpNetworkResponse(
                     body = response.body?.bytes() ?: ByteArray(0),
                     statusCode = response.code.toUShort(),
-                    headerMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap())
+                    headerMap = response.headers.toMultimap()
                 )
             }
         }
@@ -68,7 +67,7 @@ class WpRequestExecutor(
                 method = mediaUploadRequest.method().toString(),
                 body = multipartBodyBuilder.build()
             )
-            mediaUploadRequest.headerMap().toMultiMap().forEach { (key, values) ->
+            mediaUploadRequest.headerMap().forEach { (key, values) ->
                 values.forEach { value ->
                     requestBuilder.addHeader(key, value)
                 }
@@ -78,7 +77,7 @@ class WpRequestExecutor(
                 return@withContext WpNetworkResponse(
                     body = response.body?.bytes() ?: ByteArray(0),
                     statusCode = response.code.toUShort(),
-                    headerMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap())
+                    headerMap = response.headers.toMultimap()
                 )
             }
         }

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -1,16 +1,15 @@
-use std::str;
-use std::sync::Arc;
-
-use crate::request::endpoint::WpEndpointUrl;
-use crate::request::{
-    RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
-};
-use crate::ParsedUrl;
-
 use super::url_discovery::{
     self, FetchApiDetailsError, FetchApiRootUrlError, StateInitial, UrlDiscoveryAttemptError,
     UrlDiscoveryAttemptSuccess, UrlDiscoveryError, UrlDiscoveryState, UrlDiscoverySuccess,
 };
+use crate::{
+    request::{
+        endpoint::WpEndpointUrl, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
+        WpNetworkRequest, WpNetworkResponse,
+    },
+    ParsedUrl,
+};
+use std::{str, sync::Arc};
 
 const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
 
@@ -130,7 +129,7 @@ impl WpLoginClient {
         let api_root_request = WpNetworkRequest {
             method: RequestMethod::HEAD,
             url: WpEndpointUrl(parsed_site_url.url()),
-            header_map: WpNetworkHeaderMap::default().into(),
+            header_map: WpNetworkHeaderMap::default(),
             body: None,
         };
         self.request_executor
@@ -148,7 +147,7 @@ impl WpLoginClient {
                 WpNetworkRequest {
                     method: RequestMethod::GET,
                     url: WpEndpointUrl(api_root_url.url()),
-                    header_map: WpNetworkHeaderMap::default().into(),
+                    header_map: WpNetworkHeaderMap::default(),
                     body: None,
                 }
                 .into(),

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -195,7 +195,7 @@ pub enum FetchApiRootUrlError {
         header_map
     )]
     ApiRootLinkHeaderNotFound {
-        header_map: Arc<WpNetworkHeaderMap>,
+        header_map: WpNetworkHeaderMap,
         status_code: u16,
     },
 }

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -28,7 +28,7 @@ const HEADER_KEY_WP_TOTAL_PAGES: &str = "X-WP-TotalPages";
 pub struct ParsedResponse<DataType, ParamsType> {
     pub data: DataType,
     #[serde(skip)]
-    pub header_map: Arc<WpNetworkHeaderMap>,
+    pub header_map: WpNetworkHeaderMap,
     #[serde(skip)]
     pub next_page_params: Option<ParamsType>,
     #[serde(skip)]
@@ -64,7 +64,7 @@ impl InnerRequestBuilder {
         WpNetworkRequest {
             method: RequestMethod::GET,
             url: url.into(),
-            header_map: self.header_map().into(),
+            header_map: self.header_map(),
             body: None,
         }
     }
@@ -76,7 +76,7 @@ impl InnerRequestBuilder {
         WpNetworkRequest {
             method: RequestMethod::POST,
             url: url.into(),
-            header_map: self.header_map_for_post_request().into(),
+            header_map: self.header_map_for_post_request(),
             body: serde_json::to_vec(json_body)
                 .ok()
                 .map(|b| Arc::new(WpNetworkRequestBody::new(b))),
@@ -87,23 +87,24 @@ impl InnerRequestBuilder {
         WpNetworkRequest {
             method: RequestMethod::DELETE,
             url: url.into(),
-            header_map: self.header_map().into(),
+            header_map: self.header_map(),
             body: None,
         }
     }
 
     fn header_map(&self) -> WpNetworkHeaderMap {
-        let mut header_map = HeaderMap::new();
+        let mut header_map = HashMap::new();
         header_map.insert(
-            http::header::ACCEPT,
-            HeaderValue::from_static(CONTENT_TYPE_JSON),
+            http::header::ACCEPT.to_string(),
+            vec![CONTENT_TYPE_JSON.to_string()],
         );
         match self.authentication {
             WpAuthentication::None => (),
             WpAuthentication::AuthorizationHeader { ref token } => {
-                let hv = HeaderValue::from_str(&format!("Basic {}", token));
-                let hv = hv.expect("It shouldn't be possible to build WpAuthentication::AuthorizationHeader with an invalid token");
-                header_map.insert(http::header::AUTHORIZATION, hv);
+                header_map.insert(
+                    http::header::AUTHORIZATION.to_string(),
+                    vec![format!("Basic {}", token)],
+                );
             }
         };
         header_map.into()
@@ -111,9 +112,9 @@ impl InnerRequestBuilder {
 
     fn header_map_for_post_request(&self) -> WpNetworkHeaderMap {
         let mut header_map = self.header_map();
-        header_map.inner.insert(
-            http::header::CONTENT_TYPE,
-            HeaderValue::from_static(CONTENT_TYPE_JSON),
+        header_map.0.insert(
+            http::header::CONTENT_TYPE.to_string(),
+            vec![CONTENT_TYPE_JSON.to_string()],
         );
         header_map
     }
@@ -155,8 +156,8 @@ impl WpNetworkRequestBody {
 #[derive(uniffi::Object)]
 pub struct WpNetworkRequest {
     pub(crate) method: RequestMethod,
-    pub(crate) url: WpEndpointUrl,
-    pub(crate) header_map: Arc<WpNetworkHeaderMap>,
+    pub url: WpEndpointUrl,
+    pub header_map: WpNetworkHeaderMap,
     pub(crate) body: Option<Arc<WpNetworkRequestBody>>,
 }
 
@@ -166,11 +167,11 @@ impl WpNetworkRequest {
         self.method.clone()
     }
 
-    pub fn url(&self) -> WpEndpointUrl {
+    fn url(&self) -> WpEndpointUrl {
         self.url.clone()
     }
 
-    pub fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
+    fn header_map(&self) -> WpNetworkHeaderMap {
         self.header_map.clone()
     }
 
@@ -190,7 +191,7 @@ impl WpNetworkRequest {
         Self {
             method: RequestMethod::GET,
             url,
-            header_map: Arc::new(WpNetworkHeaderMap::default()),
+            header_map: WpNetworkHeaderMap::default(),
             body: None,
         }
     }
@@ -222,19 +223,14 @@ impl Debug for WpNetworkRequest {
 pub struct WpNetworkResponse {
     pub body: Vec<u8>,
     pub status_code: u16,
-    pub header_map: Arc<WpNetworkHeaderMap>,
+    pub header_map: WpNetworkHeaderMap,
 }
 
-#[derive(Debug, Default, Clone, uniffi::Object)]
-pub struct WpNetworkHeaderMap {
-    inner: HeaderMap,
-}
+uniffi::custom_newtype!(WpNetworkHeaderMap, HashMap<String, Vec<String>>);
+#[derive(Debug, Default, Clone)]
+pub struct WpNetworkHeaderMap(pub HashMap<String, Vec<String>>);
 
 impl WpNetworkHeaderMap {
-    pub fn new(header_map: HeaderMap) -> Self {
-        Self { inner: header_map }
-    }
-
     pub fn wp_total(&self) -> Option<u32> {
         self.header_value_as_u32(HEADER_KEY_WP_TOTAL)
     }
@@ -244,10 +240,29 @@ impl WpNetworkHeaderMap {
     }
 
     pub fn header_value_as_u32(&self, header_name: &str) -> Option<u32> {
-        self.inner
-            .get(header_name)
-            .and_then(|h_v| h_v.to_str().ok())
-            .and_then(|h| h.parse().ok())
+        [
+            self.0.get(header_name),
+            self.0.get(&header_name.to_lowercase()),
+        ]
+        .into_iter()
+        .flatten()
+        .flatten()
+        .collect::<Vec<_>>()
+        .first()
+        .and_then(|h| h.parse().ok())
+    }
+
+    pub fn to_http_header_map(&self) -> Result<http::HeaderMap, WpNetworkHeaderMapError> {
+        let header_map = self
+            .0
+            .iter()
+            .flat_map(|(header_name, values)| {
+                values.iter().flat_map(|header_value| {
+                    Self::build_header_name_value(header_name, header_value)
+                })
+            })
+            .collect::<Result<HeaderMap, WpNetworkHeaderMapError>>()?;
+        Ok(header_map)
     }
 
     // Splits the `header_value` by `,` then parses name & values into `HeaderName` & `HeaderValue`
@@ -280,56 +295,25 @@ impl WpNetworkHeaderMap {
             })
             .collect()
     }
+}
 
-    pub fn as_header_map(&self) -> HeaderMap {
-        self.inner.clone()
+impl From<HashMap<String, Vec<String>>> for WpNetworkHeaderMap {
+    fn from(value: HashMap<String, Vec<String>>) -> Self {
+        Self(value)
     }
 }
 
-#[uniffi::export]
-impl WpNetworkHeaderMap {
-    #[uniffi::constructor]
-    pub fn from_multi_map(
-        hash_map: HashMap<String, Vec<String>>,
-    ) -> Result<Self, WpNetworkHeaderMapError> {
-        let inner = hash_map
-            .into_iter()
-            .flat_map(|(header_name, values)| {
-                values.into_iter().flat_map(move |header_value| {
-                    Self::build_header_name_value(&header_name, &header_value)
-                })
-            })
-            .collect::<Result<HeaderMap, WpNetworkHeaderMapError>>()?;
-        Ok(Self { inner })
-    }
-
-    #[uniffi::constructor]
-    fn from_map(hash_map: HashMap<String, String>) -> Result<Self, WpNetworkHeaderMapError> {
-        let inner = hash_map
-            .into_iter()
-            .flat_map(|(header_name, header_value)| {
-                Self::build_header_name_value(&header_name, &header_value)
-            })
-            .collect::<Result<HeaderMap, WpNetworkHeaderMapError>>()?;
-        Ok(Self { inner })
-    }
-
-    pub fn to_multi_map(&self) -> HashMap<String, Vec<String>> {
+impl From<http::HeaderMap> for WpNetworkHeaderMap {
+    fn from(http_header_map: http::HeaderMap) -> Self {
         let mut header_hashmap = HashMap::new();
-        self.inner.iter().for_each(|(k, v)| {
+        http_header_map.iter().for_each(|(k, v)| {
             let v = String::from_utf8_lossy(v.as_bytes()).into_owned();
             header_hashmap
                 .entry(k.as_str().to_owned())
                 .or_insert_with(Vec::new)
                 .push(v)
         });
-        header_hashmap
-    }
-}
-
-impl From<HeaderMap> for WpNetworkHeaderMap {
-    fn from(header_map: HeaderMap) -> Self {
-        Self::new(header_map)
+        header_hashmap.into()
     }
 }
 
@@ -344,14 +328,12 @@ pub enum WpNetworkHeaderMapError {
 impl WpNetworkResponse {
     pub fn get_link_header(&self, name: &str) -> Vec<Url> {
         [
-            self.header_map.inner.get_all(LINK_HEADER_KEY),
-            self.header_map
-                .inner
-                .get_all(LINK_HEADER_KEY.to_lowercase()),
+            self.header_map.0.get(LINK_HEADER_KEY),
+            self.header_map.0.get(&LINK_HEADER_KEY.to_lowercase()),
         ]
         .into_iter()
         .flatten()
-        .flat_map(|link_header| link_header.to_str().ok())
+        .flatten()
         .flat_map(|link_header_str| parse_link_header::parse_with_rel(link_header_str).ok())
         .flat_map(|link_map| {
             link_map
@@ -495,13 +477,11 @@ mod tests {
         #[case] expected_prev_link_header: Option<&str>,
         #[case] expected_next_link_header: Option<&str>,
     ) {
+        let hash_map = [("Link".to_string(), vec![link.to_string()])].into();
         let response = WpNetworkResponse {
             body: Vec::with_capacity(0),
             status_code: 200,
-            header_map: Arc::new(
-                WpNetworkHeaderMap::from_map([("Link".to_string(), link.to_string())].into())
-                    .unwrap(),
-            ),
+            header_map: WpNetworkHeaderMap(hash_map),
         };
         assert_eq!(
             expected_prev_link_header
@@ -509,7 +489,7 @@ mod tests {
                 .as_ref(),
             response.get_link_header("prev").first(),
             "response headers: {:?}",
-            response.header_map.inner
+            response.header_map
         );
         assert_eq!(
             expected_next_link_header
@@ -517,71 +497,34 @@ mod tests {
                 .as_ref(),
             response.get_link_header("next").first(),
             "response headers: {:?}",
-            response.header_map.inner
+            response.header_map
         );
     }
 
     #[test]
-    fn test_header_map_from_map() {
-        let hash_map = [
-            ("Age".to_string(), "1,2".to_string()),
-            (
-                LINK_HEADER_KEY.to_string(),
-                "<https://one.example.com>; rel=\"preconnect\", <https://two.example.com>"
-                    .to_string(),
-            ),
-            ("User-Agent".to_string(), "".to_string()),
-        ]
-        .into();
-        let header_map = WpNetworkHeaderMap::from_map(hash_map).unwrap();
-        assert_header_map_values(&header_map, "Age", vec!["1", "2"]);
-        assert_header_map_values(
-            &header_map,
-            LINK_HEADER_KEY,
-            vec![
-                "<https://one.example.com>; rel=\"preconnect\"",
-                "<https://two.example.com>",
-            ],
+    fn header_value_as_u32() {
+        let hash_map = [("foo".to_string(), vec!["17".to_string()])].into();
+        assert_eq!(
+            WpNetworkHeaderMap(hash_map).header_value_as_u32("foo"),
+            Some(17)
         );
-        assert_header_map_values(&header_map, "User-Agent", vec![]);
-    }
 
-    #[test]
-    fn test_header_map_from_multi_map() {
-        let hash_map = [
-            ("Age".to_string(), vec!["1".to_string(), "2,3".to_string()]),
-            (
-                LINK_HEADER_KEY.to_string(),
-                vec![
-                    "<https://one.example.com>; rel=\"preconnect\", <https://two.example.com>"
-                        .to_string(),
-                ],
-            ),
-            ("Retry-After".to_string(), vec!["120".to_string()]),
-            ("User-Agent".to_string(), vec![]),
-        ]
-        .into();
-        let header_map = WpNetworkHeaderMap::from_multi_map(hash_map).unwrap();
-        assert_header_map_values(&header_map, "Age", vec!["1", "2", "3"]);
-        assert_header_map_values(
-            &header_map,
-            LINK_HEADER_KEY,
-            vec![
-                "<https://one.example.com>; rel=\"preconnect\"",
-                "<https://two.example.com>",
-            ],
+        // Assert that only the first value is parsed
+        let hash_map2 = [("bar".to_string(), vec!["17".to_string(), "21".to_string()])].into();
+        assert_eq!(
+            WpNetworkHeaderMap(hash_map2).header_value_as_u32("bar"),
+            Some(17)
         );
-        assert_header_map_values(&header_map, "Retry-After", vec!["120"]);
-        assert_header_map_values(&header_map, "User-Agent", vec![]);
     }
 
     fn assert_header_map_values(header_map: &WpNetworkHeaderMap, key: &str, values: Vec<&str>) {
         assert_eq!(
             header_map
-                .inner
-                .get_all(key)
+                .0
+                .get(key)
+                .unwrap()
                 .iter()
-                .map(|h| h.to_str().unwrap())
+                .map(|h| h.as_str())
                 .collect::<Vec<&str>>(),
             values
         );

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     SparseField,
 };
-use http::HeaderValue;
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -88,7 +87,7 @@ impl MediaRequestEndpoint {
 pub struct MediaRequestCreateResponse {
     pub data: crate::media::MediaWithEditContext,
     #[serde(skip)]
-    pub header_map: std::sync::Arc<crate::request::WpNetworkHeaderMap>,
+    pub header_map: WpNetworkHeaderMap,
 }
 
 impl From<MediaRequestCreateResponse> for ParsedResponse<MediaWithEditContext, ()> {
@@ -120,11 +119,11 @@ fn parse_as_media_request_create_response(
 #[derive(uniffi::Object)]
 pub struct MediaUploadRequest {
     pub(crate) method: RequestMethod,
-    pub(crate) url: WpEndpointUrl,
-    pub(crate) header_map: Arc<WpNetworkHeaderMap>,
-    pub(crate) file_path: String,
-    pub(crate) file_content_type: String,
-    pub(crate) media_params: HashMap<String, String>,
+    pub url: WpEndpointUrl,
+    pub header_map: WpNetworkHeaderMap,
+    pub file_path: String,
+    pub file_content_type: String,
+    pub media_params: HashMap<String, String>,
 }
 
 #[uniffi::export]
@@ -133,23 +132,23 @@ impl MediaUploadRequest {
         self.method.clone()
     }
 
-    pub fn url(&self) -> WpEndpointUrl {
+    fn url(&self) -> WpEndpointUrl {
         self.url.clone()
     }
 
-    pub fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
+    fn header_map(&self) -> WpNetworkHeaderMap {
         self.header_map.clone()
     }
 
-    pub fn file_path(&self) -> String {
+    fn file_path(&self) -> String {
         self.file_path.clone()
     }
 
-    pub fn file_content_type(&self) -> String {
+    fn file_content_type(&self) -> String {
         self.file_content_type.clone()
     }
 
-    pub fn media_params(&self) -> HashMap<String, String> {
+    fn media_params(&self) -> HashMap<String, String> {
         self.media_params.clone()
     }
 }
@@ -189,14 +188,14 @@ impl MediaRequestBuilder {
     ) -> MediaUploadRequest {
         let url = self.endpoint.create();
         let mut header_map = self.inner.header_map();
-        header_map.inner.insert(
-            http::header::CONTENT_TYPE,
-            HeaderValue::from_static(CONTENT_TYPE_MULTIPART),
+        header_map.0.insert(
+            http::header::CONTENT_TYPE.to_string(),
+            vec![CONTENT_TYPE_MULTIPART.to_string()],
         );
         MediaUploadRequest {
             method: RequestMethod::POST,
             url: self.endpoint.create().into(),
-            header_map: header_map.into(),
+            header_map,
             file_path,
             file_content_type,
             media_params: params.into(),

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -9,7 +9,7 @@ use wp_api::{
     posts::PostId,
     request::{
         endpoint::media_endpoint::MediaUploadRequest, RequestExecutor, RequestMethod,
-        WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
+        WpNetworkRequest, WpNetworkResponse,
     },
     tags::TagId,
     users::UserId,
@@ -167,19 +167,19 @@ impl AsyncWpNetworking {
             .client
             .request(
                 Self::request_method(wp_request.method()),
-                wp_request.url().0.as_str(),
+                wp_request.url.0.as_str(),
             )
-            .headers(wp_request.header_map().as_header_map());
+            .headers(wp_request.header_map.to_http_header_map().expect("WpNetworkRequest's header map should cleanly convert from HashMap<String, Vec<String>> to http::HeaderMap"));
         if let Some(body) = wp_request.body() {
             request = request.body(body.contents());
         }
         let mut response = request.send().await?;
 
-        let header_map = std::mem::take(response.headers_mut());
+        let response_header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
             status_code: response.status().as_u16(),
             body: response.bytes().await.unwrap().to_vec(),
-            header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
+            header_map: response_header_map.into(),
         })
     }
 
@@ -191,14 +191,14 @@ impl AsyncWpNetworking {
             .client
             .request(
                 Self::request_method(media_upload_request.method()),
-                media_upload_request.url().0.as_str(),
+                media_upload_request.url.0.as_str(),
             )
-            .headers(media_upload_request.header_map().as_header_map());
-        let file_path = media_upload_request.file_path();
+            .headers(media_upload_request.header_map.to_http_header_map().expect("WpNetworkRequest's header map should cleanly convert from HashMap<String, Vec<String>> to http::HeaderMap"));
+        let file_path = &media_upload_request.file_path;
         let mut file_header_map = HeaderMap::new();
         file_header_map.insert(
             http::header::CONTENT_TYPE,
-            HeaderValue::from_str(&media_upload_request.file_content_type()).unwrap(),
+            HeaderValue::from_str(&media_upload_request.file_content_type).unwrap(),
         );
         let mut form = reqwest::multipart::Form::new().part(
             "file",
@@ -207,18 +207,18 @@ impl AsyncWpNetworking {
                 .unwrap()
                 .headers(file_header_map),
         );
-        for (k, v) in media_upload_request.media_params() {
-            form = form.text(k, v)
+        for (k, v) in &media_upload_request.media_params {
+            form = form.text(k.clone(), v.clone())
         }
 
         let request = request.multipart(form);
         let mut response = request.send().await?;
 
-        let header_map = std::mem::take(response.headers_mut());
+        let response_header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
             status_code: response.status().as_u16(),
             body: response.bytes().await.unwrap().to_vec(),
-            header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
+            header_map: response_header_map.into(),
         })
     }
 

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -7,8 +7,8 @@ use wp_api::{
     media::{MediaCreateParams, MediaId, MediaListParams, MediaUpdateParams},
     posts::WpApiParamPostsOrderBy,
     request::{
-        endpoint::media_endpoint::MediaUploadRequest, RequestExecutor, WpNetworkHeaderMap,
-        WpNetworkRequest, WpNetworkResponse,
+        endpoint::media_endpoint::MediaUploadRequest, RequestExecutor, WpNetworkRequest,
+        WpNetworkResponse,
     },
     users::UserId,
     MediaUploadRequestExecutionError, RequestExecutionError, WpApiClient, WpAuthentication,
@@ -220,13 +220,13 @@ impl RequestExecutor for MediaErrNetworking {
             .client
             .request(
                 AsyncWpNetworking::request_method(media_upload_request.method()),
-                media_upload_request.url().0.as_str(),
+                media_upload_request.url.0.as_str(),
             )
-            .headers(media_upload_request.header_map().as_header_map());
+            .headers(media_upload_request.header_map.to_http_header_map().expect("WpNetworkRequest's header map should cleanly convert from HashMap<String, Vec<String>> to http::HeaderMap"));
         let mut file_header_map = HeaderMap::new();
         file_header_map.insert(
             http::header::CONTENT_TYPE,
-            HeaderValue::from_str(&media_upload_request.file_content_type()).unwrap(),
+            HeaderValue::from_str(&media_upload_request.file_content_type).unwrap(),
         );
         let mut form = reqwest::multipart::Form::new();
         match self.test_type {
@@ -234,8 +234,8 @@ impl RequestExecutor for MediaErrNetworking {
                 // don't add the file
             }
         }
-        for (k, v) in media_upload_request.media_params() {
-            form = form.text(k, v)
+        for (k, v) in &media_upload_request.media_params {
+            form = form.text(k.clone(), v.clone())
         }
         request = request.multipart(form);
 
@@ -250,7 +250,7 @@ impl RequestExecutor for MediaErrNetworking {
         Ok(WpNetworkResponse {
             status_code: response.status().as_u16(),
             body: response.bytes().await.unwrap().to_vec(),
-            header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
+            header_map: header_map.into(),
         })
     }
 }

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -7,7 +7,6 @@ use wp_api::posts::{
     SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
     WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
 };
-use wp_api::request::WpNetworkHeaderMap;
 use wp_api::tags::TagId;
 use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
@@ -22,9 +21,8 @@ async fn list_with_edit_context_number_of_pages() {
         .list_with_edit_context(&PostListParams::default())
         .await
         .assert_response();
-    let header_map = WpNetworkHeaderMap::from_multi_map(p.header_map).unwrap();
-    assert_eq!(header_map.wp_total(), Some(57));
-    assert_eq!(header_map.wp_total_pages(), Some(6));
+    assert_eq!(p.header_map.wp_total(), Some(57));
+    assert_eq!(p.header_map.wp_total_pages(), Some(6));
 }
 
 #[tokio::test]

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -128,14 +128,14 @@ fn generate_async_request_executor(
                 pub struct #response_type_ident {
                     pub data: #output_type,
                     #[serde(skip)]
-                    pub header_map: std::collections::HashMap<std::string::String, std::vec::Vec<std::string::String>>,
+                    pub header_map: #crate_ident::request::WpNetworkHeaderMap,
                     #response_pagination_params_fields
                 }
                 impl From<#response_type_ident> for #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type> {
                     fn from(value: #response_type_ident) -> Self {
                         Self {
                             data: value.data,
-                            header_map: crate::request::WpNetworkHeaderMap::from_multi_map(value.header_map).unwrap().into(),
+                            header_map: value.header_map,
                             #from_concrete_response_impl_for_pagination_params
                         }
                     }
@@ -144,7 +144,7 @@ fn generate_async_request_executor(
                     fn from(value: #crate_ident::request::ParsedResponse<#output_type, #parsed_response_params_type>) -> Self {
                         Self {
                             data: value.data,
-                            header_map: value.header_map.to_multi_map(),
+                            header_map: value.header_map,
                             #from_parsed_response_impl_for_pagination_params
                         }
                     }


### PR DESCRIPTION
This is a follow up to #490. As described in that PR, we are changing the exposed header map type to be `HashMap<String, Vec<String>>`. However, #490 doesn't change the inner type that we work with, leaving it as `http::HeaderMap`. Although there is some merit in using `http::HeaderMap` as our inner type, I don't think it outweighs the extra complexity of using 2 different types for the same thing. That's why this PR proposes converting `WpNetworkHeaderMap` to a new type for `HashMap<String, Vec<String>>`.

We still expose a function that converts this new type to `http::HeaderMap`, ensuring that Rust clients, including our integration test suite, can easily work with it.

The PR removes some unit tests that no longer make sense and adds a new one to validate that we are correctly parsing the number of pages. It also exposes additional fields for `WpNetworkRequest` so that Rust clients can use them without cloning the value - which wasn't an issue when using `Arc<T>`.

I believe there's still room for improvement in the request module, but as far as I can tell, this PR addresses our immediate needs. Any further improvements can be made in subsequent PRs.