### PR TITLE
[Api Discovery] Try root `/wp-json` if we can't find link header

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -181,22 +181,34 @@ impl WpLoginClient {
         fetch_wp_json_result: Result<FetchWpJsonSuccess, FetchWpJsonFailure>,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
         if let Some(api_root_url) = api_root_url_from_link_tag {
-            Ok(FindApiRootLinkHeaderSuccess {
+            return Ok(FindApiRootLinkHeaderSuccess {
                 parsed_site_url,
                 api_root_url,
-            })
-        } else if let Ok(success) = self
+            });
+        }
+        match self
             .fetch_and_parse_api_root_url_header(parsed_site_url.clone())
             .await
         {
-            Ok(success)
-        } else if let Ok(fetch_wp_json_success) = fetch_wp_json_result {
-            Ok(FindApiRootLinkHeaderSuccess {
-                parsed_site_url,
-                api_root_url: fetch_wp_json_success.wp_json_url,
-            })
-        } else {
-            Err(FindApiRootLinkHeaderFailure::ApiRootNotFound { parsed_site_url })
+            Ok(s) => Ok(s),
+            Err(fetch_and_parse_api_root_url_header_err) => {
+                // If we can't find the link header, but we were able to fetch `/wp-json` from the
+                // attempt url, we assume that it's the correct api root url
+                //
+                // We don't immediately rely on this because there might be cases where there are
+                // multiple `/wp-json` paths in which case we want to prioritize the one returned
+                // from the link header
+                if let Ok(fetch_wp_json_success) = fetch_wp_json_result {
+                    Ok(FindApiRootLinkHeaderSuccess {
+                        parsed_site_url,
+                        api_root_url: fetch_wp_json_success.wp_json_url,
+                    })
+                } else {
+                    // If fetching `/wp-json` wasn't successful, we return the original error from
+                    // fetching the api root link header
+                    Err(fetch_and_parse_api_root_url_header_err)
+                }
+            }
         }
     }
 

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -188,7 +188,10 @@ impl WpLoginClient {
                 parsed_site_url,
                 api_root_url,
             })
-        } else if let Ok(success) = self.fetch_and_parse_api_root_url_header(&parsed_site_url).await {
+        } else if let Ok(success) = self
+            .fetch_and_parse_api_root_url_header(&parsed_site_url)
+            .await
+        {
             Ok(success)
         } else if let Ok(response) = self.guess_api_root_url(&parsed_site_url).await {
             Ok(FindApiRootLinkHeaderSuccess {
@@ -196,9 +199,7 @@ impl WpLoginClient {
                 api_root_url: response,
             })
         } else {
-            Err(FindApiRootLinkHeaderFailure::ApiRootNotFound {
-                parsed_site_url,
-            })
+            Err(FindApiRootLinkHeaderFailure::ApiRootNotFound { parsed_site_url })
         }
     }
 
@@ -206,11 +207,11 @@ impl WpLoginClient {
         &self,
         parsed_site_url: &ParsedUrl,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
-        let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
+        let fetch_api_root_url_response = match self.fetch_api_root_url(parsed_site_url).await {
             Ok(r) => r,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::FetchApiRootUrl {
-                    parsed_site_url:parsed_site_url.clone(),
+                    parsed_site_url: parsed_site_url.clone(),
                     error,
                 })
             }
@@ -219,13 +220,13 @@ impl WpLoginClient {
             Ok(api_root_url) => api_root_url,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
-                    parsed_site_url:parsed_site_url.clone(),
+                    parsed_site_url: parsed_site_url.clone(),
                     error,
                 })
             }
         };
         Ok(FindApiRootLinkHeaderSuccess {
-            parsed_site_url:parsed_site_url.clone(),
+            parsed_site_url: parsed_site_url.clone(),
             api_root_url,
         })
     }
@@ -265,17 +266,21 @@ impl WpLoginClient {
     }
 
     /// Guess the REST API root URL from the site root. Many sites don't emit a link header or the
-    /// link tag, but the JSON API works just fine. If they use a custom REST route we won't be able to 
+    /// link tag, but the JSON API works just fine. If they use a custom REST route we won't be able to
     /// find it, but if it's a standard setup this will work.
