### PR TITLE
Combine `is_wordpress_site` with api discovery

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -67,8 +67,13 @@ impl WpLoginClient {
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
         let attempt_site_url = attempt.attempt_site_url.as_str();
-        let discovery_result = self.inner_attempt_api_discovery(attempt_site_url).await;
-        let is_wordpress_site = self.attempt_is_wordpress_site(attempt_site_url).await;
+        let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
+        let discovery_result = self
+            .inner_attempt_api_discovery(attempt_site_url, api_link_header_result.clone())
+            .await;
+        let is_wordpress_site = self
+            .attempt_is_wordpress_site(attempt_site_url, api_link_header_result)
+            .await;
         AutoDiscoveryAttemptResult {
             attempt_type: attempt.attempt_type,
             attempt_site_url: attempt.attempt_site_url,
@@ -80,8 +85,9 @@ impl WpLoginClient {
     async fn inner_attempt_api_discovery(
         &self,
         attempt_site_url: &str,
+        api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
     ) -> Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure> {
-        let api_root_url_success = self.find_api_root_url(attempt_site_url).await?;
+        let api_root_url_success = api_link_header_result?;
         let fetch_api_details_response = match self
             .fetch_wp_api_details(&api_root_url_success.api_root_url)
             .await
@@ -117,8 +123,8 @@ impl WpLoginClient {
     async fn attempt_is_wordpress_site(
         &self,
         attempt_site_url: &str,
+        api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
     ) -> IsWordPressSiteAttemptResult {
-        let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
         let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
         let parse_html_result = self
             .fetch_site(attempt_site_url)

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -4,7 +4,7 @@ use super::{
         AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
         FetchWpJsonFailure, FetchWpJsonSuccess, FindApiRootLinkHeaderFailure,
         FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult, IsWordPressSiteParseHtmlResult,
-        IsWordPressSiteResult, IsWordPressSiteUniffiResult, ParseApiRootUrlError, ParseHtmlFailure,
+        ParseApiRootUrlError, ParseHtmlFailure,
     },
     WpApiDetails,
 };
@@ -38,13 +38,6 @@ impl UniffiWpLoginClient {
     async fn api_discovery(&self, site_url: String) -> AutoDiscoveryUniffiResult {
         self.inner.api_discovery(site_url).await.into()
     }
-
-    async fn is_wordpress_site_discovery(&self, site_url: String) -> IsWordPressSiteUniffiResult {
-        self.inner
-            .is_wordpress_site_discovery(site_url)
-            .await
-            .into()
-    }
 }
 
 #[derive(Debug)]
@@ -69,29 +62,18 @@ impl WpLoginClient {
         }
     }
 
-    pub async fn is_wordpress_site_discovery(&self, site_url: String) -> IsWordPressSiteResult {
-        let attempts = futures::future::join_all(
-            url_discovery::construct_attempts(site_url)
-                .into_iter()
-                .map(|attempt| async { self.attempt_is_wordpress_site(attempt).await }),
-        )
-        .await;
-        IsWordPressSiteResult {
-            attempts: attempts.into_iter().map(|r| (r.attempt_type, r)).collect(),
-        }
-    }
-
     async fn attempt_api_discovery(
         &self,
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
-        let result = self
-            .inner_attempt_api_discovery(attempt.attempt_site_url.as_str())
-            .await;
+        let attempt_site_url = attempt.attempt_site_url.as_str();
+        let discovery_result = self.inner_attempt_api_discovery(attempt_site_url).await;
+        let is_wordpress_site = self.attempt_is_wordpress_site(attempt_site_url).await;
         AutoDiscoveryAttemptResult {
             attempt_type: attempt.attempt_type,
             attempt_site_url: attempt.attempt_site_url,
-            result,
+            api_discovery_result: discovery_result,
+            is_wordpress_site,
         }
     }
 
@@ -134,9 +116,8 @@ impl WpLoginClient {
 
     async fn attempt_is_wordpress_site(
         &self,
-        attempt: AutoDiscoveryAttempt,
+        attempt_site_url: &str,
     ) -> IsWordPressSiteAttemptResult {
-        let attempt_site_url = attempt.attempt_site_url.as_str();
         let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
         let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
         let parse_html_result = self
@@ -144,7 +125,6 @@ impl WpLoginClient {
             .await
             .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
         IsWordPressSiteAttemptResult {
-            attempt_type: attempt.attempt_type,
             api_link_header_result,
             fetch_wp_json_result,
             parse_html_result,

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -87,13 +87,20 @@ impl AutoDiscoveryResult {
     ) -> Option<&AutoDiscoveryAttemptResult> {
         self.attempts.get(attempt_type)
     }
+
+    pub fn is_wordpress_site(&self) -> bool {
+        self.attempts
+            .iter()
+            .any(|(_, result)| result.is_wordpress_site.is_successful())
+    }
 }
 
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct AutoDiscoveryAttemptResult {
     pub attempt_type: AutoDiscoveryAttemptType,
     pub attempt_site_url: String,
-    pub result: Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure>,
+    pub api_discovery_result: Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure>,
+    pub is_wordpress_site: IsWordPressSiteAttemptResult,
 }
 
 #[uniffi::export]
@@ -103,18 +110,18 @@ impl AutoDiscoveryAttemptResult {
     }
 
     fn error_message(&self) -> Option<String> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(_) => None,
             Err(error) => Some(error.error_message()),
         }
     }
 
     fn is_successful(&self) -> bool {
-        self.result.is_ok()
+        self.api_discovery_result.is_ok()
     }
 
     fn is_network_error(&self) -> bool {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(_) => false,
             Err(error) => error.is_network_error(),
         }
@@ -125,124 +132,57 @@ impl AutoDiscoveryAttemptResult {
     }
 
     fn has_failed_to_parse_site_url(&self) -> bool {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => false,
             Err(error) => error.parsed_site_url().is_none(),
         }
     }
 
     fn has_failed_to_parse_api_root_url(&self) -> Option<bool> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => Some(false),
             Err(error) => error.has_failed_to_parse_api_root_url(),
         }
     }
 
     fn has_failed_to_parse_api_details(&self) -> Option<bool> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => Some(false),
             Err(error) => error.has_failed_to_parse_api_details(),
         }
     }
 
     fn parsed_site_url(&self) -> Option<Arc<ParsedUrl>> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => Some(Arc::new(success.parsed_site_url.clone())),
             Err(error) => error.parsed_site_url().map(|p| Arc::new(p.clone())),
         }
     }
 
     fn api_root_url(&self) -> Option<Arc<ParsedUrl>> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => Some(Arc::new(success.api_root_url.clone())),
             Err(error) => error.api_root_url().map(|p| Arc::new(p.clone())),
         }
     }
 
     fn api_details(&self) -> Option<Arc<WpApiDetails>> {
-        match &self.result {
+        match &self.api_discovery_result {
             Ok(success) => Some(Arc::new(success.api_details.clone())),
             Err(_) => None,
         }
     }
 }
 
