### PR TITLE
Implement `AutoDiscoveryAttemptFailure::WpError`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-large-error-threshold = 192
+large-error-threshold = 256

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -456,24 +456,18 @@ pub enum RequestExecutionErrorReason {
         error_message: Option<String>,
         suggested_action: Option<String>,
     },
-    #[error(
-        "The server at {} requires authentication. Please provide your username and password.",
-        hostname
-    )]
+    #[error("The server at {hostname} requires authentication. Please provide your username and password.")]
     HttpAuthenticationRequiredError {
         hostname: String,
         method: Option<HttpAuthMethod>,
     },
-    #[error(
-        "The server at {} rejected your credentials. Please provide a valid username and password.",
-        hostname
-    )]
+    #[error("The server at {hostname} rejected your credentials. Please provide a valid username and password.")]
     HttpAuthenticationRejectedError {
         hostname: String,
         method: Option<HttpAuthMethod>,
     },
-    #[error("HttpForbiddenError")]
-    HttpForbiddenError,
+    #[error("The server at {hostname} denied access to the requested resource. Please check your site's configuration.")]
+    HttpForbiddenError { hostname: String },
     #[error("The server is sending invalid HTTP authentication information. Please check your site's HTTP authentication configuration.")]
     MisconfiguredHttpAuthenticationError { issue: HttpAuthMethodParsingError },
     #[error("The server is rate limiting requests in a way that will never succeed. Please check your site's rate limit configuration.")]
