### PR TITLE
Add `ResponseBodyType` and use it for `FetchAndParseApiRootFailure::ParseApiRoot` identification

### DIFF
--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -11,7 +11,8 @@ use crate::{
     ParsedUrl, RequestExecutionError, WpError,
     middleware::{PerformsRequests, WpApiMiddlewarePipeline},
     request::{
-        RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
+        RequestExecutor, RequestMethod, ResponseBodyType, WpNetworkHeaderMap, WpNetworkRequest,
+        WpNetworkResponse,
         endpoint::{WP_JSON_PATH_SEGMENTS, WpEndpointUrl},
     },
 };
@@ -312,8 +313,12 @@ impl WpLoginClient {
                     status_code: fetch_api_details_response.status_code,
                 }
             } else {
+                let response_body = fetch_api_details_response.body_as_string();
+                let response_body_type = ResponseBodyType::new(&response_body);
                 FetchAndParseApiRootFailure::ParseApiRoot {
                     parsing_error_message: error.to_string(),
+                    response_body,
+                    response_body_type,
                 }
             }
         })

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1,7 +1,8 @@
 use super::WpApiDetails;
 use crate::{
     ParseUrlError, ParsedUrl, RequestExecutionError, RequestExecutionErrorReason, WpErrorCode,
-    login::KnownApplicationPasswordBlockingPlugin, request::WpRedirect,
+    login::KnownApplicationPasswordBlockingPlugin,
+    request::{ResponseBodyType, WpRedirect},
 };
 use scraper::{Html, Selector};
 use serde::Deserialize;
@@ -422,6 +423,8 @@ pub enum FetchAndParseApiRootFailure {
     },
     ParseApiRoot {
         parsing_error_message: String,
+        response_body: String,
+        response_body_type: ResponseBodyType,
     },
     WpError {
         error_code: WpErrorCode,

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -9,8 +9,9 @@ use base64::Engine;
 use chrono::{DateTime, Utc};
 use endpoint::{ApiEndpointUrl, media_endpoint::MediaUploadRequest};
 use http::{HeaderMap, HeaderName, HeaderValue};
+use regex::Regex;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::str::FromStr;
+use std::str::{FromStr, Utf8Error};
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use url::Url;
 use uuid::Uuid;
@@ -23,6 +24,7 @@ const CONTENT_TYPE_JSON: &str = "application/json";
 const CONTENT_TYPE_MULTIPART: &str = "multipart/form-data";
 const HEADER_KEY_WP_TOTAL: &str = "X-WP-Total";
 const HEADER_KEY_WP_TOTAL_PAGES: &str = "X-WP-TotalPages";
+const MAYBE_HTML_REGEX: &str = r"<\/?[a-z][\s\S]*>";
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -530,6 +532,29 @@ impl WpNetworkResponse {
 
         Ok(None)
     }
+
+    pub fn body_type(&self) -> Result<ResponseBodyType, Utf8Error> {
+        std::str::from_utf8(&self.body).map(ResponseBodyType::new)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
+pub enum ResponseBodyType {
+    ValidJson,
+    MaybeHtml,
+    Other,
+}
+
+impl ResponseBodyType {
+    pub fn new(body_as_string: impl AsRef<str>) -> Self {
+        if is_valid_json(&body_as_string) {
+            Self::ValidJson
+        } else if is_maybe_html(&body_as_string) {
+            Self::MaybeHtml
+        } else {
+            Self::Other
+        }
+    }
 }
 
 struct HttpRetryDuration {
@@ -728,6 +753,16 @@ impl WpRedirect {
     }
 }
 
+pub fn is_maybe_html(value: impl AsRef<str>) -> bool {
+    Regex::new(MAYBE_HTML_REGEX)
+        .expect("This is a valid regex")
+        .is_match(value.as_ref())
+}
+
+pub fn is_valid_json(value: impl AsRef<str>) -> bool {
+    serde_json::from_str::<serde_json::Value>(value.as_ref()).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -741,6 +776,16 @@ mod tests {
             let value = header_value.parse().expect("Header Value must be ascii");
             self.inner.insert(header_name, value);
         }
+    }
+
+    #[rstest]
+    #[case(r#"<foo>"#, ResponseBodyType::MaybeHtml)]
+    #[case(r#"</foo>"#, ResponseBodyType::MaybeHtml)]
+    #[case(r#"{"foo": "bar"}"#, ResponseBodyType::ValidJson)]
+    #[case("foo", ResponseBodyType::Other)]
+    #[case("", ResponseBodyType::Other)]
+    fn test_response_body_type(#[case] input: &str, #[case] expected: ResponseBodyType) {
+        assert_eq!(ResponseBodyType::new(input), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
Adds `response_body_type` field to `FetchAndParseApiRootFailure::ParseApiRoot` to make it easier to identify parsing issues. For now, it implements a very basic regex to check if the response is HTML, but we intend to improve on this.