### PR TITLE
Update Rust to 1.84.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 docker_container_repo_dir=/app
 
 # Common docker options
-rust_docker_container := public.ecr.aws/docker/library/rust:1.80
+rust_docker_container := public.ecr.aws/docker/library/rust:1.84.0
 
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e TEST_ALL_PLUGINS -e CARGO_HOME=/app/.cargo $(rust_docker_container)

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -18,7 +18,7 @@ where
 // Use `PhantomData` to avoid "unused generic `T` error"
 struct StringOfJsonArrayVisitor<T>(PhantomData<T>);
 
-impl<'de, T: DeserializeOwned> de::Visitor<'de> for StringOfJsonArrayVisitor<T> {
+impl<T: DeserializeOwned> de::Visitor<'_> for StringOfJsonArrayVisitor<T> {
     type Value = Vec<T>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -47,7 +47,7 @@ where
 
 struct DeserializeI64OrStringVisitor;
 
-impl<'de> de::Visitor<'de> for DeserializeI64OrStringVisitor {
+impl de::Visitor<'_> for DeserializeI64OrStringVisitor {
     type Value = i64;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Addresses a couple new clippy warnings for lifetime elision.