### PR TITLE
Handle parsing `[]` for `WpApiDetails.authentication` field

### DIFF
--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -54,16 +54,20 @@ pub struct WpApiDetails {
     pub gmt_offset: i64,
     pub timezone_string: String,
     pub namespaces: Vec<String>,
-    pub authentication: HashMap<String, WpRestApiAuthenticationScheme>,
+    pub authentication: WpApiDetailsAuthenticationMap,
     pub site_icon_url: Option<String>,
 }
 
 #[uniffi::export]
 impl WpApiDetails {
+    pub fn has_application_passwords_authentication_url(&self) -> bool {
+        self.authentication
+            .has_application_passwords_authentication_url()
+    }
+
     pub fn find_application_passwords_authentication_url(&self) -> Option<String> {
         self.authentication
-            .get(KEY_APPLICATION_PASSWORDS)
-            .map(|auth_scheme| auth_scheme.endpoints.authorization.clone())
+            .find_application_passwords_authentication_url()
     }
 }
 
@@ -94,6 +98,35 @@ pub enum OAuthResponseUrlError {
     MissingPassword,
     #[error("Unsuccessful Login")]
     UnsuccessfulLogin,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WpApiDetailsAuthenticationMap(HashMap<String, WpRestApiAuthenticationScheme>);
+
+// If the response is `[]`, default to an empty `HashMap`
+impl<'de> Deserialize<'de> for WpApiDetailsAuthenticationMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_any(wp_serde_helper::DeserializeEmptyVecOrT::<
+                HashMap<String, WpRestApiAuthenticationScheme>,
+            >::new(Box::new(HashMap::new)))
+            .map(Self)
+    }
+}
+
+impl WpApiDetailsAuthenticationMap {
+    pub fn has_application_passwords_authentication_url(&self) -> bool {
+        self.0.contains_key(KEY_APPLICATION_PASSWORDS)
+    }
+
+    pub fn find_application_passwords_authentication_url(&self) -> Option<String> {
+        self.0
+            .get(KEY_APPLICATION_PASSWORDS)
+            .map(|auth_scheme| auth_scheme.endpoints.authorization.clone())
+    }
 }
 
 /// Return a URL to be used in application password authentication.
@@ -196,5 +229,50 @@ mod tests {
             app_id_str
         );
         assert_eq!(auth_url, ParsedUrl::parse(expected_url.as_str()).unwrap());
