### PR TITLE
Don't require importing `AsQueryValue` from `impl_as_query_value_from_to_string` macro

### DIFF
--- a/wp_api/src/categories.rs
+++ b/wp_api/src/categories.rs
@@ -1,19 +1,16 @@
-use std::{num::ParseIntError, str::FromStr};
-
-use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
-use wp_contextual::WpContextual;
-
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     taxonomies::TaxonomyType,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     WpApiParamOrder,
 };
+use serde::{Deserialize, Serialize};
+use std::{num::ParseIntError, str::FromStr};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
 
 impl_as_query_value_for_new_type!(CategoryId);
 uniffi::custom_newtype!(CategoryId, i64);

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -1,18 +1,15 @@
-use std::{collections::HashMap, num::ParseIntError, str::FromStr};
-
-use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
-use wp_contextual::WpContextual;
-
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
 };
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, num::ParseIntError, str::FromStr};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
 
 #[derive(
     Debug,

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -9,7 +9,6 @@ pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use url_query::AsQueryValue;
 use users::*;
 pub use uuid::{WpUuid, WpUuidParseError};
 

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -5,8 +5,7 @@ use crate::{
         WpApiParamPostsSearchColumn,
     },
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     JsonValue, UserId, WpApiParamOrder,
 };

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -1,12 +1,10 @@
-use std::fmt::Display;
-
-use serde::{Deserialize, Serialize};
-use wp_contextual::WpContextual;
-
 use crate::{
     impl_as_query_value_from_to_string,
-    url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
 };
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use wp_contextual::WpContextual;
 
 #[derive(Debug, Default, uniffi::Record)]
 pub struct PluginListParams {

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use crate::impl_as_query_value_from_to_string;
-use crate::url_query::AsQueryValue;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use wp_contextual::WpContextual;
 
 #[derive(

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,21 +1,18 @@
-use std::{num::ParseIntError, str::FromStr};
-
-use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
-use wp_contextual::WpContextual;
-use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
-
 use crate::{
     categories::CategoryId,
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     media::MediaId,
     tags::TagId,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     UserId, WpApiParamOrder,
 };
+use serde::{Deserialize, Serialize};
+use std::{num::ParseIntError, str::FromStr};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 #[derive(
     Debug,

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -3,7 +3,7 @@ use crate::{
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
-    AsQueryValue, IntegerOrString,
+    IntegerOrString,
 };
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -1,19 +1,16 @@
-use std::{num::ParseIntError, str::FromStr};
-
-use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
-use wp_contextual::WpContextual;
-
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     posts::PostId,
     taxonomies::TaxonomyType,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     WpApiParamOrder,
 };
+use serde::{Deserialize, Serialize};
+use std::{num::ParseIntError, str::FromStr};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
 
 impl_as_query_value_for_new_type!(TagId);
 uniffi::custom_newtype!(TagId, i64);

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -3,8 +3,7 @@ use crate::{
     post_types::PostType,
     posts::PostId,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     UserId,
 };

--- a/wp_api/src/themes.rs
+++ b/wp_api/src/themes.rs
@@ -3,7 +3,7 @@ use crate::{
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
-    AsQueryValue, BoolOrVecString,
+    BoolOrVecString,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -159,7 +159,7 @@ mod macro_helper {
     #[macro_export]
     macro_rules! impl_as_query_value_from_as_str {
         ($ident: ident) => {
-            impl AsQueryValue for $ident {
+            impl $crate::url_query::AsQueryValue for $ident {
                 fn as_query_value(&self) -> impl AsRef<str> {
                     self.as_str()
                 }
@@ -170,7 +170,7 @@ mod macro_helper {
     #[macro_export]
     macro_rules! impl_as_query_value_from_to_string {
         ($ident: ident) => {
-            impl AsQueryValue for $ident {
+            impl $crate::url_query::AsQueryValue for $ident {
                 fn as_query_value(&self) -> impl AsRef<str> {
                     self.to_string()
                 }
@@ -181,7 +181,7 @@ mod macro_helper {
     #[macro_export]
     macro_rules! impl_as_query_value_for_new_type {
         ($ident: ident) => {
-            impl AsQueryValue for $ident {
+            impl $crate::url_query::AsQueryValue for $ident {
                 fn as_query_value(&self) -> impl AsRef<str> {
                     self.0.as_query_value()
                 }

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -1,19 +1,16 @@
-use std::{
-    collections::HashMap, convert::Infallible, fmt::Display, num::ParseIntError, str::FromStr,
-};
-
-use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
-use wp_contextual::WpContextual;
-
 use crate::{
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     url_query::{
-        AppendUrlQueryPairs, AsQueryValue, FromUrlQueryPairs, QueryPairs, QueryPairsExtension,
-        UrlQueryPairsMap,
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     EnumFromStrParsingError, OptionFromStr, WpApiParamOrder, WpResponseString,
 };
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap, convert::Infallible, fmt::Display, num::ParseIntError, str::FromStr,
+};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
 
 #[derive(
     Debug,


### PR DESCRIPTION
I also deleted the extra newline between `use` statements which collapsed some of the `use` statements. The only real change in these use statements is the removal of `AsQueryValue`.

My editor sometimes puts extra newline when I use its import feature and I have been trying to manually remove them as I see them since we don't need to read the `use` statements while editing the code.