### PR TITLE
Move Login Application Errors to Rust

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -1,10 +1,11 @@
 use super::{
     url_discovery::{
-        self, AutoDiscoveryAttempt, AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptResult,
-        AutoDiscoveryAttemptSuccess, AutoDiscoveryResult, AutoDiscoveryUniffiResult,
-        FetchWpJsonFailure, FetchWpJsonSuccess, FindApiRootLinkHeaderFailure,
-        FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult, IsWordPressSiteParseHtmlResult,
-        ParseApiRootUrlError, ParseHtmlFailure, API_ROOT_LINK_HEADER,
+        self, ApplicationPasswordsNotSupportedReason, AutoDiscoveryAttempt,
+        AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptResult, AutoDiscoveryAttemptSuccess,
+        AutoDiscoveryResult, AutoDiscoveryUniffiResult, FetchWpJsonFailure, FetchWpJsonSuccess,
+        FindApiRootLinkHeaderFailure, FindApiRootLinkHeaderSuccess, IsWordPressSiteAttemptResult,
+        IsWordPressSiteParseHtmlResult, ParseApiRootUrlError, ParseHtmlFailure,
+        API_ROOT_LINK_HEADER,
     },
     WpApiDetails,
 };
@@ -121,54 +122,35 @@ impl WpLoginClient {
             };
 
         if !api_details.has_application_passwords_authentication_url() {
-            if api_details.has_application_password_blocking_plugin() {
+            let reason = if api_details.has_application_password_blocking_plugin() {
                 let plugins = api_details.application_password_blocking_plugins();
 
-                // If there's only one candidate, we can show more information in the error message
                 if plugins.len() == 1 {
-                    return Err(
-                        AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
-                            parsed_site_url: api_root_url_success.parsed_site_url,
-                            api_root_url: api_root_url_success.api_root_url,
-                            plugin: plugins[0].clone(),
-                        },
-                    );
+                    // If there's only one candidate, we can show more information in the error message
+                    Some(ApplicationPasswordsNotSupportedReason::ApplicationPasswordBlockedByPlugin {
+                        plugin: plugins.first().expect("Already verified there is one plugin").clone(),
+                    })
+                } else {
+                    // If there's more than one, for now we'll just give a generic error
+                    Some(ApplicationPasswordsNotSupportedReason::ApplicationPasswordBlockedByMultiplePlugins)
                 }
-                // If there's more than one, for now we'll just give a generic error
-                else {
-                    return Err(
-                        AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
-                            parsed_site_url: api_root_url_success.parsed_site_url,
-                            api_root_url: api_root_url_success.api_root_url,
-                        },
-                    );
-                }
-            }
-
-            // Application Passwords are disabled for non-HTTPS sites by default
-            if !api_details.uses_https() {
+            } else if !api_details.uses_https() {
+                // Application Passwords are disabled for non-HTTPS sites by default
                 if api_details.site_url_is_local_development_environment() {
-                    return Err(
-                        AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
-                            parsed_site_url: api_root_url_success.parsed_site_url,
-                            api_root_url: api_root_url_success.api_root_url,
-                        },
-                    );
+                    Some(ApplicationPasswordsNotSupportedReason::SiteIsLocalDevelopmentEnvironment)
+                } else {
+                    Some(ApplicationPasswordsNotSupportedReason::ApplicationPasswordsDisabledForHttpSite)
                 }
