### PR TITLE
Enable all generated test cases for fetching a single field

### DIFF
--- a/wp_api_integration_tests/tests/test_themes_immut.rs
+++ b/wp_api_integration_tests/tests/test_themes_immut.rs
@@ -12,19 +12,6 @@ use wp_api_integration_tests::{
 };
 
 #[tokio::test]
-#[parallel]
-async fn filter_theme_supports() {
-    api_client()
-        .themes()
-        .filter_list_with_edit_context(
-            &ThemeListParams::default(),
-            &[SparseThemeFieldWithEditContext::ThemeSupports],
-        )
-        .await
-        .assert_response();
-}
-
-#[tokio::test]
 #[apply(list_cases)]
 #[parallel]
 async fn list_with_edit_context(#[case] params: ThemeListParams) {

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -290,14 +290,11 @@ fn generate_integration_test_helper(
                         fields
                     );
                 });
-                // Only add a single field test case if the field is not a `#[WpContextualOption]`
-                // Otherwise, the server will return invalid JSON where it'll output an empty JSON
-                // array instead of an empty JSON object
-                let case_ident = format_ident!("single_field_{}", f_ident);
-                rs_test_cases.push(quote! {
-                    #[case::#case_ident(&[#sparse_field_type_ident::#variant_ident])]
-                });
             }
+            let case_ident = format_ident!("single_field_{}", f_ident);
+            rs_test_cases.push(quote! {
+                #[case::#case_ident(&[#sparse_field_type_ident::#variant_ident])]
+            });
         }
     }
     let test_cases_ident = format_ident!(


### PR DESCRIPTION
This PR partially reverts #379. We've disabled generating single field test cases for when the response would be `[]`. Now that #502 has landed, we can re-enable them.

If you'd like to verify that the tests used to fail; replace [this line](https://github.com/Automattic/wordpress-rs/blob/enable-single-field-test-cases-with-empty-array-response/wp_contextual/src/wp_contextual.rs#L26) with `quote! { serde::Deserialize }` and then run `cargo test -p wp_api_integration_tests --test 'test_themes_immut'`. This would result in the failures below. As the CI should verify, these tests should now pass due to `wp_derive::WpDeserialize` proc macro.

The PR also removes a temporary test that was added in #502 as this PR will add that as a generated test case - which is actually the first failure below.

```
failures:
    filter::filter_list_with_edit_context::case_19_single_field_theme_supports::params_1_ThemeListParams__default__
    filter::filter_list_with_edit_context::case_19_single_field_theme_supports::params_3_generate__ThemeListParams__status_Some_ThemeStatus__Inactive___
    filter::filter_list_with_embed_context::case_19_single_field_theme_supports::params_1_ThemeListParams__default__
    filter::filter_list_with_embed_context::case_19_single_field_theme_supports::params_3_generate__ThemeListParams__status_Some_ThemeStatus__Inactive___
    filter::filter_list_with_view_context::case_19_single_field_theme_supports::params_1_ThemeListParams__default__
    filter::filter_list_with_view_context::case_19_single_field_theme_supports::params_3_generate__ThemeListParams__status_Some_ThemeStatus__Inactive___
    filter::filter_retrieve_with_edit_context::case_19_single_field_theme_supports::stylesheet_1_THEME_TWENTY_TWENTY_FIVE
    filter::filter_retrieve_with_edit_context::case_19_single_field_theme_supports::stylesheet_3_THEME_TWENTY_TWENTY_THREE
    filter::filter_retrieve_with_embed_context::case_19_single_field_theme_supports::stylesheet_1_THEME_TWENTY_TWENTY_FIVE
    filter::filter_retrieve_with_embed_context::case_19_single_field_theme_supports::stylesheet_3_THEME_TWENTY_TWENTY_THREE
    filter::filter_retrieve_with_view_context::case_19_single_field_theme_supports::stylesheet_1_THEME_TWENTY_TWENTY_FIVE
    filter::filter_retrieve_with_view_context::case_19_single_field_theme_supports::stylesheet_3_THEME_TWENTY_TWENTY_THREE
```