-    async fn guess_api_root_url(&self, parsed_site_url: &ParsedUrl) -> Result<ParsedUrl, RequestExecutionError> {
+    async fn guess_api_root_url(
+        &self,
+        parsed_site_url: &ParsedUrl,
+    ) -> Result<ParsedUrl, RequestExecutionError> {
         let mut api_root_url = parsed_site_url.clone();
-        api_root_url.inner.path_segments_mut().unwrap().push("wp-json");
-
-        if let Err(error) = self.fetch_api_root_url(&api_root_url).await {
-            return Err(error)
-        } else {
-            Ok(api_root_url)
-        }
+        api_root_url
+            .inner
+            .path_segments_mut()
+            .unwrap()
+            .push("wp-json");
+        self.fetch_api_root_url(&api_root_url)
+            .await
+            .map(|_| api_root_url)
     }
 
     async fn fetch_wp_api_details(

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -188,21 +188,29 @@ impl WpLoginClient {
                 parsed_site_url,
                 api_root_url,
             })
+        } else if let Ok(success) = self.fetch_and_parse_api_root_url_header(&parsed_site_url).await {
+            Ok(success)
+        } else if let Ok(response) = self.guess_api_root_url(&parsed_site_url).await {
+            Ok(FindApiRootLinkHeaderSuccess {
+                parsed_site_url,
+                api_root_url: response,
+            })
         } else {
-            self.fetch_and_parse_api_root_url_header(parsed_site_url)
-                .await
+            Err(FindApiRootLinkHeaderFailure::ApiRootNotFound {
+                parsed_site_url,
+            })
         }
     }
 
     async fn fetch_and_parse_api_root_url_header(
         &self,
-        parsed_site_url: ParsedUrl,
+        parsed_site_url: &ParsedUrl,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
         let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
             Ok(r) => r,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::FetchApiRootUrl {
-                    parsed_site_url,
+                    parsed_site_url:parsed_site_url.clone(),
                     error,
                 })
             }
@@ -211,17 +219,18 @@ impl WpLoginClient {
             Ok(api_root_url) => api_root_url,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
-                    parsed_site_url,
+                    parsed_site_url:parsed_site_url.clone(),
                     error,
                 })
             }
         };
         Ok(FindApiRootLinkHeaderSuccess {
-            parsed_site_url,
+            parsed_site_url:parsed_site_url.clone(),
             api_root_url,
         })
     }
 
+    /// Parses the API root URL from the Link header
     fn parse_api_root_response(
         &self,
         response: WpNetworkResponse,
@@ -239,8 +248,7 @@ impl WpLoginClient {
         }
     }
 
-    // Fetches the site's homepage with a HEAD request, then extracts the Link header pointing
-    // to the WP.org API root
+    // Fetches the site's homepage with a HEAD request
     async fn fetch_api_root_url(
         &self,
         parsed_site_url: &ParsedUrl,
@@ -254,6 +262,20 @@ impl WpLoginClient {
             body: None,
         };
         self.request_executor.execute(api_root_request.into()).await
+    }
+
+    /// Guess the REST API root URL from the site root. Many sites don't emit a link header or the
+    /// link tag, but the JSON API works just fine. If they use a custom REST route we won't be able to 
+    /// find it, but if it's a standard setup this will work.
+    async fn guess_api_root_url(&self, parsed_site_url: &ParsedUrl) -> Result<ParsedUrl, RequestExecutionError> {
+        let mut api_root_url = parsed_site_url.clone();
+        api_root_url.inner.path_segments_mut().unwrap().push("wp-json");
+
+        if let Err(error) = self.fetch_api_root_url(&api_root_url).await {
+            return Err(error)
+        } else {
+            Ok(api_root_url)
+        }
     }
 
     async fn fetch_wp_api_details(

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -189,11 +189,11 @@ impl WpLoginClient {
                 api_root_url,
             })
         } else if let Ok(success) = self
