### PR TITLE
Add Swift Docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,6 +72,17 @@ steps:
           - native/swift/Sources/wordpress-api-wrapper/wp_api.swift
         agents:
           queue: mac
+      - label: ":swift: Build Docs"
+        command: |
+          .buildkite/download-xcframework.sh
+
+          echo "--- :swift: Building Documentation"
+          make swift-docs-only
+        agents:
+          queue: mac
+        depends_on: xcframework
+        artifact_paths:
+          - swift-docs.tar.gz
       - label: ":swift: :darwin: Build + Test on Simulators"
         command: .buildkite/swift-test.sh run_tests
         depends_on: xcframework

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ xcuserdata
 DerivedData
 fastlane/report.xml
 libwordPressFFI.xcframework*
+/swift-docs.tar.gz
+
 
 # Auto-generated Swift Files
 native/swift/Sources/wordpress-api-wrapper/*.swift

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,16 @@ docs:
 
 docs-archive: docs
 	@# Help: Archive the generated project documentation.
-	tar -czvf  docs.tar.gz docs
+	tar -czvf docs.tar.gz docs
+
+swift-docs: xcframework swift-docs-only
+	@# Help: Generate Xcode documentation.
+
+swift-docs-only:
+	mkdir -p docs/Swift
+	swift package --allow-writing-to-directory docs generate-documentation --target WordPressAPI --output-path docs/Swift/WordPressAPI.doccarchive --disable-indexing
+	swift package --allow-writing-to-directory docs generate-documentation --target WordPressAPIInternal --output-path docs/Swift/WordPressAPIInternal.doccarchive --disable-indexing
+	tar -czf swift-docs.tar.gz docs
 
 release-on-ci:
 	@[ -n "$(BUILDKITE_API_TOKEN)" ] || (echo "BUILDKITE_API_TOKEN is not set" && exit 1)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f97c4d6141e489daa1b3e5f1731aa4f6ea41d76057f9b254fb8e555c3e14de7b",
+  "originHash" : "46dc21ea3184e3040d4318041cb9f0ef3ef5fa28bb87a240b2d907b88b59ffd4",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -35,6 +35,24 @@
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,9 @@ var package = Package(
             targets: ["WordPressAPI"]
         )
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ],
     targets: [
         .target(
             name: "WordPressAPI",


### PR DESCRIPTION
Adds auto-documentation support for Swift.

Builds the docs and uploads them to Buildkite for each build.

Later, we'll push this somewhere interesting.

To Test:
- Ensure CI passes