### PR TITLE
Retrieve `/templates` endpoint

### DIFF
--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -1,7 +1,7 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::templates::{
     SparseTemplateFieldWithEditContext, SparseTemplateFieldWithEmbedContext,
-    SparseTemplateFieldWithViewContext,
+    SparseTemplateFieldWithViewContext, TemplateId,
 };
 use crate::SparseField;
 use wp_derive_request_builder::WpDerivedRequest;
@@ -10,6 +10,8 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum TemplatesRequest {
     #[contextual_get(url = "/templates", params = &crate::templates::TemplateListParams, output = Vec<crate::templates::SparseTemplate>, filter_by = crate::templates::SparseTemplateField)]
     List,
+    #[contextual_get(url = "/templates/<template_id>", output = crate::templates::SparseTemplate, filter_by = crate::templates::SparseTemplateField)]
+    Retrieve,
 }
 
 impl DerivedRequest for TemplatesRequest {
@@ -45,5 +47,156 @@ impl SparseField for SparseTemplateFieldWithViewContext {
             Self::PostId => "wp_id",
             _ => self.as_field_name(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate,
+        post_types::PostType,
+        posts::PostId,
+        request::endpoint::{
+            tests::{fixture_api_base_url, validate_wp_v2_endpoint},
+            ApiBaseUrl,
+        },
+        templates::{TemplateArea, TemplateListParams},
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[case(TemplateListParams::default(), "")]
+    #[case(generate!(TemplateListParams, (post_id, Some(PostId(2)))), "wp_id=2")]
+    #[case(generate!(TemplateListParams, (area, Some(TemplateArea::Header))), "area=header")]
+    #[case(generate!(TemplateListParams, (area, Some(TemplateArea::Footer))), "area=footer")]
+    #[case(generate!(TemplateListParams, (area, Some(TemplateArea::Uncategorized))), "area=uncategorized")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::Post))), "post_type=post")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::Page))), "post_type=page")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::Attachment))), "post_type=attachment")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::NavMenuItem))), "post_type=nav_menu_item")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpBlock))), "post_type=wp_block")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpTemplate))), "post_type=wp_template")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpTemplatePart))), "post_type=wp_template_part")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpNavigation))), "post_type=wp_navigation")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpFontFamily))), "post_type=wp_font_family")]
+    #[case(generate!(TemplateListParams, (post_type, Some(PostType::WpFontFace))), "post_type=wp_font_face")]
+    #[case(
+        template_list_params_with_all_fields(),
+        EXPECTED_QUERY_PAIRS_FOR_TEMPLATE_LIST_PARAMS_WITH_ALL_FIELDS
+    )]
+    fn list_templates(
+        endpoint: TemplatesRequestEndpoint,
+        #[case] params: TemplateListParams,
+        #[case] expected_additional_params: &str,
+    ) {
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/templates?context={}", context)
+            } else {
+                format!(
+                    "/templates?context={}&{}",
+                    context, expected_additional_params
+                )
+            }
+        };
+        validate_wp_v2_endpoint(
+            endpoint.list_with_edit_context(&params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(&params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(&params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(TemplateListParams::default(), &[], "/templates?context=view&_fields=")]
+    #[case(generate!(TemplateListParams, (area, Some(TemplateArea::Footer))), &[SparseTemplateFieldWithViewContext::Author], "/templates?context=view&area=footer&_fields=author")]
+    #[case(template_list_params_with_all_fields(), ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT, &format!("/templates?context=view&{}&{}", EXPECTED_QUERY_PAIRS_FOR_TEMPLATE_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_list_template_with_view_context(
+        endpoint: TemplatesRequestEndpoint,
+        #[case] params: TemplateListParams,
+        #[case] fields: &[SparseTemplateFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_view_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    fn retrieve_template(endpoint: TemplatesRequestEndpoint) {
+        let template_id = TemplateId("foo".to_string());
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(&template_id),
+            "/templates/foo?context=edit",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(&template_id),
+            "/templates/foo?context=embed",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(&template_id),
+            "/templates/foo?context=view",
+        );
+    }
+
+    #[rstest]
+    #[case(&[], "/templates/foo?context=view&_fields=")]
+    #[case(&[SparseTemplateFieldWithViewContext::Slug], "/templates/foo?context=view&_fields=slug")]
+    #[case(ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT, &format!("/templates/foo?context=view&{}", EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT))]
+    fn filter_retrieve_template_with_view_context(
+        endpoint: TemplatesRequestEndpoint,
+        #[case] fields: &[SparseTemplateFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_view_context(&TemplateId("foo".to_string()), fields),
+            expected_path,
+        );
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_TEMPLATE_LIST_PARAMS_WITH_ALL_FIELDS: &str =
+        "wp_id=2&area=header&post_type=page";
+    fn template_list_params_with_all_fields() -> TemplateListParams {
+        TemplateListParams {
+            post_id: Some(PostId(2)),
+            area: Some(TemplateArea::Header),
+            post_type: Some(PostType::Page),
+        }
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT: &str = "_fields=id%2Cslug%2Ctheme%2Ctype%2Csource%2Corigin%2Ccontent%2Ctitle%2Cdescription%2Cstatus%2Cwp_id%2Chas_theme_file%2Cauthor%2Cmodified%2Cis_custom%2Cauthor_text%2Coriginal_source";
+    const ALL_SPARSE_TEMPLATE_FIELDS_WITH_VIEW_CONTEXT: &[SparseTemplateFieldWithViewContext; 17] =
+        &[
+            SparseTemplateFieldWithViewContext::Id,
+            SparseTemplateFieldWithViewContext::Slug,
+            SparseTemplateFieldWithViewContext::Theme,
+            SparseTemplateFieldWithViewContext::TemplateType,
+            SparseTemplateFieldWithViewContext::Source,
+            SparseTemplateFieldWithViewContext::Origin,
+            SparseTemplateFieldWithViewContext::Content,
+            SparseTemplateFieldWithViewContext::Title,
+            SparseTemplateFieldWithViewContext::Description,
+            SparseTemplateFieldWithViewContext::Status,
+            SparseTemplateFieldWithViewContext::PostId,
+            SparseTemplateFieldWithViewContext::HasThemeFile,
+            SparseTemplateFieldWithViewContext::Author,
+            SparseTemplateFieldWithViewContext::Modified,
+            SparseTemplateFieldWithViewContext::IsCustom,
+            SparseTemplateFieldWithViewContext::AuthorText,
+            SparseTemplateFieldWithViewContext::OriginalSource,
+        ];
+
+    #[fixture]
+    fn endpoint(fixture_api_base_url: Arc<ApiBaseUrl>) -> TemplatesRequestEndpoint {
+        TemplatesRequestEndpoint::new(fixture_api_base_url)
     }
 }

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -8,8 +8,19 @@ use crate::{
     UserId,
 };
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+
+uniffi::custom_newtype!(TemplateId, String);
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemplateId(pub String);
+
+impl Display for TemplateId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(
     Debug,
@@ -121,7 +132,7 @@ impl FromUrlQueryPairs for TemplateListParams {
 #[derive(Debug, Serialize, Deserialize, WpContextual)]
 pub struct SparseTemplate {
     #[WpContext(edit, embed, view)]
-    pub id: Option<String>,
+    pub id: Option<TemplateId>,
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit, embed, view)]

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -67,6 +67,7 @@ pub const CATEGORY_ID_59: CategoryId = CategoryId(59);
 pub const CATEGORY_ID_INVALID: CategoryId = CategoryId(99999999);
 pub const TAG_ID_100: TagId = TagId(100);
 pub const TAG_ID_INVALID: TagId = TagId(99999999);
+pub const TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE: &str = "twentytwentyfour//single";
 pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";

--- a/wp_api_integration_tests/tests/test_templates_immut.rs
+++ b/wp_api_integration_tests/tests/test_templates_immut.rs
@@ -5,10 +5,11 @@ use wp_api::generate;
 use wp_api::post_types::PostType;
 use wp_api::templates::{
     SparseTemplateFieldWithEditContext, SparseTemplateFieldWithEmbedContext,
-    SparseTemplateFieldWithViewContext, TemplateArea, TemplateListParams,
+    SparseTemplateFieldWithViewContext, TemplateArea, TemplateId, TemplateListParams,
 };
 use wp_api_integration_tests::{
     api_client, AssertResponse, FIRST_POST_ID, POST_ID_555, POST_ID_DRAFT,
+    TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE,
 };
 
 #[tokio::test]
@@ -42,6 +43,49 @@ async fn list_with_view_context(#[case] params: TemplateListParams) {
         .list_with_view_context(&params)
         .await
         .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    let template_id = template_id_for_retrieve_tests();
+    let template = api_client()
+        .templates()
+        .retrieve_with_edit_context(&TemplateId(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE.to_string()))
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(template_id, template.id);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    let template_id = template_id_for_retrieve_tests();
+    let template = api_client()
+        .templates()
+        .retrieve_with_embed_context(&TemplateId(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE.to_string()))
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(template_id, template.id);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    let template_id = template_id_for_retrieve_tests();
+    let template = api_client()
+        .templates()
+        .retrieve_with_view_context(&template_id)
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(template_id, template.id);
+}
+
+fn template_id_for_retrieve_tests() -> TemplateId {
+    TemplateId(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE.to_string())
 }
 
 #[template]
@@ -99,6 +143,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_template_field_with_edit_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithEditContext::Slug, SparseTemplateFieldWithEditContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_edit_context(
+        #[case] fields: &[SparseTemplateFieldWithEditContext],
+    ) {
+        let template = api_client()
+            .templates()
+            .filter_retrieve_with_edit_context(&template_id_for_retrieve_tests(), fields)
+            .await
+            .assert_response()
+            .data;
+        template.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_template_field_with_embed_context_test_cases)]
     #[case(&[SparseTemplateFieldWithEmbedContext::Slug, SparseTemplateFieldWithEmbedContext::Theme])]
     #[tokio::test]
@@ -126,6 +186,22 @@ mod filter {
             });
     }
 