-
-                return Err(
-                    AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
-                        parsed_site_url: api_root_url_success.parsed_site_url,
-                        api_root_url: api_root_url_success.api_root_url,
-                    },
-                );
-            }
+            } else {
+                None
+            };
 
             Err(
                 AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
                     parsed_site_url: api_root_url_success.parsed_site_url,
                     api_root_url: api_root_url_success.api_root_url,
                     api_details,
+                    reason,
                 },
             )
         } else {

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -121,6 +121,49 @@ impl WpLoginClient {
             };
 
         if !api_details.has_application_passwords_authentication_url() {
+            if api_details.has_application_password_blocking_plugin() {
+                let plugins = api_details.application_password_blocking_plugins();
+
+                // If there's only one candidate, we can show more information in the error message
+                if plugins.len() == 1 {
+                    return Err(
+                        AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
+                            parsed_site_url: api_root_url_success.parsed_site_url,
+                            api_root_url: api_root_url_success.api_root_url,
+                            plugin: plugins[0].clone(),
+                        },
+                    );
+                }
+                // If there's more than one, for now we'll just give a generic error
+                else {
+                    return Err(
+                        AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
+                            parsed_site_url: api_root_url_success.parsed_site_url,
+                            api_root_url: api_root_url_success.api_root_url,
+                        },
+                    );
+                }
+            }
+
+            // Application Passwords are disabled for non-HTTPS sites by default
+            if !api_details.uses_https() {
+                if api_details.site_url_is_local_development_environment() {
+                    return Err(
+                        AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
+                            parsed_site_url: api_root_url_success.parsed_site_url,
+                            api_root_url: api_root_url_success.api_root_url,
+                        },
+                    );
+                }
+
+                return Err(
+                    AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
+                        parsed_site_url: api_root_url_success.parsed_site_url,
+                        api_root_url: api_root_url_success.api_root_url,
+                    },
+                );
+            }
+
             Err(
                 AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
                     parsed_site_url: api_root_url_success.parsed_site_url,

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use scraper::{Html, Selector};
 use serde::Deserialize;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 pub(crate) const API_ROOT_LINK_HEADER: &str = "https://api.w.org/";
 
@@ -421,39 +421,34 @@ pub enum AutoDiscoveryAttemptFailure {
         api_root_url: ParsedUrl,
         parsing_error_message: String,
     },
-    #[error("Application Passwords are not supported")]
+    #[error("{}", reason.as_ref().map(|r| r.error_message(parsed_site_url)).unwrap_or("Application Passwords are not supported".to_string()))]
     ApplicationPasswordsNotSupported {
         parsed_site_url: ParsedUrl,
         api_root_url: ParsedUrl,
         api_details: WpApiDetails,
+        reason: Option<ApplicationPasswordsNotSupportedReason>,
     },
-    #[error("Unable to login to {} – the {} plugin might have disabled Application Passwords. Please visit {} to learn more",
-        parsed_site_url,
-        plugin.name,
-        plugin.support_url
-    )]
+}
+
+#[derive(Debug, Clone)]
+pub enum ApplicationPasswordsNotSupportedReason {
     ApplicationPasswordBlockedByPlugin {
-        parsed_site_url: ParsedUrl,
-        api_root_url: ParsedUrl,
         plugin: KnownApplicationPasswordBlockingPlugin,
     },
-    #[error("Unable to login to {} – there are multiple installed plugins that might have disabled Application Passwords. Please disable them and try again.",
-        parsed_site_url
-    )]
-    ApplicationPasswordBlockedByMultiplePlugins {
-        parsed_site_url: ParsedUrl,
-        api_root_url: ParsedUrl,
-    },
-    #[error("This site is a local development environment. You'll need to enable application passwords to connect to it with the app.")]
-    SiteIsLocalDevelopmentEnvironment {
-        parsed_site_url: ParsedUrl,
-        api_root_url: ParsedUrl,
-    },
-    #[error("Application Passwords is not enabled for this site – this is likely because we can't establish a secure connection to it. Please add an SSL certificate to this site and try again.")]
-    ApplicationPasswordsDisabledForHttpSite {
-        parsed_site_url: ParsedUrl,
-        api_root_url: ParsedUrl,
-    },
+    ApplicationPasswordBlockedByMultiplePlugins,
+    SiteIsLocalDevelopmentEnvironment,
+    ApplicationPasswordsDisabledForHttpSite,
+}
+
+impl ApplicationPasswordsNotSupportedReason {
+    fn error_message(&self, parsed_site_url: impl Display) -> String {
+        match self {
+            Self::ApplicationPasswordBlockedByPlugin { plugin } => format!("Unable to login to {} – the {} plugin might have disabled Application Passwords. Please visit {} to learn more", parsed_site_url, plugin.name, plugin.support_url),
+            Self::ApplicationPasswordBlockedByMultiplePlugins => format!("Unable to login to {} – there are multiple installed plugins that might have disabled Application Passwords. Please disable them and try again.", parsed_site_url),
+            Self::SiteIsLocalDevelopmentEnvironment => "This site is a local development environment. You'll need to enable application passwords to connect to it with the app.".to_string(),
+            Self::ApplicationPasswordsDisabledForHttpSite => "Application Passwords is not enabled for this site – this is likely because we can't establish a secure connection to it. Please add an SSL certificate to this site and try again.".to_string(),
+    }
+    }
 }
 
 impl AutoDiscoveryAttemptFailure {
@@ -465,12 +460,6 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => false,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => false,
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => false,
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => false,
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
-                false
-            }
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => false,
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => false,
         }
     }
 
@@ -493,22 +482,6 @@ impl AutoDiscoveryAttemptFailure {
                 parsed_site_url,
                 ..
             } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
