### PR TITLE
Add a public API to convert URLSession to an RequestExecutor

### DIFF
--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -5,12 +5,6 @@ import WordPressAPIInternal
 import FoundationNetworking
 #endif
 
-extension URLSession {
-    public func asRequestExecutor() -> some RequestExecutor {
-        WpRequestExecutor(urlSession: self)
-    }
-}
-
 public protocol SafeRequestExecutor: RequestExecutor, Sendable {
     func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
 }

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -5,6 +5,12 @@ import WordPressAPIInternal
 import FoundationNetworking
 #endif
 
+extension URLSession {
+    public func asRequestExecutor() -> some RequestExecutor {
+        WpRequestExecutor(urlSession: self)
+    }
+}
+
 public protocol SafeRequestExecutor: RequestExecutor, Sendable {
     func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
 }

--- a/native/swift/Sources/wordpress-api/WordPressOrgApiClient+Extensions.swift
+++ b/native/swift/Sources/wordpress-api/WordPressOrgApiClient+Extensions.swift
@@ -1,0 +1,12 @@
+import Foundation
+import WordPressAPIInternal
+
+#if os(Linux)
+import FoundationNetworking
+#endif
+
+extension WordPressOrgApiClient {
+    public convenience init(urlSession: URLSession) {
+        self.init(requestExecutor: WpRequestExecutor(urlSession: urlSession))
+    }
+}


### PR DESCRIPTION
`WordPressOrgClient` needs a `RequestExecutor`. We need a public API to create such instances. This PR adds a simple function to convert `URLSession` to a `RequestExecutor`. I don't mind publicizing `WpRequestExecutor`. It does not make much difference compared to this PR's change.