### PR TITLE
Add uniffi bindings to ser/de `PluginInformation`

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -14,6 +14,7 @@ mod api_client; // re-exported relevant types
 mod api_error; // re-exported relevant types
 mod parsed_url; // re-exported relevant types
 mod ssl; // re-exported relevant types
+mod uniffi_serde;
 mod uuid; // re-exported relevant types
 
 pub mod application_passwords;

--- a/wp_api/src/uniffi_serde.rs
+++ b/wp_api/src/uniffi_serde.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, uniffi::Object, thiserror::Error)]
+#[error("{inner:?}")]
+pub(crate) struct UniffiSerializationError {
+    inner: serde_json::Error,
+}
+
+impl From<serde_json::Error> for UniffiSerializationError {
+    fn from(inner: serde_json::Error) -> Self {
+        Self { inner }
+    }
+}
+
+#[macro_export]
+macro_rules! uniffi_export_serialization {
+    ($func_name:ident, $type:ty) => {
+        paste::paste! {
+            #[uniffi::export]
+            fn [<serialize_ $func_name>](value: $type) -> Result<Vec<u8>, Arc<$crate::uniffi_serde::UniffiSerializationError>> {
+                serde_json::to_vec(&value)
+                    .map_err(|e| Arc::new(e.into()))
+            }
+
+            #[uniffi::export]
+            fn [<deserialize_ $func_name>](value: Vec<u8>) -> Result<$type, Arc<$crate::uniffi_serde::UniffiSerializationError>> {
+                serde_json::from_slice(&value)
+                    .map_err(|e| Arc::new(e.into()))
+            }
+        }
+    };
+}