-                parsed_site_url,
-                ..
-            } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
-                parsed_site_url,
-                ..
-            } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
-                parsed_site_url,
-                ..
-            } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
-                parsed_site_url,
-                ..
-            } => Some(parsed_site_url),
         }
     }
 
@@ -527,14 +500,6 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => Some(false),
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(false),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
-                Some(false)
-            }
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
-                Some(false)
-            }
         }
     }
 
@@ -547,21 +512,6 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(api_root_url),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
                 api_root_url, ..
-            } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
-                api_root_url,
-                ..
-            } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
-                api_root_url,
-                ..
-            } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
-                api_root_url, ..
-            } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
-                api_root_url,
-                ..
             } => Some(api_root_url),
         }
     }
@@ -579,14 +529,6 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(true),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
-                Some(false)
-            }
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
-                Some(false)
-            }
         }
     }
 
@@ -598,14 +540,6 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
-                Some(true)
-            }
-            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
-                Some(true)
-            }
         }
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1,7 +1,8 @@
 use super::WpApiDetails;
 use crate::{
-    request::WpNetworkHeaderMap, request::WpRedirect, ParseUrlError, ParsedUrl,
-    RequestExecutionError, RequestExecutionErrorReason,
+    login::KnownApplicationPasswordBlockingPlugin, request::WpNetworkHeaderMap,
+    request::WpRedirect, ParseUrlError, ParsedUrl, RequestExecutionError,
+    RequestExecutionErrorReason,
 };
 use scraper::{Html, Selector};
 use serde::Deserialize;
@@ -426,6 +427,33 @@ pub enum AutoDiscoveryAttemptFailure {
         api_root_url: ParsedUrl,
         api_details: WpApiDetails,
     },
+    #[error("Unable to login to {} – the {} plugin might have disabled Application Passwords. Please visit {} to learn more",
+        parsed_site_url,
+        plugin.name,
+        plugin.support_url
+    )]
+    ApplicationPasswordBlockedByPlugin {
+        parsed_site_url: ParsedUrl,
+        api_root_url: ParsedUrl,
+        plugin: KnownApplicationPasswordBlockingPlugin,
+    },
+    #[error("Unable to login to {} – there are multiple installed plugins that might have disabled Application Passwords. Please disable them and try again.",
+        parsed_site_url
+    )]
+    ApplicationPasswordBlockedByMultiplePlugins {
+        parsed_site_url: ParsedUrl,
+        api_root_url: ParsedUrl,
+    },
+    #[error("This site is a local development environment. You'll need to enable application passwords to connect to it with the app.")]
+    SiteIsLocalDevelopmentEnvironment {
+        parsed_site_url: ParsedUrl,
+        api_root_url: ParsedUrl,
+    },
+    #[error("Application Passwords is not enabled for this site – this is likely because we can't establish a secure connection to it. Please add an SSL certificate to this site and try again.")]
+    ApplicationPasswordsDisabledForHttpSite {
+        parsed_site_url: ParsedUrl,
+        api_root_url: ParsedUrl,
+    },
 }
 
 impl AutoDiscoveryAttemptFailure {
@@ -437,6 +465,12 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => false,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => false,
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => false,
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => false,
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
+                false
+            }
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => false,
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => false,
         }
     }
 
@@ -459,6 +493,22 @@ impl AutoDiscoveryAttemptFailure {
                 parsed_site_url,
                 ..
             } => Some(parsed_site_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
+                parsed_site_url,
+                ..
+            } => Some(parsed_site_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
+                parsed_site_url,
+                ..
+            } => Some(parsed_site_url),
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
+                parsed_site_url,
+                ..
+            } => Some(parsed_site_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
+                parsed_site_url,
+                ..
+            } => Some(parsed_site_url),
         }
     }
 
@@ -477,6 +527,14 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => Some(false),
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(false),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
+                Some(false)
+            }
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
+                Some(false)
+            }
         }
     }
 
@@ -489,6 +547,21 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(api_root_url),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
                 api_root_url, ..
+            } => Some(api_root_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin {
+                api_root_url,
+                ..
+            } => Some(api_root_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins {
+                api_root_url,
+                ..
+            } => Some(api_root_url),
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment {
+                api_root_url, ..
+            } => Some(api_root_url),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite {
+                api_root_url,
+                ..
             } => Some(api_root_url),
         }
     }
@@ -506,6 +579,14 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(true),
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
+                Some(false)
+            }
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(false),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
+                Some(false)
+            }
         }
     }
 
