### PR TITLE
Add `https` auto discovery attempt for `http` urls

### DIFF
--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -19,6 +19,28 @@ impl AutoDiscoveryAttempt {
             attempt_type,
         }
     }
+
+    fn user_input(attempt_site_url: impl Into<String>) -> Self {
+        Self::new(attempt_site_url, AutoDiscoveryAttemptType::UserInput)
+    }
+
+    fn auto_https(attempt_site_url: impl Into<String>) -> Self {
+        Self::new(attempt_site_url, AutoDiscoveryAttemptType::AutoHttps)
+    }
+
+    fn auto_remove_wp_admin_suffix(attempt_site_url: impl Into<String>) -> Self {
+        Self::new(
+            attempt_site_url,
+            AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
+        )
+    }
+
+    fn auto_remove_wp_login_suffix(attempt_site_url: impl Into<String>) -> Self {
+        Self::new(
+            attempt_site_url,
+            AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix,
+        )
+    }
 }
 
 #[derive(Debug, uniffi::Record)]
@@ -482,35 +504,31 @@ pub enum AutoDiscoveryAttemptType {
 }
 
 pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAttempt> {
-    let mut attempts = vec![AutoDiscoveryAttempt::new(
-        input_site_url.clone(),
-        AutoDiscoveryAttemptType::UserInput,
-    )];
+    let mut attempts = vec![AutoDiscoveryAttempt::user_input(input_site_url.clone())];
     if !input_site_url.starts_with("http") {
-        attempts.push(AutoDiscoveryAttempt::new(
-            format!("https://{}", input_site_url),
-            AutoDiscoveryAttemptType::AutoHttps,
-        ))
+        attempts.push(AutoDiscoveryAttempt::auto_https(format!(
+            "https://{}",
+            input_site_url
+        )));
+    } else if !input_site_url.starts_with("https") {
+        // Url starts with `http`, but not `https`
+        attempts.push(AutoDiscoveryAttempt::auto_https(
+            input_site_url.replacen("http", "https", 1),
+        ));
     }
     if let Some(a) = input_site_url
         .strip_suffix("wp-admin")
         .or_else(|| input_site_url.strip_suffix("wp-admin/"))
         .or_else(|| input_site_url.strip_suffix("wp-admin.php"))
     {
-        attempts.push(AutoDiscoveryAttempt::new(
-            a,
-            AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
-        ))
+        attempts.push(AutoDiscoveryAttempt::auto_remove_wp_admin_suffix(a));
     }
     if let Some(a) = input_site_url
         .strip_suffix("wp-login")
         .or_else(|| input_site_url.strip_suffix("wp-login/"))
         .or_else(|| input_site_url.strip_suffix("wp-login.php"))
     {
-        attempts.push(AutoDiscoveryAttempt::new(
-            a,
-            AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix,
-        ))
+        attempts.push(AutoDiscoveryAttempt::auto_remove_wp_login_suffix(a));
     }
     attempts
 }
