### PR TITLE
Add `wp_localization_parser` crate to make parsing accessible from other crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,7 +4140,16 @@ dependencies = [
  "serde_json",
  "syn",
  "trybuild",
+ "wp_localization_parser",
  "wp_serde_helper",
+]
+
+[[package]]
+name = "wp_localization_parser"
+version = "0.1.0"
+dependencies = [
+ "fluent-syntax",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "wp_derive_request_builder",
   "wp_localization",
   "wp_localization_macro",
+  "wp_localization_parser",
   "jetpack",
   "wp_com",
   "wp_serde_helper",

--- a/wp_localization_macro/Cargo.toml
+++ b/wp_localization_macro/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"] }
+wp_localization_parser = { path = "../wp_localization_parser" }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/wp_localization_macro/src/wp_messages.rs
+++ b/wp_localization_macro/src/wp_messages.rs
@@ -1,9 +1,9 @@
 use convert_case::{Case, Casing};
-use fluent_syntax::ast::{self, Entry, Expression, InlineExpression, PatternElement};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::env;
 use syn::{DeriveInput, Ident, parse_macro_input};
+use wp_localization_parser::TranslationEntry;
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -13,164 +13,87 @@ include!(concat!(
 pub fn wp_messages(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let original_input = input.clone();
     let messages_ident = parse_macro_input!(input as DeriveInput).ident;
-    let entries = parse_messages();
+    let entries = wp_localization_parser::parse(LOCALIZATION_CONTENTS)
+        .expect("Localization file should be parseable");
 
     proc_macro::TokenStream::from_iter([
         // Since attribute macros completely replace the input, we need to manually preserve it
         original_input,
-        bindings::generate_bindings(messages_ident, entries).into(),
+        generate_bindings(messages_ident, entries).into(),
     ])
 }
 
-fn parse_messages() -> impl Iterator<Item = TranslationEntry> {
-    let resource = fluent_syntax::parser::parse(LOCALIZATION_CONTENTS)
-        .expect("Localization file should be parseable");
-    resource.body.into_iter().flat_map(|e| {
-        if let Entry::Message(message) = e {
-            let mut documentation = String::new();
-            let key = message.id.name;
-            let placeables = if let Some(pattern) = message.value {
-                pattern
-                    .elements
-                    .into_iter()
-                    .filter_map(|pattern_element| match pattern_element {
-                        PatternElement::TextElement { value } => {
-                            documentation.push_str(value);
-                            None
-                        }
-                        PatternElement::Placeable { expression } => {
-                            if let Some(placeable_element) =
-                                EntryPlaceable::placeable_from_expression(&expression)
-                            {
-                                documentation
-                                    .push_str(format!("{{${}}}", placeable_element.0).as_str());
-                                Some(placeable_element)
-                            } else {
-                                None
-                            }
-                        }
-                    })
-                    .collect()
-            } else {
-                vec![]
-            };
-            Some(TranslationEntry {
-                documentation,
-                key,
-                placeables,
-            })
+fn generate_bindings(
+    messages_ident: Ident,
+    entries: impl Iterator<Item = TranslationEntry>,
+) -> TokenStream {
+    let functions = entries.map(|e| {
+        if e.placeables.is_empty() {
+            generate_argless_function(&e)
         } else {
-            None
+            generate_function(&e)
         }
-    })
-}
-
-#[derive(Debug)]
-struct EntryPlaceable(&'static str);
-
-impl EntryPlaceable {
-    fn placeable_from_expression(expression: &Expression<&'static str>) -> Option<Self> {
-        match expression {
-            ast::Expression::Select { .. } => {
-                // Select expressions are not supported yet
-                None
-            }
-            ast::Expression::Inline(inline) => {
-                if let InlineExpression::VariableReference { id } = inline {
-                    Some(Self(id.name))
-                } else {
-                    // Only `fluent_syntax::ast::InlineExpression::VariableReference` supported
-                    None
-                }
-            }
+    });
+    quote! {
+        impl #messages_ident<'_> {
+            #(#functions)*
         }
     }
 }
 
-#[derive(Debug)]
-struct TranslationEntry {
-    documentation: String,
-    key: &'static str,
-    placeables: Vec<EntryPlaceable>,
-}
-
-impl TranslationEntry {
-    fn key_as_function_name(&self) -> Ident {
-        format_ident!("{}", self.key.to_case(Case::Snake))
-    }
-
-    fn key_as_token_string(&self) -> String {
-        format_ident!("{}", self.key).to_string()
+fn generate_argless_function(entry: &TranslationEntry) -> TokenStream {
+    let function_name = translation_entry_key_as_function_name(entry);
+    let entry_key = translation_entry_key_as_token_string(entry);
+    let documentation = generate_documentation(entry);
+    quote! {
+        #documentation
+        pub fn #function_name<'a>() -> crate::MessageBundle<'a> {
+            crate::MessageBundle::new(#entry_key, None)
+        }
     }
 }
 
-mod bindings {
-    use super::*;
+fn generate_documentation(entry: &TranslationEntry) -> TokenStream {
+    let doc = &entry.documentation;
+    quote! {
+        #[doc = #doc]
+    }
+}
 
-    pub(super) fn generate_bindings(
-        messages_ident: Ident,
-        entries: impl Iterator<Item = TranslationEntry>,
-    ) -> TokenStream {
-        let functions = entries.map(|e| {
-            if e.placeables.is_empty() {
-                generate_argless_function(&e)
-            } else {
-                generate_function(&e)
-            }
-        });
+fn generate_function(entry: &TranslationEntry) -> TokenStream {
+    let function_name = translation_entry_key_as_function_name(entry);
+    let entry_key = translation_entry_key_as_token_string(entry);
+    let documentation = generate_documentation(entry);
+    let args = entry.placeables.iter().map(|placeable| {
+        let placeable_ident = format_ident!("{}", placeable.0);
         quote! {
-            impl #messages_ident<'_> {
-                #(#functions)*
-            }
+            #placeable_ident: impl Into<fluent_bundle::FluentValue<'a>>,
+        }
+    });
+    let map_inserts = entry.placeables.iter().map(|placeable| {
+        let placeable_string = placeable.0;
+        let placeable_ident = format_ident!("{}", placeable_string);
+        quote! {
+            map.insert(std::borrow::Cow::Borrowed(#placeable_string), #placeable_ident.into());
+        }
+    });
+    quote! {
+        #documentation
+        pub fn #function_name<'a>(#(#args)*) -> crate::MessageBundle<'a> {
+            let map = {
+                let mut map = std::collections::HashMap::new();
+                #(#map_inserts)*
+                map
+            };
+            crate::MessageBundle::new(#entry_key, Some(map))
         }
     }
+}
 
-    fn generate_argless_function(entry: &TranslationEntry) -> TokenStream {
-        let function_name = entry.key_as_function_name();
-        let entry_key = entry.key_as_token_string();
-        let documentation = generate_documentation(entry);
-        quote! {
-            #documentation
-            pub fn #function_name<'a>() -> crate::MessageBundle<'a> {
-                crate::MessageBundle::new(#entry_key, None)
-            }
-        }
-    }
+fn translation_entry_key_as_function_name(entry: &TranslationEntry) -> Ident {
+    format_ident!("{}", entry.key.to_case(Case::Snake))
+}
 
-    fn generate_documentation(entry: &TranslationEntry) -> TokenStream {
-        let doc = &entry.documentation;
-        quote! {
-            #[doc = #doc]
-        }
-    }
-
-    fn generate_function(entry: &TranslationEntry) -> TokenStream {
-        let function_name = entry.key_as_function_name();
-        let entry_key = entry.key_as_token_string();
-        let documentation = generate_documentation(entry);
-        let args = entry.placeables.iter().map(|placeable| {
-            let placeable_ident = format_ident!("{}", placeable.0);
-            quote! {
-                #placeable_ident: impl Into<fluent_bundle::FluentValue<'a>>,
-            }
-        });
-        let map_inserts = entry.placeables.iter().map(|placeable| {
-            let placeable_string = placeable.0;
-            let placeable_ident = format_ident!("{}", placeable_string);
-            quote! {
-                map.insert(std::borrow::Cow::Borrowed(#placeable_string), #placeable_ident.into());
-            }
-        });
-        quote! {
-            #documentation
-            pub fn #function_name<'a>(#(#args)*) -> crate::MessageBundle<'a> {
-                let map = {
-                    let mut map = std::collections::HashMap::new();
-                    #(#map_inserts)*
-                    map
-                };
-                crate::MessageBundle::new(#entry_key, Some(map))
-            }
-        }
-    }
+fn translation_entry_key_as_token_string(entry: &TranslationEntry) -> String {
+    format_ident!("{}", entry.key).to_string()
 }

--- a/wp_localization_parser/Cargo.toml
+++ b/wp_localization_parser/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wp_localization_parser"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+fluent-syntax = { workspace = true }
+thiserror = { workspace = true }

--- a/wp_localization_parser/src/lib.rs
+++ b/wp_localization_parser/src/lib.rs
@@ -1,0 +1,81 @@
+use fluent_syntax::ast::{self, Entry, Expression, InlineExpression, PatternElement};
+
+#[derive(Debug)]
+pub struct EntryPlaceable(pub &'static str);
+
+impl EntryPlaceable {
+    pub fn placeable_from_expression(expression: &Expression<&'static str>) -> Option<Self> {
+        match expression {
+            ast::Expression::Select { .. } => {
+                // Select expressions are not supported yet
+                None
+            }
+            ast::Expression::Inline(inline) => {
+                if let InlineExpression::VariableReference { id } = inline {
+                    Some(Self(id.name))
+                } else {
+                    // Only `fluent_syntax::ast::InlineExpression::VariableReference` supported
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TranslationEntry {
+    pub documentation: String,
+    pub key: &'static str,
+    pub placeables: Vec<EntryPlaceable>,
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum LocalizationFileContentsParsingError {
+    #[error("Localization file contents couldn't be parsed")]
+    Generic,
+}
+
+pub fn parse(
+    input: &'static str,
+) -> Result<impl Iterator<Item = TranslationEntry>, LocalizationFileContentsParsingError> {
+    let resource = fluent_syntax::parser::parse(input)
+        .map_err(|_| LocalizationFileContentsParsingError::Generic)?;
+    Ok(resource.body.into_iter().flat_map(|e| {
+        if let Entry::Message(message) = e {
+            let mut documentation = String::new();
+            let key = message.id.name;
+            let placeables = if let Some(pattern) = message.value {
+                pattern
+                    .elements
+                    .into_iter()
+                    .filter_map(|pattern_element| match pattern_element {
+                        PatternElement::TextElement { value } => {
+                            documentation.push_str(value);
+                            None
+                        }
+                        PatternElement::Placeable { expression } => {
+                            if let Some(placeable_element) =
+                                EntryPlaceable::placeable_from_expression(&expression)
+                            {
+                                documentation
+                                    .push_str(format!("{{${}}}", placeable_element.0).as_str());
+                                Some(placeable_element)
+                            } else {
+                                None
+                            }
+                        }
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
+            Some(TranslationEntry {
+                documentation,
+                key,
+                placeables,
+            })
+        } else {
+            None
+        }
+    }))
+}


### PR DESCRIPTION
The parsing logic will be used in #575, so it needs to be accessible outside of the proc macro crate.

This PR only moves the existing code without any functional changes. The only minor change is that `parse` function now returns a `Result` just so we can avoid unwrapping it in a library crate. The error type that's used is pretty basic at the moment, but we might end up adding more information as we build on our tooling.

I also removed the `wp_messages::bindings` mod because the module separation is no longer useful.