-#[derive(Debug, uniffi::Record)]
-pub struct IsWordPressSiteUniffiResult {
-    pub user_input_attempt: Arc<IsWordPressSiteAttemptResult>,
-    pub successful_attempt: Option<Arc<IsWordPressSiteAttemptResult>>,
-    pub auto_https_attempt: Option<Arc<IsWordPressSiteAttemptResult>>,
-    pub auto_dot_php_extension_for_wp_admin_attempt: Option<Arc<IsWordPressSiteAttemptResult>>,
-}
-
-#[derive(Debug)]
-pub struct IsWordPressSiteResult {
-    pub attempts: HashMap<AutoDiscoveryAttemptType, IsWordPressSiteAttemptResult>,
-}
-
-impl From<IsWordPressSiteResult> for IsWordPressSiteUniffiResult {
-    fn from(value: IsWordPressSiteResult) -> Self {
-        let get_attempt_result = |attempt_type| {
-            value
-                .get_attempt(&attempt_type)
-                .map(|a| Arc::new(a.clone()))
-        };
-        Self {
-            user_input_attempt: Arc::new(value.user_input_attempt().clone()),
-            successful_attempt: value.find_successful().map(|a| Arc::new(a.clone())),
-            auto_https_attempt: get_attempt_result(AutoDiscoveryAttemptType::AutoHttps),
-            auto_dot_php_extension_for_wp_admin_attempt: get_attempt_result(
-                AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin,
-            ),
-        }
-    }
-}
-
-impl IsWordPressSiteResult {
-    pub fn is_successful(&self) -> bool {
-        self.attempts
-            .iter()
-            .any(|(_, result)| result.is_successful())
-    }
-
-    pub fn user_input_attempt(&self) -> &IsWordPressSiteAttemptResult {
-        self.get_attempt(&AutoDiscoveryAttemptType::UserInput)
-            .expect("User input url is always attempted")
-    }
-
-    pub fn get_attempt(
-        &self,
-        attempt_type: &AutoDiscoveryAttemptType,
-    ) -> Option<&IsWordPressSiteAttemptResult> {
-        self.attempts.get(attempt_type)
-    }
-
-    pub fn find_successful(&self) -> Option<&IsWordPressSiteAttemptResult> {
-        // If the user attempt is successful, prefer it over other attempts
-        let user_input_attempt = self.user_input_attempt();
-        if user_input_attempt.is_successful() {
-            return Some(user_input_attempt);
-        }
-        self.attempts.iter().find_map(|(_, result)| {
-            if result.is_successful() {
-                Some(result)
-            } else {
-                None
-            }
-        })
-    }
-}
-
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct IsWordPressSiteAttemptResult {
-    pub attempt_type: AutoDiscoveryAttemptType,
     pub api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
     pub fetch_wp_json_result: Result<FetchWpJsonSuccess, FetchWpJsonFailure>,
     pub parse_html_result: Result<IsWordPressSiteParseHtmlResult, ParseHtmlFailure>,
 }
 
 impl IsWordPressSiteAttemptResult {
-    fn is_successful(&self) -> bool {
+    pub fn is_successful(&self) -> bool {
         self.api_link_header_result.is_ok()
             || self.fetch_wp_json_result.is_ok()
             || self
@@ -411,18 +351,6 @@ pub enum AutoDiscoveryAttemptFailure {
 }
 
 impl AutoDiscoveryAttemptFailure {
-    pub fn into_attempt_result(
-        self,
-        attempt_type: AutoDiscoveryAttemptType,
-        attempt_site_url: String,
-    ) -> AutoDiscoveryAttemptResult {
-        AutoDiscoveryAttemptResult {
-            attempt_type,
-            attempt_site_url,
-            result: Err(self),
-        }
-    }
-
     pub fn error_message(&self) -> String {
         match self {
             AutoDiscoveryAttemptFailure::ParseSiteUrl { error } => error.to_string(),

--- a/wp_api_integration_tests/tests/test_login_err.rs
+++ b/wp_api_integration_tests/tests/test_login_err.rs
@@ -16,7 +16,7 @@ async fn test_login_flow_err_parse_api_details(#[case] site_url: &str) {
         .attempts
         .remove(&AutoDiscoveryAttemptType::UserInput)
         .unwrap()
-        .result
+        .api_discovery_result
         .unwrap_err();
     assert_eq!(
         original_attempt_error.has_failed_to_parse_api_details(),
@@ -37,7 +37,7 @@ async fn test_login_flow_err_network_error(#[case] site_url: &str) {
         .attempts
         .remove(&AutoDiscoveryAttemptType::UserInput)
         .unwrap()
-        .result
+        .api_discovery_result
         .unwrap_err();
     assert!(
         original_attempt_error.is_network_error(),

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -1,7 +1,7 @@
 use rstest::rstest;
 use serial_test::parallel;
 use std::sync::Arc;
-use wp_api::login::{login_client::WpLoginClient, url_discovery::IsWordPressSiteParseHtmlResult};
+use wp_api::login::login_client::WpLoginClient;
 use wp_api_integration_tests::AsyncWpNetworking;
 
 const LOCALHOST_AUTH_URL: &str = "http://localhost/wp-admin/authorize-application.php";
@@ -64,38 +64,45 @@ async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str
         "Auto discovery failed: {:#?}",
         result
     );
+
+    let successful_attempt = result
+        .find_successful()
+        .expect("Already verified that auto discovery is successful");
     assert_eq!(
-        result
-            .find_successful()
-            .expect("Already verified that auto discovery is successful")
-            .result
+        successful_attempt
+            .api_discovery_result
             .clone()
             .expect("Already verified that auto discovery is successful")
             .api_details
             .find_application_passwords_authentication_url(),
         Some(expected_auth_url.to_string())
     );
-}
 
-#[rstest]
-#[case("http://localhost")]
-#[tokio::test]
-#[parallel]
-async fn test_is_wordpress_site(#[case] site_url: &str) {
-    let client = WpLoginClient::new(Arc::new(AsyncWpNetworking::default()));
-    let result = client
-        .is_wordpress_site_discovery(site_url.to_string())
-        .await;
-    let successful_attempt = result.find_successful().unwrap();
-    assert!(successful_attempt.api_link_header_result.is_ok());
-    assert!(successful_attempt.fetch_wp_json_result.is_ok());
-    assert_eq!(
-        successful_attempt.parse_html_result,
-        Ok(IsWordPressSiteParseHtmlResult {
-            has_wordpress_generator_meta_tag: true,
-            // `wp-content` is not mentioned in relevant `http://localhost` HTML source tags
-            mentions_wp_content: false,
-            mentions_wp_includes: true
-        })
+    let is_wordpress_site = &successful_attempt.is_wordpress_site;
+    assert!(
+        is_wordpress_site.is_successful(),
+        "'{site_url}' is incorrectly marked as non-WordPress site: {:#?}",
+        result
     );
+    assert!(is_wordpress_site.api_link_header_result.is_ok());
+
+    // We can't do a reasonable assertion of `is_wordpress_site.fetch_wp_json_result` because not
+    // all of the test cases will return a parseable JSON from `/wp-json`.
+    //
+    // assert!(is_wordpress_site.fetch_wp_json_result.is_ok());
+    //
+    // ---
+    //
+    // We can't do a reasonable assertion of `is_wordpress_site.parse_html_result` because each
+    // test site has a different configuration, so we have a mixed results of
+    // `has_wordpress_generator_meta_tag`, `mentions_wp_content` & `mentions_wp_includes` fields.
+    //
+    // assert_eq!(
+    //     is_wordpress_site.parse_html_result,
+    //     Ok(IsWordPressSiteParseHtmlResult {
+    //         has_wordpress_generator_meta_tag: true,
+    //         mentions_wp_content: true,
+    //         mentions_wp_includes: true
+    //     })
+    // );
 }


### PR DESCRIPTION
This PR is a follow up to #536 and moves `is_wordpress_site` logic, so it's part of API discovery.