@@ -545,36 +563,33 @@ pub enum FetchApiDetailsError {
 
 #[cfg(test)]
 mod tests {
+    use super::AutoDiscoveryAttempt as A;
     use super::*;
     use rstest::*;
 
     #[rstest]
-    #[case("localhost", vec![AutoDiscoveryAttempt::new("localhost", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("https://localhost", AutoDiscoveryAttemptType::AutoHttps)])]
-    #[case("http://localhost", vec![AutoDiscoveryAttempt::new("http://localhost", AutoDiscoveryAttemptType::UserInput)])]
-    #[case("http://localhost/wp-json", vec![AutoDiscoveryAttempt::new("http://localhost/wp-json", AutoDiscoveryAttemptType::UserInput)])]
-    #[case("http://localhost/wp-admin.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin.php", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
-    #[case("http://localhost/wp-admin", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
-    #[case("http://localhost/wp-admin/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-admin/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix)])]
-    #[case("http://localhost/wp-login.php", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login.php", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
-    #[case("http://localhost/wp-login", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
-    #[case("http://localhost/wp-login/", vec![AutoDiscoveryAttempt::new("http://localhost/wp-login/", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("http://localhost/", AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix)])]
-    #[case("orchestremetropolitain.com/wp-json", vec![AutoDiscoveryAttempt::new("orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::UserInput), AutoDiscoveryAttempt::new("https://orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::AutoHttps)])]
-    #[case("https://orchestremetropolitain.com", vec![AutoDiscoveryAttempt::new("https://orchestremetropolitain.com", AutoDiscoveryAttemptType::UserInput)])]
-    #[case(
-        "https://orchestremetropolitain.com/fr/",
-        vec![AutoDiscoveryAttempt::new("https://orchestremetropolitain.com/fr/", AutoDiscoveryAttemptType::UserInput)]
-    )]
-    #[case(
-        "https://orchestremetropolitain.com/wp-json",
-        vec![AutoDiscoveryAttempt::new("https://orchestremetropolitain.com/wp-json", AutoDiscoveryAttemptType::UserInput)]
+    #[case::localhost("localhost", vec![A::user_input("localhost"), A::auto_https("https://localhost")])]
+    #[case::http_localhost("http://localhost", vec![A::user_input("http://localhost"), A::auto_https("https://localhost")])]
+    #[case::http_localhost_wp_json("http://localhost/wp-json", vec![A::user_input("http://localhost/wp-json"), A::auto_https("https://localhost/wp-json")])]
+    #[case::http_localhost_wp_admin_php("http://localhost/wp-admin.php", vec![A::user_input("http://localhost/wp-admin.php"), A::auto_https("https://localhost/wp-admin.php"), A::auto_remove_wp_admin_suffix("http://localhost/")])]
+    #[case::http_localhost_wp_admin("http://localhost/wp-admin", vec![A::user_input("http://localhost/wp-admin"), A::auto_https("https://localhost/wp-admin") ,A::auto_remove_wp_admin_suffix("http://localhost/")])]
+    #[case::http_localhost_wp_admin_slash("http://localhost/wp-admin/", vec![A::user_input("http://localhost/wp-admin/"), A::auto_https("https://localhost/wp-admin/"), A::auto_remove_wp_admin_suffix("http://localhost/")])]
+    #[case::http_localhost_wp_login_php("http://localhost/wp-login.php", vec![A::user_input("http://localhost/wp-login.php"), A::auto_https("https://localhost/wp-login.php"), A::auto_remove_wp_login_suffix("http://localhost/")])]
+    #[case::http_localhost_wp_login("http://localhost/wp-login", vec![A::user_input("http://localhost/wp-login"), A::auto_https("https://localhost/wp-login"), A::auto_remove_wp_login_suffix("http://localhost/")])]
+    #[case::http_localhost_wp_login_slash("http://localhost/wp-login/", vec![A::user_input("http://localhost/wp-login/"), A::auto_https("https://localhost/wp-login/"), A::auto_remove_wp_login_suffix("http://localhost/")])]
+    #[case::automatticwidgets_wp_json("automatticwidgets.wpcomstaging.com/wp-json", vec![A::user_input("automatticwidgets.wpcomstaging.com/wp-json"), A::auto_https("https://automatticwidgets.wpcomstaging.com/wp-json")])]
+    #[case::automatticwidgets_https("https://automatticwidgets.wpcomstaging.com", vec![A::user_input("https://automatticwidgets.wpcomstaging.com")])]
+    #[case::automatticwidgets_https_wp_json(
+        "https://automatticwidgets.wpcomstaging.com/wp-json",
+        vec![A::user_input("https://automatticwidgets.wpcomstaging.com/wp-json")]
     )]
     fn test_construct_attempts(
         #[case] input_site_url: &str,
-        #[case] mut expected_attempts: Vec<AutoDiscoveryAttempt>,
+        #[case] expected_attempts: Vec<AutoDiscoveryAttempt>,
     ) {
-        let mut found_attempts = construct_attempts(input_site_url.to_string());
-        found_attempts.sort();
-        expected_attempts.sort();
-        assert_eq!(found_attempts, expected_attempts)
+        assert_eq!(
+            construct_attempts(input_site_url.to_string()),
+            expected_attempts
+        )
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -20,22 +20,22 @@ impl AutoDiscoveryAttempt {
         }
     }
 
