### PR TITLE
Process middleware pipeline before mapping `RequestExecutionError`

### DIFF
--- a/wp_api/src/middleware.rs
+++ b/wp_api/src/middleware.rs
@@ -6,7 +6,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 
 #[derive(Debug, Default, uniffi::Object)]
 pub struct WpApiMiddlewarePipeline {
-    middlewares: Vec<Arc<dyn WpApiMiddleware>>,
+    pub middlewares: Vec<Arc<dyn WpApiMiddleware>>,
 }
 
 #[uniffi::export]
@@ -87,6 +87,14 @@ pub trait PerformsRequests {
         let pipeline = &self.get_middleware_pipeline();
         let response = self.get_request_executor().execute(request.clone()).await?;
 
+        let response = pipeline
+            .process(
+                self.get_request_executor().clone(),
+                response,
+                request.clone(),
+            )
+            .await?;
+
         // TODO: `WpApiError::try_parse` also handles this case. Neither of these seem like the
         // correct way to handle these errors, because neither implementation is "central" enough.
         // Since there isn't a great place to handle this at the moment, and it's not clear whether
@@ -99,13 +107,7 @@ pub trait PerformsRequests {
             });
         }
 
-        pipeline
-            .process(
-                self.get_request_executor().clone(),
-                response,
-                request.clone(),
-            )
-            .await
+        Ok(response)
     }
 }
 
@@ -172,7 +174,7 @@ impl WpApiMiddleware for RetryAfterMiddleware {
 // MARK: - ApiDiscoveryAuthenticationMiddleware
 
 #[derive(Debug, uniffi::Object)]
-struct ApiDiscoveryAuthenticationMiddleware {
+pub struct ApiDiscoveryAuthenticationMiddleware {
     username: String,
     password: String,
 }
@@ -180,7 +182,7 @@ struct ApiDiscoveryAuthenticationMiddleware {
 #[uniffi::export]
 impl ApiDiscoveryAuthenticationMiddleware {
     #[uniffi::constructor]
-    fn new(username: String, password: String) -> Self {
+    pub fn new(username: String, password: String) -> Self {
         println!("Creating HTTP authentication middleware");
         Self { username, password }
     }

--- a/wp_api_integration_tests/tests/test_login_immut.rs
+++ b/wp_api_integration_tests/tests/test_login_immut.rs
@@ -2,7 +2,8 @@ use rstest::rstest;
 use serial_test::parallel;
 use std::sync::Arc;
 use wp_api::{
-    login::login_client::WpLoginClient, middleware::WpApiMiddlewarePipeline,
+    login::login_client::WpLoginClient,
+    middleware::{ApiDiscoveryAuthenticationMiddleware, WpApiMiddleware, WpApiMiddlewarePipeline},
     reqwest_request_executor::ReqwestRequestExecutor,
 };
 
@@ -63,10 +64,42 @@ const VANILLA_WP_AUTH_URL: &str = "https://vanilla.wpmt.co/wp-admin/authorize-ap
 #[tokio::test]
 #[parallel]
 async fn test_login_flow(#[case] site_url: &str, #[case] expected_auth_url: &str) {
+    login_flow_helper(site_url, expected_auth_url, vec![]).await;
+}
+
+#[rstest]
+#[case(
+    "https://basic-auth.wpmt.co",
+    "https://basic-auth.wpmt.co/wp-admin/authorize-application.php"
+)]
+#[tokio::test]
+#[parallel]
+async fn test_login_flow_with_authentication_middleware(
+    #[case] site_url: &str,
+    #[case] expected_auth_url: &str,
+) {
+    login_flow_helper(
+        site_url,
+        expected_auth_url,
+        vec![Arc::new(ApiDiscoveryAuthenticationMiddleware::new(
+            // These credentials are safe to check into the repo
+            "test@example.com".to_string(),
+            "str0ngp4ssw0rd!".to_string(),
+        ))],
+    )
+    .await;
+}
+
+async fn login_flow_helper(
+    site_url: &str,
+    expected_auth_url: &str,
+    middlewares: Vec<Arc<dyn WpApiMiddleware>>,
+) {
     let client = WpLoginClient::new(
         Arc::new(ReqwestRequestExecutor::new(true)),
-        Arc::new(WpApiMiddlewarePipeline::default()),
+        Arc::new(WpApiMiddlewarePipeline { middlewares }),
     );
+
     let result = client.api_discovery(site_url.to_string()).await;
     assert!(
         result.is_successful(),


### PR DESCRIPTION
Addresses an ordering issue in `PerformsRequests` and adds an integration test for it.