### PR TITLE
Adds `test_gmt_date_time_from_time_stamp`

### DIFF
--- a/wp_api/src/date.rs
+++ b/wp_api/src/date.rs
@@ -70,3 +70,21 @@ mod native_test_helper {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::unix_epoch_plus_one_day(60 * 60 * 24, "1970-01-02T00:00:00+00:00")]
+    #[case::unix_epoch_plus_one_month(60 * 60 * 24 * 31, "1970-02-01T00:00:00+00:00")]
+    #[case::unix_epoch_plus_one_year(60 * 60 * 24 * 365, "1971-01-01T00:00:00+00:00")]
+    #[case::year_3000(32503680000, "3000-01-01T00:00:00+00:00")]
+    fn test_gmt_date_time_from_time_stamp(#[case] seconds: i64, #[case] expected_date_str: &str) {
+        assert_eq!(
+            WpGmtDateTime::from_timestamp(seconds).0.to_rfc3339(),
+            expected_date_str
+        );
+    }
+}


### PR DESCRIPTION
Addresses [this suggestion](https://github.com/Automattic/wordpress-rs/pull/550#discussion_r1955362197) from #550.