-    fn user_input(attempt_site_url: impl Into<String>) -> Self {
+    fn with_user_input_attempt_type(attempt_site_url: impl Into<String>) -> Self {
         Self::new(attempt_site_url, AutoDiscoveryAttemptType::UserInput)
     }
 
-    fn auto_https(attempt_site_url: impl Into<String>) -> Self {
+    fn with_auto_https_attempt_type(attempt_site_url: impl Into<String>) -> Self {
         Self::new(attempt_site_url, AutoDiscoveryAttemptType::AutoHttps)
     }
 
-    fn auto_remove_wp_admin_suffix(attempt_site_url: impl Into<String>) -> Self {
+    fn with_auto_remove_wp_admin_suffix_attempt_type(attempt_site_url: impl Into<String>) -> Self {
         Self::new(
             attempt_site_url,
             AutoDiscoveryAttemptType::AutoRemoveWpAdminSuffix,
         )
     }
 
-    fn auto_remove_wp_login_suffix(attempt_site_url: impl Into<String>) -> Self {
+    fn with_auto_remove_wp_login_suffix_attempt_type(attempt_site_url: impl Into<String>) -> Self {
         Self::new(
             attempt_site_url,
             AutoDiscoveryAttemptType::AutoRemoveWpLoginSuffix,
@@ -504,15 +504,17 @@ pub enum AutoDiscoveryAttemptType {
 }
 
 pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAttempt> {
-    let mut attempts = vec![AutoDiscoveryAttempt::user_input(input_site_url.clone())];
+    let mut attempts = vec![AutoDiscoveryAttempt::with_user_input_attempt_type(
+        input_site_url.clone(),
+    )];
     if !input_site_url.starts_with("http") {
-        attempts.push(AutoDiscoveryAttempt::auto_https(format!(
+        attempts.push(AutoDiscoveryAttempt::with_auto_https_attempt_type(format!(
             "https://{}",
             input_site_url
         )));
     } else if !input_site_url.starts_with("https") {
         // Url starts with `http`, but not `https`
-        attempts.push(AutoDiscoveryAttempt::auto_https(
+        attempts.push(AutoDiscoveryAttempt::with_auto_https_attempt_type(
             input_site_url.replacen("http", "https", 1),
         ));
     }
@@ -521,14 +523,14 @@ pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAtt
         .or_else(|| input_site_url.strip_suffix("wp-admin/"))
         .or_else(|| input_site_url.strip_suffix("wp-admin.php"))
     {
-        attempts.push(AutoDiscoveryAttempt::auto_remove_wp_admin_suffix(a));
+        attempts.push(AutoDiscoveryAttempt::with_auto_remove_wp_admin_suffix_attempt_type(a));
     }
     if let Some(a) = input_site_url
         .strip_suffix("wp-login")
         .or_else(|| input_site_url.strip_suffix("wp-login/"))
         .or_else(|| input_site_url.strip_suffix("wp-login.php"))
     {
-        attempts.push(AutoDiscoveryAttempt::auto_remove_wp_login_suffix(a));
+        attempts.push(AutoDiscoveryAttempt::with_auto_remove_wp_login_suffix_attempt_type(a));
     }
     attempts
 }
@@ -568,20 +570,20 @@ mod tests {
     use rstest::*;
 
     #[rstest]
-    #[case::localhost("localhost", vec![A::user_input("localhost"), A::auto_https("https://localhost")])]
-    #[case::http_localhost("http://localhost", vec![A::user_input("http://localhost"), A::auto_https("https://localhost")])]
-    #[case::http_localhost_wp_json("http://localhost/wp-json", vec![A::user_input("http://localhost/wp-json"), A::auto_https("https://localhost/wp-json")])]
-    #[case::http_localhost_wp_admin_php("http://localhost/wp-admin.php", vec![A::user_input("http://localhost/wp-admin.php"), A::auto_https("https://localhost/wp-admin.php"), A::auto_remove_wp_admin_suffix("http://localhost/")])]
-    #[case::http_localhost_wp_admin("http://localhost/wp-admin", vec![A::user_input("http://localhost/wp-admin"), A::auto_https("https://localhost/wp-admin") ,A::auto_remove_wp_admin_suffix("http://localhost/")])]
-    #[case::http_localhost_wp_admin_slash("http://localhost/wp-admin/", vec![A::user_input("http://localhost/wp-admin/"), A::auto_https("https://localhost/wp-admin/"), A::auto_remove_wp_admin_suffix("http://localhost/")])]
-    #[case::http_localhost_wp_login_php("http://localhost/wp-login.php", vec![A::user_input("http://localhost/wp-login.php"), A::auto_https("https://localhost/wp-login.php"), A::auto_remove_wp_login_suffix("http://localhost/")])]
-    #[case::http_localhost_wp_login("http://localhost/wp-login", vec![A::user_input("http://localhost/wp-login"), A::auto_https("https://localhost/wp-login"), A::auto_remove_wp_login_suffix("http://localhost/")])]
-    #[case::http_localhost_wp_login_slash("http://localhost/wp-login/", vec![A::user_input("http://localhost/wp-login/"), A::auto_https("https://localhost/wp-login/"), A::auto_remove_wp_login_suffix("http://localhost/")])]
-    #[case::automatticwidgets_wp_json("automatticwidgets.wpcomstaging.com/wp-json", vec![A::user_input("automatticwidgets.wpcomstaging.com/wp-json"), A::auto_https("https://automatticwidgets.wpcomstaging.com/wp-json")])]
-    #[case::automatticwidgets_https("https://automatticwidgets.wpcomstaging.com", vec![A::user_input("https://automatticwidgets.wpcomstaging.com")])]
+    #[case::localhost("localhost", vec![A::with_user_input_attempt_type("localhost"), A::with_auto_https_attempt_type("https://localhost")])]
+    #[case::http_localhost("http://localhost", vec![A::with_user_input_attempt_type("http://localhost"), A::with_auto_https_attempt_type("https://localhost")])]
+    #[case::http_localhost_wp_json("http://localhost/wp-json", vec![A::with_user_input_attempt_type("http://localhost/wp-json"), A::with_auto_https_attempt_type("https://localhost/wp-json")])]
+    #[case::http_localhost_wp_admin_php("http://localhost/wp-admin.php", vec![A::with_user_input_attempt_type("http://localhost/wp-admin.php"), A::with_auto_https_attempt_type("https://localhost/wp-admin.php"), A::with_auto_remove_wp_admin_suffix_attempt_type("http://localhost/")])]
+    #[case::http_localhost_wp_admin("http://localhost/wp-admin", vec![A::with_user_input_attempt_type("http://localhost/wp-admin"), A::with_auto_https_attempt_type("https://localhost/wp-admin") ,A::with_auto_remove_wp_admin_suffix_attempt_type("http://localhost/")])]
+    #[case::http_localhost_wp_admin_slash("http://localhost/wp-admin/", vec![A::with_user_input_attempt_type("http://localhost/wp-admin/"), A::with_auto_https_attempt_type("https://localhost/wp-admin/"), A::with_auto_remove_wp_admin_suffix_attempt_type("http://localhost/")])]
+    #[case::http_localhost_wp_login_php("http://localhost/wp-login.php", vec![A::with_user_input_attempt_type("http://localhost/wp-login.php"), A::with_auto_https_attempt_type("https://localhost/wp-login.php"), A::with_auto_remove_wp_login_suffix_attempt_type("http://localhost/")])]
+    #[case::http_localhost_wp_login("http://localhost/wp-login", vec![A::with_user_input_attempt_type("http://localhost/wp-login"), A::with_auto_https_attempt_type("https://localhost/wp-login"), A::with_auto_remove_wp_login_suffix_attempt_type("http://localhost/")])]
+    #[case::http_localhost_wp_login_slash("http://localhost/wp-login/", vec![A::with_user_input_attempt_type("http://localhost/wp-login/"), A::with_auto_https_attempt_type("https://localhost/wp-login/"), A::with_auto_remove_wp_login_suffix_attempt_type("http://localhost/")])]
+    #[case::automatticwidgets_wp_json("automatticwidgets.wpcomstaging.com/wp-json", vec![A::with_user_input_attempt_type("automatticwidgets.wpcomstaging.com/wp-json"), A::with_auto_https_attempt_type("https://automatticwidgets.wpcomstaging.com/wp-json")])]
+    #[case::automatticwidgets_https("https://automatticwidgets.wpcomstaging.com", vec![A::with_user_input_attempt_type("https://automatticwidgets.wpcomstaging.com")])]
     #[case::automatticwidgets_https_wp_json(
         "https://automatticwidgets.wpcomstaging.com/wp-json",
-        vec![A::user_input("https://automatticwidgets.wpcomstaging.com/wp-json")]
+        vec![A::with_user_input_attempt_type("https://automatticwidgets.wpcomstaging.com/wp-json")]
     )]
     fn test_construct_attempts(
         #[case] input_site_url: &str,

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -7,6 +7,8 @@ use wp_api_integration_tests::AsyncWpNetworking;
 const LOCALHOST_AUTH_URL: &str = "http://localhost/wp-admin/authorize-application.php";
 const AUTOMATTIC_WIDGETS_AUTH_URL: &str =
     "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php";
+const OPTIONAL_HTTPS_SITE_URL: &str =
+    "https://optional-https.wpmt.co/wp-admin/authorize-application.php";
 const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-application.php";
 
 #[rstest]
@@ -38,10 +40,8 @@ const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
 #[case("automatticwidgets.wpcomstaging.com/ ", AUTOMATTIC_WIDGETS_AUTH_URL)]
 #[case("vanilla.wpmt.co", VANILLA_WP_SITE_URL)]
 #[case("http://vanilla.wpmt.co", VANILLA_WP_SITE_URL)]
-#[case(
-    "https://optional-https.wpmt.co",
-    "https://optional-https.wpmt.co/wp-admin/authorize-application.php"
-)]
+#[case("http://optional-https.wpmt.co", OPTIONAL_HTTPS_SITE_URL)]
+#[case("https://optional-https.wpmt.co", OPTIONAL_HTTPS_SITE_URL)]
 #[case(
     "https://わぷー.wpmt.co",
     "https://xn--39j4bws.wpmt.co/wp-admin/authorize-application.php"

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -7,9 +7,9 @@ use wp_api_integration_tests::AsyncWpNetworking;
 const LOCALHOST_AUTH_URL: &str = "http://localhost/wp-admin/authorize-application.php";
 const AUTOMATTIC_WIDGETS_AUTH_URL: &str =
     "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php";
-const OPTIONAL_HTTPS_SITE_URL: &str =
+const OPTIONAL_HTTPS_AUTH_URL: &str =
     "https://optional-https.wpmt.co/wp-admin/authorize-application.php";
-const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-application.php";
+const VANILLA_WP_AUTH_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-application.php";
 
 #[rstest]
 #[case("http://localhost", LOCALHOST_AUTH_URL)]
@@ -38,10 +38,10 @@ const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
     AUTOMATTIC_WIDGETS_AUTH_URL
 )]
 #[case("automatticwidgets.wpcomstaging.com/ ", AUTOMATTIC_WIDGETS_AUTH_URL)]
-#[case("vanilla.wpmt.co", VANILLA_WP_SITE_URL)]
-#[case("http://vanilla.wpmt.co", VANILLA_WP_SITE_URL)]
-#[case("http://optional-https.wpmt.co", OPTIONAL_HTTPS_SITE_URL)]
-#[case("https://optional-https.wpmt.co", OPTIONAL_HTTPS_SITE_URL)]
+#[case("vanilla.wpmt.co", VANILLA_WP_AUTH_URL)]
+#[case("http://vanilla.wpmt.co", VANILLA_WP_AUTH_URL)]
+#[case("http://optional-https.wpmt.co", OPTIONAL_HTTPS_AUTH_URL)]
+#[case("https://optional-https.wpmt.co", OPTIONAL_HTTPS_AUTH_URL)]
 #[case(
     "https://わぷー.wpmt.co",
     "https://xn--39j4bws.wpmt.co/wp-admin/authorize-application.php"
@@ -52,7 +52,7 @@ const VANILLA_WP_SITE_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
 )]
 #[case(
     "http://wordpress-1315525-4803651.cloudwaysapps.com",
-    "https://vanilla.wpmt.co/wp-admin/authorize-application.php"
+    VANILLA_WP_AUTH_URL
 )]
 #[case(
     "https://aggressive-caching.wpmt.co",


### PR DESCRIPTION
If the url starts with `http`, but not `https`, we now add a new `AutoHttps` api discovery attempt type. The PR also adds `http://optional-https.wpmt.co` as a test case, which was resulting in a parsing error before this PR. Finally, the PR adds some helpers to `AutoDiscoveryAttempt` and improves the readability of the unit tests - although it's still quite difficult.