### PR TITLE
List `/templates`

### DIFF
--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -13,6 +13,7 @@ use crate::request::{
         site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
         tags_endpoint::{TagsRequestBuilder, TagsRequestExecutor},
         taxonomies_endpoint::{TaxonomiesRequestBuilder, TaxonomiesRequestExecutor},
+        templates_endpoint::{TemplatesRequestBuilder, TemplatesRequestExecutor},
         themes_endpoint::{ThemesRequestBuilder, ThemesRequestExecutor},
         users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
         wp_site_health_tests_endpoint::{
@@ -56,6 +57,7 @@ pub struct WpApiRequestBuilder {
     site_settings: Arc<SiteSettingsRequestBuilder>,
     tags: Arc<TagsRequestBuilder>,
     taxonomies: Arc<TaxonomiesRequestBuilder>,
+    templates: Arc<TemplatesRequestBuilder>,
     themes: Arc<ThemesRequestBuilder>,
     users: Arc<UsersRequestBuilder>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestBuilder>,
@@ -78,6 +80,7 @@ impl WpApiRequestBuilder {
             site_settings,
             tags,
             taxonomies,
+            templates,
             themes,
             users,
             wp_site_health_tests
@@ -117,6 +120,7 @@ pub struct WpApiClient {
     site_settings: Arc<SiteSettingsRequestExecutor>,
     tags: Arc<TagsRequestExecutor>,
     taxonomies: Arc<TaxonomiesRequestExecutor>,
+    templates: Arc<TemplatesRequestExecutor>,
     themes: Arc<ThemesRequestExecutor>,
     users: Arc<UsersRequestExecutor>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestExecutor>,
@@ -145,6 +149,7 @@ impl WpApiClient {
             site_settings,
             tags,
             taxonomies,
+            templates,
             themes,
             users,
             wp_site_health_tests
@@ -163,6 +168,7 @@ api_client_generate_endpoint_impl!(WpApi, search);
 api_client_generate_endpoint_impl!(WpApi, site_settings);
 api_client_generate_endpoint_impl!(WpApi, tags);
 api_client_generate_endpoint_impl!(WpApi, taxonomies);
+api_client_generate_endpoint_impl!(WpApi, templates);
 api_client_generate_endpoint_impl!(WpApi, themes);
 api_client_generate_endpoint_impl!(WpApi, users);
 api_client_generate_endpoint_impl!(WpApi, wp_site_health_tests);

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -31,6 +31,7 @@ pub mod search_results;
 pub mod site_settings;
 pub mod tags;
 pub mod taxonomies;
+pub mod templates;
 pub mod themes;
 pub mod url_query;
 pub mod users;

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -13,6 +13,7 @@ pub mod search_endpoint;
 pub mod site_settings_endpoint;
 pub mod tags_endpoint;
 pub mod taxonomies_endpoint;
+pub mod templates_endpoint;
 pub mod themes_endpoint;
 pub mod users_endpoint;
 pub mod wp_site_health_tests_endpoint;

--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -1,0 +1,49 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::templates::{
+    SparseTemplateFieldWithEditContext, SparseTemplateFieldWithEmbedContext,
+    SparseTemplateFieldWithViewContext,
+};
+use crate::SparseField;
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum TemplatesRequest {
+    #[contextual_get(url = "/templates", params = &crate::templates::TemplateListParams, output = Vec<crate::templates::SparseTemplate>, filter_by = crate::templates::SparseTemplateField)]
+    List,
+}
+
+impl DerivedRequest for TemplatesRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+impl SparseField for SparseTemplateFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseTemplateFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseTemplateFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
+}

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -1,0 +1,212 @@
+use crate::{
+    impl_as_query_value_from_as_str,
+    post_types::PostType,
+    posts::PostId,
+    url_query::{
+        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
+        UrlQueryPairsMap,
+    },
+    EnumFromStrParsingError, UserId,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TemplateStatus {
+    Draft,
+    Future,
+    Pending,
+    Private,
+    #[default]
+    Publish,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(TemplateStatus);
+
+impl TemplateStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Draft => "draft",
+            Self::Future => "future",
+            Self::Pending => "pending",
+            Self::Private => "private",
+            Self::Publish => "publish",
+            Self::Custom(status) => status,
+        }
+    }
+}
+
+impl FromStr for TemplateStatus {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draft" => Ok(Self::Draft),
+            "future" => Ok(Self::Future),
+            "pending" => Ok(Self::Pending),
+            "private" => Ok(Self::Private),
+            "publish" => Ok(Self::Publish),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TemplateArea {
+    Header,
+    Footer,
+    Uncategorized,
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl_as_query_value_from_as_str!(TemplateArea);
+
+impl TemplateArea {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Header => "header",
+            Self::Footer => "footer",
+            Self::Uncategorized => "uncategorized",
+            Self::Custom(area) => area,
+        }
+    }
+}
+
+impl FromStr for TemplateArea {
+    type Err = EnumFromStrParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "header" => Ok(Self::Header),
+            "footer" => Ok(Self::Footer),
+            "uncategorized" => Ok(Self::Uncategorized),
+            value => Ok(Self::Custom(value.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+pub struct TemplateListParams {
+    /// Limit to the specified post id.
+    #[uniffi(default = None)]
+    pub post_id: Option<PostId>,
+    /// Limit to the specified template part area.
+    #[uniffi(default = None)]
+    pub area: Option<TemplateArea>,
+    /// Post type to get the templates for.
+    #[uniffi(default = None)]
+    pub post_type: Option<PostType>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum TemplateListParamsField {
+    #[strum(serialize = "wp_id")]
+    PostId,
+    #[strum(serialize = "area")]
+    Area,
+    #[strum(serialize = "post_type")]
+    PostType,
+}
+
+impl AppendUrlQueryPairs for TemplateListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair(TemplateListParamsField::PostId, self.post_id.as_ref())
+            .append_option_query_value_pair(TemplateListParamsField::Area, self.area.as_ref())
+            .append_option_query_value_pair(
+                TemplateListParamsField::PostType,
+                self.post_type.as_ref(),
+            );
+    }
+}
+
+impl FromUrlQueryPairs for TemplateListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            post_id: query_pairs.get(TemplateListParamsField::PostId),
+            area: query_pairs.get(TemplateListParamsField::Area),
+            post_type: query_pairs.get(TemplateListParamsField::PostType),
+        })
+    }
+
+    fn supports_pagination() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseTemplate {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub theme: Option<String>,
+    #[serde(rename = "type")]
+    #[WpContext(edit, embed, view)]
+    pub template_type: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub source: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
+    pub origin: Option<String>,
+    // TODO: Object or String or it's `[]`
+    #[WpContext(edit, embed, view)]
+    pub content: Option<SparseTemplateContent>,
+    //// TODO: Object or String
+    //#[WpContext(edit, embed, view)]
+    //pub title: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub description: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub status: Option<TemplateStatus>,
+    #[serde(rename = "wp_id")]
+    #[WpContext(edit, embed, view)]
+    pub post_id: Option<PostId>,
+    #[WpContext(edit, embed, view)]
+    pub has_theme_file: Option<bool>,
+    #[WpContext(edit, embed, view)]
+    pub author: Option<UserId>,
+    #[WpContext(edit, view)]
+    pub modified: Option<bool>,
+    #[WpContext(edit, view, embed)]
+    pub is_custom: Option<bool>,
+    // TODO: `author_text` & `original_source` fields are missing from documentation
+    #[WpContext(edit, view, embed)]
+    pub author_text: Option<String>,
+    #[WpContext(edit, view, embed)]
+    pub original_source: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseTemplateContent {
+    #[WpContext(edit)]
+    pub raw: Option<String>,
+    #[WpContext(edit, view)]
+    pub rendered: Option<String>,
+    #[WpContext(edit, view)]
+    pub protected: Option<bool>,
+    #[WpContext(edit)]
+    pub block_version: Option<u32>,
+}

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -155,7 +155,7 @@ impl FromUrlQueryPairs for TemplateListParams {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+#[derive(Debug, Serialize, Deserialize, WpContextual)]
 pub struct SparseTemplate {
     #[WpContext(edit, embed, view)]
     pub id: Option<String>,
@@ -173,7 +173,7 @@ pub struct SparseTemplate {
     pub origin: Option<String>,
     // TODO: Object or String or it's `[]`
     #[WpContext(edit, embed, view)]
-    pub content: Option<SparseTemplateContent>,
+    pub content: Option<SparseTemplateContentWrapper>,
     //// TODO: Object or String
     //#[WpContext(edit, embed, view)]
     //pub title: Option<String>,
@@ -199,14 +199,17 @@ pub struct SparseTemplate {
     pub original_source: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[serde(untagged)]
+pub enum SparseTemplateContentWrapper {
+    Object(SparseTemplateContent),
+    String(String),
+}
+
+#[derive(Debug, Serialize, wp_derive::WpDeserialize, uniffi::Record)]
 pub struct SparseTemplateContent {
-    #[WpContext(edit)]
     pub raw: Option<String>,
-    #[WpContext(edit, view)]
     pub rendered: Option<String>,
-    #[WpContext(edit, view)]
     pub protected: Option<bool>,
-    #[WpContext(edit)]
     pub block_version: Option<u32>,
 }

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -171,12 +171,10 @@ pub struct SparseTemplate {
     #[WpContext(edit, embed, view)]
     #[WpContextualOption]
     pub origin: Option<String>,
-    // TODO: Object or String or it's `[]`
     #[WpContext(edit, embed, view)]
     pub content: Option<SparseTemplateContentWrapper>,
-    //// TODO: Object or String
-    //#[WpContext(edit, embed, view)]
-    //pub title: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub title: Option<SparseTemplateTitleWrapper>,
     #[WpContext(edit, embed, view)]
     pub description: Option<String>,
     #[WpContext(edit, embed, view)]
@@ -192,7 +190,6 @@ pub struct SparseTemplate {
     pub modified: Option<bool>,
     #[WpContext(edit, view, embed)]
     pub is_custom: Option<bool>,
-    // TODO: `author_text` & `original_source` fields are missing from documentation
     #[WpContext(edit, view, embed)]
     pub author_text: Option<String>,
     #[WpContext(edit, view, embed)]
@@ -212,4 +209,17 @@ pub struct SparseTemplateContent {
     pub rendered: Option<String>,
     pub protected: Option<bool>,
     pub block_version: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[serde(untagged)]
+pub enum SparseTemplateTitleWrapper {
+    Object(SparseTemplateTitle),
+    String(String),
+}
+
+#[derive(Debug, Serialize, wp_derive::WpDeserialize, uniffi::Record)]
+pub struct SparseTemplateTitle {
+    pub raw: Option<String>,
+    pub rendered: Option<String>,
 }

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -1,15 +1,14 @@
 use crate::{
-    impl_as_query_value_from_as_str,
+    impl_as_query_value_from_to_string,
     post_types::PostType,
     posts::PostId,
     url_query::{
         AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
         UrlQueryPairsMap,
     },
-    EnumFromStrParsingError, UserId,
+    UserId,
 };
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 
@@ -25,8 +24,11 @@ use wp_contextual::WpContextual;
     Serialize,
     Deserialize,
     uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum TemplateStatus {
     Draft,
     Future,
@@ -35,76 +37,38 @@ pub enum TemplateStatus {
     #[default]
     Publish,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(TemplateStatus);
-
-impl TemplateStatus {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Draft => "draft",
-            Self::Future => "future",
-            Self::Pending => "pending",
-            Self::Private => "private",
-            Self::Publish => "publish",
-            Self::Custom(status) => status,
-        }
-    }
-}
-
-impl FromStr for TemplateStatus {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "draft" => Ok(Self::Draft),
-            "future" => Ok(Self::Future),
-            "pending" => Ok(Self::Pending),
-            "private" => Ok(Self::Private),
-            "publish" => Ok(Self::Publish),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(TemplateStatus);
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, uniffi::Enum,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum TemplateArea {
     Header,
     Footer,
     Uncategorized,
     #[serde(untagged)]
+    #[strum(default)]
     Custom(String),
 }
 
-impl_as_query_value_from_as_str!(TemplateArea);
-
-impl TemplateArea {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Header => "header",
-            Self::Footer => "footer",
-            Self::Uncategorized => "uncategorized",
-            Self::Custom(area) => area,
-        }
-    }
-}
-
-impl FromStr for TemplateArea {
-    type Err = EnumFromStrParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "header" => Ok(Self::Header),
-            "footer" => Ok(Self::Footer),
-            "uncategorized" => Ok(Self::Uncategorized),
-            value => Ok(Self::Custom(value.to_string())),
-        }
-    }
-}
+impl_as_query_value_from_to_string!(TemplateArea);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct TemplateListParams {

--- a/wp_api/src/wordpress_org/update_check.rs
+++ b/wp_api/src/wordpress_org/update_check.rs
@@ -270,7 +270,7 @@ mod tests {
         let body = request.unwrap().body.unwrap().contents();
         let body_string = String::from_utf8(body).unwrap();
         let body_map = body_string
-            .split("&")
+            .split('&')
             .flat_map(|x| url::form_urlencoded::parse(x.as_bytes()))
             .collect::<HashMap<_, _>>();
         assert!(body_map.contains_key("plugins"));

--- a/wp_api_integration_tests/tests/test_templates_immut.rs
+++ b/wp_api_integration_tests/tests/test_templates_immut.rs
@@ -1,0 +1,155 @@
+use rstest::*;
+use rstest_reuse::{self, apply, template};
+use serial_test::parallel;
+use wp_api::generate;
+use wp_api::post_types::PostType;
+use wp_api::templates::{
+    SparseTemplateFieldWithEditContext, SparseTemplateFieldWithEmbedContext,
+    SparseTemplateFieldWithViewContext, TemplateArea, TemplateListParams,
+};
+use wp_api_integration_tests::{
+    api_client, AssertResponse, FIRST_POST_ID, POST_ID_555, POST_ID_DRAFT,
+};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: TemplateListParams) {
+    api_client()
+        .templates()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: TemplateListParams) {
+    api_client()
+        .templates()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: TemplateListParams) {
+    api_client()
+        .templates()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[template]
+#[rstest]
+#[case::default(TemplateListParams::default())]
+#[case::post_id_first_post(generate!(TemplateListParams, (post_id, Some(FIRST_POST_ID))))]
+#[case::post_id_555(generate!(TemplateListParams, (post_id, Some(POST_ID_555))))]
+#[case::post_id_draft(generate!(TemplateListParams, (post_id, Some(POST_ID_DRAFT))))]
+#[case::area_header(generate!(TemplateListParams, (area, Some(TemplateArea::Header))))]
+#[case::area_footer(generate!(TemplateListParams, (area, Some(TemplateArea::Footer))))]
+#[case::area_uncategorized(generate!(TemplateListParams, (area, Some(TemplateArea::Uncategorized))))]
+#[case::post_type_post(generate!(TemplateListParams, (post_type, Some(PostType::Post))))]
+#[case::post_type_page(generate!(TemplateListParams, (post_type, Some(PostType::Page))))]
+#[case::post_type_attachment(generate!(TemplateListParams, (post_type, Some(PostType::Attachment))))]
+#[case::post_type_nav_menu_item(generate!(TemplateListParams, (post_type, Some(PostType::NavMenuItem))))]
+#[case::post_type_wp_block(generate!(TemplateListParams, (post_type, Some(PostType::WpBlock))))]
+#[case::post_type_wp_template(generate!(TemplateListParams, (post_type, Some(PostType::WpTemplate))))]
+#[case::post_type_wp_template_part(generate!(TemplateListParams, (post_type, Some(PostType::WpTemplatePart))))]
+#[case::post_type_wp_navigation(generate!(TemplateListParams, (post_type, Some(PostType::WpNavigation))))]
+#[case::post_type_wp_font_family(generate!(TemplateListParams, (post_type, Some(PostType::WpFontFamily))))]
+#[case::post_type_wp_font_face(generate!(TemplateListParams, (post_type, Some(PostType::WpFontFace))))]
+pub fn list_cases(#[case] params: TemplateListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_template_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_template_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_template_field_with_view_context_test_cases!();
+
+    #[apply(sparse_template_field_with_edit_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithEditContext::Slug, SparseTemplateFieldWithEditContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_edit_context(
+        #[case] fields: &[SparseTemplateFieldWithEditContext],
+        #[values(
+            TemplateListParams::default(),
+            generate!(TemplateListParams, (post_id, Some(FIRST_POST_ID))),
+            generate!(TemplateListParams, (area, Some(TemplateArea::Header))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Post))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Page)))
+        )]
+        params: TemplateListParams,
+    ) {
+        api_client()
+            .templates()
+            .filter_list_with_edit_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|template| {
+                template.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_template_field_with_embed_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithEmbedContext::Slug, SparseTemplateFieldWithEmbedContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseTemplateFieldWithEmbedContext],
+        #[values(
+            TemplateListParams::default(),
+            generate!(TemplateListParams, (post_id, Some(FIRST_POST_ID))),
+            generate!(TemplateListParams, (area, Some(TemplateArea::Header))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Post))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Page)))
+        )]
+        params: TemplateListParams,
+    ) {
+        api_client()
+            .templates()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|template| {
+                template.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_template_field_with_view_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithViewContext::Slug, SparseTemplateFieldWithViewContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseTemplateFieldWithViewContext],
+        #[values(
+            TemplateListParams::default(),
+            generate!(TemplateListParams, (post_id, Some(FIRST_POST_ID))),
+            generate!(TemplateListParams, (area, Some(TemplateArea::Header))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Post))),
+            generate!(TemplateListParams, (post_type, Some(PostType::Page)))
+        )]
+        params: TemplateListParams,
+    ) {
+        api_client()
+            .templates()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|template| {
+                template.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+}


### PR DESCRIPTION
Follows established patterns to implement list [`/templates` endpoint.](https://developer.wordpress.org/rest-api/reference/wp_templates/#retrieve-a-template)

Note that `SparseTemplateContent` is not implemented as a contextual type even though some fields aren't available for some contexts. This is due to a weird combination of the `content` field being available for all 3 contexts, while `SparseTemplateContent` fields being available for only `edit` & `embed` contexts **and** `content` might be either a `String` or an `Object`. The implementation in this PR is the simplest solution I could come up with and I think it's a decent tradeoff because it won't cause any logic errors. The only drawback is that some fields will always be `None` for some contexts.

Note that I had to take a very long break during this implementation, so a lot of the details are not fresh on my mind. I did skim through the implementation a few times and didn't see anything missing/wrong, but I definitely might have missed something. Having said that, I have a lot more to implement for `/templates`, so I should be able to find any issues while doing that work. I just wanted to get this PR out as soon as possible as I need to switch to some login related work and I don't want this one to drag on even longer.