### PR TITLE
[Buildkite] Test Android Staging on `ami-0ed66347bb94c070a` -> `ami-03794d38ac4991af7`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -152,7 +152,7 @@ steps:
           cd ./native/kotlin
           ./gradlew detektMain detektTest
         agents:
-          queue: android
+          queue: android-staging
       - label: ":kotlin: Publish `rs.wordpress.api:kotlin`"
         key: "publish-wp-api-kotlin"
         plugins: [$CI_TOOLKIT]
@@ -168,7 +168,7 @@ steps:
           echo "--- :kotlin: Publishing `rs.wordpress.api:kotlin`"
           .buildkite/publish-wp-api-kotlin.sh
         agents:
-          queue: android
+          queue: android-staging
       - label: ":kotlin: Publish `rs.wordpress.api:android`"
         key: "publish-wp-api-android"
         plugins: [$CI_TOOLKIT]
@@ -187,7 +187,7 @@ steps:
           echo "--- :kotlin: Publishing `rs.wordpress.api:android`"
           .buildkite/publish-wp-api-android.sh
         agents:
-          queue: android
+          queue: android-staging
 
   # Docker Group
   - group: ":wordpress: End-to-end Tests"


### PR DESCRIPTION
Related: [buildkite-ci#610](https://github.com/Automattic/buildkite-ci/pull/610)

AMI Name: `android-build-image-6.12.0v1.7-rc-1` -> `android-build-image-6.12.0v1.8-rc-1`

-----

## Description:

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0ed66347bb94c070a` works as expected.

-----

## To Test:

Check CI and verify everything is working as expected with the `android-staging` agent.