### PR TITLE
Introduce `WpGmtDateTime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -3663,6 +3664,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "chrono",
  "futures",
  "http 1.2.0",
  "indoc",
@@ -3787,6 +3789,7 @@ dependencies = [
 name = "wp_serde_helper"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rstest",
  "serde",
  "serde_json",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/DateConversionTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/DateConversionTest.kt
@@ -1,0 +1,26 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.assertDateIsConvertedFromNativeToRustCorrectly
+import uniffi.wp_api.assertionExampleDateThatCanBeUsedToVerifyConversionBetweenRustAndNative
+import java.text.SimpleDateFormat
+import java.util.Date
+
+// The date has to match the `EXAMPLE_DATE` from `wp_api/src/date.rs`
+private const val EXAMPLE_DATE: String = "2020-08-14T15:00:00+02:00"
+
+class DateConversionTest {
+    @Test
+    fun testDateIsConvertedCorrectlyFromKotlinToRust() = runTest {
+        val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
+        val date: Date = parser.parse(EXAMPLE_DATE)
+        assertDateIsConvertedFromNativeToRustCorrectly(date)
+    }
+
+    @Test
+    fun testDateIsConvertedCorrectlyBetweenKotlinAndRust() = runTest {
+        val dateFromRust = assertionExampleDateThatCanBeUsedToVerifyConversionBetweenRustAndNative()
+        assertDateIsConvertedFromNativeToRustCorrectly(dateFromRust)
+    }
+}

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostsEndpointTest.kt
@@ -8,6 +8,7 @@ import uniffi.wp_api.PostRetrieveParams
 import uniffi.wp_api.SparsePostFieldWithEditContext
 import uniffi.wp_api.WpErrorCode
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class PostsEndpointTest {
@@ -87,5 +88,16 @@ class PostsEndpointTest {
             requestBuilder.posts().listWithEditContext(nextPageResponse.prevPageParams!!)
         }.assertSuccessAndRetrieveData()
         assert(prevPageResponse.data.isNotEmpty())
+    }
+
+    @Test
+    fun ensureDateGmtIsParsedCorrectly() = runTest {
+        val post = client.request { requestBuilder ->
+            requestBuilder.posts().retrieveWithEditContext(1, PostRetrieveParams())
+        }.assertSuccessAndRetrieveData().data
+        assertEquals(
+            testCredentials.firstPostDateGmt,
+            TestCredentials.UTC_DATE_FORMAT.format(post.dateGmt)
+        )
     }
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import uniffi.wp_api.ParsedUrl
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.TimeZone
 
 @Serializable
 data class TestCredentials(
@@ -21,7 +23,9 @@ data class TestCredentials(
     @SerialName("subscriber_password")
     val subscriberPassword: String,
     @SerialName("subscriber_password_uuid")
-    val subscriberPasswordUuid: String
+    val subscriberPasswordUuid: String,
+    @SerialName("first_post_date_gmt")
+    val firstPostDateGmt: String
 ) {
     companion object {
         private val json by lazy {
@@ -31,6 +35,12 @@ data class TestCredentials(
             val file =
                 File(Companion::class.java.classLoader.getResource("test_credentials.json")!!.file)
             json.decodeFromString<TestCredentials>(file.readText())
+        }
+
+        val UTC_DATE_FORMAT by lazy {
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss").apply {
+                this.timeZone = TimeZone.getTimeZone("UTC")
+            }
         }
     }
 

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -90,6 +90,7 @@ create_test_credentials () {
   local PASSWORD_PROTECTED_POST_ID
   local PASSWORD_PROTECTED_COMMENT_ID
   local PASSWORD_PROTECTED_COMMENT_AUTHOR
+  local FIRST_POST_DATE_GMT
   local WORDPRESS_VERSION
   SITE_URL="http://localhost"
   ADMIN_USERNAME="test@example.com"
@@ -106,6 +107,8 @@ create_test_credentials () {
 
   PASSWORD_PROTECTED_COMMENT_AUTHOR="setup-test-site.sh"
   PASSWORD_PROTECTED_COMMENT_ID="$(wp comment create --comment_post_ID="$PASSWORD_PROTECTED_POST_ID" --comment_content="test_comment_for_password_protected_post" --comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" --porcelain)"
+
+  FIRST_POST_DATE_GMT=$(wp post get 1 --fields=post_date_gmt --format=csv | sed -n '2 p' | cut -d ',' -f 2 | cut -d'"' -f 2)
 
   WORDPRESS_VERSION="$(wp core version)"
 
@@ -129,6 +132,7 @@ create_test_credentials () {
     password_protected_comment_id="$PASSWORD_PROTECTED_COMMENT_ID" \
     password_protected_comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" \
     trashed_post_id="$TRASHED_POST_ID" \
+    first_post_date_gmt="$FIRST_POST_DATE_GMT" \
     wordpress_core_version="$WORDPRESS_VERSION" \
     > /app/test_credentials.json
 }

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -13,6 +13,7 @@ name = "wp_api"
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true, features = [ "serde" ] }
 futures = { workspace = true }
 http = { workspace = true }
 indoc = { workspace = true }
@@ -21,7 +22,7 @@ parse_link_header = { workspace = true }
 paste = { workspace = true }
 regex = { workspace = true }
 scraper = { workspace = true }
-serde = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = [ "derive", "rc" ] }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -28,3 +28,45 @@ uniffi::custom_type!(WpGmtDateTime, i64, {
     lower: |date_time| date_time.0.timestamp(),
     try_lift: |seconds| Ok(WpGmtDateTime::from_timestamp(seconds)),
 });
+
+// Assertion functions that should only be used by the native test suite
+// These are hidden from the Rust public API, but will be visible/usable in the generated bindings
+mod native_test_helper {
+    use super::WpGmtDateTime;
+    use chrono::offset::FixedOffset;
+
+    const OFFSET_FOR_EXAMPLE_DATE: i32 = 60 * 60 * 2;
+    const EXAMPLE_DATE: &str = "2020-08-14T15:00:00+02:00";
+
+    #[uniffi::export]
+    fn assertion_example_date_that_can_be_used_to_verify_conversion_between_rust_and_native(
+    ) -> WpGmtDateTime {
+        EXAMPLE_DATE
+            .parse::<WpGmtDateTime>()
+            .expect("Example date is parseable")
+    }
+
+    #[uniffi::export]
+    fn assert_date_is_converted_from_native_to_rust_correctly(date: WpGmtDateTime) {
+        assert_eq!(
+            date.0
+                .with_timezone(
+                    &FixedOffset::east_opt(OFFSET_FOR_EXAMPLE_DATE)
+                        .expect("Example offset is valid")
+                )
+                .to_rfc3339(),
+            EXAMPLE_DATE
+        );
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_that_helper_functions_work_correctly() {
+            let date = assertion_example_date_that_can_be_used_to_verify_conversion_between_rust_and_native();
+            assert_date_is_converted_from_native_to_rust_correctly(date);
+        }
+    }
+}

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -1,0 +1,25 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use wp_serde_helper::wp_utc_date_format;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WpGmtDateTime(#[serde(with = "wp_utc_date_format")] pub DateTime<Utc>);
+
+impl WpGmtDateTime {
+    pub fn from_timestamp(seconds: i64) -> Self {
+        let date_time =
+            DateTime::<Utc>::from_timestamp(seconds, 0).unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+        Self(date_time)
+    }
+}
+
+impl FromStr for WpGmtDateTime {
+    type Err = chrono::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<DateTime<Utc>>()
+            .map(Self)
+            .map_err(Into::<Self::Err>::into)
+    }
+}

--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -23,3 +23,8 @@ impl FromStr for WpGmtDateTime {
             .map_err(Into::<Self::Err>::into)
     }
 }
+
+uniffi::custom_type!(WpGmtDateTime, i64, {
+    lower: |date_time| date_time.0.timestamp(),
+    try_lift: |seconds| Ok(WpGmtDateTime::from_timestamp(seconds)),
+});

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -3,7 +3,6 @@ pub use api_error::{
     MediaUploadRequestExecutionError, ParsedRequestError, RequestExecutionError,
     RequestExecutionErrorReason, WpApiError, WpError, WpErrorCode,
 };
-use date::WpGmtDateTime;
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use serde::{Deserialize, Serialize};
@@ -205,11 +204,6 @@ macro_rules! generate {
         obj
     }};
 }
-
-uniffi::custom_type!(WpGmtDateTime, f64, {
-    lower: |date_time| date_time.0.timestamp() as f64,
-    try_lift: |seconds| Ok(WpGmtDateTime::from_timestamp(seconds.round() as i64)),
-});
 
 uniffi::setup_scaffolding!();
 

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -3,6 +3,7 @@ pub use api_error::{
     MediaUploadRequestExecutionError, ParsedRequestError, RequestExecutionError,
     RequestExecutionErrorReason, WpApiError, WpError, WpErrorCode,
 };
+use date::WpGmtDateTime;
 pub use parsed_url::{ParseUrlError, ParsedUrl};
 use plugins::*;
 use serde::{Deserialize, Serialize};
@@ -19,6 +20,7 @@ mod uuid; // re-exported relevant types
 pub mod application_passwords;
 pub mod categories;
 pub mod comments;
+pub mod date;
 pub mod login;
 pub mod media;
 pub mod plugins;
@@ -203,6 +205,11 @@ macro_rules! generate {
         obj
     }};
 }
+
+uniffi::custom_type!(WpGmtDateTime, f64, {
+    lower: |date_time| date_time.0.timestamp() as f64,
+    try_lift: |seconds| Ok(WpGmtDateTime::from_timestamp(seconds.round() as i64)),
+});
 
 uniffi::setup_scaffolding!();
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,5 +1,6 @@
 use crate::{
     categories::CategoryId,
+    date::WpGmtDateTime,
     impl_as_query_value_for_new_type, impl_as_query_value_from_to_string,
     media::MediaId,
     tags::TagId,
@@ -81,10 +82,10 @@ pub struct PostListParams {
     pub search: Option<String>,
     /// Limit response to posts published after a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub after: Option<String>,
+    pub after: Option<WpGmtDateTime>,
     /// Limit response to posts modified after a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub modified_after: Option<String>,
+    pub modified_after: Option<WpGmtDateTime>,
     /// Limit result set to posts assigned to specific authors.
     #[uniffi(default = [])]
     pub author: Vec<UserId>,
@@ -93,10 +94,10 @@ pub struct PostListParams {
     pub author_exclude: Vec<UserId>,
     /// Limit response to posts published before a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub before: Option<String>,
+    pub before: Option<WpGmtDateTime>,
     /// Limit response to posts modified before a given ISO8601 compliant date.
     #[uniffi(default = None)]
-    pub modified_before: Option<String>,
+    pub modified_before: Option<WpGmtDateTime>,
     /// Ensure result set excludes specific IDs.
     #[uniffi(default = [])]
     pub exclude: Vec<PostId>,
@@ -244,12 +245,12 @@ impl FromUrlQueryPairs for PostListParams {
             page: query_pairs.get(PostListParamsField::Page),
             per_page: query_pairs.get(PostListParamsField::PerPage),
             search: query_pairs.get(PostListParamsField::Search),
-            after: query_pairs.get(PostListParamsField::After),
-            modified_after: query_pairs.get(PostListParamsField::ModifiedAfter),
+            after: query_pairs.get_wp_date_time(PostListParamsField::After),
+            modified_after: query_pairs.get_wp_date_time(PostListParamsField::ModifiedAfter),
             author: query_pairs.get_csv(PostListParamsField::Author),
             author_exclude: query_pairs.get_csv(PostListParamsField::AuthorExclude),
-            before: query_pairs.get(PostListParamsField::Before),
-            modified_before: query_pairs.get(PostListParamsField::ModifiedBefore),
+            before: query_pairs.get_wp_date_time(PostListParamsField::Before),
+            modified_before: query_pairs.get_wp_date_time(PostListParamsField::ModifiedBefore),
             exclude: query_pairs.get_csv(PostListParamsField::Exclude),
             include: query_pairs.get_csv(PostListParamsField::Include),
             offset: query_pairs.get(PostListParamsField::Offset),
@@ -473,7 +474,7 @@ pub struct SparsePost {
     #[WpContext(edit, embed, view)]
     pub date: Option<String>,
     #[WpContext(edit, view)]
-    pub date_gmt: Option<String>,
+    pub date_gmt: Option<WpGmtDateTime>,
     #[WpContext(edit, view)]
     #[WpContextualField]
     pub guid: Option<SparsePostGuid>,
@@ -482,7 +483,7 @@ pub struct SparsePost {
     #[WpContext(edit, view)]
     pub modified: Option<String>,
     #[WpContext(edit, view)]
-    pub modified_gmt: Option<String>,
+    pub modified_gmt: Option<WpGmtDateTime>,
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit, view)]
@@ -710,7 +711,13 @@ impl PostFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{generate, unit_test_common::assert_expected_and_from_query_pairs};
+    use crate::{
+        generate,
+        unit_test_common::{
+            assert_expected_and_from_query_pairs, unit_test_example_date_as_option,
+            unit_test_example_date_as_query_value,
+        },
+    };
     use rstest::*;
 
     #[rstest]
@@ -718,12 +725,12 @@ mod tests {
     #[case(generate!(PostListParams, (page, Some(2))), "page=2")]
     #[case(generate!(PostListParams, (per_page, Some(2))), "per_page=2")]
     #[case(generate!(PostListParams, (search, Some("foo".to_string()))), "search=foo")]
-    #[case(generate!(PostListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PostListParams, (modified_after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_after"))]
     #[case(generate!(PostListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
     #[case(generate!(PostListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
-    #[case(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PostListParams, (modified_before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_before"))]
     #[case(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
     #[case(generate!(PostListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
     #[case(generate!(PostListParams, (offset, Some(2))), "offset=2")]
@@ -761,38 +768,59 @@ mod tests {
     #[case(generate!(PostListParams, (tags, vec![TagId(1), TagId(2)])), "tags=1%2C2")]
     #[case(generate!(PostListParams, (tags_exclude, vec![TagId(1), TagId(2)])), "tags_exclude=1%2C2")]
     #[case(generate!(PostListParams, (sticky, Some(true))), "sticky=true")]
-    #[case(PostListParams {
-        page: Some(11),
-        per_page: Some(22),
-        search: Some("s_q".to_string()),
-        after: Some("d_a".to_string()),
-        modified_after: Some("d_m_a".to_string()),
-        author: vec![UserId(111), UserId(112)],
-        author_exclude: vec![UserId(211), UserId(212)],
-        before: Some("d_b".to_string()),
-        modified_before: Some("d_m_b".to_string()),
-        exclude: vec![PostId(1111), PostId(1112)],
-        include: vec![PostId(2111), PostId(2112)],
-        offset: Some(11111),
-        order: Some(WpApiParamOrder::Desc),
-        orderby: Some(WpApiParamPostsOrderBy::Slug),
-        search_columns: vec![
-            WpApiParamPostsSearchColumn::PostContent,
-            WpApiParamPostsSearchColumn::PostExcerpt,
-        ],
-        slug: vec!["sl_1".to_string(), "sl_2".to_string()],
-        status: vec![PostStatus::Draft, PostStatus::Future],
-        tax_relation: Some(WpApiParamPostsTaxRelation::Or),
-        categories: vec![CategoryId(333333), CategoryId(333334)],
-        categories_exclude: vec![CategoryId(444444), CategoryId(444445)],
-        tags: vec![TagId(555555), TagId(555556)],
-        tags_exclude: vec![TagId(666666), TagId(666667)],
-        sticky: Some(true),
-        },
-        "page=11&per_page=22&search=s_q&after=d_a&modified_after=d_m_a&author=111%2C112&author_exclude=211%2C212&before=d_b&modified_before=d_m_b&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=slug&search_columns=post_content%2Cpost_excerpt&slug=sl_1%2Csl_2&status=draft%2Cfuture&tax_relation=OR&categories=333333%2C333334&categories_exclude=444444%2C444445&tags=555555%2C555556&tags_exclude=666666%2C666667&sticky=true"
+    #[case(
+        post_list_params_with_all_fields(),
+        &expected_query_pairs_for_post_list_params_with_all_fields()
     )]
     #[trace]
     fn test_post_list_query_pairs(#[case] params: PostListParams, #[case] expected_query: &str) {
         assert_expected_and_from_query_pairs(params, expected_query);
+    }
+
+    fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!("page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true")
+    }
+
+    fn post_list_params_with_all_fields() -> PostListParams {
+        PostListParams {
+            after: unit_test_example_date_as_option(),
+            author: vec![UserId(1), UserId(2)],
+            author_exclude: vec![UserId(1), UserId(2)],
+            before: unit_test_example_date_as_option(),
+            categories: vec![CategoryId(1), CategoryId(2)],
+            categories_exclude: vec![CategoryId(1), CategoryId(2)],
+            exclude: vec![PostId(1), PostId(2)],
+            include: vec![PostId(1), PostId(2)],
+            modified_after: unit_test_example_date_as_option(),
+            modified_before: unit_test_example_date_as_option(),
+            offset: Some(2),
+            order: Some(WpApiParamOrder::Asc),
+            orderby: Some(WpApiParamPostsOrderBy::Author),
+            page: Some(2),
+            per_page: Some(2),
+            search: Some("foo".to_string()),
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+                WpApiParamPostsSearchColumn::PostTitle,
+            ],
+            slug: vec!["foo".to_string(), "bar".to_string()],
+            status: vec![
+                PostStatus::Draft,
+                PostStatus::Future,
+                PostStatus::Pending,
+                PostStatus::Private,
+                PostStatus::Publish,
+                PostStatus::Custom("foo".to_string()),
+            ],
+            sticky: Some(true),
+            tags: vec![TagId(1), TagId(2)],
+            tags_exclude: vec![TagId(1), TagId(2)],
+            tax_relation: Some(WpApiParamPostsTaxRelation::And),
+        }
     }
 }

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -82,6 +82,9 @@ mod tests {
             ApiBaseUrl,
         },
         tags::TagId,
+        unit_test_common::{
+            unit_test_example_date_as_option, unit_test_example_date_as_query_value,
+        },
         UserId, WpApiParamOrder,
     };
     use rstest::*;
@@ -102,12 +105,12 @@ mod tests {
     #[case(generate!(PostListParams, (page, Some(2))), "page=2")]
     #[case(generate!(PostListParams, (per_page, Some(2))), "per_page=2")]
     #[case(generate!(PostListParams, (search, Some("foo".to_string()))), "search=foo")]
-    #[case(generate!(PostListParams, (after, Some("2023-08-14 17:00:00.000".to_string()))), "after=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_after, Some("2023-08-14 17:00:00.000".to_string()))), "modified_after=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PostListParams, (modified_after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_after"))]
     #[case(generate!(PostListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
     #[case(generate!(PostListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
-    #[case(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))), "before=2023-08-14+17%3A00%3A00.000")]
-    #[case(generate!(PostListParams, (modified_before, Some("2023-08-14 17:00:00.000".to_string()))), "modified_before=2023-08-14+17%3A00%3A00.000")]
+    #[case(generate!(PostListParams, (before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PostListParams, (modified_before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_before"))]
     #[case(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])), "exclude=1%2C2")]
     #[case(generate!(PostListParams, (include, vec![PostId(1), PostId(2)])), "include=1%2C2")]
     #[case(generate!(PostListParams, (offset, Some(2))), "offset=2")]
@@ -144,7 +147,7 @@ mod tests {
     #[case(generate!(PostListParams, (sticky, Some(true))), "sticky=true")]
     #[case(
         post_list_params_with_all_fields(),
-        EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS
+        &expected_query_pairs_for_post_list_params_with_all_fields()
     )]
     fn list_posts(
         endpoint: PostsRequestEndpoint,
@@ -175,7 +178,7 @@ mod tests {
     #[rstest]
     #[case(PostListParams::default(), &[], "/posts?context=edit&_fields=")]
     #[case(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparsePostFieldWithEditContext::Author], "/posts?context=edit&orderby=author&_fields=author")]
-    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT, &format!("/posts?context=edit&{}&{}", EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT))]
+    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT, &format!("/posts?context=edit&{}&{}", expected_query_pairs_for_post_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EDIT_CONTEXT))]
     fn filter_list_post_with_edit_context(
         endpoint: PostsRequestEndpoint,
         #[case] params: PostListParams,
@@ -191,7 +194,7 @@ mod tests {
     #[rstest]
     #[case(PostListParams::default(), &[], "/posts?context=embed&_fields=")]
     #[case(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparsePostFieldWithEmbedContext::Author], "/posts?context=embed&orderby=author&_fields=author")]
-    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT, &format!("/posts?context=embed&{}&{}", EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS, EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT))]
+    #[case(post_list_params_with_all_fields(), ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT, &format!("/posts?context=embed&{}&{}", expected_query_pairs_for_post_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_POST_FIELDS_WITH_EMBED_CONTEXT))]
     fn filter_list_post_with_embed_context(
         endpoint: PostsRequestEndpoint,
         #[case] params: PostListParams,
@@ -272,20 +275,26 @@ mod tests {
         validate_wp_v2_endpoint(endpoint.update(&PostId(54)), "/posts/54");
     }
 
-    const EXPECTED_QUERY_PAIRS_FOR_POST_LIST_PARAMS_WITH_ALL_FIELDS: &str =
-        "page=2&per_page=2&search=foo&after=2023-08-14+17%3A00%3A00.000&modified_after=2023-08-14+17%3A00%3A00.000&author=1%2C2&author_exclude=1%2C2&before=2023-08-14+17%3A00%3A00.000&modified_before=2023-08-14+17%3A00%3A00.000&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true";
+    fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!("page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&tax_relation=AND&categories=1%2C2&categories_exclude=1%2C2&tags=1%2C2&tags_exclude=1%2C2&sticky=true")
+    }
+
     fn post_list_params_with_all_fields() -> PostListParams {
         PostListParams {
-            after: Some("2023-08-14 17:00:00.000".to_string()),
+            after: unit_test_example_date_as_option(),
             author: vec![UserId(1), UserId(2)],
             author_exclude: vec![UserId(1), UserId(2)],
-            before: Some("2023-08-14 17:00:00.000".to_string()),
+            before: unit_test_example_date_as_option(),
             categories: vec![CategoryId(1), CategoryId(2)],
             categories_exclude: vec![CategoryId(1), CategoryId(2)],
             exclude: vec![PostId(1), PostId(2)],
             include: vec![PostId(1), PostId(2)],
-            modified_after: Some("2023-08-14 17:00:00.000".to_string()),
-            modified_before: Some("2023-08-14 17:00:00.000".to_string()),
+            modified_after: unit_test_example_date_as_option(),
+            modified_before: unit_test_example_date_as_option(),
             offset: Some(2),
             order: Some(WpApiParamOrder::Asc),
             orderby: Some(WpApiParamPostsOrderBy::Author),

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -1,4 +1,7 @@
-use crate::url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap};
+use crate::{
+    date::WpGmtDateTime,
+    url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap},
+};
 use url::Url;
 
 #[cfg(test)]
@@ -21,4 +24,18 @@ where
         url.query_pairs().into_iter().collect(),
     ));
     assert_eq!(Some(params), parsed_params);
+}
+
+#[cfg(test)]
+pub fn unit_test_example_date_as_option() -> Option<WpGmtDateTime> {
+    Some(
+        "2024-02-09T02:14:13+0000"
+            .parse::<WpGmtDateTime>()
+            .expect("Example date is parseable"),
+    )
+}
+
+#[cfg(test)]
+pub fn unit_test_example_date_as_query_value(key: &str) -> String {
+    format!("{key}=2024-02-09T02%3A14%3A13%2B00%3A00")
 }

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -1,7 +1,6 @@
+use crate::{date::WpGmtDateTime, impl_as_query_value_from_to_string, OptionFromStr};
 use std::{borrow::Cow, collections::HashMap, str::FromStr};
 use url::{form_urlencoded, UrlQuery};
-
-use crate::{impl_as_query_value_from_to_string, OptionFromStr};
 
 pub(crate) type QueryPairs<'a> = form_urlencoded::Serializer<'a, UrlQuery<'a>>;
 
@@ -95,6 +94,12 @@ impl AsQueryValue for String {
     }
 }
 
+impl AsQueryValue for WpGmtDateTime {
+    fn as_query_value(&self) -> impl AsRef<str> {
+        self.0.to_rfc3339()
+    }
+}
+
 #[derive(Debug)]
 pub struct UrlQueryPairsMap<'a> {
     inner: HashMap<Cow<'a, str>, Cow<'a, str>>,
@@ -127,6 +132,12 @@ impl<'a> UrlQueryPairsMap<'a> {
                     .collect::<Option<Vec<_>>>()
             })
             .unwrap_or_default()
+    }
+
+    pub(crate) fn get_wp_date_time<'b>(&self, key: impl Into<&'b str>) -> Option<WpGmtDateTime> {
+        self.inner
+            .get(key.into())
+            .and_then(|v| v.parse::<WpGmtDateTime>().ok())
     }
 }
 

--- a/wp_api/uniffi.toml
+++ b/wp_api/uniffi.toml
@@ -4,6 +4,12 @@ android_cleaner = false
 cdylib_name = "wp_api"
 generate_immutable_records = true
 
+[bindings.kotlin.custom_types.WpGmtDateTime]
+type_name = "Date"
+imports = ["java.util.Date", "java.time.Instant"]
+into_custom = "Date.from(Instant.ofEpochSecond({}))"
+from_custom = "{}.toInstant().epochSecond"
+
 [bindings.swift]
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_api_uniffi"

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use wp_api::{
     categories::CategoryId,
     comments::CommentId,
+    date::WpGmtDateTime,
     media::MediaId,
     posts::PostId,
     request::{
@@ -284,4 +285,8 @@ impl<T: std::fmt::Debug, E: std::error::Error> AssertResponse for Result<T, E> {
         assert!(self.is_ok(), "Request failed with: {}", self.unwrap_err());
         self.unwrap()
     }
+}
+
+pub fn unwrapped_wp_gmt_date_time(s: &str) -> WpGmtDateTime {
+    s.parse::<WpGmtDateTime>().expect("Expected a valid date")
 }

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -38,7 +38,14 @@ pub struct TestCredentials {
     pub password_protected_comment_id: i64,
     pub password_protected_comment_author: &'static str,
     pub trashed_post_id: i64,
+    pub first_post_date_gmt: &'static str,
     pub wordpress_core_version: &'static str,
+}
+
+impl TestCredentials {
+    pub fn date_format() -> &'static str {
+        "%Y-%m-%d %H:%M:%S"
+    }
 }
 
 pub mod backend;

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -168,6 +168,25 @@ async fn retrieve_password_protected_with_view_context() {
 }
 
 #[tokio::test]
+#[parallel]
+async fn ensure_date_gmt_is_parsed_correctly() {
+    let test_credentials = TestCredentials::instance();
+    let post = api_client()
+        .posts()
+        .retrieve_with_edit_context(&FIRST_POST_ID, &PostRetrieveParams::default())
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        post.date_gmt
+            .0
+            .format(TestCredentials::date_format())
+            .to_string(),
+        test_credentials.first_post_date_gmt
+    );
+}
+
+#[tokio::test]
 #[rstest]
 #[parallel]
 #[case(PostListParams { per_page: Some(1), ..Default::default() })]

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -1,16 +1,20 @@
 use rstest::*;
 use rstest_reuse::{self, apply, template};
 use serial_test::parallel;
-use wp_api::categories::CategoryId;
-use wp_api::posts::{
-    PostId, PostListParams, PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
-    SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
-    WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+use wp_api::{
+    categories::CategoryId,
+    generate,
+    posts::{
+        PostId, PostListParams, PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
+        SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext, WpApiParamPostsOrderBy,
+        WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
+    },
+    tags::TagId,
+    WpApiParamOrder,
 };
-use wp_api::tags::TagId;
-use wp_api::{generate, WpApiParamOrder};
 use wp_api_integration_tests::{
-    api_client, AssertResponse, TestCredentials, FIRST_POST_ID, FIRST_USER_ID, SECOND_USER_ID,
+    api_client, unwrapped_wp_gmt_date_time, AssertResponse, TestCredentials, FIRST_POST_ID,
+    FIRST_USER_ID, SECOND_USER_ID,
 };
 
 #[tokio::test]
@@ -198,12 +202,12 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[case::page(generate!(PostListParams, (page, Some(1))))]
 #[case::per_page(generate!(PostListParams, (per_page, Some(3))))]
 #[case::search(generate!(PostListParams, (search, Some("foo".to_string()))))]
-#[case::after(generate!(PostListParams, (after, Some("2020-08-14 17:00:00.000".to_string()))))]
-#[case::modified_after(generate!(PostListParams, (modified_after, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::after(generate!(PostListParams, (after, Some(unwrapped_wp_gmt_date_time("2020-08-14T17:00:00+0200")))))]
+#[case::modified_after(generate!(PostListParams, (modified_after, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0200")))))]
 #[case::author(generate!(PostListParams, (author, vec![FIRST_USER_ID, SECOND_USER_ID])))]
 #[case::author_exclude(generate!(PostListParams, (author_exclude, vec![SECOND_USER_ID])))]
-#[case::before(generate!(PostListParams, (before, Some("2023-08-14 17:00:00.000".to_string()))))]
-#[case::modified_before(generate!(PostListParams, (modified_before, Some("2024-01-14 17:00:00.000".to_string()))))]
+#[case::before(generate!(PostListParams, (before, Some(unwrapped_wp_gmt_date_time("2023-08-14T17:00:00+0000")))))]
+#[case::modified_before(generate!(PostListParams, (modified_before, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0000")))))]
 #[case::exclude(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])))]
 #[case::include(generate!(PostListParams, (include, vec![PostId(1)])))]
 #[case::offset(generate!(PostListParams, (offset, Some(2))))]
@@ -218,7 +222,7 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[case::tags(generate!(PostListParams, (tags, vec![TagId(1)])))]
 #[case::tags_exclude(generate!(PostListParams, (tags_exclude, vec![TagId(1)])))]
 #[case::sticky(generate!(PostListParams, (sticky, Some(true))))]
-pub fn list_cases(#[case] params: PostListParams) {}
+fn list_cases(#[case] params: PostListParams) {}
 
 mod filter {
     use super::*;

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -9,8 +9,8 @@ use wp_api::posts::{
 use wp_api_integration_tests::{
     api_client,
     backend::{Backend, RestoreServer},
-    AssertResponse, CATEGORY_ID_59, FIRST_POST_ID, MEDIA_ID_611, POST_TEMPLATE_SINGLE_WITH_SIDEBAR,
-    SECOND_USER_ID, TAG_ID_100,
+    unwrapped_wp_gmt_date_time, AssertResponse, CATEGORY_ID_59, FIRST_POST_ID, MEDIA_ID_611,
+    POST_TEMPLATE_SINGLE_WITH_SIDEBAR, SECOND_USER_ID, TAG_ID_100,
 };
 use wp_cli::WpCliPost;
 
@@ -166,7 +166,10 @@ generate_update_test!(
     date_gmt,
     "2024-09-09T12:00:00".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.date_gmt, "2024-09-09T12:00:00");
+        assert_eq!(
+            updated_post.date_gmt,
+            unwrapped_wp_gmt_date_time("2024-09-09T12:00:00+0000")
+        );
         assert_eq!(updated_post_from_wp_cli.date_gmt, "2024-09-09 12:00:00");
     }
 );

--- a/wp_serde_helper/Cargo.toml
+++ b/wp_serde_helper/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = { workspace = true, features = [ "serde" ] }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -4,6 +4,10 @@ use serde::{
 };
 use std::{fmt, marker::PhantomData};
 
+pub use wp_serde_date::wp_utc_date_format;
+
+mod wp_serde_date;
+
 pub fn serialize_as_json_string<T, S, E>(value: &T, s: S) -> Result<S::Ok, E>
 where
     T: Serialize,

--- a/wp_serde_helper/src/wp_serde_date.rs
+++ b/wp_serde_helper/src/wp_serde_date.rs
@@ -1,0 +1,56 @@
+// https://core.trac.wordpress.org/ticket/41032
+const WP_DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
+
+pub mod wp_utc_date_format {
+    use super::WP_DATE_FORMAT;
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", date.format(WP_DATE_FORMAT)))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        NaiveDateTime::parse_from_str(&s, WP_DATE_FORMAT)
+            .map_err(serde::de::Error::custom)
+            .map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Datelike, Timelike, Utc};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Foo {
+        #[serde(with = "wp_utc_date_format")]
+        pub wp_utc_date_time: DateTime<Utc>,
+    }
+
+    #[test]
+    fn test_deserialize_date() {
+        let json_str = r#"
+          {
+            "wp_utc_date_time": "2024-09-18T22:37:19"
+          }
+        "#;
+
+        let foo: Foo = serde_json::from_str(json_str).unwrap();
+
+        assert_eq!(foo.wp_utc_date_time.year_ce(), (true, 2024));
+        assert_eq!(foo.wp_utc_date_time.month(), 9);
+        assert_eq!(foo.wp_utc_date_time.day(), 18);
+        assert_eq!(foo.wp_utc_date_time.minute(), 37);
+        assert_eq!(foo.wp_utc_date_time.second(), 19);
+        assert_eq!(foo.wp_utc_date_time.hour(), 22);
+    }
+}


### PR DESCRIPTION
This PR introduces `WpGmtDateTime` which is a wrapper for [`chrono::DateTime<chrono::offset::Utc>`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html).

We use `uniffi::custom_type!` macro to convert it into `java.util.Date` in Kotlin bindings using `i64` as the underlying value. To make sure this conversion is done correctly, we export a couple assertion functions in the native bindings. These assertion functions are used in Kotlin to make sure the dates are converted correctly between Rust and Kotlin. We'll do the same for Swift in a follow up PR.