@@ -520,7 +514,9 @@ impl RequestExecutionErrorReason {
                             method: None,
                         }
                     } else {
-                        RequestExecutionErrorReason::HttpForbiddenError
+                        RequestExecutionErrorReason::HttpForbiddenError {
+                            hostname: response.request_url.0.clone(),
+                        }
                     }
                 }
             },

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -484,6 +484,14 @@ pub enum RequestExecutionErrorReason {
 
 impl RequestExecutionErrorReason {
     pub fn try_from_response(response: &WpNetworkResponse) -> Option<Self> {
+        // TODO: We are currently parsing the response for `WpError` twice. There is currently no
+        // good way to avoid it, but we are planning to rework some of the error handling once we
+        // finish the login work. At that time, we'll try to remove the double parsing.
+        if WpError::try_parse(&response.body).is_some() {
+            // If the response is a `WpError`, don't map it to an auth error
+            return None;
+        }
+
         if !response.is_http_authentication_required() {
             return None;
         }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -61,7 +61,7 @@ fn maybe_json_response(response: &String) -> String {
 
 impl ParsedRequestError for WpApiError {
     fn try_parse(response: &WpNetworkResponse) -> Option<Self> {
-        if let Some(wp_error) = WpError::try_parse(&response.body, response.status_code) {
+        if let Some(wp_error) = WpError::try_parse(&response.body) {
             Some(Self::WpError {
                 error_code: wp_error.code,
                 error_message: wp_error.message,
@@ -108,12 +108,12 @@ pub struct WpError {
 }
 
 impl WpError {
-    pub fn try_parse(response_body: &[u8], _response_status_code: u16) -> Option<Self> {
+    pub fn try_parse(response_body: &[u8]) -> Option<Self> {
         serde_json::from_slice::<WpError>(response_body).ok()
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, uniffi::Error)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, uniffi::Error)]
 pub enum WpErrorCode {
     #[serde(rename = "rest_already_trashed")]
     AlreadyTrashed,

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -197,6 +197,8 @@ pub enum WpErrorCode {
     CommentTrashPost,
     #[serde(rename = "empty_content")]
     EmptyContent,
+    #[serde(rename = "rest_forbidden")]
+    Forbidden,
     #[serde(rename = "rest_forbidden_context")]
     ForbiddenContext,
     #[serde(rename = "rest_forbidden_param")]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -472,6 +472,8 @@ pub enum RequestExecutionErrorReason {
         hostname: String,
         method: Option<HttpAuthMethod>,
     },
+    #[error("HttpForbiddenError")]
+    HttpForbiddenError,
     #[error("The server is sending invalid HTTP authentication information. Please check your site's HTTP authentication configuration.")]
     MisconfiguredHttpAuthenticationError { issue: HttpAuthMethodParsingError },
     #[error("The server is rate limiting requests in a way that will never succeed. Please check your site's rate limit configuration.")]
@@ -484,15 +486,15 @@ pub enum RequestExecutionErrorReason {
 
 impl RequestExecutionErrorReason {
     pub fn try_from_response(response: &WpNetworkResponse) -> Option<Self> {
+        if response.status_code != 401 && response.status_code != 403 {
+            return None;
+        }
+
         // TODO: We are currently parsing the response for `WpError` twice. There is currently no
         // good way to avoid it, but we are planning to rework some of the error handling once we
         // finish the login work. At that time, we'll try to remove the double parsing.
         if WpError::try_parse(&response.body).is_some() {
             // If the response is a `WpError`, don't map it to an auth error
-            return None;
-        }
-
-        if !response.is_http_authentication_required() {
             return None;
         }
 
@@ -511,9 +513,16 @@ impl RequestExecutionErrorReason {
                         }
                     }
                 }
-                None => RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError {
-                    issue: HttpAuthMethodParsingError::Unknown,
-                },
+                None => {
+                    if response.request_header_map.has_http_authentication() {
+                        RequestExecutionErrorReason::HttpAuthenticationRejectedError {
+                            hostname: response.request_url.0.clone(),
+                            method: None,
+                        }
+                    } else {
+                        RequestExecutionErrorReason::HttpForbiddenError
+                    }
+                }
             },
             Err(e) => {
                 RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError { issue: e }

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -62,16 +62,16 @@ pub struct WpApiDetails {
     pub site_icon_url: Option<String>,
 }
 
-impl TryFrom<Vec<u8>> for WpApiDetails {
+impl TryFrom<&[u8]> for WpApiDetails {
     type Error = serde_json::Error;
 
-    fn try_from(mut value: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         // If the body starts with the UTF-8 BOM, remove it
         if value.starts_with(&[0xEF, 0xBB, 0xBF]) {
-            value.drain(0..3);
+            serde_json::from_slice::<WpApiDetails>(&value[3..])
+        } else {
+            serde_json::from_slice::<WpApiDetails>(value)
         }
-
-        serde_json::from_slice::<WpApiDetails>(&value)
     }
 }
 
@@ -369,7 +369,7 @@ mod tests {
     fn test_api_details_json(#[case] input: &str) {
         let json = test_json(input).expect("Failed to read test resource");
 
-        let result = WpApiDetails::try_from(json);
+        let result = WpApiDetails::try_from(json.as_slice());
 
         assert!(
             result.is_ok(),

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -16,7 +16,7 @@ use crate::{
         endpoint::{WpEndpointUrl, WP_JSON_PATH_SEGMENTS},
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
     },
-    ParseUrlError, ParsedUrl, RequestExecutionError,
+    ParseUrlError, ParsedUrl, RequestExecutionError, WpError,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -134,17 +134,11 @@ impl WpLoginClient {
                 })
             }
         };
-        let api_details: WpApiDetails =
-            match WpApiDetails::try_from(fetch_api_details_response.body) {
-                Ok(api_details) => api_details,
-                Err(error) => {
-                    return Err(AutoDiscoveryAttemptFailure::ParseApiDetails {
-                        parsed_site_url: api_root_url_success.parsed_site_url,
-                        api_root_url: api_root_url_success.api_root_url,
-                        parsing_error_message: error.to_string(),
-                    });
-                }
-            };
+        let api_details = self.parse_api_details(
+            &fetch_api_details_response,
+            Arc::clone(&api_root_url_success.parsed_site_url),
+            Arc::clone(&api_root_url_success.api_root_url),
+        )?;
 
         if !api_details.has_application_passwords_authentication_url() {
             let reason = if api_details.has_application_password_blocking_plugin() {
@@ -369,6 +363,31 @@ impl WpLoginClient {
         )
         .await
         .map_err(|error| ParseHtmlFailure::FetchSite { error })
+    }
+
+    fn parse_api_details(
+        &self,
+        fetch_api_details_response: &WpNetworkResponse,
+        parsed_site_url: Arc<ParsedUrl>,
+        api_root_url: Arc<ParsedUrl>,
+    ) -> Result<WpApiDetails, AutoDiscoveryAttemptFailure> {
+        WpApiDetails::try_from(fetch_api_details_response.body.as_slice()).map_err(|error| {
+            if let Some(wp_error) = WpError::try_parse(&fetch_api_details_response.body) {
+                AutoDiscoveryAttemptFailure::WpError {
+                    parsed_site_url,
+                    api_root_url,
+                    error_code: wp_error.code,
+                    error_message: wp_error.message,
+                    status_code: fetch_api_details_response.status_code,
+                }
+            } else {
+                AutoDiscoveryAttemptFailure::ParseApiDetails {
+                    parsed_site_url,
+                    api_root_url,
+                    parsing_error_message: error.to_string(),
+                }
+            }
+        })
     }
 }
 

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -134,7 +134,7 @@ impl WpLoginClient {
                 })
             }
         };
-        let api_details = self.parse_api_details(
+        let api_details = Self::parse_api_details(
             &fetch_api_details_response,
             Arc::clone(&api_root_url_success.parsed_site_url),
             Arc::clone(&api_root_url_success.api_root_url),
@@ -366,7 +366,6 @@ impl WpLoginClient {
     }
 
     fn parse_api_details(
-        &self,
         fetch_api_details_response: &WpNetworkResponse,
         parsed_site_url: Arc<ParsedUrl>,
         api_root_url: Arc<ParsedUrl>,
@@ -398,5 +397,38 @@ impl PerformsRequests for WpLoginClient {
 
     fn get_request_executor(&self) -> Arc<dyn RequestExecutor> {
         self.request_executor.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{unit_test_common::wp_network_response_from_json, WpErrorCode};
+
+    #[test]
+    fn test_parse_api_details_wp_error_rest_forbidden() {
+        let json = r#"{
+          "code": "rest_forbidden",
+          "message": "REST API access is restricted."
+        }"#;
+        let response = wp_network_response_from_json(json, 403);
+        let parsed_url = Arc::new(ParsedUrl::parse("http://example.com").expect("valid url"));
+        let result = WpLoginClient::parse_api_details(
+            &response,
+            Arc::clone(&parsed_url),
+            Arc::clone(&parsed_url),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(AutoDiscoveryAttemptFailure::WpError {
+                    error_code: WpErrorCode::Forbidden,
+                    status_code: 403,
+                    ..
+                })
+            ),
+            "{:#?}",
+            result
+        );
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1,8 +1,8 @@
 use super::WpApiDetails;
 use crate::{
-    login::KnownApplicationPasswordBlockingPlugin, request::WpNetworkHeaderMap,
-    request::WpRedirect, ParseUrlError, ParsedUrl, RequestExecutionError,
-    RequestExecutionErrorReason,
+    login::KnownApplicationPasswordBlockingPlugin,
+    request::{WpNetworkHeaderMap, WpRedirect},
+    ParseUrlError, ParsedUrl, RequestExecutionError, RequestExecutionErrorReason, WpErrorCode,
 };
 use scraper::{Html, Selector};
 use serde::Deserialize;
@@ -469,6 +469,19 @@ pub enum AutoDiscoveryAttemptFailure {
         api_root_url: Arc<ParsedUrl>,
         parsing_error_message: String,
     },
+    #[error(
+        "WpError {{\n\tstatus_code: {}\n\terror_code: {:?}\n\terror_message: \"{}\"",
+        status_code,
+        error_code,
+        error_message
+    )]
+    WpError {
+        parsed_site_url: Arc<ParsedUrl>,
+        api_root_url: Arc<ParsedUrl>,
+        error_code: WpErrorCode,
+        error_message: String,
+        status_code: u16,
+    },
     #[error("{}", reason.as_ref().map(|r| r.error_message(parsed_site_url)).unwrap_or("Application Passwords are not supported".to_string()))]
     ApplicationPasswordsNotSupported {
         parsed_site_url: Arc<ParsedUrl>,
@@ -502,33 +515,36 @@ impl ApplicationPasswordsNotSupportedReason {
 impl AutoDiscoveryAttemptFailure {
     pub fn is_network_error(&self) -> bool {
         match self {
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => true,
-            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => true,
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => false,
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => false,
-            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => false,
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => false,
+            Self::FetchApiRootUrl { .. } => true,
+            Self::FetchApiDetails { .. } => true,
+            Self::ParseSiteUrl { .. } => false,
+            Self::ParseApiRootUrl { .. } => false,
+            Self::ParseApiDetails { .. } => false,
+            Self::WpError { .. } => false,
+            Self::ApplicationPasswordsNotSupported { .. } => false,
         }
     }
 
     pub fn parsed_site_url(&self) -> Option<&ParsedUrl> {
         match self {
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl {
+            Self::ParseSiteUrl { .. } => None,
+            Self::FetchApiRootUrl {
                 parsed_site_url, ..
             } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl {
+            Self::ParseApiRootUrl {
                 parsed_site_url, ..
             } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::FetchApiDetails {
+            Self::FetchApiDetails {
                 parsed_site_url, ..
             } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ParseApiDetails {
+            Self::ParseApiDetails {
                 parsed_site_url, ..
             } => Some(parsed_site_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
-                parsed_site_url,
-                ..
+            Self::WpError {
+                parsed_site_url, ..
+            } => Some(parsed_site_url),
+            Self::ApplicationPasswordsNotSupported {
+                parsed_site_url, ..
             } => Some(parsed_site_url),
         }
     }
@@ -536,58 +552,63 @@ impl AutoDiscoveryAttemptFailure {
     // If it failed while parsing the site url or fetching the api root url, we never tried to
     // parse it, so we return `None`
     //
-    // If we fail to parse with `AutoDiscoveryAttemptFailure::ParseApiRootUrl`, we return
-    // `Some(true)`, because that's exactly when the failure happened.
+    // If we fail to parse with `Self::ParseApiRootUrl`, we return `Some(true)`, because
+    // that's exactly when the failure happened.
     //
     // If an error occurs after parsing the api root url, we return `Some(false)`.
     pub fn has_failed_to_parse_api_root_url(&self) -> Option<bool> {
         match self {
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(false),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
+            Self::ParseSiteUrl { .. } => None,
+            Self::FetchApiRootUrl { .. } => None,
+            Self::ParseApiRootUrl { .. } => Some(true),
+            Self::FetchApiDetails { .. } => Some(false),
+            Self::ParseApiDetails { .. } => Some(false),
+            Self::WpError { .. } => Some(false),
+            Self::ApplicationPasswordsNotSupported { .. } => Some(false),
         }
     }
 
     pub fn api_root_url(&self) -> Option<&ParsedUrl> {
         match self {
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiDetails { api_root_url, .. } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::ParseApiDetails { api_root_url, .. } => Some(api_root_url),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported {
-                api_root_url, ..
-            } => Some(api_root_url),
+            Self::ParseSiteUrl { .. } => None,
+            Self::FetchApiRootUrl { .. } => None,
+            Self::ParseApiRootUrl { .. } => None,
+            Self::FetchApiDetails { api_root_url, .. } => Some(api_root_url),
+            Self::ParseApiDetails { api_root_url, .. } => Some(api_root_url),
+            Self::WpError { api_root_url, .. } => Some(api_root_url),
+            Self::ApplicationPasswordsNotSupported { api_root_url, .. } => Some(api_root_url),
         }
     }
 
     // If it failed while parsing the site url, fetching the api root url, parsing the api root url
     // or fetching the api details, we never tried to parse it, so we return `None`.
     //
-    // If we fail to parse with `AutoDiscoveryAttemptFailure::ParseApiDetails`, we return
-    // `Some(true)`, because that's exactly when the failure happened.
+    // If we fail to parse with `Self::ParseApiDetails`, we return `Some(true)`, because
+    // that's exactly when the failure happened.
+    //
+    // If we parse the api details as `Self::WpError`, we return `Some(false)`, because the
+    // response was parseable.
     pub fn has_failed_to_parse_api_details(&self) -> Option<bool> {
         match self {
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => Some(true),
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(false),
+            Self::ParseSiteUrl { .. } => None,
+            Self::FetchApiRootUrl { .. } => None,
+            Self::ParseApiRootUrl { .. } => None,
+            Self::FetchApiDetails { .. } => None,
+            Self::ParseApiDetails { .. } => Some(true),
+            Self::WpError { .. } => Some(false),
+            Self::ApplicationPasswordsNotSupported { .. } => Some(false),
         }
     }
 
     pub fn is_application_passwords_disabled(&self) -> Option<bool> {
         match self {
-            AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiRootUrl { .. } => None,
-            AutoDiscoveryAttemptFailure::FetchApiDetails { .. } => None,
-            AutoDiscoveryAttemptFailure::ParseApiDetails { .. } => None,
-            AutoDiscoveryAttemptFailure::ApplicationPasswordsNotSupported { .. } => Some(true),
+            Self::ParseSiteUrl { .. } => None,
+            Self::FetchApiRootUrl { .. } => None,
+            Self::ParseApiRootUrl { .. } => None,
+            Self::FetchApiDetails { .. } => None,
+            Self::ParseApiDetails { .. } => None,
+            Self::WpError { .. } => None,
+            Self::ApplicationPasswordsNotSupported { .. } => Some(true),
         }
     }
 }

--- a/wp_api/src/middleware.rs
+++ b/wp_api/src/middleware.rs
@@ -202,7 +202,7 @@ impl WpApiMiddleware for ApiDiscoveryAuthenticationMiddleware {
             return Ok(response);
         }
 
-        if !response.is_http_authentication_required() {
+        if response.status_code != 401 && response.status_code != 403 {
             return Ok(response);
         }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -492,10 +492,6 @@ impl WpNetworkResponse {
             .map(|d| d.seconds)
     }
 
-    pub fn is_http_authentication_required(&self) -> bool {
-        self.status_code == 401 || self.status_code == 403
-    }
-
     pub fn get_http_auth_method(
         &self,
     ) -> Result<Option<HttpAuthMethod>, HttpAuthMethodParsingError> {

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -1,7 +1,9 @@
 use crate::{
     date::WpGmtDateTime,
+    request::{endpoint::WpEndpointUrl, WpNetworkHeaderMap, WpNetworkResponse},
     url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap},
 };
+use std::sync::Arc;
 use url::Url;
 
 #[cfg(test)]
@@ -38,4 +40,15 @@ pub fn unit_test_example_date_as_option() -> Option<WpGmtDateTime> {
 #[cfg(test)]
 pub fn unit_test_example_date_as_query_value(key: &str) -> String {
     format!("{key}=2024-02-09T02%3A14%3A13%2B00%3A00")
+}
+
+#[cfg(test)]
+pub fn wp_network_response_from_json(json: &str, status_code: u16) -> WpNetworkResponse {
+    WpNetworkResponse {
+        body: json.into(),
+        status_code,
+        response_header_map: Arc::new(WpNetworkHeaderMap::default()),
+        request_url: WpEndpointUrl("http://example.com".to_string()),
+        request_header_map: Arc::new(WpNetworkHeaderMap::default()),
+    }
 }


### PR DESCRIPTION
Addresses #605. During api discovery, if `/wp-json` returns a `WpError`, we now parse that into `AutoDiscoveryAttemptFailure::WpError` error variant. Since this case is difficult to cover with an integration test, the PR adds a unit test to verify that we are able to parse this JSON correctly.