### PR TITLE
Bundle wp_api and wp_localization into one Swift package

### DIFF
--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 echo "--- :arrow_down: Downloading xcframework"
 buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
 buildkite-agent artifact download native/swift/Sources/wordpress-api-wrapper/wp_api.swift . --step "xcframework"
+buildkite-agent artifact download native/swift/Sources/wordpress-api-wrapper/wp_localization.swift . --step "xcframework"
 unzip target/libwordpressFFI.xcframework.zip -d .
 rm target/libwordpressFFI.xcframework.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,7 @@ steps:
         artifact_paths:
           - target/libwordpressFFI.xcframework.zip
           - native/swift/Sources/wordpress-api-wrapper/wp_api.swift
+          - native/swift/Sources/wordpress-api-wrapper/wp_localization.swift
         agents:
           queue: mac
       - label: ":swift: Build Docs"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ included:
   - native/swift
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - native/swift/Sources/wordpress-api-wrapper/wp_api.swift # auto-generated code
+  - native/swift/Sources/wordpress-api-wrapper/wp_localization.swift # auto-generated code
 disabled_rules:
   # Don't think we should enable this rule.
   # See https://github.com/realm/SwiftLint/issues/5263 for context.
@@ -12,4 +13,3 @@ disabled_rules:
   - type_name
   # The library is still developing. We'll allow todo at this stage.
   - todo
-

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,7 +118,11 @@ def xcframework_file_path
 end
 
 def xcframework_bindings_file_path
-  File.join(PROJECT_ROOT, 'native', 'swift', 'Sources', 'wordpress-api-wrapper', 'wp_api.swift')
+  dir = File.join(PROJECT_ROOT, 'native', 'swift', 'Sources', 'wordpress-api-wrapper')
+  [
+    File.join(dir, 'wp_api.swift'),
+    File.join(dir, 'wp_localization.swift'),
+  ]
 end
 
 def remove_lane_context_values(names)

--- a/wp_localization/uniffi.toml
+++ b/wp_localization/uniffi.toml
@@ -1,0 +1,6 @@
+[bindings.swift]
+ffi_module_name = "libwordpressFFI"
+ffi_module_filename = "wp_localization_uniffi"
+generate_module_map = false
+generate_immutable_records = true
+experimental_sendable_value_types = true


### PR DESCRIPTION
The existing `libwordpressFFI.xcframework` (a.k.a, the static library of our Rust code) now contains both wp_api and wp_localization crates. The existing `WordPressAPIInternal` Swift package now contains bindings for both crates.