### PR TITLE
Change `SSLCertificateInfo` to be a `uniffi::object`

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -1,8 +1,9 @@
+use crate::{
+    request::{request_or_response_body_as_string, WpRedirect},
+    ssl::SSLCertificateInfo,
+};
 use serde::Deserialize;
-
-use crate::request::request_or_response_body_as_string;
-use crate::request::WpRedirect;
-use crate::ssl::SSLCertificateInfo;
+use std::sync::Arc;
 
 pub trait ParsedRequestError
 where
@@ -440,10 +441,10 @@ pub enum RequestExecutionErrorReason {
     // A case where there's an SSL certificate present, but it's untrusted (maybe it's self-signed, expired, or for the wrong domain)
     InvalidSslError {
         // The SSL certificate for the site we're trying to contact
-        site_certificate: Option<SSLCertificateInfo>,
+        site_certificate: Option<Arc<SSLCertificateInfo>>,
 
         // Any other certificates in the trust chain
-        certificate_chain: Vec<SSLCertificateInfo>,
+        certificate_chain: Vec<Arc<SSLCertificateInfo>>,
 
         // The error message provided by the HTTP stack
         error_message: Option<String>,

--- a/wp_api/src/ssl.rs
+++ b/wp_api/src/ssl.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use x509_cert::{
     der::Decode,
     ext::pkix::{name::GeneralName::DnsName, SubjectAltName},
@@ -9,19 +10,22 @@ use x509_cert::{
 //
 // If this returns `None`, we weren't able to parse the certificate
 #[uniffi::export]
-pub fn parse_certificate(data: &[u8]) -> Option<SSLCertificateInfo> {
+pub fn parse_certificate(data: &[u8]) -> Option<Arc<SSLCertificateInfo>> {
     let certificate = Certificate::from_der(data).ok()?;
     let certificate = certificate.tbs_certificate();
 
-    Some(SSLCertificateInfo {
-        common_name: extract_data_as_string(certificate.subject().common_name())?,
-        alternative_names: extract_alternative_names(certificate),
-        issuer: SSLCertificateIssuer {
-            common_name: extract_data_as_string(certificate.issuer().common_name())?,
-            organization: extract_data_as_string(certificate.issuer().organization()),
-            country: extract_data_as_string(certificate.issuer().country()),
-        },
-    })
+    Some(
+        SSLCertificateInfo {
+            common_name: extract_data_as_string(certificate.subject().common_name())?,
+            alternative_names: extract_alternative_names(certificate),
+            issuer: SSLCertificateIssuer {
+                common_name: extract_data_as_string(certificate.issuer().common_name())?,
+                organization: extract_data_as_string(certificate.issuer().organization()),
+                country: extract_data_as_string(certificate.issuer().country()),
+            },
+        }
+        .into(),
+    )
 }
 
 fn extract_data_as_string(data: x509_cert::der::Result<Option<impl AsRef<str>>>) -> Option<String> {
@@ -45,7 +49,7 @@ fn extract_alternative_names(cert: &x509_cert::certificate::TbsCertificateInner)
         .collect()
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Object)]
 pub struct SSLCertificateInfo {
     /// The domain this certificate is valid for (or the signer's name, if this is an intermediate or root certificate)
     pub common_name: String,
@@ -53,6 +57,21 @@ pub struct SSLCertificateInfo {
     pub alternative_names: Vec<String>,
     /// Information about whomever signed this certificate
     pub issuer: SSLCertificateIssuer,
+}
+
+#[uniffi::export]
+impl SSLCertificateInfo {
+    fn common_name(&self) -> String {
+        self.common_name.clone()
+    }
+
+    fn alternative_names(&self) -> Vec<String> {
+        self.alternative_names.clone()
+    }
+
+    fn issuer(&self) -> SSLCertificateIssuer {
+        self.issuer.clone()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]

--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -1,6 +1,8 @@
 use crate::{
     api_error::RequestExecutionErrorReason,
-    request::{endpoint::WpEndpointUrl, RequestExecutor, WpNetworkRequest, WpNetworkResponse, WpRedirect},
+    request::{
+        endpoint::WpEndpointUrl, RequestExecutor, WpNetworkRequest, WpNetworkResponse, WpRedirect,
+    },
     wordpress_org::update_check::UpdateCheckRequest,
     ParsedUrl, PluginWithViewContext, PluginWpOrgDirectorySlug, RequestExecutionError,
 };


### PR DESCRIPTION
This addresses the [result_large_err](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err) clippy warnings.