### PR TITLE
Update Rust to 1.84.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 docker_container_repo_dir=/app
 
 # Common docker options
-rust_docker_container := public.ecr.aws/docker/library/rust:1.84.0
+rust_docker_container := public.ecr.aws/docker/library/rust:1.84.1
 
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e TEST_ALL_PLUGINS -e CARGO_HOME=/app/.cargo $(rust_docker_container)


### PR DESCRIPTION
`1.84.1` Docker image is now available in [ecr.aws](https://gallery.ecr.aws/docker/library/rust).