### PR TITLE
Add `Sendable` to a few Rust types

### DIFF
--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -43,6 +43,12 @@ public typealias UsersRequestListWithEditContextResponse = WordPressAPIInternal.
 public typealias UsersRequestListWithViewContextResponse = WordPressAPIInternal.UsersRequestListWithViewContextResponse
 public typealias UsersRequestListWithEmbedContextResponse = WordPressAPIInternal.UsersRequestListWithEmbedContextResponse
 
+extension UsersRequestUpdateResponse: @unchecked Sendable {}
+extension UsersRequestDeleteResponse: @unchecked Sendable {}
+extension UsersRequestRetrieveMeWithViewContextResponse: @unchecked Sendable {}
+extension UsersRequestRetrieveMeWithEditContextResponse: @unchecked Sendable {}
+extension UsersRequestRetrieveMeWithEmbedContextResponse: @unchecked Sendable {}
+
 // MARK: - Plugins
 
 public typealias SparsePlugin = WordPressAPIInternal.SparsePlugin

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -62,6 +62,9 @@ public typealias PluginUpdateParams = WordPressAPIInternal.PluginUpdateParams
 public typealias PluginCreateParams = WordPressAPIInternal.PluginCreateParams
 public typealias PluginDeleteResponse = WordPressAPIInternal.PluginDeleteResponse
 public typealias PluginsRequestExecutor = WordPressAPIInternal.PluginsRequestExecutor
+extension PluginsRequestListWithViewContextResponse: @unchecked Sendable {}
+extension PluginsRequestListWithEditContextResponse: @unchecked Sendable {}
+extension PluginsRequestListWithEmbedContextResponse: @unchecked Sendable {}
 extension PluginsRequestExecutor: @unchecked Sendable {}
 
 // MARK: – Application Passwords


### PR DESCRIPTION
These types are used in Swift 6 code in the app side, which throws concurrency check errors unless they conform to `Sendable`.

I don't think we need to do this manually for too long. Hopefully, the auto-`Sendable` feature will be released in the next uniffi-rs release.