### PR TITLE
Introduce `WpNaiveDateTime` & `WpGmtDateTime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -3663,6 +3664,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "chrono",
  "futures",
  "http 1.2.0",
  "indoc",
@@ -3787,6 +3789,7 @@ dependencies = [
 name = "wp_serde_helper"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rstest",
  "serde",
  "serde_json",

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -13,6 +13,7 @@ name = "wp_api"
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true, features = [ "serde" ] }
 futures = { workspace = true }
 http = { workspace = true }
 indoc = { workspace = true }
@@ -21,7 +22,7 @@ parse_link_header = { workspace = true }
 paste = { workspace = true }
 regex = { workspace = true }
 scraper = { workspace = true }
-serde = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = [ "derive", "rc" ] }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -1,0 +1,54 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use wp_serde_helper::{wp_naive_date_format, wp_utc_date_format};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, uniffi::Object)]
+#[serde(transparent)]
+pub struct WpGmtDateTime {
+    #[serde(with = "wp_utc_date_format")]
+    pub inner: DateTime<Utc>,
+}
+
+impl WpGmtDateTime {
+    pub fn to_rfc3339(&self) -> String {
+        self.inner.to_rfc3339()
+    }
+}
+
+impl From<DateTime<Utc>> for WpGmtDateTime {
+    fn from(value: DateTime<Utc>) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl From<std::time::SystemTime> for WpGmtDateTime {
+    fn from(value: std::time::SystemTime) -> Self {
+        Self {
+            inner: value.into(),
+        }
+    }
+}
+
+impl FromStr for WpGmtDateTime {
+    type Err = chrono::format::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<DateTime<Utc>>().map(|inner| Self { inner })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, uniffi::Object)]
+#[serde(transparent)]
+pub struct WpNaiveDateTime {
+    #[serde(with = "wp_naive_date_format")]
+    pub inner: NaiveDateTime,
+}
+
+impl FromStr for WpNaiveDateTime {
+    type Err = chrono::format::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<NaiveDateTime>().map(|inner| Self { inner })
+    }
+}

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{format::ParseErrorKind, DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use wp_serde_helper::{wp_naive_date_format, wp_utc_date_format};
@@ -10,7 +10,13 @@ pub struct WpGmtDateTime {
     pub inner: DateTime<Utc>,
 }
 
+#[uniffi::export]
 impl WpGmtDateTime {
+    #[uniffi::constructor]
+    pub fn parse(date: &str) -> Result<Self, WpGmtDateTimeParseError> {
+        date.parse::<WpGmtDateTime>()
+    }
+
     pub fn to_rfc3339(&self) -> String {
         self.inner.to_rfc3339()
     }
@@ -31,10 +37,12 @@ impl From<std::time::SystemTime> for WpGmtDateTime {
 }
 
 impl FromStr for WpGmtDateTime {
-    type Err = chrono::format::ParseError;
+    type Err = WpGmtDateTimeParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<DateTime<Utc>>().map(|inner| Self { inner })
+        s.parse::<DateTime<Utc>>()
+            .map(|inner| Self { inner })
+            .map_err(Into::<Self::Err>::into)
     }
 }
 
@@ -50,5 +58,64 @@ impl FromStr for WpNaiveDateTime {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse::<NaiveDateTime>().map(|inner| Self { inner })
+    }
+}
+
+/// This enum is a direct copy of [`chrono::format::ParseErrorKind`](https://docs.rs/chrono/latest/chrono/format/enum.ParseErrorKind.html)
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, thiserror::Error, uniffi::Error)]
+#[non_exhaustive]
+pub enum WpGmtDateTimeParseError {
+    /// Given field is out of permitted range
+    #[error("Given field is out of permitted range")]
+    OutOfRange,
+
+    /// There is no possible date and time value with given set of fields.
+    ///
+    /// This does not include the out-of-range conditions, which are trivially invalid.
+    /// It includes the case that there are one or more fields that are inconsistent to each other.
+    #[error("There is no possible date and time value with given set of fields")]
+    Impossible,
+
+    /// Given set of fields is not enough to make a requested date and time value.
+    ///
+    /// Note that there *may* be a case that given fields constrain the possible values so much
+    /// that there is a unique possible value. Chrono only tries to be correct for
+    /// most useful sets of fields however, as such constraint solving can be expensive.
+    #[error("Given set of fields is not enough to make a requested date and time value")]
+    NotEnough,
+
+    /// The input string has some invalid character sequence for given formatting items.
+    #[error("The input string has some invalid character sequence for given formatting items")]
+    Invalid,
+
+    /// The input string has been prematurely ended.
+    #[error("The input string has been prematurely ended")]
+    TooShort,
+
+    /// All formatting items have been read but there is a remaining input.
+    #[error("All formatting items have been read but there is a remaining input")]
+    TooLong,
+
+    /// There was an error on the formatting string, or there were non-supported formatting items.
+    #[error(
+        "There was an error on the formatting string, or there were non-supported formatting items"
+    )]
+    BadFormat,
+}
+
+impl From<chrono::format::ParseError> for WpGmtDateTimeParseError {
+    fn from(value: chrono::format::ParseError) -> Self {
+        match value.kind() {
+            ParseErrorKind::OutOfRange => Self::OutOfRange,
+            ParseErrorKind::Impossible => Self::Impossible,
+            ParseErrorKind::NotEnough => Self::NotEnough,
+            ParseErrorKind::Invalid => Self::Invalid,
+            ParseErrorKind::TooShort => Self::TooShort,
+            ParseErrorKind::TooLong => Self::TooLong,
+            ParseErrorKind::BadFormat => Self::BadFormat,
+            _ => panic!(
+                "A new error kind is added to `chrono::format::ParseErrorKind`, we need to handle that by adding it to `WpGmtDateTimeParseError`"
+            ),
+        }
     }
 }

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -19,6 +19,7 @@ mod uuid; // re-exported relevant types
 pub mod application_passwords;
 pub mod categories;
 pub mod comments;
+pub mod date;
 pub mod login;
 pub mod media;
 pub mod plugins;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,5 +1,6 @@
 use crate::{
     categories::CategoryId,
+    date::{WpGmtDateTime, WpNaiveDateTime},
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     media::MediaId,
     tags::TagId,
@@ -9,7 +10,7 @@ use crate::{
     UserId, WpApiParamOrder,
 };
 use serde::{Deserialize, Serialize};
-use std::{num::ParseIntError, str::FromStr};
+use std::{num::ParseIntError, str::FromStr, sync::Arc};
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
 use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
@@ -81,10 +82,10 @@ pub struct PostListParams {
     pub search: Option<String>,
     /// Limit response to posts published after a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub after: Option<String>,
+    pub after: Option<Arc<WpGmtDateTime>>,
     /// Limit response to posts modified after a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub modified_after: Option<String>,
+    pub modified_after: Option<Arc<WpGmtDateTime>>,
     /// Limit result set to posts assigned to specific authors.
     #[uniffi(default = [])]
     pub author: Vec<UserId>,
@@ -93,10 +94,10 @@ pub struct PostListParams {
     pub author_exclude: Vec<UserId>,
     /// Limit response to posts published before a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub before: Option<String>,
+    pub before: Option<Arc<WpGmtDateTime>>,
     /// Limit response to posts modified before a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub modified_before: Option<String>,
+    pub modified_before: Option<Arc<WpGmtDateTime>>,
     /// Ensure result set excludes specific IDs.
     #[uniffi(default = [])]
     pub exclude: Vec<PostId>,
@@ -244,12 +245,12 @@ impl FromUrlQueryPairs for PostListParams {
             page: query_pairs.get(PostListParamsField::Page),
             per_page: query_pairs.get(PostListParamsField::PerPage),
             search: query_pairs.get(PostListParamsField::Search),
-            after: query_pairs.get(PostListParamsField::After),
-            modified_after: query_pairs.get(PostListParamsField::ModifiedAfter),
+            after: query_pairs.get_arc_wp_date_time(PostListParamsField::After),
+            modified_after: query_pairs.get_arc_wp_date_time(PostListParamsField::ModifiedAfter),
             author: query_pairs.get_csv(PostListParamsField::Author),
             author_exclude: query_pairs.get_csv(PostListParamsField::AuthorExclude),
-            before: query_pairs.get(PostListParamsField::Before),
-            modified_before: query_pairs.get(PostListParamsField::ModifiedBefore),
+            before: query_pairs.get_arc_wp_date_time(PostListParamsField::Before),
+            modified_before: query_pairs.get_arc_wp_date_time(PostListParamsField::ModifiedBefore),
             exclude: query_pairs.get_csv(PostListParamsField::Exclude),
             include: query_pairs.get_csv(PostListParamsField::Include),
             offset: query_pairs.get(PostListParamsField::Offset),
@@ -470,19 +471,19 @@ impl std::fmt::Display for PostId {
 pub struct SparsePost {
     #[WpContext(edit, embed, view)]
     pub id: Option<PostId>,
-    #[WpContext(edit, embed, view)]
-    pub date: Option<String>,
+    #[WpContext(edit, view, embed)]
+    pub date: Option<Arc<WpNaiveDateTime>>,
     #[WpContext(edit, view)]
-    pub date_gmt: Option<String>,
+    pub date_gmt: Option<Arc<WpGmtDateTime>>,
     #[WpContext(edit, view)]
     #[WpContextualField]
     pub guid: Option<SparsePostGuid>,
     #[WpContext(edit, embed, view)]
     pub link: Option<String>,
     #[WpContext(edit, view)]
-    pub modified: Option<String>,
+    pub modified: Option<Arc<WpNaiveDateTime>>,
     #[WpContext(edit, view)]
-    pub modified_gmt: Option<String>,
+    pub modified_gmt: Option<Arc<WpGmtDateTime>>,
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit, view)]
@@ -710,7 +711,13 @@ impl PostFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{generate, unit_test_common::assert_expected_and_from_query_pairs};
+    use crate::{
+        generate,
+        unit_test_common::{
+            assert_expected_and_from_query_pairs, unit_test_example_date_as_option_arc,
+            unit_test_example_date_as_query_value,
+        },
+    };
     use rstest::*;
 
     #[rstest]
@@ -718,12 +725,12 @@ mod tests {
     #[case(generate!(PostListParams, (page, Some(2))), "page=2")]
     #[case(generate!(PostListParams, (per_page, Some(2))), "per_page=2")]
     #[case(generate!(PostListParams, (search, Some("foo".to_string()))), "search=foo")]
-    #[case(generate!(PostListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (after, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PostListParams, (modified_after, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("modified_after"))]
     #[case(generate!(PostListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
     #[case(generate!(PostListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
-    #[case(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (before, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PostListParams, (modified_before, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("modified_before"))]
     #[case(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
     #[case(generate!(PostListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
     #[case(generate!(PostListParams, (offset, Some(2))), "offset=2")]
@@ -761,38 +768,59 @@ mod tests {
     #[case(generate!(PostListParams, (tags, vec![TagId(1), TagId(2)])), "tags=1%2C2")]
     #[case(generate!(PostListParams, (tags_exclude, vec![TagId(1), TagId(2)])), "tags_exclude=1%2C2")]
     #[case(generate!(PostListParams, (sticky, Some(true))), "sticky=true")]
-    #[case(PostListParams {
-        page: Some(11),
-        per_page: Some(22),
-        search: Some("s_q".to_string()),
-        after: Some("d_a".to_string()),
-        modified_after: Some("d_m_a".to_string()),
-        author: vec![UserId(111), UserId(112)],
-        author_exclude: vec![UserId(211), UserId(212)],
-        before: Some("d_b".to_string()),
-        modified_before: Some("d_m_b".to_string()),
-        exclude: vec![PostId(1111), PostId(1112)],
-        include: vec![PostId(2111), PostId(2112)],
-        offset: Some(11111),
-        order: Some(WpApiParamOrder::Desc),
-        orderby: Some(WpApiParamPostsOrderBy::Slug),
-        search_columns: vec![
-            WpApiParamPostsSearchColumn::PostContent,
-            WpApiParamPostsSearchColumn::PostExcerpt,
-        ],
-        slug: vec!["sl_1".to_string(), "sl_2".to_string()],
-        status: vec![PostStatus::Draft, PostStatus::Future],
-        tax_relation: Some(WpApiParamPostsTaxRelation::Or),
-        categories: vec![CategoryId(333333), CategoryId(333334)],
-        categories_exclude: vec![CategoryId(444444), CategoryId(444445)],
-        tags: vec![TagId(555555), TagId(555556)],
-        tags_exclude: vec![TagId(666666), TagId(666667)],
-        sticky: Some(true),
-        },
-        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&tax_relation=OR&categories=333333%2C333334&categories_exclude=444444%2C444445&tags=555555%2C555556&tags_exclude=666666%2C666667&sticky=true"
+    #[case(
+        post_list_params_with_all_fields(),
+        &expected_query_pairs_for_post_list_params_with_all_fields()
     )]
     #[trace]
     fn test_post_list_query_pairs(#[case] params: PostListParams, #[case] expected_query: &str) {
         assert_expected_and_from_query_pairs(params, expected_query);
+    }
+
+    fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!("page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true")
+    }
+
+    fn post_list_params_with_all_fields() -> PostListParams {
+        PostListParams {
+            after: unit_test_example_date_as_option_arc(),
+            author: vec![UserId(1), UserId(2)],
+            author_exclude: vec![UserId(1), UserId(2)],
+            before: unit_test_example_date_as_option_arc(),
+            categories: vec![CategoryId(1), CategoryId(2)],
+            categories_exclude: vec![CategoryId(1), CategoryId(2)],
+            exclude: vec![PostId(1), PostId(2)],
+            include: vec![PostId(1), PostId(2)],
+            modified_after: unit_test_example_date_as_option_arc(),
+            modified_before: unit_test_example_date_as_option_arc(),
+            offset: Some(2),
+            order: Some(WpApiParamOrder::Asc),
+            orderby: Some(WpApiParamPostsOrderBy::Author),
+            page: Some(2),
+            per_page: Some(2),
+            search: Some("foo".to_string()),
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+                WpApiParamPostsSearchColumn::PostTitle,
+            ],
+            slug: vec!["foo".to_string(), "bar".to_string()],
+            status: vec![
+                PostStatus::Draft,
+                PostStatus::Future,
+                PostStatus::Pending,
+                PostStatus::Private,
+                PostStatus::Publish,
+                PostStatus::Custom("foo".to_string()),
+            ],
+            sticky: Some(true),
+            tags: vec![TagId(1), TagId(2)],
+            tags_exclude: vec![TagId(1), TagId(2)],
+            tax_relation: Some(WpApiParamPostsTaxRelation::And),
+        }
     }
 }

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -82,6 +82,9 @@ mod tests {
             ApiBaseUrl,
         },
         tags::TagId,
+        unit_test_common::{
+            unit_test_example_date_as_option_arc, unit_test_example_date_as_query_value,
+        },
         UserId, WpApiParamOrder,
     };
     use rstest::*;
@@ -102,12 +105,12 @@ mod tests {
     #[case(generate!(PostListParams, (page, Some(2))), "page=2")]
     #[case(generate!(PostListParams, (per_page, Some(2))), "per_page=2")]
     #[case(generate!(PostListParams, (search, Some("foo".to_string()))), "search=foo")]
-    #[case(generate!(PostListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (after, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PostListParams, (modified_after, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("modified_after"))]
     #[case(generate!(PostListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
     #[case(generate!(PostListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
-    #[case(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (before, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PostListParams, (modified_before, unit_test_example_date_as_option_arc())), &unit_test_example_date_as_query_value("modified_before"))]
     #[case(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
     #[case(generate!(PostListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
     #[case(generate!(PostListParams, (offset, Some(2))), "offset=2")]
@@ -144,7 +147,7 @@ mod tests {
     #[case(generate!(PostListParams, (sticky, Some(true))), "sticky=true")]
     #[case(
         post_list_params_with_all_fields(),
-        EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS
+        &expected_query_pairs_for_post_list_params_with_all_fields()
     )]
     fn list_posts(
         endpoint: PostsRequestEndpoint,
@@ -175,7 +178,7 @@ mod tests {
     #[rstest]
     #[case(PostListParams::default(), &[], "/posts?context=edit&_fields=")]
     #[case(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparsePostFieldWithEditContext::Author], "/posts?context=edit&orderby=author&_fields=author")]
-    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT, &format!("/posts?context=edit&{}&{}", EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT))]
+    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT, &format!("/posts?context=edit&{}&{}", expected_query_pairs_for_post_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT))]
     fn filter_list_post_with_edit_context(
         endpoint: PostsRequestEndpoint,
         #[case] params: PostListParams,
@@ -191,7 +194,7 @@ mod tests {
     #[rstest]
     #[case(PostListParams::default(), &[], "/posts?context=embed&_fields=")]
     #[case(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparsePostFieldWithEmbedContext::Author], "/posts?context=embed&orderby=author&_fields=author")]
-    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT, &format!("/posts?context=embed&{}&{}", EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT))]
+    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT, &format!("/posts?context=embed&{}&{}", expected_query_pairs_for_post_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT))]
     fn filter_list_post_with_embed_context(
         endpoint: PostsRequestEndpoint,
         #[case] params: PostListParams,
@@ -272,20 +275,26 @@ mod tests {
         validate_wp_v2_endpoint(endpoint.update(&PostId(54)), "/posts/54");
     }
 
-    const EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS: &str =
-        "page=2&per_page=2&search=foo&after=2023-08-14+17%3A00%3A00.000&modified_after=2023-08-14+17%3A00%3A00.000&author=1%2C2&author_exclude=1%2C2&before=2023-08-14+17%3A00%3A00.000&modified_before=2023-08-14+17%3A00%3A00.000&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true";
+    fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!("page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true")
+    }
+
     fn post_list_params_with_all_fields() -> PostListParams {
         PostListParams {
-            after: Some("2023-08-14 17:00:00.000".to_string()),
+            after: unit_test_example_date_as_option_arc(),
             author: vec![UserId(1), UserId(2)],
             author_exclude: vec![UserId(1), UserId(2)],
-            before: Some("2023-08-14 17:00:00.000".to_string()),
+            before: unit_test_example_date_as_option_arc(),
             categories: vec![CategoryId(1), CategoryId(2)],
             categories_exclude: vec![CategoryId(1), CategoryId(2)],
             exclude: vec![PostId(1), PostId(2)],
             include: vec![PostId(1), PostId(2)],
-            modified_after: Some("2023-08-14 17:00:00.000".to_string()),
-            modified_before: Some("2023-08-14 17:00:00.000".to_string()),
+            modified_after: unit_test_example_date_as_option_arc(),
+            modified_before: unit_test_example_date_as_option_arc(),
             offset: Some(2),
             order: Some(WpApiParamOrder::Asc),
             orderby: Some(WpApiParamPostsOrderBy::Author),

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -1,4 +1,8 @@
-use crate::url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap};
+use crate::{
+    date::WpGmtDateTime,
+    url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap},
+};
+use std::sync::Arc;
 use url::Url;
 
 #[cfg(test)]
@@ -21,4 +25,19 @@ where
         url.query_pairs().into_iter().collect(),
     ));
     assert_eq!(Some(params), parsed_params);
+}
+
+#[cfg(test)]
+pub fn unit_test_example_date_as_option_arc() -> Option<Arc<WpGmtDateTime>> {
+    Some(
+        "2024-02-09T02:14:13+0000"
+            .parse::<WpGmtDateTime>()
+            .expect("Example date is parseable")
+            .into(),
+    )
+}
+
+#[cfg(test)]
+pub fn unit_test_example_date_as_query_value(key: &str) -> String {
+    format!("{key}=2024-02-09T02%3A14%3A13%2B00%3A00")
 }

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr};
+use crate::{date::WpGmtDateTime, impl_as_query_value_from_to_string, OptionFromStr};
+use std::{borrow::Cow, collections::HashMap, str::FromStr, sync::Arc};
 use url::{form_urlencoded, UrlQuery};
-
-use crate::{impl_as_query_value_from_to_string, OptionFromStr};
 
 pub(crate) type QueryPairs<'a> = form_urlencoded::Serializer<'a, UrlQuery<'a>>;
 
@@ -95,6 +94,12 @@ impl AsQueryValue for String {
     }
 }
 
+impl AsQueryValue for Arc<WpGmtDateTime> {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.to_rfc3339()
+    }
+}
+
 #[derive(Debug)]
 pub struct UrlQueryPairsMap<'a> {
     inner: HashMap<Cow<'a, str>, Cow<'a, str>>,
@@ -127,6 +132,16 @@ impl<'a> UrlQueryPairsMap<'a> {
                     .collect::<Option<Vec<_>>>()
             })
             .unwrap_or_default()
+    }
+
+    pub(crate) fn get_arc_wp_date_time<'b>(
+        &self,
+        key: impl Into<&'b str>,
+    ) -> Option<Arc<WpGmtDateTime>> {
+        self.inner
+            .get(key.into())
+            .and_then(|v| v.parse::<WpGmtDateTime>().ok())
+            .map(|d| d.into())
     }
 }
 

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use wp_api::{
     categories::CategoryId,
     comments::CommentId,
+    date::{WpGmtDateTime, WpNaiveDateTime},
     media::MediaId,
     posts::PostId,
     request::{
@@ -284,4 +285,16 @@ impl<T: std::fmt::Debug, E: std::error::Error> AssertResponse for Result<T, E> {
         assert!(self.is_ok(), "Request failed with: {}", self.unwrap_err());
         self.unwrap()
     }
+}
+
+pub fn expected_wp_gmt_date_time(s: &str) -> Arc<WpGmtDateTime> {
+    s.parse::<WpGmtDateTime>()
+        .expect("Expected a valid date")
+        .into()
+}
+
+pub fn expected_wp_naive_date_time(s: &str) -> Arc<WpNaiveDateTime> {
+    s.parse::<WpNaiveDateTime>()
+        .expect("Expected a valid date")
+        .into()
 }

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,16 +1,20 @@
 use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
-use wp_api::categories::CategoryId;
-use wp_api::posts::{
-    PostId, PostListParams, PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
-    SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
-    WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+use wp_api::{
+    categories::CategoryId,
+    generate,
+    posts::{
+        PostId, PostListParams, PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
+        SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
+        WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+    },
+    tags::TagId,
+    WpApiParamOrder,
 };
-use wp_api::tags::TagId;
-use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
-    api_client, AssertResponse, TestCredentials, FIRST_POST_ID, FIRST_USER_ID, SECOND_USER_ID,
+    api_client, expected_wp_gmt_date_time, AssertResponse, TestCredentials, FIRST_POST_ID,
+    FIRST_USER_ID, SECOND_USER_ID,
 };
 
 #[tokio::test]
@@ -198,12 +202,12 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[case::page(generate!(PostListParams, (page, Some(1))))]
 #[case::per_page(generate!(PostListParams, (per_page, Some(3))))]
 #[case::search(generate!(PostListParams, (search, Some("foo".to_string()))))]
-#[case::after(generate!(PostListParams, (after, Some("2020-08-14 17:00:00.000".to_string()))))]
-#[case::modified_after(generate!(PostListParams, (modified_after, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::after(generate!(PostListParams, (after, Some(expected_wp_gmt_date_time("2020-08-14T17:00:00+0200")))))]
+#[case::modified_after(generate!(PostListParams, (modified_after, Some(expected_wp_gmt_date_time("2024-01-14T17:00:00+0200")))))]
 #[case::author(generate!(PostListParams, (author, vec![FIRST_USER_ID, SECOND_USER_ID])))]
 #[case::author_exclude(generate!(PostListParams, (author_exclude, vec![SECOND_USER_ID])))]
-#[case::before(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))))]
-#[case::modified_before(generate!(PostListParams, (modified_before, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::before(generate!(PostListParams, (before, Some(expected_wp_gmt_date_time("2023-08-14T17:00:00+0000")))))]
+#[case::modified_before(generate!(PostListParams, (modified_before, Some(expected_wp_gmt_date_time("2024-01-14T17:00:00+0000")))))]
 #[case::exclude(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])))]
 #[case::include(generate!(PostListParams, (include, vec![PostId(1)])))]
 #[case::offset(generate!(PostListParams, (offset, Some(2))))]
@@ -218,7 +222,7 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[case::tags(generate!(PostListParams, (tags, vec![TagId(1)])))]
 #[case::tags_exclude(generate!(PostListParams, (tags_exclude, vec![TagId(1)])))]
 #[case::sticky(generate!(PostListParams, (sticky, Some(true))))]
-pub fn list_cases(#[case] params: PostListParams) {}
+fn list_cases(#[case] params: PostListParams) {}
 
 mod filter {
     use super::*;

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -9,8 +9,8 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_59, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
-    SECOND_USER_ID, TAG_ID_100,
+    expected_wp_gmt_date_time, expected_wp_naive_date_time, AssertResponse, CATEGORY_ID_59,
+    FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR, SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
 
@@ -156,7 +156,10 @@ generate_update_test!(
     date,
     "2024-09-09T12:00:00".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.date, "2024-09-09T12:00:00");
+        assert_eq!(
+            updated_post.date,
+            expected_wp_naive_date_time("2024-09-09T12:00:00")
+        );
         assert_eq!(updated_post_from_wp_cli.date, "2024-09-09 12:00:00");
     }
 );
@@ -166,7 +169,10 @@ generate_update_test!(
     date_gmt,
     "2024-09-09T12:00:00".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.date_gmt, "2024-09-09T12:00:00");
+        assert_eq!(
+            updated_post.date_gmt,
+            expected_wp_gmt_date_time("2024-09-09T12:00:00+0000")
+        );
         assert_eq!(updated_post_from_wp_cli.date_gmt, "2024-09-09 12:00:00");
     }
 );

--- a/wp_serde_helper/Cargo.toml
+++ b/wp_serde_helper/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = { workspace = true, features = [ "serde" ] }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -4,6 +4,11 @@ use serde::{
 };
 use std::{fmt, marker::PhantomData};
 
+pub use wp_serde_date::wp_naive_date_format;
+pub use wp_serde_date::wp_utc_date_format;
+
+mod wp_serde_date;
+
 pub fn serialize_as_json_string<T, S, E>(value: &T, s: S) -> Result<S::Ok, E>
 where
     T: Serialize,

--- a/wp_serde_helper/src/wp_serde_date.rs
+++ b/wp_serde_helper/src/wp_serde_date.rs
@@ -1,0 +1,95 @@
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Deserializer};
+
+// https://core.trac.wordpress.org/ticket/41032
+const WP_DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+
+fn deserialize_to_native_date_time<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    NaiveDateTime::parse_from_str(&s, WP_DATE_FORMAT).map_err(serde::de::Error::custom)
+}
+
+pub mod wp_naive_date_format {
+    use super::{deserialize_to_native_date_time, WP_DATE_FORMAT};
+    use chrono::NaiveDateTime;
+    use serde::{self, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", date.format(WP_DATE_FORMAT)))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_to_native_date_time(deserializer)
+    }
+}
+
+pub mod wp_utc_date_format {
+    use super::{deserialize_to_native_date_time, WP_DATE_FORMAT};
+    use chrono::{DateTime, Utc};
+    use serde::{self, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", date.format(WP_DATE_FORMAT)))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let dt = deserialize_to_native_date_time(deserializer)?;
+        Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Datelike, Timelike, Utc};
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Foo {
+        #[serde(with = "wp_naive_date_format")]
+        pub wp_naive_date_time: NaiveDateTime,
+        #[serde(with = "wp_utc_date_format")]
+        pub wp_utc_date_time: DateTime<Utc>,
+    }
+
+    #[test]
+    fn test_deserialize_date() {
+        let json_str = r#"
+          {
+            "wp_naive_date_time": "2024-09-18T20:37:19",
+            "wp_utc_date_time": "2024-09-18T22:37:19"
+          }
+        "#;
+
+        let foo: Foo = serde_json::from_str(json_str).unwrap();
+        assert_eq!(foo.wp_naive_date_time.year_ce(), (true, 2024));
+        assert_eq!(foo.wp_naive_date_time.month(), 9);
+        assert_eq!(foo.wp_naive_date_time.day(), 18);
+        assert_eq!(foo.wp_naive_date_time.minute(), 37);
+        assert_eq!(foo.wp_naive_date_time.second(), 19);
+
+        assert_eq!(foo.wp_utc_date_time.year_ce(), (true, 2024));
+        assert_eq!(foo.wp_utc_date_time.month(), 9);
+        assert_eq!(foo.wp_utc_date_time.day(), 18);
+        assert_eq!(foo.wp_utc_date_time.minute(), 37);
+        assert_eq!(foo.wp_utc_date_time.second(), 19);
+
+        assert_eq!(foo.wp_naive_date_time.hour(), 20);
+        assert_eq!(foo.wp_utc_date_time.hour(), 22);
+    }
+}


### PR DESCRIPTION
This PR introduces `WpNaiveDateTime` and `WpGmtDateTime` types for use across all endpoints. It's currently only used for `/posts`, but I plan to switch to using these types at other endpoints in a follow-up.

We're using two different types because the WordPress API returns both `date` and `date_gmt` types for most of its endpoints. The `date_gmt` field contains a date with timezone information, whereas the `date` field is in the user's timezone, which isn't known when we parse the date. That's why we're using `WpNaiveDateTime`, which requires timezone information.
