### PR TITLE
Test authentication middleware with incorrect credentials

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -482,27 +482,34 @@ pub enum RequestExecutionErrorReason {
 
 impl RequestExecutionErrorReason {
     pub fn try_from_response(response: &WpNetworkResponse) -> Option<Self> {
-        if response.is_http_authentication_required()
-            && !response.request_header_map.has_http_authentication()
-        {
-            let reason = match response.get_http_auth_method() {
-                Ok(maybe_method) => match maybe_method {
-                    Some(method) => RequestExecutionErrorReason::HttpAuthenticationRequiredError {
-                        hostname: response.request_url.0.clone(),
-                        method: Some(method),
-                    },
-                    None => RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError {
-                        issue: HttpAuthMethodParsingError::Unknown,
-                    },
-                },
-                Err(e) => {
-                    RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError { issue: e }
-                }
-            };
-            Some(reason)
-        } else {
-            None
+        if !response.is_http_authentication_required() {
+            return None;
         }
+
+        let reason = match response.get_http_auth_method() {
+            Ok(maybe_method) => match maybe_method {
+                Some(method) => {
+                    if response.request_header_map.has_http_authentication() {
+                        RequestExecutionErrorReason::HttpAuthenticationRejectedError {
+                            hostname: response.request_url.0.clone(),
+                            method: Some(method),
+                        }
+                    } else {
+                        RequestExecutionErrorReason::HttpAuthenticationRequiredError {
+                            hostname: response.request_url.0.clone(),
+                            method: Some(method),
+                        }
+                    }
+                }
+                None => RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError {
+                    issue: HttpAuthMethodParsingError::Unknown,
+                },
+            },
+            Err(e) => {
+                RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError { issue: e }
+            }
+        };
+        Some(reason)
     }
 }
 

--- a/wp_api_integration_tests/tests/test_login_err.rs
+++ b/wp_api_integration_tests/tests/test_login_err.rs
@@ -2,9 +2,13 @@ use rstest::rstest;
 use serial_test::parallel;
 use std::sync::Arc;
 use wp_api::{
-    login::{login_client::WpLoginClient, url_discovery::AutoDiscoveryAttemptType},
-    middleware::WpApiMiddlewarePipeline,
+    login::{
+        login_client::WpLoginClient,
+        url_discovery::{AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptType},
+    },
+    middleware::{ApiDiscoveryAuthenticationMiddleware, WpApiMiddleware, WpApiMiddlewarePipeline},
     reqwest_request_executor::ReqwestRequestExecutor,
+    RequestExecutionError, RequestExecutionErrorReason,
 };
 
 #[rstest]
@@ -12,17 +16,7 @@ use wp_api::{
 #[tokio::test]
 #[parallel]
 async fn test_login_flow_err_network_error(#[case] site_url: &str) {
-    let client = WpLoginClient::new(
-        Arc::new(ReqwestRequestExecutor::new(true)),
-        Arc::new(WpApiMiddlewarePipeline::default()),
-    );
-    let mut result = client.api_discovery(site_url.to_string()).await;
-    let original_attempt_error = result
-        .attempts
-        .remove(&AutoDiscoveryAttemptType::UserInput)
-        .unwrap()
-        .api_discovery_result
-        .unwrap_err();
+    let original_attempt_error = login_flow_err_helper(site_url, vec![]).await;
     assert!(
         original_attempt_error.is_network_error(),
         "{:#?}",
@@ -34,22 +28,72 @@ async fn test_login_flow_err_network_error(#[case] site_url: &str) {
 #[case("https://wordfence.wpmt.co")]
 #[tokio::test]
 #[parallel]
-async fn application_passwords_not_supported(#[case] site_url: &str) {
-    let client = WpLoginClient::new(
-        Arc::new(ReqwestRequestExecutor::new(true)),
-        Arc::new(WpApiMiddlewarePipeline::default()),
-    );
-    let mut result = client.api_discovery(site_url.to_string()).await;
-    let original_attempt_error = result
-        .attempts
-        .remove(&AutoDiscoveryAttemptType::UserInput)
-        .unwrap()
-        .api_discovery_result
-        .unwrap_err();
+async fn test_login_flow_err_application_passwords_not_supported(#[case] site_url: &str) {
+    let original_attempt_error = login_flow_err_helper(site_url, vec![]).await;
     assert_eq!(
         original_attempt_error.is_application_passwords_disabled(),
         Some(true),
         "{:#?}",
         original_attempt_error
     );
+}
+
+#[rstest]
+#[case("https://basic-auth.wpmt.co")]
+#[tokio::test]
+#[parallel]
+async fn test_login_flow_err_http_authentication_required_error(#[case] site_url: &str) {
+    let original_attempt_error = login_flow_err_helper(site_url, vec![]).await;
+    assert!(matches!(
+        original_attempt_error,
+        AutoDiscoveryAttemptFailure::FetchApiRootUrl {
+            error: RequestExecutionError::RequestExecutionFailed {
+                reason: RequestExecutionErrorReason::HttpAuthenticationRequiredError { .. },
+                ..
+            },
+            ..
+        }
+    ));
+}
+
+#[rstest]
+#[case("https://basic-auth.wpmt.co")]
+#[tokio::test]
+#[parallel]
+async fn test_login_flow_err_http_authentication_rejected_error(#[case] site_url: &str) {
+    let original_attempt_error = login_flow_err_helper(
+        site_url,
+        vec![Arc::new(ApiDiscoveryAuthenticationMiddleware::new(
+            "invalid".to_string(),
+            "invalid".to_string(),
+        ))],
+    )
+    .await;
+    assert!(matches!(
+        original_attempt_error,
+        AutoDiscoveryAttemptFailure::FetchApiRootUrl {
+            error: RequestExecutionError::RequestExecutionFailed {
+                reason: RequestExecutionErrorReason::HttpAuthenticationRejectedError { .. },
+                ..
+            },
+            ..
+        }
+    ));
+}
+
+async fn login_flow_err_helper(
+    site_url: &str,
+    middlewares: Vec<Arc<dyn WpApiMiddleware>>,
+) -> AutoDiscoveryAttemptFailure {
+    WpLoginClient::new(
+        Arc::new(ReqwestRequestExecutor::new(true)),
+        Arc::new(WpApiMiddlewarePipeline { middlewares }),
+    )
+    .api_discovery(site_url.to_string())
+    .await
+    .attempts
+    .remove(&AutoDiscoveryAttemptType::UserInput)
+    .unwrap()
+    .api_discovery_result
+    .unwrap_err()
 }


### PR DESCRIPTION
Updates `RequestExecutionErrorReason::try_from_response` to use `RequestExecutionErrorReason::HttpAuthenticationRejectedError` if the original request had authentication headers. It also adds 2 new login error flow tests for `RequestExecutionErrorReason::HttpAuthenticationRequiredError` & `RequestExecutionErrorReason::HttpAuthenticationRejectedError`.