### PR TITLE
Adds `#[derive(wp_derive::WpDeserialize)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "url",
  "uuid",
  "wp_contextual",
+ "wp_derive",
  "wp_derive_request_builder",
  "wp_serde_helper",
 ]
@@ -3383,6 +3384,22 @@ dependencies = [
  "thiserror",
  "trybuild",
  "uniffi",
+]
+
+[[package]]
+name = "wp_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "rstest",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "trybuild",
+ "wp_serde_helper",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,8 @@ dependencies = [
  "thiserror",
  "trybuild",
  "uniffi",
+ "wp_derive",
+ "wp_serde_helper",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "wp_api_integration_tests_backend",
   "wp_cli",
   "wp_contextual",
+  "wp_derive",
   "wp_derive_request_builder",
   "wp_serde_helper",
   "wp_uniffi_bindgen",

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 uniffi = { workspace = true }
 uuid = { workspace = true, features = [ "v4" ] }
 wp_contextual = { path = "../wp_contextual" }
+wp_derive = { path = "../wp_derive" }
 wp_derive_request_builder = { path = "../wp_derive_request_builder", features = [ "generate_request_builder" ] }
 wp_serde_helper = { path = "../wp_serde_helper" }
 

--- a/wp_api_integration_tests/tests/test_themes_immut.rs
+++ b/wp_api_integration_tests/tests/test_themes_immut.rs
@@ -12,6 +12,19 @@ use wp_api_integration_tests::{
 };
 
 #[tokio::test]
+#[parallel]
+async fn filter_theme_supports() {
+    api_client()
+        .themes()
+        .filter_list_with_edit_context(
+            &ThemeListParams::default(),
+            &[SparseThemeFieldWithEditContext::ThemeSupports],
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
 #[apply(list_cases)]
 #[parallel]
 async fn list_with_edit_context(#[case] params: ThemeListParams) {

--- a/wp_contextual/Cargo.toml
+++ b/wp_contextual/Cargo.toml
@@ -22,3 +22,5 @@ uniffi = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true, features = ["diff"] }
+wp_derive = { path = "../wp_derive" }
+wp_serde_helper = { path = "../wp_serde_helper" }

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -20,11 +20,16 @@ pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
     let parsed_fields = parse_fields(fields)?;
 
     let contextual_token_streams = WpContextAttr::iter().map(|current_context| {
-        let generate_type = |ident, generated_fields: &Vec<GeneratedContextualField>| {
+        let generate_type = |is_sparse, ident, generated_fields: &Vec<GeneratedContextualField>| {
             if !generated_fields.is_empty() {
+                let deserialize_derive = if is_sparse {
+                    quote! { wp_derive::WpDeserialize }
+                } else {
+                    quote! { serde::Deserialize }
+                };
                 let fields_to_add = generated_fields.iter().map(|f| &f.field);
                 quote! {
-                    #[derive(Debug, serde::Serialize, serde::Deserialize, uniffi::Record)]
+                    #[derive(Debug, serde::Serialize, #deserialize_derive, uniffi::Record)]
                     pub struct #ident {
                         #(#fields_to_add,)*
                     }
@@ -60,10 +65,10 @@ pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
             &ident_name_for_context(original_ident_name.as_str(), current_context),
             original_ident.span(),
         );
-        let non_sparse_type = generate_type(&non_sparse_ident, &non_sparse_type_fields);
+        let non_sparse_type = generate_type(false, &non_sparse_ident, &non_sparse_type_fields);
         let sparse_field_type =
             generate_sparse_field_type(&sparse_field_ident, &sparse_type_fields);
-        let sparse_type = generate_type(&sparse_ident, &sparse_type_fields);
+        let sparse_type = generate_type(true, &sparse_ident, &sparse_type_fields);
         let integration_test_helpers =
             generate_integration_test_helper(sparse_ident, sparse_field_ident, &sparse_type_fields);
         Ok(TokenStream::from_iter([

--- a/wp_derive/Cargo.toml
+++ b/wp_derive/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "wp_derive"
+version = "0.1.0"
+edition = "2021"
+autotests = false
+
+[lib]
+proc-macro = true
+
+[[test]]
+name = "tests"
+path = "tests/parser_tests.rs"
+
+[dependencies]
+proc-macro-crate = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true, features = [ "derive" ] }
+syn = { workspace = true, features = ["extra-traits"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+serde_json = { workspace = true }
+trybuild = { workspace = true, features = ["diff"] }
+wp_serde_helper = { path = "../wp_serde_helper" }

--- a/wp_derive/src/lib.rs
+++ b/wp_derive/src/lib.rs
@@ -1,0 +1,8 @@
+use proc_macro::TokenStream;
+
+mod wp_deserialize;
+
+#[proc_macro_derive(WpDeserialize)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    wp_deserialize::derive(input)
+}

--- a/wp_derive/src/wp_deserialize.rs
+++ b/wp_derive/src/wp_deserialize.rs
@@ -1,10 +1,12 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::{
     braced,
     parse::{Parse, ParseBuffer, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
+    spanned::Spanned,
+    token::Comma,
     Attribute, Field, Token,
 };
 
@@ -111,6 +113,37 @@ impl ParsedStruct {
     }
 }
 
+impl ParsedStruct {
+    fn parse_fields(content: ParseBuffer) -> syn::Result<Punctuated<Field, Comma>> {
+        let fields = content.parse_terminated(Field::parse_named, Token![,])?;
+
+        let non_optional_field_type = fields.iter().find_map(|f| {
+            match &f.ty {
+                syn::Type::Path(type_path) => {
+                    let first_segment = &type_path.path.segments[0];
+
+                    // `Option` type has only one segment with an ident `Option`
+                    if type_path.path.segments.len() != 1 || first_segment.ident != "Option" {
+                        Some(&f.ty)
+                    } else {
+                        None
+                    }
+                }
+                _ => Some(&f.ty),
+            }
+        });
+
+        if let Some(non_optional_field_type) = non_optional_field_type {
+            let mut original_type = non_optional_field_type.to_token_stream().to_string();
+            original_type.retain(|c| !c.is_whitespace());
+            return Err(WpDeserializeParseError::NonOptionalField { original_type }
+                .into_syn_error(non_optional_field_type.span()));
+        }
+
+        Ok(fields)
+    }
+}
+
 impl Parse for ParsedStruct {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let attrs = Attribute::parse_outer(input)?;
@@ -119,11 +152,27 @@ impl Parse for ParsedStruct {
         let struct_ident: Ident = input.parse()?;
         let content: ParseBuffer;
         let _brace_token = braced!(content in input);
-        let fields = content.parse_terminated(Field::parse_named, Token![,])?;
+        let fields = Self::parse_fields(content)?;
+
         Ok(Self {
             attrs,
             struct_ident,
             fields,
         })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum WpDeserializeParseError {
+    #[error(
+        "`WpDeserialize` only supports optional fields, consired replacing with `Option<{}>`",
+        original_type
+    )]
+    NonOptionalField { original_type: String },
+}
+
+impl WpDeserializeParseError {
+    fn into_syn_error(self, span: proc_macro2::Span) -> syn::Error {
+        syn::Error::new(span, self.to_string())
     }
 }

--- a/wp_derive/src/wp_deserialize.rs
+++ b/wp_derive/src/wp_deserialize.rs
@@ -1,0 +1,129 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{
+    braced,
+    parse::{Parse, ParseBuffer, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    Attribute, Field, Token,
+};
+
+pub(crate) fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let parsed_struct = parse_macro_input!(input as ParsedStruct);
+    TokenStream::from_iter([
+        parsed_struct.generate_cloned_type_with_new_name(),
+        parsed_struct.generate_all_fields_set_to_none_implementation(),
+        parsed_struct.generate_from_implementation_for_cloned_type(),
+        parsed_struct.generate_custom_deserializer(),
+    ])
+    .into()
+}
+
+#[derive(Debug)]
+struct ParsedStruct {
+    attrs: Vec<Attribute>,
+    struct_ident: Ident,
+    fields: Punctuated<Field, Token![,]>,
+}
+
+impl ParsedStruct {
+    fn cloned_type_ident(&self) -> Ident {
+        format_ident!("DeserializeHelper{}", self.struct_ident.to_string())
+    }
+
+    fn generate_cloned_type_with_new_name(&self) -> TokenStream {
+        let attrs = &self.attrs;
+        let fields = &self.fields;
+        let ident = format_ident!("{}", self.cloned_type_ident());
+        quote! {
+            #[derive(Debug, serde::Deserialize)]
+            #(#attrs)*
+            struct #ident {
+                #fields
+            }
+        }
+    }
+
+    fn generate_all_fields_set_to_none_implementation(&self) -> TokenStream {
+        let cloned_type_ident = &self.cloned_type_ident();
+        let f = self.fields.iter().map(|f| {
+            if let Some(field_ident) = &f.ident {
+                quote! {
+                    #field_ident: None
+                }
+            } else {
+                panic!("All fields should have an ident");
+            }
+        });
+        quote! {
+            impl #cloned_type_ident {
+                fn all_fields_none() -> Self {
+                    Self {
+                        #(#f,)*
+                    }
+                }
+            }
+        }
+    }
+
+    fn generate_from_implementation_for_cloned_type(&self) -> TokenStream {
+        let struct_ident = &self.struct_ident;
+        let cloned_type_ident = &self.cloned_type_ident();
+        let f = self.fields.iter().map(|f| {
+            if let Some(field_ident) = &f.ident {
+                quote! {
+                    #field_ident: value.#field_ident
+                }
+            } else {
+                panic!("All fields should have an ident");
+            }
+        });
+        quote! {
+            impl From<#cloned_type_ident> for #struct_ident {
+                fn from(value: #cloned_type_ident) -> Self {
+                    Self {
+                        #(#f,)*
+                    }
+                }
+            }
+        }
+    }
+
+    fn generate_custom_deserializer(&self) -> TokenStream {
+        let struct_ident = &self.struct_ident;
+        let cloned_type_ident = &self.cloned_type_ident();
+        quote! {
+            impl<'de> serde::Deserialize<'de> for #struct_ident {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer
+                        .deserialize_any(wp_serde_helper::DeserializeEmptyVecOrT::<#cloned_type_ident>::new(
+                            Box::new(|| {
+                                #cloned_type_ident::all_fields_none()
+                            })
+                        ))
+                        .map(|internal| Self::from(internal))
+                }
+            }
+        }
+    }
+}
+
+impl Parse for ParsedStruct {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = Attribute::parse_outer(input)?;
+        let _vis: syn::Visibility = input.parse()?;
+        let _struct_token: Token![struct] = input.parse()?;
+        let struct_ident: Ident = input.parse()?;
+        let content: ParseBuffer;
+        let _brace_token = braced!(content in input);
+        let fields = content.parse_terminated(Field::parse_named, Token![,])?;
+        Ok(Self {
+            attrs,
+            struct_ident,
+            fields,
+        })
+    }
+}

--- a/wp_derive/tests/fail/non_optional_field.rs
+++ b/wp_derive/tests/fail/non_optional_field.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+use wp_derive::WpDeserialize;
+
+#[derive(Serialize, WpDeserialize)]
+pub struct Foo {
+    pub bar: Vec<u32>,
+}
+
+fn main() {}

--- a/wp_derive/tests/fail/non_optional_field.stderr
+++ b/wp_derive/tests/fail/non_optional_field.stderr
@@ -1,0 +1,5 @@
+error: `WpDeserialize` only supports optional fields, consired replacing with `Option<Vec<u32>>`
+ --> tests/fail/non_optional_field.rs:6:14
+  |
+6 |     pub bar: Vec<u32>,
+  |              ^^^

--- a/wp_derive/tests/parser_tests.rs
+++ b/wp_derive/tests/parser_tests.rs
@@ -1,0 +1,6 @@
+#[test]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/pass/*.rs");
+    t.compile_fail("tests/fail/*.rs");
+}

--- a/wp_derive/tests/pass/basic_wp_deserialize.rs
+++ b/wp_derive/tests/pass/basic_wp_deserialize.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+use wp_derive::WpDeserialize;
+
+#[derive(Serialize, WpDeserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SparseFoo {
+    #[serde(rename = "bbar")]
+    pub bar: Option<u32>,
+}
+
+fn main() {
+    // Validate that "[]" is parsed successfully
+    let result = serde_json::from_str::<SparseFoo>("[]");
+    assert!(result.unwrap().bar.is_none());
+
+    // Validate that `serde(rename = "bbar")` attribute is preserved
+    let json = r#"{"bbar": 2}"#;
+    let result = serde_json::from_str::<SparseFoo>(json);
+    assert_eq!(result.unwrap().bar, Some(2));
+}

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{
     de::{self, DeserializeOwned, Unexpected},
-    ser, Deserializer, Serialize, Serializer,
+    ser, Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{fmt, marker::PhantomData};
 
@@ -82,6 +82,47 @@ where
     D: Deserializer<'de>,
 {
     deserializer.deserialize_any(DeserializeI64OrStringVisitor)
+}
+
+pub struct DeserializeEmptyVecOrT<T> {
+    fallback: Box<dyn Fn() -> T>,
+}
+
+impl<T> DeserializeEmptyVecOrT<T> {
+    pub fn new(fallback: Box<dyn Fn() -> T>) -> Self {
+        Self { fallback }
+    }
+}
+
+impl<'de, T> de::Visitor<'de> for DeserializeEmptyVecOrT<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("empty Vec or T")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        if seq.next_element::<Self::Value>()?.is_none() {
+            // It's an empty vec
+            Ok((self.fallback)())
+        } else {
+            // not an empty vec
+            Err(serde::de::Error::invalid_type(Unexpected::Seq, &self))
+        }
+    }
+
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::MapAccess<'de>,
+    {
+        Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR introduces `#[derive(wp_derive::WpDeserialize)]` procedural macro.