-            .fetch_and_parse_api_root_url_header(&parsed_site_url)
+            .fetch_and_parse_api_root_url_header(parsed_site_url.clone())
             .await
         {
             Ok(success)
-        } else if let Ok(response) = self.guess_api_root_url(&parsed_site_url).await {
+        } else if let Ok(response) = self.guess_api_root_url(parsed_site_url.clone()).await {
             Ok(FindApiRootLinkHeaderSuccess {
                 parsed_site_url,
                 api_root_url: response,
@@ -205,13 +205,13 @@ impl WpLoginClient {
 
     async fn fetch_and_parse_api_root_url_header(
         &self,
-        parsed_site_url: &ParsedUrl,
+        parsed_site_url: ParsedUrl,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
-        let fetch_api_root_url_response = match self.fetch_api_root_url(parsed_site_url).await {
+        let fetch_api_root_url_response = match self.fetch_api_root_url(&parsed_site_url).await {
             Ok(r) => r,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::FetchApiRootUrl {
-                    parsed_site_url: parsed_site_url.clone(),
+                    parsed_site_url,
                     error,
                 })
             }
@@ -220,7 +220,7 @@ impl WpLoginClient {
             Ok(api_root_url) => api_root_url,
             Err(error) => {
                 return Err(FindApiRootLinkHeaderFailure::ParseApiRootUrl {
-                    parsed_site_url: parsed_site_url.clone(),
+                    parsed_site_url,
                     error,
                 })
             }
@@ -270,9 +270,9 @@ impl WpLoginClient {
     /// find it, but if it's a standard setup this will work.
     async fn guess_api_root_url(
         &self,
-        parsed_site_url: &ParsedUrl,
+        parsed_site_url: ParsedUrl,
     ) -> Result<ParsedUrl, RequestExecutionError> {
-        let mut api_root_url = parsed_site_url.clone();
+        let mut api_root_url = parsed_site_url;
         api_root_url
             .inner
             .path_segments_mut()

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     ParseUrlError, ParsedUrl, RequestExecutionError,
 };
-use std::{str, sync::Arc};
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Debug, uniffi::Object)]
@@ -65,20 +65,21 @@ impl WpLoginClient {
         &self,
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
-        // TODO: Create a `ParsedUrl` here instead of parsing it in every helper
-        let attempt_site_url = &attempt.attempt_site_url.clone();
+        let parsed_attempt_site_url_result = ParsedUrl::parse(&attempt.attempt_site_url);
         let parse_html_result = self
-            .fetch_site(attempt_site_url)
+            .fetch_site(parsed_attempt_site_url_result.clone())
             .await
             .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
         let api_root_url_from_link_tag = parse_html_result
             .as_ref()
             .ok()
             .and_then(|h| h.api_root_url_from_link_tag.clone());
-        let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
+        let fetch_wp_json_result = self
+            .fetch_wp_json(parsed_attempt_site_url_result.clone())
+            .await;
         let api_link_header_result = self
             .find_api_root_url(
-                attempt_site_url,
+                parsed_attempt_site_url_result.clone(),
                 api_root_url_from_link_tag,
                 fetch_wp_json_result.clone(),
             )
@@ -172,11 +173,11 @@ impl WpLoginClient {
 
     async fn find_api_root_url(
         &self,
-        attempt_site_url: &str,
+        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
         api_root_url_from_link_tag: Option<ParsedUrl>,
         fetch_wp_json_result: Result<FetchWpJsonSuccess, FetchWpJsonFailure>,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
-        let parsed_site_url = ParsedUrl::parse(attempt_site_url)
+        let parsed_site_url = parsed_attempt_site_url_result
             .map_err(|error| FindApiRootLinkHeaderFailure::ParseSiteUrl { error })?;
         if let Some(api_root_url) = api_root_url_from_link_tag {
             Ok(FindApiRootLinkHeaderSuccess {
@@ -281,10 +282,10 @@ impl WpLoginClient {
 
     async fn fetch_wp_json(
         &self,
-        attempt_site_url: &str,
+        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
     ) -> Result<FetchWpJsonSuccess, FetchWpJsonFailure> {
         let wp_json_url = {
-            let mut wp_json_url = ParsedUrl::parse(attempt_site_url)
+            let mut wp_json_url = parsed_attempt_site_url_result
                 .map_err(|error| FetchWpJsonFailure::ParseSiteUrl { error })?;
             wp_json_url
                 .inner
@@ -329,9 +330,9 @@ impl WpLoginClient {
 
     async fn fetch_site(
         &self,
-        attempt_site_url: &str,
+        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
     ) -> Result<WpNetworkResponse, ParseHtmlFailure> {
-        let site_url = ParsedUrl::parse(attempt_site_url)
+        let site_url = parsed_attempt_site_url_result
             .map_err(|error| ParseHtmlFailure::ParseSiteUrl { error })?;
         self.request_executor
             .execute(

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -65,21 +65,24 @@ impl WpLoginClient {
         &self,
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
-        let parsed_attempt_site_url_result = ParsedUrl::parse(&attempt.attempt_site_url);
+        let parsed_site_url = match ParsedUrl::parse(&attempt.attempt_site_url) {
+            Ok(u) => u,
+            Err(e) => {
+                return AutoDiscoveryAttemptResult::from_parse_site_url_error(attempt, e);
+            }
+        };
         let parse_html_result = self
-            .fetch_site(parsed_attempt_site_url_result.clone())
+            .fetch_site(&parsed_site_url)
             .await
             .map(|r| IsWordPressSiteParseHtmlResult::parse_response(&r.body_as_string()));
         let api_root_url_from_link_tag = parse_html_result
             .as_ref()
             .ok()
             .and_then(|h| h.api_root_url_from_link_tag.clone());
-        let fetch_wp_json_result = self
-            .fetch_wp_json(parsed_attempt_site_url_result.clone())
-            .await;
+        let fetch_wp_json_result = self.fetch_wp_json(parsed_site_url.clone()).await;
         let api_link_header_result = self
             .find_api_root_url(
-                parsed_attempt_site_url_result.clone(),
+                parsed_site_url.clone(),
                 api_root_url_from_link_tag,
                 fetch_wp_json_result.clone(),
             )
@@ -173,12 +176,10 @@ impl WpLoginClient {
 
     async fn find_api_root_url(
         &self,
-        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
+        parsed_site_url: ParsedUrl,
         api_root_url_from_link_tag: Option<ParsedUrl>,
         fetch_wp_json_result: Result<FetchWpJsonSuccess, FetchWpJsonFailure>,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
-        let parsed_site_url = parsed_attempt_site_url_result
-            .map_err(|error| FindApiRootLinkHeaderFailure::ParseSiteUrl { error })?;
         if let Some(api_root_url) = api_root_url_from_link_tag {
             Ok(FindApiRootLinkHeaderSuccess {
                 parsed_site_url,
@@ -282,11 +283,10 @@ impl WpLoginClient {
 
     async fn fetch_wp_json(
         &self,
-        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
+        parsed_site_url: ParsedUrl,
     ) -> Result<FetchWpJsonSuccess, FetchWpJsonFailure> {
         let wp_json_url = {
-            let mut wp_json_url = parsed_attempt_site_url_result
-                .map_err(|error| FetchWpJsonFailure::ParseSiteUrl { error })?;
+            let mut wp_json_url = parsed_site_url;
             wp_json_url
                 .inner
                 .path_segments_mut()
@@ -330,17 +330,15 @@ impl WpLoginClient {
 
     async fn fetch_site(
         &self,
-        parsed_attempt_site_url_result: Result<ParsedUrl, ParseUrlError>,
+        parsed_site_url: &ParsedUrl,
     ) -> Result<WpNetworkResponse, ParseHtmlFailure> {
-        let site_url = parsed_attempt_site_url_result
-            .map_err(|error| ParseHtmlFailure::ParseSiteUrl { error })?;
         self.request_executor
             .execute(
                 WpNetworkRequest {
                     uuid: Uuid::new_v4().into(),
                     retry_count: 0,
                     method: RequestMethod::GET,
-                    url: WpEndpointUrl(site_url.url()),
+                    url: WpEndpointUrl(parsed_site_url.url()),
                     header_map: WpNetworkHeaderMap::default().into(),
                     body: None,
                 }

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -12,8 +12,8 @@ use super::{
 use crate::{
     login::url_discovery::RootWpJson,
     request::{
-        endpoint::WpEndpointUrl, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
-        WpNetworkRequest, WpNetworkResponse,
+        endpoint::{WpEndpointUrl, WP_JSON_PATH_SEGMENTS},
+        RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
     ParseUrlError, ParsedUrl, RequestExecutionError,
 };
@@ -292,7 +292,7 @@ impl WpLoginClient {
                 .map_err(|_| FetchWpJsonFailure::ParseSiteUrl {
                     error: ParseUrlError::RelativeUrlWithCannotBeABaseBase,
                 })?
-                .push("wp-json");
+                .extend(WP_JSON_PATH_SEGMENTS);
             wp_json_url
         };
         let fetch_wp_json_response = match self

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -195,9 +195,8 @@ impl WpLoginClient {
                 // If we can't find the link header, but we were able to fetch `/wp-json` from the
                 // attempt url, we assume that it's the correct api root url
                 //
-                // We don't immediately rely on this because there might be cases where there are
-                // multiple `/wp-json` paths in which case we want to prioritize the one returned
-                // from the link header
+                // We don't immediately rely on this because there might be cases where `/wp-json`
+                // exists, but its not the actual API root
                 if let Ok(fetch_wp_json_success) = fetch_wp_json_result {
                     Ok(FindApiRootLinkHeaderSuccess {
                         parsed_site_url,
@@ -258,7 +257,7 @@ impl WpLoginClient {
         }
     }
 
-    // Fetches the site's homepage with a HEAD request
+    // Fetches the site's homepage headers with a HEAD request
     async fn fetch_api_root_url(
         &self,
         parsed_site_url: &ParsedUrl,

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -226,7 +226,7 @@ impl WpLoginClient {
             }
         };
         Ok(FindApiRootLinkHeaderSuccess {
-            parsed_site_url: parsed_site_url.clone(),
+            parsed_site_url,
             api_root_url,
         })
     }

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -276,7 +276,7 @@ impl WpLoginClient {
         api_root_url
             .inner
             .path_segments_mut()
-            .unwrap()
+            .expect("`parsed_site_url` is already parsed and should have path segments")
             .push("wp-json");
         self.fetch_api_root_url(&api_root_url)
             .await

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -65,7 +65,8 @@ impl WpLoginClient {
         &self,
         attempt: AutoDiscoveryAttempt,
     ) -> AutoDiscoveryAttemptResult {
-        let attempt_site_url = attempt.attempt_site_url.as_str();
+        // TODO: Create a `ParsedUrl` here instead of parsing it in every helper
+        let attempt_site_url = &attempt.attempt_site_url.clone();
         let parse_html_result = self
             .fetch_site(attempt_site_url)
             .await
@@ -74,15 +75,22 @@ impl WpLoginClient {
             .as_ref()
             .ok()
             .and_then(|h| h.api_root_url_from_link_tag.clone());
+        let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
         let api_link_header_result = self
-            .find_api_root_url(attempt_site_url, api_root_url_from_link_tag)
+            .find_api_root_url(
+                attempt_site_url,
+                api_root_url_from_link_tag,
+                fetch_wp_json_result.clone(),
+            )
             .await;
         let discovery_result = self
             .inner_attempt_api_discovery(api_link_header_result.clone())
             .await;
-        let is_wordpress_site = self
-            .attempt_is_wordpress_site(attempt_site_url, api_link_header_result, parse_html_result)
-            .await;
+        let is_wordpress_site = IsWordPressSiteAttemptResult {
+            api_link_header_result,
+            fetch_wp_json_result,
+            parse_html_result,
+        };
         AutoDiscoveryAttemptResult {
             attempt_type: attempt.attempt_type,
             attempt_site_url: attempt.attempt_site_url,
@@ -162,24 +170,11 @@ impl WpLoginClient {
         }
     }
 
-    async fn attempt_is_wordpress_site(
-        &self,
-        attempt_site_url: &str,
-        api_link_header_result: Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure>,
-        parse_html_result: Result<IsWordPressSiteParseHtmlResult, ParseHtmlFailure>,
-    ) -> IsWordPressSiteAttemptResult {
-        let fetch_wp_json_result = self.fetch_wp_json(attempt_site_url).await;
-        IsWordPressSiteAttemptResult {
-            api_link_header_result,
-            fetch_wp_json_result,
-            parse_html_result,
-        }
-    }
-
     async fn find_api_root_url(
         &self,
         attempt_site_url: &str,
         api_root_url_from_link_tag: Option<ParsedUrl>,
+        fetch_wp_json_result: Result<FetchWpJsonSuccess, FetchWpJsonFailure>,
     ) -> Result<FindApiRootLinkHeaderSuccess, FindApiRootLinkHeaderFailure> {
         let parsed_site_url = ParsedUrl::parse(attempt_site_url)
             .map_err(|error| FindApiRootLinkHeaderFailure::ParseSiteUrl { error })?;
@@ -193,10 +188,10 @@ impl WpLoginClient {
             .await
         {
             Ok(success)
-        } else if let Ok(response) = self.guess_api_root_url(parsed_site_url.clone()).await {
+        } else if let Ok(fetch_wp_json_success) = fetch_wp_json_result {
             Ok(FindApiRootLinkHeaderSuccess {
                 parsed_site_url,
-                api_root_url: response,
+                api_root_url: fetch_wp_json_success.wp_json_url,
             })
         } else {
             Err(FindApiRootLinkHeaderFailure::ApiRootNotFound { parsed_site_url })
@@ -263,24 +258,6 @@ impl WpLoginClient {
             body: None,
         };
         self.request_executor.execute(api_root_request.into()).await
-    }
-
-    /// Guess the REST API root URL from the site root. Many sites don't emit a link header or the
-    /// link tag, but the JSON API works just fine. If they use a custom REST route we won't be able to
-    /// find it, but if it's a standard setup this will work.
-    async fn guess_api_root_url(
-        &self,
-        parsed_site_url: ParsedUrl,
-    ) -> Result<ParsedUrl, RequestExecutionError> {
-        let mut api_root_url = parsed_site_url;
-        api_root_url
-            .inner
-            .path_segments_mut()
-            .expect("`parsed_site_url` is already parsed and should have path segments")
-            .push("wp-json");
-        self.fetch_api_root_url(&api_root_url)
-            .await
-            .map(|_| api_root_url)
     }
 
     async fn fetch_wp_api_details(

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -220,6 +220,22 @@ impl AutoDiscoveryAttemptResult {
     }
 }
 
+impl AutoDiscoveryAttemptResult {
+    pub(crate) fn from_parse_site_url_error(
+        attempt: AutoDiscoveryAttempt,
+        error: ParseUrlError,
+    ) -> Self {
+        Self {
+            attempt_type: attempt.attempt_type,
+            attempt_site_url: attempt.attempt_site_url,
+            api_discovery_result: Err(AutoDiscoveryAttemptFailure::ParseSiteUrl {
+                error: error.clone(),
+            }),
+            is_wordpress_site: IsWordPressSiteAttemptResult::from_parse_site_url_error(error),
+        }
+    }
+}
+
 // Does the given URL look like it's on a local development environment for the purposes of the Login Spec?
 pub fn is_local_dev_environment_url(parsed_site_url: &ParsedUrl) -> bool {
     if let Some(hostname) = parsed_site_url.inner.host_str() {
@@ -252,6 +268,18 @@ impl IsWordPressSiteAttemptResult {
                         || r.mentions_wp_includes
                 })
                 .unwrap_or(false)
+    }
+
+    pub fn from_parse_site_url_error(error: ParseUrlError) -> Self {
+        Self {
+            api_link_header_result: Err(FindApiRootLinkHeaderFailure::ParseSiteUrl {
+                error: error.clone(),
+            }),
+            fetch_wp_json_result: Err(FetchWpJsonFailure::ParseSiteUrl {
+                error: error.clone(),
+            }),
+            parse_html_result: Err(ParseHtmlFailure::ParseSiteUrl { error }),
+        }
     }
 }
 
@@ -369,8 +397,8 @@ pub enum FindApiRootLinkHeaderFailure {
         error: ParseApiRootUrlError,
     },
     ApiRootNotFound {
-        parsed_site_url: ParsedUrl
-    }
+        parsed_site_url: ParsedUrl,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -567,15 +595,15 @@ impl From<FindApiRootLinkHeaderFailure> for AutoDiscoveryAttemptFailure {
                 parsed_site_url,
                 error,
             },
-            FindApiRootLinkHeaderFailure::ApiRootNotFound {
-                parsed_site_url,
-            } => Self::ParseApiRootUrl {
-                parsed_site_url,
-                error: ParseApiRootUrlError::ApiRootLinkHeaderNotFound {
-                    status_code: 404,
-                    header_map: Arc::new(WpNetworkHeaderMap::default()),
-                },
-            },
+            FindApiRootLinkHeaderFailure::ApiRootNotFound { parsed_site_url } => {
+                Self::ParseApiRootUrl {
+                    parsed_site_url,
+                    error: ParseApiRootUrlError::ApiRootLinkHeaderNotFound {
+                        status_code: 404,
+                        header_map: Arc::new(WpNetworkHeaderMap::default()),
+                    },
+                }
+            }
         }
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -368,6 +368,9 @@ pub enum FindApiRootLinkHeaderFailure {
         parsed_site_url: ParsedUrl,
         error: ParseApiRootUrlError,
     },
+    ApiRootNotFound {
+        parsed_site_url: ParsedUrl
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -563,6 +566,15 @@ impl From<FindApiRootLinkHeaderFailure> for AutoDiscoveryAttemptFailure {
             } => Self::ParseApiRootUrl {
                 parsed_site_url,
                 error,
+            },
+            FindApiRootLinkHeaderFailure::ApiRootNotFound {
+                parsed_site_url,
+            } => Self::ParseApiRootUrl {
+                parsed_site_url,
+                error: ParseApiRootUrlError::ApiRootLinkHeaderNotFound {
+                    status_code: 404,
+                    header_map: Arc::new(WpNetworkHeaderMap::default()),
+                },
             },
         }
     }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -396,9 +396,6 @@ pub enum FindApiRootLinkHeaderFailure {
         parsed_site_url: ParsedUrl,
         error: ParseApiRootUrlError,
     },
-    ApiRootNotFound {
-        parsed_site_url: ParsedUrl,
-    },
 }
 
 #[derive(Debug, Clone)]
@@ -595,15 +592,6 @@ impl From<FindApiRootLinkHeaderFailure> for AutoDiscoveryAttemptFailure {
                 parsed_site_url,
                 error,
             },
-            FindApiRootLinkHeaderFailure::ApiRootNotFound { parsed_site_url } => {
-                Self::ParseApiRootUrl {
-                    parsed_site_url,
-                    error: ParseApiRootUrlError::ApiRootLinkHeaderNotFound {
-                        status_code: 404,
-                        header_map: Arc::new(WpNetworkHeaderMap::default()),
-                    },
-                }
-            }
         }
     }
 }

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -16,7 +16,7 @@ pub mod themes_endpoint;
 pub mod users_endpoint;
 pub mod wp_site_health_tests_endpoint;
 
-const WP_JSON_PATH_SEGMENTS: [&str; 1] = ["wp-json"];
+pub const WP_JSON_PATH_SEGMENTS: [&str; 1] = ["wp-json"];
 
 uniffi::custom_newtype!(WpEndpointUrl, String);
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I started this PR as suggestions for https://github.com/Automattic/wordpress-rs/pull/607, but since I pretty much re-wrote the entire thing - and implemented a few other improvements, I think it's easier to review the PR by targeting `trunk` directly. I still kept the original commit from @jkmassel just as a reference.

In some cases we can't find the api root url from the link header or by parsing the home page, but we can still access it by trying `{site_url}/wp-json`. This PR adds this as a fallback mechanism to `find_api_root_url` step.

Note that we were already making a request to `{site_url}/wp-json` as part of `is_wordpress_site` discovery. So, I moved this to an earlier step and re-used its result instead of making a separate request. Having said that, in some cases we are still making 2 requests to `/wp-json`, one before we find the api root and one afterwards. It should be possible to re-use the result of the initial request when the api root is the same as `{site_url}/wp-json`, so we'll want to fix that in a separate PR.

I've also included a general improvement to the api discovery by parsing the attempt url at the beginning and then short cutting the entire api discovery attempt if parsing fails. This shouldn't result any practical changes, but it saves us from parsing the same url multiple times and it also simplifies the error handling in api discovery helpers.