### PR TITLE
Add 429 support to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +149,90 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -149,6 +256,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -235,6 +348,19 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "brotli"
@@ -392,6 +518,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +576,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "cssparser"
@@ -612,6 +753,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +913,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +1037,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "goblin"
@@ -1340,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1580,9 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loom"
@@ -1635,6 +1840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1988,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2009,21 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3304,6 +3541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +3925,7 @@ dependencies = [
 name = "wp_api"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "async-trait",
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+async-std = "1.10"
 base64 = "0.22"
 chrono = "0.4"
 clap = "4.5"

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -2,10 +2,12 @@ package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import uniffi.wp_api.WpLoginClientConfiguration
 import kotlin.test.assertEquals
 
 class ApiUrlDiscoveryTest {
-    private val loginClient: WpLoginClient = WpLoginClient()
+    private val loginClient: WpLoginClient = WpLoginClient(config = WpLoginClientConfiguration(true,
+        1u, 3u))
 
     @Test
     fun testFindsCorrectApiUrls() = runTest {

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -6,13 +6,31 @@ import kotlinx.coroutines.withContext
 import uniffi.wp_api.AutoDiscoveryUniffiResult
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpLoginClient
+import uniffi.wp_api.WpLoginClientConfiguration
+import uniffi.wp_api.uniffiwploginclientWithConfig
 
-class WpLoginClient(
-    private val requestExecutor: RequestExecutor = WpRequestExecutor(),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
-) {
-    private val internalClient by lazy {
-        UniffiWpLoginClient(requestExecutor)
+class WpLoginClient {
+    private val requestExecutor: RequestExecutor
+    private val dispatcher: CoroutineDispatcher
+    private val internalClient: UniffiWpLoginClient
+
+    constructor(
+        requestExecutor: RequestExecutor = WpRequestExecutor(),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) {
+        this.requestExecutor = requestExecutor
+        this.dispatcher = dispatcher
+        this.internalClient = UniffiWpLoginClient(requestExecutor)
+    }
+
+    constructor(
+        requestExecutor: RequestExecutor = WpRequestExecutor(),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        config: WpLoginClientConfiguration
+    ) {
+        this.requestExecutor = requestExecutor
+        this.dispatcher = dispatcher
+        this.internalClient = uniffiwploginclientWithConfig(requestExecutor, config)
     }
 
     suspend fun apiDiscovery(siteUrl: String): AutoDiscoveryUniffiResult = withContext(dispatcher) {

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -1,0 +1,18 @@
+import WordPressAPIInternal
+
+// This file defines "stapling" extensions – anywhere we want to "staple" a free-floating function to an object
+
+extension UniffiWpLoginClient {
+    static func withConfig(
+        requestExecutor: any RequestExecutor,
+        config: WpLoginClientConfiguration
+    ) -> UniffiWpLoginClient {
+        return uniffiwploginclientWithConfig(requestExecutor: requestExecutor, config: config)
+    }
+}
+
+extension WpLoginClientConfiguration {
+    public static var `default`: WpLoginClientConfiguration {
+        defaultWpLoginClientConfiguration()
+    }
+}

--- a/native/swift/Sources/wordpress-api/LoginAPI.swift
+++ b/native/swift/Sources/wordpress-api/LoginAPI.swift
@@ -16,11 +16,17 @@ public final class WordPressLoginClient {
     private let requestExecutor: SafeRequestExecutor
     private let client: UniffiWpLoginClient
 
-    public convenience init(urlSession: URLSession) {
+    public convenience init(
+        urlSession: URLSession,
+        loginConfiguration: WpLoginClientConfiguration = .default
+    ) {
         self.init(requestExecutor: WpRequestExecutor(urlSession: urlSession))
     }
 
-    init(requestExecutor: SafeRequestExecutor) {
+    init(
+        requestExecutor: SafeRequestExecutor,
+        loginConfiguration: WpLoginClientConfiguration = .default
+    ) {
         self.requestExecutor = requestExecutor
         self.client = UniffiWpLoginClient(requestExecutor: requestExecutor)
     }

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -12,6 +12,7 @@ name = "wp_api"
 
 [dependencies]
 async-trait = { workspace = true }
+async-std = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true, features = [ "serde" ] }
 futures = { workspace = true }

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -15,8 +15,10 @@ use crate::{
         endpoint::WpEndpointUrl, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
         WpNetworkRequest, WpNetworkResponse,
     },
-    ParseUrlError, ParsedUrl, RequestExecutionError,
+    ParseUrlError, ParsedUrl, RequestExecutionError, RequestExecutionErrorReason,
 };
+use async_std::task;
+use std::time::Duration;
 use std::{str, sync::Arc};
 use uuid::Uuid;
 
@@ -253,26 +255,25 @@ impl WpLoginClient {
             header_map: WpNetworkHeaderMap::default().into(),
             body: None,
         };
-        self.request_executor.execute(api_root_request.into()).await
+        self.perform(api_root_request.into()).await
     }
 
     async fn fetch_wp_api_details(
         &self,
         api_root_url: &ParsedUrl,
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
-        self.request_executor
-            .execute(
-                WpNetworkRequest {
-                    uuid: Uuid::new_v4().into(),
-                    retry_count: 0,
-                    method: RequestMethod::GET,
-                    url: WpEndpointUrl(api_root_url.url()),
-                    header_map: WpNetworkHeaderMap::default().into(),
-                    body: None,
-                }
-                .into(),
-            )
-            .await
+        self.perform(
+            WpNetworkRequest {
+                uuid: Uuid::new_v4().into(),
+                retry_count: 0,
+                method: RequestMethod::GET,
+                url: WpEndpointUrl(api_root_url.url()),
+                header_map: WpNetworkHeaderMap::default().into(),
+                body: None,
+            }
+            .into(),
+        )
+        .await
     }
 
     async fn fetch_wp_json(
@@ -292,8 +293,7 @@ impl WpLoginClient {
             wp_json_url
         };
         let fetch_wp_json_response = match self
-            .request_executor
-            .execute(
+            .perform(
                 WpNetworkRequest {
                     uuid: Uuid::new_v4().into(),
                     retry_count: 0,
@@ -329,19 +329,49 @@ impl WpLoginClient {
     ) -> Result<WpNetworkResponse, ParseHtmlFailure> {
         let site_url = ParsedUrl::parse(attempt_site_url)
             .map_err(|error| ParseHtmlFailure::ParseSiteUrl { error })?;
-        self.request_executor
-            .execute(
-                WpNetworkRequest {
-                    uuid: Uuid::new_v4().into(),
-                    retry_count: 0,
-                    method: RequestMethod::GET,
-                    url: WpEndpointUrl(site_url.url()),
-                    header_map: WpNetworkHeaderMap::default().into(),
-                    body: None,
+        self.perform(
+            WpNetworkRequest {
+                uuid: Uuid::new_v4().into(),
+                retry_count: 0,
+                method: RequestMethod::GET,
+                url: WpEndpointUrl(site_url.url()),
+                header_map: WpNetworkHeaderMap::default().into(),
+                body: None,
+            }
+            .into(),
+        )
+        .await
+        .map_err(|error| ParseHtmlFailure::FetchSite { error })
+    }
+
+    async fn perform(
+        &self,
+        request: Arc<WpNetworkRequest>,
+    ) -> Result<WpNetworkResponse, RequestExecutionError> {
+        let mut retry_count = 0;
+
+        loop {
+            let response = self.request_executor.execute(request.clone()).await?;
+
+            if retry_count >= 3 {
+                return Err(RequestExecutionError::RequestExecutionFailed {
+                    status_code: Some(response.status_code),
+                    redirects: None,
+                    reason: RequestExecutionErrorReason::MisconfiguredRateLimitError {},
+                });
+            }
+
+            if response.is_http_429() {
+                let retry_after = response.get_retry_after();
+                if let Some(retry_after) = retry_after {
+                    task::sleep(Duration::from_secs(retry_after)).await;
+                } else {
+                    return Ok(response); // It's not ok, but we'll let the layer above handle that – we have no idea how long to wait so we shouldn't try
                 }
-                .into(),
-            )
-            .await
-            .map_err(|error| ParseHtmlFailure::FetchSite { error })
+                retry_count += 1;
+            } else {
+                return Ok(response);
+            }
+        }
     }
 }

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -36,9 +36,18 @@ impl UniffiWpLoginClient {
                 .into(),
         }
     }
-
     async fn api_discovery(&self, site_url: String) -> AutoDiscoveryUniffiResult {
         self.inner.api_discovery(site_url).await.into()
+    }
+}
+
+#[uniffi::export]
+fn uniffiwploginclient_with_config(
+    request_executor: Arc<dyn RequestExecutor>,
+    config: WpLoginClientConfiguration,
+) -> UniffiWpLoginClient {
+    UniffiWpLoginClient {
+        inner: WpLoginClient::new(request_executor, config).into(),
     }
 }
 
@@ -47,6 +56,11 @@ pub struct WpLoginClientConfiguration {
     pub should_auto_retry_on_rate_limit: bool,
     pub max_retries: u32,
     pub max_retry_wait_seconds: u64,
+}
+
+#[uniffi::export]
+fn default_wp_login_client_configuration() -> WpLoginClientConfiguration {
+    WpLoginClientConfiguration::default()
 }
 
 impl Default for WpLoginClientConfiguration {

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -32,7 +32,8 @@ impl UniffiWpLoginClient {
     #[uniffi::constructor]
     fn new(request_executor: Arc<dyn RequestExecutor>) -> Self {
         Self {
-            inner: WpLoginClient::new(request_executor).into(),
+            inner: WpLoginClient::new(request_executor, WpLoginClientConfiguration::default())
+                .into(),
         }
     }
 
@@ -41,14 +42,38 @@ impl UniffiWpLoginClient {
     }
 }
 
+#[derive(Debug, uniffi::Record)]
+pub struct WpLoginClientConfiguration {
+    pub should_auto_retry_on_rate_limit: bool,
+    pub max_retries: u32,
+    pub max_retry_wait_seconds: u64,
+}
+
+impl Default for WpLoginClientConfiguration {
+    fn default() -> Self {
+        Self {
+            should_auto_retry_on_rate_limit: true,
+            max_retries: 3,
+            max_retry_wait_seconds: 60,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct WpLoginClient {
     request_executor: Arc<dyn RequestExecutor>,
+    config: WpLoginClientConfiguration,
 }
 
 impl WpLoginClient {
-    pub fn new(request_executor: Arc<dyn RequestExecutor>) -> Self {
-        Self { request_executor }
+    pub fn new(
+        request_executor: Arc<dyn RequestExecutor>,
+        config: WpLoginClientConfiguration,
+    ) -> Self {
+        Self {
+            request_executor,
+            config,
+        }
     }
 
     pub async fn api_discovery(&self, site_url: String) -> AutoDiscoveryResult {
@@ -353,7 +378,7 @@ impl WpLoginClient {
         loop {
             let response = self.request_executor.execute(request.clone()).await?;
 
-            if retry_count >= 3 {
+            if retry_count >= self.config.max_retries {
                 return Err(RequestExecutionError::RequestExecutionFailed {
                     status_code: Some(response.status_code),
                     redirects: None,
@@ -361,9 +386,15 @@ impl WpLoginClient {
                 });
             }
 
-            if response.is_http_429() {
+            if response.is_http_429() && self.config.should_auto_retry_on_rate_limit {
                 let retry_after = response.get_retry_after();
-                if let Some(retry_after) = retry_after {
+
+                if let Some(mut retry_after) = retry_after {
+                    // If the server sends some super-long value, we don't want to wait that long
+                    if retry_after > self.config.max_retry_wait_seconds {
+                        retry_after = self.config.max_retry_wait_seconds;
+                    }
+
                     task::sleep(Duration::from_secs(retry_after)).await;
                 } else {
                     return Ok(response); // It's not ok, but we'll let the layer above handle that – we have no idea how long to wait so we shouldn't try

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -18,6 +18,7 @@ const CONTENT_TYPE_MULTIPART: &str = "multipart/form-data";
 const LINK_HEADER_KEY: &str = "Link";
 const HEADER_KEY_WP_TOTAL: &str = "X-WP-Total";
 const HEADER_KEY_WP_TOTAL_PAGES: &str = "X-WP-TotalPages";
+const HEADER_KEY_RETRY_AFTER: &str = "Retry-After";
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -278,6 +279,13 @@ impl WpNetworkHeaderMap {
             .and_then(|h| h.parse().ok())
     }
 
+    pub fn header_value_as_u64(&self, header_name: &str) -> Option<u64> {
+        self.inner
+            .get(header_name)
+            .and_then(|h_v| h_v.to_str().ok())
+            .and_then(|h| h.parse().ok())
+    }
+
     // Splits the `header_value` by `,` then parses name & values into `HeaderName` & `HeaderValue`
     fn build_header_name_value(
         header_name: &str,
@@ -438,6 +446,15 @@ impl WpNetworkResponse {
         F: Fn(&WpNetworkResponse) -> Result<T, WpApiError>,
     {
         parser(self)
+    }
+
+    pub fn is_http_429(&self) -> bool {
+        self.status_code == 429
+    }
+
+    pub fn get_retry_after(&self) -> Option<u64> {
+        // TODO: Handle the case where the header is a string like "120 seconds" or a date like "Tue, 21 Feb 2025 10:00:00 GMT"
+        self.header_map.header_value_as_u64("retry-after")
     }
 }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -454,7 +454,7 @@ impl WpNetworkResponse {
 
     pub fn get_retry_after(&self) -> Option<u64> {
         // TODO: Handle the case where the header is a string like "120 seconds" or a date like "Tue, 21 Feb 2025 10:00:00 GMT"
-        self.header_map.header_value_as_u64("retry-after")
+        self.header_map.header_value_as_u64(HEADER_KEY_RETRY_AFTER)
     }
 }
 


### PR DESCRIPTION
This PR is a proposal for how to add automated 429 retry (and a mechanism to bail out if there are too many retry responses). 

We can later apply it to the main API client, because we should have some mechanism of handling that there too, but I'd like to start here, get feedback on the approach, then carry on.

This PR deliberately doesn't:

1. Handle non-integer `Retry-After` values
2. Do anything about `401` or `403` responses, which IMHO should be handled in the same place – treating these like a transport error makes sense because we can't do anything unless they're resolved.

