### PR TITLE
Improve constructed attempts for api discovery and handle parsing link tag for api root url

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -67,12 +67,20 @@ impl WpLoginClient {
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
         let attempt_site_url = attempt.attempt_site_url.as_str();
+        let parse_html_result = self
+            .fetch_site(attempt_site_url)
+            .await
+            .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
         let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
         let discovery_result = self
-            .inner_attempt_api_discovery(attempt_site_url, api_link_header_result.clone())
+            .inner_attempt_api_discovery(
+                attempt_site_url,
+                api_link_header_result.clone(),
+                parse_html_result.clone(),
+            )
             .await;
         let is_wordpress_site = self
-            .attempt_is_wordpress_site(attempt_site_url, api_link_header_result)
+            .attempt_is_wordpress_site(attempt_site_url, api_link_header_result, parse_html_result)
             .await;
         AutoDiscoveryAttemptResult {
             attempt_type: attempt.attempt_type,
@@ -86,6 +94,7 @@ impl WpLoginClient {
         &self,
         attempt_site_url: &str,
         api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
+        parse_html_result: Result<IsWordPressSiteParseHtmlResult, ParseHtmlFailure>,
     ) -> Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure> {
         let api_root_url_success = api_link_header_result?;
         let fetch_api_details_response = match self
@@ -124,12 +133,9 @@ impl WpLoginClient {
         &self,
         attempt_site_url: &str,
         api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
+        parse_html_result: Result<IsWordPressSiteParseHtmlResult, ParseHtmlFailure>,
     ) -> IsWordPressSiteAttemptResult {
         let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
-        let parse_html_result = self
-            .fetch_site(attempt_site_url)
-            .await
-            .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
         IsWordPressSiteAttemptResult {
             api_link_header_result,
             fetch_wp_json_result,

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -71,13 +71,15 @@ impl WpLoginClient {
             .fetch_site(attempt_site_url)
             .await
             .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
-        let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
+        let api_root_url_from_link_tag = parse_html_result
+            .as_ref()
+            .ok()
+            .and_then(|h| h.api_root_url_from_link_tag.clone());
+        let api_link_header_result = self
+            .find_api_root_url(attempt_site_url, api_root_url_from_link_tag)
+            .await;
         let discovery_result = self
-            .inner_attempt_api_discovery(
-                attempt_site_url,
-                api_link_header_result.clone(),
-                parse_html_result.clone(),
-            )
+            .inner_attempt_api_discovery(attempt_site_url, api_link_header_result.clone())
             .await;
         let is_wordpress_site = self
             .attempt_is_wordpress_site(attempt_site_url, api_link_header_result, parse_html_result)
@@ -94,7 +96,6 @@ impl WpLoginClient {
         &self,
         attempt_site_url: &str,
         api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
-        parse_html_result: Result<IsWordPressSiteParseHtmlResult, ParseHtmlFailure>,
     ) -> Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure> {
         let api_root_url_success = api_link_header_result?;
         let fetch_api_details_response = match self
@@ -146,9 +147,25 @@ impl WpLoginClient {
     async fn find_api_root_url(
         &self,
         attempt_site_url: &str,
+        api_root_url_from_link_tag: Option<ParsedUrl>,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
         let parsed_site_url = ParsedUrl::parse(attempt_site_url)
             .map_err(|error| FindApiRootLinkHeaderFailure::ParseSiteUrl { error })?;
+        if let Some(api_root_url) = api_root_url_from_link_tag {
+            Ok(FindApiRootLinkHeaderSuccess {
+                parsed_site_url,
+                api_root_url,
+            })
+        } else {
+            self.fetch_and_parse_api_root_url_header(parsed_site_url)
+                .await
+        }
+    }
+
+    async fn fetch_and_parse_api_root_url_header(
+        &self,
+        parsed_site_url: ParsedUrl,
+    ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
         let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
             Ok(r) => r,
             Err(error) => {

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -464,6 +464,7 @@ pub enum AutoDiscoveryAttemptType {
     UserInput,
     AutoHttps,
     AutoRemoveWpAdminSuffix,
+    AutoRemoveWpLoginSuffix,
 }
 
 impl AutoDiscoveryAttemptType {
@@ -491,6 +492,16 @@ pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAtt
         attempts.push(AutoDiscoveryAttempt::new(
             a,
             AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
+        ))
+    }
+    if let Some(a) = input_site_url
+        .strip_suffix("wp-login")
+        .or_else(|| input_site_url.strip_suffix("wp-login/"))
+        .or_else(|| input_site_url.strip_suffix("wp-login.php"))
+    {
+        attempts.push(AutoDiscoveryAttempt::new(
+            a,
+            AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix,
         ))
     }
     attempts
@@ -536,6 +547,9 @@ mod tests {
     #[case("http://localhost/wp-admin.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
     #[case("http://localhost/wp-admin", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
     #[case("http://localhost/wp-admin/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
+    #[case("http://localhost/wp-login.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login.php", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
+    #[case("http://localhost/wp-login", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
+    #[case("http://localhost/wp-login/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
     #[case("orchestremetropolitain.com/wp-json", vec![AutoDiscoveryAttempt::new("orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("https://orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::AutoHttps)])]
     #[case("https://orchestremetropolitain.com", vec![AutoDiscoveryAttempt::new("https://orchestremetropolitain.com", AutoDiscoveryAttemptType::UserInput)])]
     #[case(

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -216,6 +216,10 @@ pub struct RootWpJson {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IsWordPressSiteParseHtmlResult {
+    /// `href` attribute of a link tag if it has `rel` attribute of "https://api.w.org/".
+    /// For example:
+    /// <link href="http://localhost/wp-json/" rel="https://api.w.org/">
+    pub api_root_url_from_link_tag: Option<ParsedUrl>,
     /// Whether the HTML has 'generator' meta tag that mentions `WordPress`
     pub has_wordpress_generator_meta_tag: bool,
     /// Whether the HTML `link`, `script`, `style` tags mention `wp-content`
@@ -228,6 +232,7 @@ impl IsWordPressSiteParseHtmlResult {
     const HTML_ATTR_NAME: &str = "name";
     const HTML_ATTR_CONTENT: &str = "content";
     const HTML_ATTR_HREF: &str = "href";
+    const HTML_ATTR_REL: &str = "rel";
     const HTML_ATTR_SRC: &str = "src";
     const META_TAG_GENERATOR: &str = "generator";
     const META_TAG_GENERATOR_CONTENT_INCLUDES: &str = "WordPress";
@@ -262,8 +267,17 @@ impl IsWordPressSiteParseHtmlResult {
                     )
                 },
             );
+        let api_root_url_from_link_tag = html.select(&link_selector).find_map(|e| {
+            if let Some(API_ROOT_LINK_HEADER) = e.attr(Self::HTML_ATTR_REL) {
+                e.attr(Self::HTML_ATTR_HREF)
+                    .and_then(|u| ParsedUrl::parse(u).ok())
+            } else {
+                None
+            }
+        });
 
         Self {
+            api_root_url_from_link_tag,
             has_wordpress_generator_meta_tag: Self::html_has_generator_tag(&html),
             mentions_wp_content,
             mentions_wp_includes,

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -42,7 +42,7 @@ impl From<AutoDiscoveryResult> for AutoDiscoveryUniffiResult {
             successful_attempt: value.find_successful().map(|a| Arc::new(a.clone())),
             auto_https_attempt: get_attempt_result(AutoDiscoveryAttemptType::AutoHttps),
             auto_dot_php_extension_for_wp_admin_attempt: get_attempt_result(
-                AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin,
+                AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
             ),
             is_successful: value.is_successful(),
         }
@@ -463,7 +463,7 @@ impl From<FindApiRootLinkHeaderFailure> for AutoDiscoveryAttemptFailure {
 pub enum AutoDiscoveryAttemptType {
     UserInput,
     AutoHttps,
-    AutoDotPhpExtensionForWpAdmin,
+    AutoRemoveWpAdminSuffix,
 }
 
 impl AutoDiscoveryAttemptType {
@@ -483,18 +483,14 @@ pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAtt
             AutoDiscoveryAttemptType::AutoHttps,
         ))
     }
-    if input_site_url.ends_with("wp-admin") {
+    if let Some(a) = input_site_url
+        .strip_suffix("wp-admin")
+        .or_else(|| input_site_url.strip_suffix("wp-admin/"))
+        .or_else(|| input_site_url.strip_suffix("wp-admin.php"))
+    {
         attempts.push(AutoDiscoveryAttempt::new(
-            format!("{}.php", input_site_url),
-            AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin,
-        ))
-    } else if input_site_url.ends_with("wp-admin/") {
-        let mut s = input_site_url.clone();
-        s.pop()
-            .expect("Already verified that there is at least one char");
-        attempts.push(AutoDiscoveryAttempt::new(
-            format!("{}.php", s),
-            AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin,
+            a,
+            AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
         ))
     }
     attempts
@@ -537,9 +533,9 @@ mod tests {
     #[case("localhost", vec![AutoDiscoveryAttempt::new("localhost", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("https://localhost", AutoDiscoveryAttemptType::AutoHttps)])]
     #[case("http://localhost", vec![AutoDiscoveryAttempt::new("http://localhost", AutoDiscoveryAttemptType::UserInput)])]
     #[case("http://localhost/wp-json", vec![AutoDiscoveryAttempt::new("http://localhost/wp-json", AutoDiscoveryAttemptType::UserInput)])]
-    #[case("http://localhost/wp-admin.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::UserInput)])]
-    #[case("http://localhost/wp-admin", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin)])]
-    #[case("http://localhost/wp-admin/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::AutoDotPhpExtensionForWpAdmin)])]
+    #[case("http://localhost/wp-admin.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
+    #[case("http://localhost/wp-admin", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
+    #[case("http://localhost/wp-admin/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
     #[case("orchestremetropolitain.com/wp-json", vec![AutoDiscoveryAttempt::new("orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("https://orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::AutoHttps)])]
     #[case("https://orchestremetropolitain.com", vec![AutoDiscoveryAttempt::new("https://orchestremetropolitain.com", AutoDiscoveryAttemptType::UserInput)])]
     #[case(

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -54,6 +54,10 @@ const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
     "http://wordpress-1315525-4803651.cloudwaysapps.com",
     "https://vanilla.wpmt.co/wp-admin/authorize-application.php"
 )]
+#[case(
+    "https://aggressive-caching.wpmt.co",
+    "https://aggressive-caching.wpmt.co/wp-admin/authorize-application.php"
+)] // Returns gzip responses, may not always include Link header
 #[tokio::test]
 #[parallel]
 async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str) {


### PR DESCRIPTION
This PR improves the constructed api discovery attempts by removing the `wp-admin`, `wp-admin.php`, `wp-admin/`, `wp-login`, `wp-login.php` & `wp-login/` suffixes.

It also checks the link tags in the source HTML to find the api root url following this pattern: `<link href="http://localhost/wp-json/" rel="https://api.w.org/">`. Since we always parse HTML, I've made this as the first thing we do, so if we find the link tag, we don't request the header anymore.

This setup doesn't seem correct to me, but I think it works. So, instead of trying to figure everything out in one go, I'd like to see if this does what we need to do and if so, then improve it.

---

We have had one last case remaining in https://github.com/Automattic/wordpress-rs/pull/265 where the API discovery didn't work. I think with the addition of this new implementation, it now works. However, the authorization url in #265 was `https://jetpack.wpmt.co/wp-admin/authorize-application.php` whereas according to this implementation it's `https://aggressive-caching.wpmt.co/wp-admin/authorize-application.php`.