--- a/wp_api/src/uniffi_serde.rs
+++ b/wp_api/src/uniffi_serde.rs
@@ -1,12 +1,14 @@
-#[derive(Debug, uniffi::Object, thiserror::Error)]
-#[error("{inner:?}")]
-pub(crate) struct UniffiSerializationError {
-    inner: serde_json::Error,
+#[derive(Debug, uniffi::Error, thiserror::Error)]
+pub(crate) enum UniffiSerializationError {
+    #[error("{reason:?}")]
+    Serde { reason: String },
 }
 
 impl From<serde_json::Error> for UniffiSerializationError {
-    fn from(inner: serde_json::Error) -> Self {
-        Self { inner }
+    fn from(error: serde_json::Error) -> Self {
+        UniffiSerializationError::Serde {
+            reason: error.to_string(),
+        }
     }
 }
 
@@ -15,15 +17,13 @@ macro_rules! uniffi_export_serialization {
     ($func_name:ident, $type:ty) => {
         paste::paste! {
             #[uniffi::export]
-            fn [<serialize_ $func_name>](value: $type) -> Result<Vec<u8>, Arc<$crate::uniffi_serde::UniffiSerializationError>> {
-                serde_json::to_vec(&value)
-                    .map_err(|e| Arc::new(e.into()))
+            fn [<serialize_ $func_name>](value: $type) -> Result<Vec<u8>, $crate::uniffi_serde::UniffiSerializationError> {
+                Ok(serde_json::to_vec(&value)?)
             }
 
             #[uniffi::export]
-            fn [<deserialize_ $func_name>](value: Vec<u8>) -> Result<$type, Arc<$crate::uniffi_serde::UniffiSerializationError>> {
-                serde_json::from_slice(&value)
-                    .map_err(|e| Arc::new(e.into()))
+            fn [<deserialize_ $func_name>](value: Vec<u8>) -> Result<$type, $crate::uniffi_serde::UniffiSerializationError> {
+                Ok(serde_json::from_slice(&value)?)
             }
         }
     };

--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -6,7 +6,7 @@ use crate::{
     wordpress_org::update_check::UpdateCheckRequest,
     ParsedUrl, PluginWithViewContext, PluginWpOrgDirectorySlug, RequestExecutionError,
 };
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{result::Result, sync::Arc};
 use url::Url;
 
@@ -147,6 +147,8 @@ impl WordPressOrgApiClient {
 }
 
 #[derive(
+    Serialize,
+    Deserialize,
     Debug,
     PartialEq,
     Eq,
@@ -164,6 +166,11 @@ pub enum WordPressOrgApiPluginDirectoryCategory {
     Recommended,
     Featured,
 }
+
+crate::uniffi_export_serialization!(
+    plugin_directory_category,
+    WordPressOrgApiPluginDirectoryCategory
+);
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Error)]
 pub enum WordPressOrgApiClientError {

--- a/wp_api/src/wordpress_org/plugin_directory.rs
+++ b/wp_api/src/wordpress_org/plugin_directory.rs
@@ -1,8 +1,8 @@
 use super::de::deserialize_default_values;
-use serde::Deserialize;
-use std::{collections::HashMap, fmt::Debug};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct PluginInformation {
     pub name: String,
     pub slug: String,
@@ -60,14 +60,14 @@ pub struct PluginInformation {
     pub preview_link: String,
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, uniffi::Record)]
 pub struct ContributorDetails {
     pub profile: String,
     pub avatar: String,
     pub display_name: String,
 }
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct Ratings {
     #[serde(rename = "5")]
     pub five_star: u32,
@@ -82,7 +82,7 @@ pub struct Ratings {
 }
 
 /// https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#screenshots
-#[derive(Deserialize, Debug, uniffi::Enum)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Enum)]
 #[serde(untagged)]
 pub enum Screenshots {
     Named(HashMap<String, Screenshot>),
@@ -95,13 +95,13 @@ impl Default for Screenshots {
     }
 }
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct Screenshot {
     pub src: String,
     pub caption: String,
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq, Default, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default, uniffi::Record)]
 pub struct Banners {
     #[serde(deserialize_with = "deserialize_default_values", alias = "1x")]
     pub low: String,
@@ -109,7 +109,7 @@ pub struct Banners {
     pub high: String,
 }
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct Icons {
     #[serde(rename = "1x")]
     pub low: Option<String>,
@@ -119,18 +119,21 @@ pub struct Icons {
     pub default: Option<String>,
 }
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct QueryPluginResponse {
     pub info: QueryPluginResponseInfo,
     pub plugins: Vec<PluginInformation>,
 }
 
-#[derive(Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct QueryPluginResponseInfo {
     pub page: u64,
     pub pages: u64,
     pub results: u64,
 }
+
+crate::uniffi_export_serialization!(plugin_information, PluginInformation);
+crate::uniffi_export_serialization!(plugin_information_list, Vec<PluginInformation>);
 
 #[cfg(test)]
 mod tests {
@@ -327,5 +330,34 @@ mod tests {
             include_str!("../../tests/plugin-directory/plugin_directory_single_plugin_case_1.json");
         let parsed = serde_json::from_str::<PluginInformation>(json_string);
         assert!(parsed.is_ok(), "Failed to parse JSON: {:?}", parsed.err());
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let json_string =
+            include_str!("../../tests/plugin-directory/plugin-with-expected-types.json");
+        let plugin = serde_json::from_str::<PluginInformation>(json_string).unwrap();
+        let serialized = serialize_plugin_information(plugin).unwrap();
+        let deserialized = deserialize_plugin_information(serialized).unwrap();
+
+        let expected = serde_json::from_str::<PluginInformation>(json_string).unwrap();
+        assert_eq!(deserialized.name, expected.name);
+        assert_eq!(deserialized.author, expected.author);
+    }
+
+    #[test]
+    fn serialization_list_round_trip() {
+        let json_string =
+            include_str!("../../tests/plugin-directory/plugin-with-expected-types.json");
+        let plugin = serde_json::from_str::<PluginInformation>(json_string).unwrap();
+        let serialized = serialize_plugin_information_list(vec![plugin]).unwrap();
+        let deserialized = deserialize_plugin_information_list(serialized)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let expected = serde_json::from_str::<PluginInformation>(json_string).unwrap();
+        assert_eq!(deserialized.name, expected.name);
+        assert_eq!(deserialized.author, expected.author);
     }
 }

--- a/wp_api/src/wordpress_org/plugin_directory.rs
+++ b/wp_api/src/wordpress_org/plugin_directory.rs
@@ -2,7 +2,7 @@ use super::de::deserialize_default_values;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug};
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct PluginInformation {
     pub name: String,
     pub slug: String,
@@ -60,14 +60,14 @@ pub struct PluginInformation {
     pub preview_link: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct ContributorDetails {
     pub profile: String,
     pub avatar: String,
     pub display_name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct Ratings {
     #[serde(rename = "5")]
     pub five_star: u32,
@@ -82,7 +82,7 @@ pub struct Ratings {
 }
 
 /// https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#screenshots
-#[derive(Serialize, Deserialize, Debug, uniffi::Enum)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Enum)]
 #[serde(untagged)]
 pub enum Screenshots {
     Named(HashMap<String, Screenshot>),
@@ -95,7 +95,7 @@ impl Default for Screenshots {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct Screenshot {
     pub src: String,
     pub caption: String,
@@ -109,7 +109,7 @@ pub struct Banners {
     pub high: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct Icons {
     #[serde(rename = "1x")]
     pub low: Option<String>,
@@ -119,13 +119,13 @@ pub struct Icons {
     pub default: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct QueryPluginResponse {
     pub info: QueryPluginResponseInfo,
     pub plugins: Vec<PluginInformation>,
 }
 
-#[derive(Serialize, Deserialize, Debug, uniffi::Record)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, uniffi::Record)]
 pub struct QueryPluginResponseInfo {
     pub page: u64,
     pub pages: u64,
@@ -341,8 +341,7 @@ mod tests {
         let deserialized = deserialize_plugin_information(serialized).unwrap();
 
         let expected = serde_json::from_str::<PluginInformation>(json_string).unwrap();
-        assert_eq!(deserialized.name, expected.name);
-        assert_eq!(deserialized.author, expected.author);
+        assert_eq!(deserialized, expected);
     }
 
     #[test]
@@ -357,7 +356,6 @@ mod tests {
             .unwrap();
 
         let expected = serde_json::from_str::<PluginInformation>(json_string).unwrap();
-        assert_eq!(deserialized.name, expected.name);
-        assert_eq!(deserialized.author, expected.author);
+        assert_eq!(deserialized, expected);
     }
 }

--- a/wp_api/src/wordpress_org/plugin_directory.rs
+++ b/wp_api/src/wordpress_org/plugin_directory.rs
@@ -1,6 +1,6 @@
 use super::de::deserialize_default_values;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Serialize, Deserialize, Debug, uniffi::Record)]
 pub struct PluginInformation {


### PR DESCRIPTION
Add a macro to generate two functions to ser/de a Rust instance to binary: `serialize_xxx` and `deserialize_xxx`. These two functions are internal APIs and are only exported as uniffi bindings.

I tried to use `bincode`, but due to [some known issues](https://github.com/bincode-org/bincode/blob/0ab1f715ae824b84010f0d020a0ecd47227223e2/src/features/serde/mod.rs#L42-L51), it can't ser/de `PluginInformation`. Even though `serde_json` may be slow, it's guaranteed to be correct since it's used to ser/de all types in this library.