### PR TITLE
Refactor auto discovery attempt to have a separate `find_api_root_url` helper

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -1,17 +1,20 @@
-use std::str;
-use std::sync::Arc;
-
-use super::url_discovery::{
-    self, AutoDiscoveryAttempt, AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptResult,
-    AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
-    ParseApiRootUrlError,
+use super::{
+    url_discovery::{
+        self, AutoDiscoveryAttempt, AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptResult,
+        AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
+        FindApiRootLinkHeaderFailure, FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult,
+        ParseApiRootUrlError,
+    },
+    WpApiDetails,
 };
-use super::WpApiDetails;
-use crate::request::endpoint::WpEndpointUrl;
-use crate::request::{
-    RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
+use crate::{
+    request::{
+        endpoint::WpEndpointUrl, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
+        WpNetworkRequest, WpNetworkResponse,
+    },
+    ParsedUrl, RequestExecutionError,
 };
-use crate::{ParsedUrl, RequestExecutionError};
+use std::{str, sync::Arc};
 
 const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
 
@@ -74,34 +77,16 @@ impl WpLoginClient {
         &self,
         attempt_site_url: &str,
     ) -> Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure> {
-        let parsed_site_url = ParsedUrl::parse(attempt_site_url)
-            .map_err(|error| AutoDiscoveryAttemptFailure::ParseSiteUrl { error })?;
-        let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
-            Ok(r) => r,
-            Err(error) => {
-                return Err(AutoDiscoveryAttemptFailure::FetchApiRootUrl {
-                    parsed_site_url,
-                    error,
-                })
-            }
-        };
-        let api_root_url =
-            match self.parse_api_root_response(&parsed_site_url, fetch_api_root_url_response) {
-                Ok(api_root_url) => api_root_url,
-                Err(error) => {
-                    return Err(AutoDiscoveryAttemptFailure::ParseApiRootUrl {
-                        parsed_site_url,
-                        error,
-                    })
-                }
-            };
-
-        let fetch_api_details_response = match self.fetch_wp_api_details(&api_root_url).await {
+        let api_root_url_success = self.find_api_root_url(attempt_site_url).await?;
+        let fetch_api_details_response = match self
+            .fetch_wp_api_details(&api_root_url_success.api_root_url)
+            .await
+        {
             Ok(r) => r,
             Err(error) => {
                 return Err(AutoDiscoveryAttemptFailure::FetchApiDetails {
-                    parsed_site_url,
-                    api_root_url,
+                    parsed_site_url: api_root_url_success.parsed_site_url,
+                    api_root_url: api_root_url_success.api_root_url,
                     error,
                 })
             }
@@ -111,17 +96,48 @@ impl WpLoginClient {
                 Ok(api_details) => api_details,
                 Err(error) => {
                     return Err(AutoDiscoveryAttemptFailure::ParseApiDetails {
-                        parsed_site_url,
-                        api_root_url,
+                        parsed_site_url: api_root_url_success.parsed_site_url,
+                        api_root_url: api_root_url_success.api_root_url,
                         parsing_error_message: error.to_string(),
                     })
                 }
             };
 
         Ok(AutoDiscoveryAttemptSuccess {
+            parsed_site_url: api_root_url_success.parsed_site_url,
+            api_root_url: api_root_url_success.api_root_url,
+            api_details,
+        })
+    }
+
+    async fn find_api_root_url(
+        &self,
+        attempt_site_url: &str,
+    ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
+        let parsed_site_url = ParsedUrl::parse(attempt_site_url)
+            .map_err(|error| FindApiRootLinkHeaderFailure::ParseSiteUrl { error })?;
+        let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
+            Ok(r) => r,
+            Err(error) => {
+                return Err(FindApiRootLinkHeaderFailure::FetchApiRootUrl {
+                    parsed_site_url,
+                    error,
+                })
+            }
+        };
+        let api_root_url =
+            match self.parse_api_root_response(&parsed_site_url, fetch_api_root_url_response) {
+                Ok(api_root_url) => api_root_url,
+                Err(error) => {
+                    return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
+                        parsed_site_url,
+                        error,
+                    })
+                }
+            };
+        Ok(FindApiRootLinkHeaderSuccess {
             parsed_site_url,
             api_root_url,
-            api_details,
         })
     }
 

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -2,8 +2,7 @@ use super::{
     url_discovery::{
         self, AutoDiscoveryAttempt, AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptResult,
         AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
-        FindApiRootLinkHeaderFailure, FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult,
-        ParseApiRootUrlError,
+        FindApiRootLinkHeaderFailure, FindApiRootLinkHeaderSuccess, ParseApiRootUrlError,
     },
     WpApiDetails,
 };

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -166,6 +166,27 @@ impl AutoDiscoveryAttemptResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct FindApiRootLinkHeaderSuccess {
+    pub parsed_site_url: ParsedUrl,
+    pub api_root_url: ParsedUrl,
+}
+
+#[derive(Debug, Clone)]
+pub enum FindApiRootLinkHeaderFailure {
+    ParseSiteUrl {
+        error: ParseUrlError,
+    },
+    FetchApiRootUrl {
+        parsed_site_url: ParsedUrl,
+        error: RequestExecutionError,
+    },
+    ParseApiRootUrl {
+        parsed_site_url: ParsedUrl,
+        error: ParseApiRootUrlError,
+    },
+}
+
+#[derive(Debug, Clone)]
 pub struct AutoDiscoveryAttemptSuccess {
     pub parsed_site_url: ParsedUrl,
     pub api_root_url: ParsedUrl,
@@ -292,6 +313,28 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => None,
             AutoDiscoveryAttemptFailure::FetchApiDetails { api_root_url, .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(true),
+        }
+    }
+}
+
+impl From<FindApiRootLinkHeaderFailure> for AutoDiscoveryAttemptFailure {
+    fn from(value: FindApiRootLinkHeaderFailure) -> Self {
+        match value {
+            FindApiRootLinkHeaderFailure::ParseSiteUrl { error } => Self::ParseSiteUrl { error },
+            FindApiRootLinkHeaderFailure::FetchApiRootUrl {
+                parsed_site_url,
+                error,
+            } => Self::FetchApiRootUrl {
+                parsed_site_url,
+                error,
+            },
+            FindApiRootLinkHeaderFailure::ParseApiRootUrl {
+                parsed_site_url,
+                error,
+            } => Self::ParseApiRootUrl {
+                parsed_site_url,
+                error,
+            },
         }
     }
 }


### PR DESCRIPTION
This PR refactors `WpLoginClient::inner_attempt_api_discovery` to extract the checking the link header logic into a new function `WpLoginClient::find_api_root_url` with its own success and failure types. This is done so that the same logic can be utilized while implementing the `is_wordpress_site` logic.

The diff for this looks quite confusing which is why I am separating into its own PR. I might actually have to do some further refactoring, but if I combine the changes, it'll be difficult to understand what's going on even if the reviewer goes through it commit by commit.