+    #[apply(sparse_template_field_with_embed_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithEmbedContext::Slug, SparseTemplateFieldWithEmbedContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_embed_context(
+        #[case] fields: &[SparseTemplateFieldWithEmbedContext],
+    ) {
+        let template = api_client()
+            .templates()
+            .filter_retrieve_with_embed_context(&template_id_for_retrieve_tests(), fields)
+            .await
+            .assert_response()
+            .data;
+        template.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
     #[apply(sparse_template_field_with_view_context_test_cases)]
     #[case(&[SparseTemplateFieldWithViewContext::Slug, SparseTemplateFieldWithViewContext::Theme])]
     #[tokio::test]
@@ -151,5 +227,21 @@ mod filter {
             .for_each(|template| {
                 template.assert_that_instance_fields_nullability_match_provided_fields(fields)
             });
+    }
+
+    #[apply(sparse_template_field_with_view_context_test_cases)]
+    #[case(&[SparseTemplateFieldWithViewContext::Slug, SparseTemplateFieldWithViewContext::Theme])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_view_context(
+        #[case] fields: &[SparseTemplateFieldWithViewContext],
+    ) {
+        let template = api_client()
+            .templates()
+            .filter_retrieve_with_view_context(&template_id_for_retrieve_tests(), fields)
+            .await
+            .assert_response()
+            .data;
+        template.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
 }


### PR DESCRIPTION
Follows established patterns to implement [retrieve `/templates` endpoint.](https://developer.wordpress.org/rest-api/reference/wp_templates/#retrieve-a-template-2)