---

### Why

WordPress REST API can sometimes return `[]` as a response when we expect it a JSON object. An example of this would be:
```
$ curl -s --user test@example.com:$(jq .admin_password test_credentials.json) "http://localhost/wp-json/wp/v2/themes?context=edit&_fields=theme_supports" | jq .
```
would result in:
```
[
  [],
  {
    "theme_supports": {
      "align-wide": false,
      _omitted_
    }
  },
  []
]
```
This shows a JSON Array might include both JSON Objects as well as empty JSON Arrays.

---

The issue described above is a common issue for all endpoints across the WordPress REST API, so we address it with a new procedural macro `wp_derive::WpDeserialize`. This is a drop in replacement for `serde::Deserialize`, but it has a major restriction. All the fields of the applied type has to be `Option<T>`. This restriction is there to prevent us from misusing it.

When all fields are `Option<T>`, we can set all of them to `None` when we parse `[]`. However, if we were to allow non optional fields, we'd need to come up with reasonable fallback values for every type. We could have used `std::default::Default` trait as a fallback which would make sense in a lot of cases such as `Vec`, `HashMap` etc where there is a clear empty value to fallback to. However, for types such as integers it can result in hard to track logic errors.

Enforcing `Option<T>` for all fields is a good starting point and addresses all our needs at the moment. However, if we find it limiting, we could implement a `fallback` attribute to support other types.

---

### Implementation Details

I've considered adding an internal visitor from the proc macro vs depending on the `wp_serde_helper` crate and ended up going for the latter. This should make it easier to maintain and reuse the deserializer. If having `wp_serde_helper` as a dependency becomes an issue, it should be simple to change it to an internal visitor.

In order to move the deserializer to `wp_serde_helper`, I've used a function pointer to create the fallback option. This should also provide some extra flexibility for us if we decide to support types other than `Option<T>`.

The PR adds a single test case to showcase that it works as expected. Feel free to checkout the fdfe3734a88f33f5b88dcb78efa85dd5ff6e27dc hash and validate that the new test is failing without the `WpDeserialize` changes. This test is temporarily added and I intend to remove it in a follow up PR. Instead, I'd like to partially revert #379 so that we'll generate the test cases where we get `[]` in the response to validate that we can always parse it correctly.

I didn't add many test cases for the new proc macro because there aren't many things that can go wrong with it. It also doesn't contain any complicated logic. Having said that, I'll add new tests if I come across any other errors while working with it.