@@ -517,6 +598,14 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => None,
             AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(true),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByPlugin { .. } => Some(true),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordBlockedByMultiplePlugins { .. } => {
+                Some(true)
+            }
+            AutoDiscoveryAttemptFailure::SiteIsLocalDevelopmentEnvironment { .. } => Some(true),
+            AutoDiscoveryAttemptFailure::ApplicationPasswordsDisabledForHttpSite { .. } => {
+                Some(true)
+            }
         }
     }
 }
@@ -610,6 +699,11 @@ pub enum FetchApiDetailsError {
     },
     #[error("Api details couldn't be parsed from response: {:?}", response)]
     ApiDetailsCouldntBeParsed { reason: String, response: String },
+    #[error(
+        "Unable to login to {:?}. Please double-check that this is a WordPress site",
+        hostname
+    )]
+    NotAWordPressSiteError { hostname: String },
 }
 
 #[cfg(test)]

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -633,11 +633,6 @@ pub enum FetchApiDetailsError {
     },
     #[error("Api details couldn't be parsed from response: {:?}", response)]
     ApiDetailsCouldntBeParsed { reason: String, response: String },
-    #[error(
-        "Unable to login to {:?}. Please double-check that this is a WordPress site",
-        hostname
-    )]
-    NotAWordPressSiteError { hostname: String },
 }
 
 #[cfg(test)]

--- a/wp_api/src/parsed_url.rs
+++ b/wp_api/src/parsed_url.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+use std::fmt::Display;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, uniffi::Object)]
@@ -8,6 +10,20 @@ pub struct ParsedUrl {
 impl ParsedUrl {
     pub fn new(url: Url) -> Self {
         Self { inner: url }
+    }
+}
+
+impl Display for ParsedUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.inner.path() == "/" {
+            write!(
+                f,
+                "{}",
+                self.inner.host_str().unwrap_or(self.inner.as_str())
+            )
+        } else {
+            write!(f, "{}", self.inner.as_str())
+        }
     }
 }
 
@@ -111,5 +127,15 @@ mod tests {
     #[case("https://xn--u-ccb.com", ParseUrlError::IdnaError)]
     fn parse_url_error(#[case] input: &str, #[case] expected_err: ParseUrlError) {
         assert_eq!(ParsedUrl::try_from(input).unwrap_err(), expected_err);
+    }
+
+    #[rstest]
+    #[case("https://example.com", "example.com")]
+    #[case("http://example.com", "example.com")]
+    #[case("http://example.com/path", "http://example.com/path")]
+    #[case("http://subdomain.example.com", "subdomain.example.com")]
+    fn display_url(#[case] input: &str, #[case] expected_display: &str) {
+        let url = ParsedUrl::parse(input).unwrap();
+        assert_eq!(format!("{}", url), expected_display);
     }
 }

--- a/wp_api/src/parsed_url.rs
+++ b/wp_api/src/parsed_url.rs
@@ -15,15 +15,7 @@ impl ParsedUrl {
 
 impl Display for ParsedUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.inner.path() == "/" {
-            write!(
-                f,
-                "{}",
-                self.inner.host_str().unwrap_or(self.inner.as_str())
-            )
-        } else {
-            write!(f, "{}", self.inner.as_str())
-        }
+        write!(f, "{}", self.inner)
     }
 }
 
@@ -38,6 +30,18 @@ impl ParsedUrl {
 
     pub fn url(&self) -> String {
         self.inner.to_string()
+    }
+
+    /// A user-facing URL string that omits unnecessary details.
+    pub fn pretty_url(&self) -> String {
+        if self.inner.path() == "/" {
+            self.inner
+                .host_str()
+                .unwrap_or(self.inner.as_str())
+                .to_string()
+        } else {
+            self.inner.to_string()
+        }
     }
 }
 
@@ -134,8 +138,8 @@ mod tests {
     #[case("http://example.com", "example.com")]
     #[case("http://example.com/path", "http://example.com/path")]
     #[case("http://subdomain.example.com", "subdomain.example.com")]
-    fn display_url(#[case] input: &str, #[case] expected_display: &str) {
+    fn pretty_url(#[case] input: &str, #[case] expected_display: &str) {
         let url = ParsedUrl::parse(input).unwrap();
-        assert_eq!(format!("{}", url), expected_display);
+        assert_eq!(url.pretty_url(), expected_display);
     }
 }


### PR DESCRIPTION
Moves a bunch of application-layer login errors out of #532, pushing them down into Rust so the implementation can be shared between Swift and Kotlin.

This is a separate PR to keep things small and easy-to-review. 