### PR TITLE
Don't allow `dead_code` or `unused_variables`

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -107,7 +107,7 @@ pub struct WpError {
 }
 
 impl WpError {
-    pub fn try_parse(response_body: &[u8], response_status_code: u16) -> Option<Self> {
+    pub fn try_parse(response_body: &[u8], _response_status_code: u16) -> Option<Self> {
         serde_json::from_slice::<WpError>(response_body).ok()
     }
 }

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code)]
 
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
 pub use api_error::{

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub use api_client::{WpApiClient, WpApiRequestBuilder};
 pub use api_error::{
     MediaUploadRequestExecutionError, ParsedRequestError, RequestExecutionError,

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -69,7 +69,7 @@ impl WpLoginClient {
         let attempt_site_url = attempt.attempt_site_url.as_str();
         let api_link_header_result = self.find_api_root_url(attempt_site_url).await;
         let discovery_result = self
-            .inner_attempt_api_discovery(attempt_site_url, api_link_header_result.clone())
+            .inner_attempt_api_discovery(api_link_header_result.clone())
             .await;
         let is_wordpress_site = self
             .attempt_is_wordpress_site(attempt_site_url, api_link_header_result)
@@ -84,7 +84,6 @@ impl WpLoginClient {
 
     async fn inner_attempt_api_discovery(
         &self,
-        attempt_site_url: &str,
         api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
     ) -> Result<AutoDiscoveryAttemptSuccess, AutoDiscoveryAttemptFailure> {
         let api_root_url_success = api_link_header_result?;
@@ -152,16 +151,15 @@ impl WpLoginClient {
                 })
             }
         };
-        let api_root_url =
-            match self.parse_api_root_response(&parsed_site_url, fetch_api_root_url_response) {
-                Ok(api_root_url) => api_root_url,
-                Err(error) => {
-                    return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
-                        parsed_site_url,
-                        error,
-                    })
-                }
-            };
+        let api_root_url = match self.parse_api_root_response(fetch_api_root_url_response) {
+            Ok(api_root_url) => api_root_url,
+            Err(error) => {
+                return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
+                    parsed_site_url,
+                    error,
+                })
+            }
+        };
         Ok(FindApiRootLinkHeaderSuccess {
             parsed_site_url,
             api_root_url,
@@ -170,7 +168,6 @@ impl WpLoginClient {
 
     fn parse_api_root_response(
         &self,
-        site_url: &ParsedUrl,
         response: WpNetworkResponse,
     ) -> Result<ParsedUrl, ParseApiRootUrlError> {
         match response
@@ -259,7 +256,7 @@ impl WpLoginClient {
         let root_wp_json = match serde_json::from_slice::<RootWpJson>(&fetch_wp_json_response.body)
         {
             Ok(r) => r,
-            Err(error) => return Err(FetchWpJsonFailure::ParseWpJson { wp_json_url }),
+            Err(_) => return Err(FetchWpJsonFailure::ParseWpJson { wp_json_url }),
         };
         Ok(FetchWpJsonSuccess {
             wp_json_url,

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -4,8 +4,6 @@ use scraper::{Html, Selector};
 use serde::Deserialize;
 use std::{collections::HashMap, sync::Arc};
 
-const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct AutoDiscoveryAttempt {
     pub(crate) attempt_site_url: String,
@@ -464,12 +462,6 @@ pub enum AutoDiscoveryAttemptType {
     UserInput,
     AutoHttps,
     AutoDotPhpExtensionForWpAdmin,
-}
-
-impl AutoDiscoveryAttemptType {
-    fn is_the_site_url_same_as_the_user_input(&self) -> bool {
-        matches!(self, AutoDiscoveryAttemptType::UserInput)
-    }
 }
 
 pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAttempt> {

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -133,21 +133,21 @@ impl AutoDiscoveryAttemptResult {
 
     fn has_failed_to_parse_site_url(&self) -> bool {
         match &self.api_discovery_result {
-            Ok(success) => false,
+            Ok(_success) => false,
             Err(error) => error.parsed_site_url().is_none(),
         }
     }
 
     fn has_failed_to_parse_api_root_url(&self) -> Option<bool> {
         match &self.api_discovery_result {
-            Ok(success) => Some(false),
+            Ok(_success) => Some(false),
             Err(error) => error.has_failed_to_parse_api_root_url(),
         }
     }
 
     fn has_failed_to_parse_api_details(&self) -> Option<bool> {
         match &self.api_discovery_result {
-            Ok(success) => Some(false),
+            Ok(_success) => Some(false),
             Err(error) => error.has_failed_to_parse_api_details(),
         }
     }
@@ -406,8 +406,8 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
             AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::FetchApiDetails { api_root_url, .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(false),
+            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(false),
         }
     }
 
@@ -431,8 +431,8 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
             AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiDetails { api_root_url, .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(true),
+            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
+            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(true),
         }
     }
 }

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -1,20 +1,15 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
-
-use endpoint::{media_endpoint::MediaUploadRequest, ApiEndpointUrl};
-use http::{HeaderMap, HeaderName, HeaderValue};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use url::Url;
-use uuid::Uuid;
-
+use self::endpoint::WpEndpointUrl;
 use crate::{
-    api_error::{
-        MediaUploadRequestExecutionError, ParsedRequestError, RequestExecutionError, WpError,
-    },
+    api_error::{MediaUploadRequestExecutionError, ParsedRequestError, RequestExecutionError},
     url_query::{FromUrlQueryPairs, UrlQueryPairsMap},
     WpApiError, WpAuthentication,
 };
-
-use self::endpoint::WpEndpointUrl;
+use endpoint::{media_endpoint::MediaUploadRequest, ApiEndpointUrl};
+use http::{HeaderMap, HeaderName, HeaderValue};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use url::Url;
+use uuid::Uuid;
 
 pub mod endpoint;
 
@@ -421,31 +416,6 @@ impl WpNetworkResponse {
     {
         parser(self)
     }
-
-    fn parse_response_for_errors(&self) -> Result<(), WpApiError> {
-        if let Ok(wp_error) = serde_json::from_slice::<WpError>(&self.body) {
-            Err(WpApiError::WpError {
-                error_code: wp_error.code,
-                error_message: wp_error.message,
-                status_code: self.status_code,
-                response: self.body_as_string(),
-            })
-        } else {
-            let status = http::StatusCode::from_u16(self.status_code).map_err(|_| {
-                WpApiError::InvalidHttpStatusCode {
-                    status_code: self.status_code,
-                }
-            })?;
-            if status.is_client_error() || status.is_server_error() {
-                Err(WpApiError::UnknownError {
-                    status_code: self.status_code,
-                    response: self.body_as_string(),
-                })
-            } else {
-                Ok(())
-            }
-        }
-    }
 }
 
 impl Debug for WpNetworkResponse {
@@ -487,7 +457,7 @@ pub struct WpRedirect {
 }
 
 impl WpRedirect {
-    fn new(source: String, destination: String) -> Self {
+    pub fn new(source: String, destination: String) -> Self {
         WpRedirect {
             source,
             destination,

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -1,7 +1,5 @@
 use url::Url;
 
-use crate::SparseField;
-
 pub mod application_passwords_endpoint;
 pub mod categories_endpoint;
 pub mod comments_endpoint;
@@ -38,10 +36,6 @@ pub struct ApiEndpointUrl {
 impl ApiEndpointUrl {
     pub fn new(url: Url) -> Self {
         Self { url }
-    }
-
-    fn url(&self) -> &Url {
-        &self.url
     }
 
     pub fn as_str(&self) -> &str {
@@ -88,13 +82,6 @@ impl ApiBaseUrl {
         site_base_url.try_into()
     }
 
-    fn by_appending(&self, segment: &str) -> Url {
-        self.url
-            .clone()
-            .append(segment)
-            .expect("ApiBaseUrl is already parsed, so this can't result in an error")
-    }
-
     pub fn by_extending_and_splitting_by_forward_slash<I>(&self, segments: I) -> Url
     where
         I: IntoIterator,
@@ -113,26 +100,16 @@ impl ApiBaseUrl {
             }))
             .expect("ApiBaseUrl is already parsed, so this can't result in an error")
     }
-
-    fn as_str(&self) -> &str {
-        self.url.as_str()
-    }
 }
 
 trait UrlExtension {
-    fn append(self, segment: &str) -> Result<Url, ()>;
     fn extend<I>(self, segments: I) -> Result<Url, ()>
     where
         I: IntoIterator,
         I::Item: AsRef<str>;
-    fn append_filter_fields(self, fields: &[impl SparseField]) -> Url;
 }
 
 impl UrlExtension for Url {
-    fn append(self, segment: &str) -> Result<Url, ()> {
-        self.extend([segment])
-    }
-
     fn extend<I>(mut self, segments: I) -> Result<Url, ()>
     where
         I: IntoIterator,
@@ -147,19 +124,6 @@ impl UrlExtension for Url {
 
         self.path_segments_mut()?.extend(segments);
         Ok(self)
-    }
-
-    fn append_filter_fields(mut self, fields: &[impl SparseField]) -> Url {
-        self.query_pairs_mut().append_pair(
-            "_fields",
-            fields
-                .iter()
-                .map(|f| f.as_str())
-                .collect::<Vec<&str>>()
-                .join(",")
-                .as_str(),
-        );
-        self
     }
 }
 
@@ -216,19 +180,9 @@ mod macros {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use rstest::*;
-
-    #[test]
-    fn append_url() {
-        let url = Url::parse("https://example.com").unwrap();
-        assert_eq!(
-            url.append("bar").unwrap().as_str(),
-            "https://example.com/bar"
-        );
-    }
+    use std::sync::Arc;
 
     #[test]
     fn extend_url() {
@@ -257,11 +211,6 @@ mod tests {
     ) {
         let api_base_url: ApiBaseUrl = test_base_url.try_into().unwrap();
         let expected_wp_json_url = wp_json_endpoint(test_base_url);
-        assert_eq!(expected_wp_json_url, api_base_url.as_str());
-        assert_eq!(
-            api_base_url.by_appending("bar").as_str(),
-            format!("{}/bar", expected_wp_json_url)
-        );
         assert_eq!(
             api_base_url
                 .by_extending_and_splitting_by_forward_slash(["bar", "baz"])
@@ -292,10 +241,6 @@ mod tests {
         url
     }
 
-    fn wp_json_endpoint_by_appending(base_url: &str, suffix: &str) -> String {
-        format!("{}{}", wp_json_endpoint(base_url), suffix)
-    }
-
     #[fixture]
     pub fn fixture_api_base_url() -> Arc<ApiBaseUrl> {
         ApiBaseUrl::try_from("https://example.com").unwrap().into()
@@ -314,7 +259,7 @@ mod tests {
             endpoint_url.as_str(),
             format!(
                 "{}{}{}",
-                fixture_api_base_url().as_str(),
+                fixture_api_base_url().url.as_str(),
                 namespace.as_str(),
                 path
             )

--- a/wp_api/src/request/endpoint/categories_endpoint.rs
+++ b/wp_api/src/request/endpoint/categories_endpoint.rs
@@ -204,12 +204,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, &[], "/categories/54?context=view&_fields=")]
-    #[case(Some("foo"), &[SparseCategoryFieldWithViewContext::Count], "/categories/54?context=view&_fields=count")]
-    #[case(Some("foo"), ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT, &format!("/categories/54?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT))]
+    #[case(&[], "/categories/54?context=view&_fields=")]
+    #[case(&[SparseCategoryFieldWithViewContext::Count], "/categories/54?context=view&_fields=count")]
+    #[case(ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT, &format!("/categories/54?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_CATEGORY_FIELDS_WITH_VIEW_CONTEXT))]
     fn filter_retrieve_category_with_view_context(
         endpoint: CategoriesRequestEndpoint,
-        #[case] password: Option<&str>,
         #[case] fields: &[SparseCategoryFieldWithViewContext],
         #[case] expected_path: &str,
     ) {

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -187,7 +187,6 @@ impl MediaRequestBuilder {
         file_path: String,
         file_content_type: String,
     ) -> MediaUploadRequest {
-        let url = self.endpoint.create();
         let mut header_map = self.inner.header_map();
         header_map.inner.insert(
             http::header::CONTENT_TYPE,

--- a/wp_api/src/request/endpoint/tags_endpoint.rs
+++ b/wp_api/src/request/endpoint/tags_endpoint.rs
@@ -193,12 +193,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, &[], "/tags/54?context=view&_fields=")]
-    #[case(Some("foo"), &[SparseTagFieldWithViewContext::Count], "/tags/54?context=view&_fields=count")]
-    #[case(Some("foo"), ALL_SPARSE_TAG_FIELDS_WITH_VIEW_CONTEXT, &format!("/tags/54?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_TAG_FIELDS_WITH_VIEW_CONTEXT))]
+    #[case(&[], "/tags/54?context=view&_fields=")]
+    #[case(&[SparseTagFieldWithViewContext::Count], "/tags/54?context=view&_fields=count")]
+    #[case(ALL_SPARSE_TAG_FIELDS_WITH_VIEW_CONTEXT, &format!("/tags/54?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_TAG_FIELDS_WITH_VIEW_CONTEXT))]
     fn filter_retrieve_tag_with_view_context(
         endpoint: TagsRequestEndpoint,
-        #[case] password: Option<&str>,
         #[case] fields: &[SparseTagFieldWithViewContext],
         #[case] expected_path: &str,
     ) {

--- a/wp_api/src/ssl.rs
+++ b/wp_api/src/ssl.rs
@@ -33,7 +33,7 @@ fn extract_data_as_string(data: x509_cert::der::Result<Option<impl AsRef<str>>>)
 }
 
 fn extract_alternative_names(cert: &x509_cert::certificate::TbsCertificateInner) -> Vec<String> {
-    let Ok(Some((critical, alternative_names))) = cert.get_extension::<SubjectAltName>() else {
+    let Ok(Some((_critical, alternative_names))) = cert.get_extension::<SubjectAltName>() else {
         return vec![];
     };
     alternative_names

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -146,7 +146,7 @@ where
 }
 
 impl FromUrlQueryPairs for () {
-    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+    fn from_url_query_pairs(_query_pairs: UrlQueryPairsMap) -> Option<Self> {
         None
     }
 

--- a/wp_api/src/wordpress_org/plugin_directory.rs
+++ b/wp_api/src/wordpress_org/plugin_directory.rs
@@ -1,10 +1,6 @@
-#![allow(dead_code)]
-
-use serde::Deserialize;
-
-use std::{collections::HashMap, fmt::Debug};
-
 use super::de::deserialize_default_values;
+use serde::Deserialize;
+use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Deserialize, Debug, uniffi::Record)]
 pub struct PluginInformation {


### PR DESCRIPTION
The clippy warnings for `dead_code` and `unused_variables` were disabled back when this project was a prototype and somehow it survived until now. This PR re-enables these warnings and addresses the warnings.