+    }
+
+    #[test]
+    fn test_parse_wp_api_details_authentication_map() {
+        let json = r#"{
+          "authentication": {
+            "application-passwords": {
+              "endpoints": {
+                "authorization": "http://localhost/wp-admin/authorize-application.php"
+              }
+            }
+          }
+        }"#;
+        let result = serde_json::from_str::<WpApiDetailsAuthenticationMapWrapper>(json);
+        assert!(
+            result.is_ok(),
+            "Failed to parse json as `WpApiDetailsAuthenticationMap`"
+        );
+        assert_eq!(
+            result
+                .expect("Already verified result is Ok")
+                .authentication
+                .find_application_passwords_authentication_url(),
+            Some("http://localhost/wp-admin/authorize-application.php".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_vec_as_wp_api_details_authentication_map() {
+        let json = r#"{"authentication": []}"#;
+        let result = serde_json::from_str::<WpApiDetailsAuthenticationMapWrapper>(json);
+        assert!(
+            result.is_ok(),
+            "Failed to parse '[]' as `WpApiDetailsAuthenticationMap`"
+        );
+        assert!(result
+            .expect("Already verified result is Ok")
+            .authentication
+            .0
+            .is_empty());
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct WpApiDetailsAuthenticationMapWrapper {
+        authentication: WpApiDetailsAuthenticationMap,
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -83,6 +83,12 @@ impl AutoDiscoveryResult {
             .any(|(_, result)| result.is_successful())
     }
 
+    pub fn is_successful_and_has_authorization_url(&self) -> bool {
+        self.attempts
+            .iter()
+            .any(|(_, result)| result.is_successful_and_has_authorization_url())
+    }
+
     pub fn find_successful(&self) -> Option<&AutoDiscoveryAttemptResult> {
         // If the user attempt is successful, prefer it over other attempts
         let user_input_attempt = self.user_input_attempt();
@@ -91,6 +97,21 @@ impl AutoDiscoveryResult {
         }
         self.attempts.iter().find_map(|(_, result)| {
             if result.is_successful() {
+                Some(result)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn find_successful_with_authorization_url(&self) -> Option<&AutoDiscoveryAttemptResult> {
+        // If the user attempt is successful, prefer it over other attempts
+        let user_input_attempt = self.user_input_attempt();
+        if user_input_attempt.is_successful_and_has_authorization_url() {
+            return Some(user_input_attempt);
+        }
+        self.attempts.iter().find_map(|(_, result)| {
+            if result.is_successful_and_has_authorization_url() {
                 Some(result)
             } else {
                 None
@@ -140,6 +161,15 @@ impl AutoDiscoveryAttemptResult {
 
     fn is_successful(&self) -> bool {
         self.api_discovery_result.is_ok()
+    }
+
+    fn is_successful_and_has_authorization_url(&self) -> bool {
+        match &self.api_discovery_result {
+            Ok(attempt) => attempt
+                .api_details
+                .has_application_passwords_authentication_url(),
+            Err(_) => false,
+        }
     }
 
     fn is_network_error(&self) -> bool {

--- a/wp_api_integration_tests/tests/test_login_err.rs
+++ b/wp_api_integration_tests/tests/test_login_err.rs
@@ -6,27 +6,6 @@ use wp_api::login::url_discovery::AutoDiscoveryAttemptType;
 use wp_api_integration_tests::AsyncWpNetworking;
 
 #[rstest]
-#[case("http://optional-https.wpmt.co")] // Fails because it's `http`
-#[tokio::test]
-#[parallel]
-async fn test_login_flow_err_parse_api_details(#[case] site_url: &str) {
-    let client = WpLoginClient::new(Arc::new(AsyncWpNetworking::default()));
-    let mut result = client.api_discovery(site_url.to_string()).await;
-    let original_attempt_error = result
-        .attempts
-        .remove(&AutoDiscoveryAttemptType::UserInput)
-        .unwrap()
-        .api_discovery_result
-        .unwrap_err();
-    assert_eq!(
-        original_attempt_error.has_failed_to_parse_api_details(),
-        Some(true),
-        "{:#?}",
-        original_attempt_error
-    );
-}
-
-#[rstest]
 #[case("http://jalib923knblakis9ba92q3nbaslkes.nope")]
 #[tokio::test]
 #[parallel]

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -64,13 +64,13 @@ async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str
     let client = WpLoginClient::new(Arc::new(AsyncWpNetworking::default()));
     let result = client.api_discovery(site_url.to_string()).await;
     assert!(
-        result.is_successful(),
+        result.is_successful_and_has_authorization_url(),
         "Auto discovery failed: {:#?}",
         result
     );
 
     let successful_attempt = result
-        .find_successful()
+        .find_successful_with_authorization_url()
         .expect("Already verified that auto discovery is successful");
     assert_eq!(
         successful_attempt
@@ -109,4 +109,30 @@ async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str
     //         mentions_wp_includes: true
     //     })
     // );
+}
+
+#[rstest]
+#[case("https://wordfence.wpmt.co")]
+#[tokio::test]
+#[parallel]
+async fn successful_but_does_not_have_authorization_url(#[case] site_url: &str) {
+    let client = WpLoginClient::new(Arc::new(AsyncWpNetworking::default()));
+    let result = client.api_discovery(site_url.to_string()).await;
+    assert!(
+        result.is_successful(),
+        "Auto discovery failed: {:#?}",
+        result
+    );
+    let successful_attempt = result
+        .find_successful()
+        .expect("Already verified that auto discovery is successful");
+    assert_eq!(
+        successful_attempt
+            .api_discovery_result
+            .clone()
+            .expect("Already verified that auto discovery is successful")
+            .api_details
+            .find_application_passwords_authentication_url(),
+        None
+    );
 }


### PR DESCRIPTION
This PR handles cases where the server returns `"authentication": []` from `/wp-json` endpoint. This used to result in a parsing error, but now we are defaulting to an empty `HashMap`.

This change means that now the API discovery may succeed without an authorization url. So, the PR introduces two new helpers: `is_successful_and_has_authorization_url` & `find_successful_with_authorization_url` which should be preferred over `is_successful` and `find_successful` counterparts when the authorization url is required.

The PR adds unit tests to make sure we are parsing the `authentication` field correctly when the response is `[]` as well as when it's a proper map. It also adds a new api discovery test case for `https://wordfence.wpmt.co` which returns `[]` for the `authentication` field.

`http://optional-https.wpmt.co` has been removed as a failure test case in 798516e4cdfaf084fa5770986c1a757e724d7f56 because it's now part of the successful test cases.

---

Note that our proc macro `wp_derive::WpDeserialize` is not compatible with `#[serde(transparent)]`. I'll open a follow up PR to handle this case as a parsing error, so that we don't accidentally use it.