### PR TITLE
Add missing `API_ROOT_LINK_HEADER` to `url_discovery` mod

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -4,7 +4,7 @@ use super::{
         AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
         FetchWpJsonFailure, FetchWpJsonSuccess, FindApiRootLinkHeaderFailure,
         FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult, IsWordPressSiteParseHtmlResult,
-        ParseApiRootUrlError, ParseHtmlFailure,
+        ParseApiRootUrlError, ParseHtmlFailure, API_ROOT_LINK_HEADER,
     },
     WpApiDetails,
 };
@@ -18,8 +18,6 @@ use crate::{
 };
 use std::{str, sync::Arc};
 use uuid::Uuid;
-
-const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
 
 #[derive(Debug, uniffi::Object)]
 struct UniffiWpLoginClient {

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -4,6 +4,8 @@ use scraper::{Html, Selector};
 use serde::Deserialize;
 use std::{collections::HashMap, sync::Arc};
 
+pub(crate) const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct AutoDiscoveryAttempt {
     pub(crate) attempt_site_url: String,


### PR DESCRIPTION
This was caused by merging https://github.com/Automattic/wordpress-rs/pull/538 without rebasing after https://github.com/Automattic/wordpress-rs/pull/542 was merged.