### PR TITLE
Add Featured and Recommended categories to WP.org directory category

### DIFF
--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -1,5 +1,6 @@
 use crate::{
     api_error::RequestExecutionErrorReason,
+    impl_as_query_value_from_to_string,
     request::{
         endpoint::WpEndpointUrl, RequestExecutor, WpNetworkRequest, WpNetworkResponse, WpRedirect,
     },
@@ -146,24 +147,17 @@ impl WordPressOrgApiClient {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, uniffi::Enum)]
+#[derive(Debug, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum WordPressOrgApiPluginDirectoryCategory {
     New,
     Popular,
     Updated,
     TopRated,
+    Recommended,
+    Featured,
 }
-
-impl WordPressOrgApiPluginDirectoryCategory {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            WordPressOrgApiPluginDirectoryCategory::New => "new",
-            WordPressOrgApiPluginDirectoryCategory::Popular => "popular",
-            WordPressOrgApiPluginDirectoryCategory::Updated => "updated",
-            WordPressOrgApiPluginDirectoryCategory::TopRated => "top-rated",
-        }
-    }
-}
+impl_as_query_value_from_to_string!(WordPressOrgApiPluginDirectoryCategory);
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
 pub enum WordPressOrgApiClientError {

--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -1,6 +1,5 @@
 use crate::{
     api_error::RequestExecutionErrorReason,
-    impl_as_query_value_from_to_string,
     request::{
         endpoint::WpEndpointUrl, RequestExecutor, WpNetworkRequest, WpNetworkResponse, WpRedirect,
     },
@@ -79,7 +78,7 @@ impl WordPressOrgApiClient {
             Some(category) => {
                 let mut url = url;
                 url.query_pairs_mut()
-                    .append_pair("browse", category.as_str());
+                    .append_pair("browse", category.as_ref());
                 url
             }
             None => url,
@@ -147,7 +146,15 @@ impl WordPressOrgApiClient {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+    strum_macros::AsRefStr,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum WordPressOrgApiPluginDirectoryCategory {
     New,
@@ -157,7 +164,6 @@ pub enum WordPressOrgApiPluginDirectoryCategory {
     Recommended,
     Featured,
 }
-impl_as_query_value_from_to_string!(WordPressOrgApiPluginDirectoryCategory);
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
 pub enum WordPressOrgApiClientError {
@@ -203,6 +209,7 @@ impl From<RequestExecutionError> for WordPressOrgApiClientError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::*;
 
     #[test]
     fn test_plugin_info_requests_include_icons() {
@@ -220,5 +227,20 @@ mod tests {
         assert!(!request.url.0.contains("request[per_page]"));
         assert!(request.url.0.contains("page=3"));
         assert!(request.url.0.contains("per_page=24"));
+    }
+
+    #[rstest]
+    #[case(WordPressOrgApiPluginDirectoryCategory::New, "new")]
+    #[case(WordPressOrgApiPluginDirectoryCategory::Popular, "popular")]
+    #[case(WordPressOrgApiPluginDirectoryCategory::Updated, "updated")]
+    #[case(WordPressOrgApiPluginDirectoryCategory::TopRated, "top-rated")]
+    #[case(WordPressOrgApiPluginDirectoryCategory::Recommended, "recommended")]
+    #[case(WordPressOrgApiPluginDirectoryCategory::Featured, "featured")]
+    fn test_browse_plugins(
+        #[case] category: WordPressOrgApiPluginDirectoryCategory,
+        #[case] expected: &str,
+    ) {
+        let request = WordPressOrgApiClient::browse_plugins_request(Some(category), 3, 24);
+        assert!(request.url.0.contains(&format!("browse={}", expected)));
     }
 }


### PR DESCRIPTION
Add `Featured` and `Recommended` categories. Plus, use `strum` on the category enum like other similar enums.