### PR TITLE
Extract Kotlin changes from `Add Login Spec` PR

### DIFF
--- a/native/kotlin/api/android/build.gradle.kts
+++ b/native/kotlin/api/android/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
         }
     }
     implementation(libs.okhttp)
+    implementation(libs.okhttp.tls)
     implementation(libs.jna) {
         artifact {
             type = "aar"

--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -40,6 +40,7 @@ testing {
                 implementation(project())
 
                 implementation(libs.okhttp)
+                implementation(libs.okhttp.tls)
                 implementation(rootProject.libs.kotlin.test)
                 implementation(rootProject.libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinx.serialization)
@@ -69,6 +70,7 @@ tasks.named("check") {
 
 dependencies {
     implementation(libs.okhttp)
+    implementation(libs.okhttp.tls)
     implementation(libs.jna)
     implementation(libs.kotlinx.coroutines.core)
 }
@@ -122,6 +124,7 @@ tasks.named("processIntegrationTestResources").configure {
     dependsOn(rootProject.tasks.named("copyDesktopJniLibs"))
     dependsOn(rootProject.tasks.named("copyTestCredentials"))
     dependsOn(rootProject.tasks.named("copyTestMedia"))
+    dependsOn(rootProject.tasks.named("copySampleJSON"))
 }
 
 project.afterEvaluate {

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -278,7 +278,6 @@ class ApiUrlDiscoveryTest {
         val httpClient = WpHttpClient.DefaultHttpClient()
         val executor = WpRequestExecutor(httpClient)
         httpClient.addAllowedHostname("wordpress-1315525-4803651.cloudwaysapps.com")
-        httpClient.addAllowedHostname("vanilla.wpmt.co")
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -277,9 +277,9 @@ class ApiUrlDiscoveryTest {
     fun testInvalidHttpsWithExceptionWorks() = runTest {
         val httpClient = WpHttpClient.DefaultHttpClient()
         val executor = WpRequestExecutor(httpClient)
-        httpClient.addAllowedAlternativeNameForHostname(
-            "wordpress-1315525-4803651.cloudwaysapps.com",
-            "vanilla.wpmt.co"
+        httpClient.addAllowedAlternativeNamesForHostname(
+            "vanilla.wpmt.co",
+            listOf("wordpress-1315525-4803651.cloudwaysapps.com")
         )
 
         assertEquals(

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -2,22 +2,292 @@ package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import uniffi.wp_api.ApiDiscoveryAuthenticationMiddleware
+import uniffi.wp_api.RetryAfterMiddleware
+import uniffi.wp_api.WpApiMiddlewarePipeline
+import uniffi.wp_api.WpNetworkResponse
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import uniffi.wp_api.ApplicationPasswordsNotSupportedReason
+import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.ApplicationPasswordsDisabledForHttpSite
+import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.SiteIsLocalDevelopmentEnvironment
+import uniffi.wp_api.AutoDiscoveryAttemptFailure
+import uniffi.wp_api.FetchAndParseApiRootFailure
+import uniffi.wp_api.FindApiRootFailure
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.RequestExecutionException
 
+@Execution(ExecutionMode.CONCURRENT)
 class ApiUrlDiscoveryTest {
     private val loginClient: WpLoginClient = WpLoginClient()
 
-    @Test
-    fun testFindsCorrectApiUrls() = runTest {
-        val apiDiscoveryResult =
-            loginClient.apiDiscovery("https://automatticwidgets.wpcomstaging.com/")
+    @Test // Spec Example 1
+    fun testValidSiteWorksCorrectly() = runTest {
         assertEquals(
-            "https://automatticwidgets.wpcomstaging.com/wp-json/",
-            apiDiscoveryResult.apiRootUrl.url()
-        )
-        assertEquals(
-            "https://automatticwidgets.wpcomstaging.com/wp-admin/authorize-application.php",
-            apiDiscoveryResult.apiDetails.findApplicationPasswordsAuthenticationUrl()
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://vanilla.wpmt.co")
         )
     }
+
+    @Test // Spec Example 2
+    fun testLocalDevelopmentEnvironment() = runTest {
+        val executor = MockRequestExecutor(listOf(
+            Stub.forUrl("http://localhost/", WpNetworkResponse.withApiRoot("http://localhost/wp-json")),
+            Stub.forUrl("https://localhost/", WpNetworkResponse.withApiRoot("http://localhost/wp-json")),
+            Stub.forUrl("http://localhost/wp-json", WpNetworkResponse.jsonResponse("/localhost-json-root.json")),
+            Stub.forUrl("https://localhost/wp-json", WpNetworkResponse.jsonResponse("/localhost-json-root.json")),
+        ))
+
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            val client = WpLoginClient(executor)
+            client.loginUrl("http://localhost")
+        }.let { e ->
+            val reason = getApplicationPasswordsNotSupportedReason(e)
+            assertInstanceOf(SiteIsLocalDevelopmentEnvironment::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 3
+    fun testAdminUrlProvided() = runTest {
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://vanilla.wpmt.co/wp-login.php")
+        )
+
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://vanilla.wpmt.co/wp-admin")
+        )
+    }
+
+    @Test // Spec Example 4
+    fun testAutoHttpsSupport() = runTest {
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("http://vanilla.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 5
+    fun testHttpOnlySite() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("http://no-https.wpmt.co")
+        }.let { e ->
+            val reason = getApplicationPasswordsNotSupportedReason(e)
+            assertInstanceOf(ApplicationPasswordsDisabledForHttpSite::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 6
+    fun testHttpOnlySiteWithApplicationPasswordsEnabled() = runTest {
+        assertEquals(
+            "http://no-https-with-application-passwords.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("http://no-https-with-application-passwords.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 7
+    fun testAggressivelyCachedSiteWithNoLinkHeader() = runTest {
+        assertEquals(
+            "https://aggressive-caching.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://aggressive-caching.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 8
+    fun testSiteWithApplicationPasswordsDisabledByWordFence() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("https://wordfence.wpmt.co")
+        }.let { e ->
+            val reason = getApplicationPasswordsNotSupportedReason(e)
+            assertInstanceOf(ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin::class.java, reason)
+
+            val plugin = (reason as ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin).plugin
+            assertEquals(plugin.name, "Wordfence")
+        }
+    }
+
+    @Test // Spec Example 9
+    fun testNotWordPressSite() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("https://google.com")
+        }.let { e ->
+            val reason = getFindApiRootFailure(e)
+            assertInstanceOf(FindApiRootFailure.ProbablyNotAWordPressSite::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 10
+    fun testWordPressSubdirectoryWithLinkHeader() = runTest {
+        assertEquals(
+            "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://subdirectory.wpmt.co/index.php?link_header=true")
+        )
+    }
+
+    @Test // Spec Example 11
+    fun testWordPressSubdirectoryWithLinkTag() = runTest {
+        assertEquals(
+            "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://subdirectory.wpmt.co?link_tag=true")
+        )
+    }
+
+    @Test // Spec Example 12
+    fun testWordPressSubdirectoryWithRedirect() = runTest {
+        assertEquals(
+            "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://subdirectory.wpmt.co/index.php?redirect=true")
+        )
+    }
+
+    @Test // Spec Example 13 (with no credentials)
+    fun testWordPressHttpBasicWithMissingCredentials() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("https://basic-auth.wpmt.co")
+        }.let { e ->
+            val reason = getRequestExecutionErrorReason(e)
+            assertInstanceOf(RequestExecutionErrorReason.HttpAuthenticationRequiredError::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 13 (with invalid credentials)
+    fun testWordPressHttpBasicWithInvalidCredentials() = runTest {
+        val invalid = ApiDiscoveryAuthenticationMiddleware(username = "invalid", password = "invalid")
+        val client = WpLoginClient(
+            WpRequestExecutor(),
+            WpApiMiddlewarePipeline(middlewares = listOf(invalid))
+        )
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            client.loginUrl("https://basic-auth.wpmt.co")
+        }.let { e ->
+            val reason = getRequestExecutionErrorReason(e)
+            assertInstanceOf(RequestExecutionErrorReason.HttpAuthenticationRejectedError::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 13 (with valid credentials)
+    fun testWordPressHttpBasicWithValidCredentials() = runTest {
+        val valid = ApiDiscoveryAuthenticationMiddleware(username = "test@example.com", password = "str0ngp4ssw0rd!")
+
+        val client = WpLoginClient(
+            WpRequestExecutor(),
+            WpApiMiddlewarePipeline(middlewares = listOf(valid))
+        )
+
+        assertEquals(
+            "https://basic-auth.wpmt.co/wp-admin/authorize-application.php",
+            client.loginUrl("https://basic-auth.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 14
+    fun testWordPressCustomRestApiPrefix() = runTest {
+        assertEquals(
+            "https://custom-rest-prefix.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://custom-rest-prefix.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 15
+    fun testWordPressHeavyRateLimiting() = runTest {
+        assertEquals(
+            "https://aggressive-rate-limiting.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.loginUrl("https://aggressive-rate-limiting.wpmt.co")
+        )
+    }
+
+    @Test // Spec Example 15
+    fun testWordPressHeavyRateLimitingThatNeverSucceeds() = runTest {
+        val executor = MockRequestExecutor(listOf(
+            Stub.forHost("aggressive-rate-limiting.wpmt.co", WpNetworkResponse.retryResponse(1u))
+        ))
+
+        val middleware = RetryAfterMiddleware(maxRetries = 3u, maxRetryWaitSeconds = 1u)
+
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            val client = WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
+            client.loginUrl("https://aggressive-rate-limiting.wpmt.co")
+        }.let { e ->
+            val reason = getRequestExecutionErrorReason(e)
+            assertInstanceOf(RequestExecutionErrorReason.MisconfiguredRateLimitError::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 16
+    fun testInvalidUrl() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("https://valid-looking-url-but-not-actually.foo")
+        }.let { e ->
+            val reason = getRequestExecutionErrorReason(e)
+            assertInstanceOf(RequestExecutionErrorReason.NonExistentSiteError::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 17
+    fun testInvalidHTTPsFails() = runTest {
+        assertFailsWith<AutoDiscoveryAttemptFailure>() {
+            loginClient.loginUrl("https://wordpress-1315525-4803651.cloudwaysapps.com")
+        }.let { e ->
+            val reason = getRequestExecutionErrorReason(e)
+            assertInstanceOf(RequestExecutionErrorReason.InvalidSslError::class.java, reason)
+        }
+    }
+
+    @Test // Spec Example 17 (with exception)
+    fun testInvalidHttpsWithExceptionWorks() = runTest {
+        val executor = WpRequestExecutor()
+        executor.addAllowedAlternativeNameForHostname("wordpress-1315525-4803651.cloudwaysapps.com", "vanilla.wpmt.co")
+
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            WpLoginClient(requestExecutor = executor).loginUrl("https://wordpress-1315525-4803651.cloudwaysapps.com")
+        )
+    }
+
+    private fun getApplicationPasswordsNotSupportedReason(error: AutoDiscoveryAttemptFailure): ApplicationPasswordsNotSupportedReason? {
+        return when(val failure = getFetchAndParseApiRootFailure(error)) {
+            is FetchAndParseApiRootFailure.ApplicationPasswordsNotSupported -> failure.reason
+            else -> null
+        }
+    }
+
+    private fun getFetchAndParseApiRootFailure(error: AutoDiscoveryAttemptFailure): FetchAndParseApiRootFailure? {
+        return when(error) {
+            is AutoDiscoveryAttemptFailure.FetchAndParseApiRoot -> error.fetchAndParseApiRootFailure
+            else -> null
+        }
+    }
+
+    private fun getFindApiRootFailure(error: AutoDiscoveryAttemptFailure): FindApiRootFailure? {
+        return when (error) {
+            is AutoDiscoveryAttemptFailure.FindApiRoot -> error.findApiRootFailure
+            else -> null
+        }
+    }
+
+    private fun getRequestExecutionErrorReason(error: AutoDiscoveryAttemptFailure): RequestExecutionErrorReason? {
+        when(val failure = getFindApiRootFailure(error)) {
+            is FindApiRootFailure.FetchHomepage -> return extract(failure.error)
+            else -> {}
+        }
+
+        when(val failure = getFetchAndParseApiRootFailure(error)) {
+            is FetchAndParseApiRootFailure.FetchApiRoot -> return extract(failure.error)
+            else -> {}
+        }
+
+        return null
+    }
+
+    private fun extract(error: RequestExecutionException): RequestExecutionErrorReason? {
+        return when(error) {
+            is RequestExecutionException.RequestExecutionFailed -> error.reason
+            else -> null
+        }
+    }
+
 }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -277,7 +277,10 @@ class ApiUrlDiscoveryTest {
     fun testInvalidHttpsWithExceptionWorks() = runTest {
         val httpClient = WpHttpClient.DefaultHttpClient()
         val executor = WpRequestExecutor(httpClient)
-        httpClient.addAllowedHostname("wordpress-1315525-4803651.cloudwaysapps.com")
+        httpClient.addAllowedAlternativeNameForHostname(
+            "wordpress-1315525-4803651.cloudwaysapps.com",
+            "vanilla.wpmt.co"
+        )
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -1,6 +1,7 @@
 package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -34,12 +35,26 @@ class ApiUrlDiscoveryTest {
 
     @Test // Spec Example 2
     fun testLocalDevelopmentEnvironment() = runTest {
-        val executor = MockRequestExecutor(listOf(
-            Stub.forUrl("http://localhost/", WpNetworkResponse.withApiRoot("http://localhost/wp-json")),
-            Stub.forUrl("https://localhost/", WpNetworkResponse.withApiRoot("http://localhost/wp-json")),
-            Stub.forUrl("http://localhost/wp-json", WpNetworkResponse.jsonResponse("/localhost-json-root.json")),
-            Stub.forUrl("https://localhost/wp-json", WpNetworkResponse.jsonResponse("/localhost-json-root.json")),
-        ))
+        val executor = MockRequestExecutor(
+            listOf(
+                Stub.forUrl(
+                    "http://localhost/",
+                    WpNetworkResponse.withApiRoot("http://localhost/wp-json")
+                ),
+                Stub.forUrl(
+                    "https://localhost/",
+                    WpNetworkResponse.withApiRoot("http://localhost/wp-json")
+                ),
+                Stub.forUrl(
+                    "http://localhost/wp-json",
+                    WpNetworkResponse.jsonResponse("/localhost-json-root.json")
+                ),
+                Stub.forUrl(
+                    "https://localhost/wp-json",
+                    WpNetworkResponse.jsonResponse("/localhost-json-root.json")
+                ),
+            )
+        )
 
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
             val client = WpLoginClient(executor)
@@ -103,9 +118,13 @@ class ApiUrlDiscoveryTest {
             loginClient.loginUrl("https://wordfence.wpmt.co")
         }.let { e ->
             val reason = getApplicationPasswordsNotSupportedReason(e)
-            assertInstanceOf(ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin::class.java, reason)
+            assertInstanceOf(
+                ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin::class.java,
+                reason
+            )
 
-            val plugin = (reason as ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin).plugin
+            val plugin =
+                (reason as ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin).plugin
             assertEquals(plugin.name, "Wordfence")
         }
     }
@@ -150,32 +169,40 @@ class ApiUrlDiscoveryTest {
             loginClient.loginUrl("https://basic-auth.wpmt.co")
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(RequestExecutionErrorReason.HttpAuthenticationRequiredError::class.java, reason)
+            assertInstanceOf(
+                RequestExecutionErrorReason.HttpAuthenticationRequiredError::class.java,
+                reason
+            )
         }
     }
 
     @Test // Spec Example 13 (with invalid credentials)
     fun testWordPressHttpBasicWithInvalidCredentials() = runTest {
-        val invalid = ApiDiscoveryAuthenticationMiddleware(username = "invalid", password = "invalid")
+        val invalid =
+            ApiDiscoveryAuthenticationMiddleware(username = "invalid", password = "invalid")
         val client = WpLoginClient(
-            WpRequestExecutor(),
-            WpApiMiddlewarePipeline(middlewares = listOf(invalid))
+            WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(invalid))
         )
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
             client.loginUrl("https://basic-auth.wpmt.co")
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(RequestExecutionErrorReason.HttpAuthenticationRejectedError::class.java, reason)
+            assertInstanceOf(
+                RequestExecutionErrorReason.HttpAuthenticationRejectedError::class.java,
+                reason
+            )
         }
     }
 
     @Test // Spec Example 13 (with valid credentials)
     fun testWordPressHttpBasicWithValidCredentials() = runTest {
-        val valid = ApiDiscoveryAuthenticationMiddleware(username = "test@example.com", password = "str0ngp4ssw0rd!")
+        val valid = ApiDiscoveryAuthenticationMiddleware(
+            username = "test@example.com",
+            password = "str0ngp4ssw0rd!"
+        )
 
         val client = WpLoginClient(
-            WpRequestExecutor(),
-            WpApiMiddlewarePipeline(middlewares = listOf(valid))
+            WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(valid))
         )
 
         assertEquals(
@@ -202,18 +229,27 @@ class ApiUrlDiscoveryTest {
 
     @Test // Spec Example 15
     fun testWordPressHeavyRateLimitingThatNeverSucceeds() = runTest {
-        val executor = MockRequestExecutor(listOf(
-            Stub.forHost("aggressive-rate-limiting.wpmt.co", WpNetworkResponse.retryResponse(1u))
-        ))
+        val executor = MockRequestExecutor(
+            listOf(
+                Stub.forHost(
+                    "aggressive-rate-limiting.wpmt.co",
+                    WpNetworkResponse.retryResponse(1u)
+                )
+            )
+        )
 
         val middleware = RetryAfterMiddleware(maxRetries = 3u, maxRetryWaitSeconds = 1u)
 
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            val client = WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
+            val client =
+                WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
             client.loginUrl("https://aggressive-rate-limiting.wpmt.co")
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(RequestExecutionErrorReason.MisconfiguredRateLimitError::class.java, reason)
+            assertInstanceOf(
+                RequestExecutionErrorReason.MisconfiguredRateLimitError::class.java,
+                reason
+            )
         }
     }
 
@@ -239,8 +275,11 @@ class ApiUrlDiscoveryTest {
 
     @Test // Spec Example 17 (with exception)
     fun testInvalidHttpsWithExceptionWorks() = runTest {
-        val executor = WpRequestExecutor()
-        executor.addAllowedAlternativeNameForHostname("wordpress-1315525-4803651.cloudwaysapps.com", "vanilla.wpmt.co")
+        val httpClient = WpHttpClient.DefaultHttpClient()
+        val executor = WpRequestExecutor(httpClient)
+        httpClient.addAllowedAlternativeNameForHostname(
+            "wordpress-1315525-4803651.cloudwaysapps.com", "vanilla.wpmt.co"
+        )
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
@@ -248,15 +287,25 @@ class ApiUrlDiscoveryTest {
         )
     }
 
+    @Test
+    fun testCustomOkHttpClient() = runTest {
+        val executor =
+            WpRequestExecutor(httpClient = WpHttpClient.CustomOkHttpClient(client = OkHttpClient()))
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            WpLoginClient(requestExecutor = executor).loginUrl("https://vanilla.wpmt.co")
+        )
+    }
+
     private fun getApplicationPasswordsNotSupportedReason(error: AutoDiscoveryAttemptFailure): ApplicationPasswordsNotSupportedReason? {
-        return when(val failure = getFetchAndParseApiRootFailure(error)) {
+        return when (val failure = getFetchAndParseApiRootFailure(error)) {
             is FetchAndParseApiRootFailure.ApplicationPasswordsNotSupported -> failure.reason
             else -> null
         }
     }
 
     private fun getFetchAndParseApiRootFailure(error: AutoDiscoveryAttemptFailure): FetchAndParseApiRootFailure? {
-        return when(error) {
+        return when (error) {
             is AutoDiscoveryAttemptFailure.FetchAndParseApiRoot -> error.fetchAndParseApiRootFailure
             else -> null
         }
@@ -270,12 +319,12 @@ class ApiUrlDiscoveryTest {
     }
 
     private fun getRequestExecutionErrorReason(error: AutoDiscoveryAttemptFailure): RequestExecutionErrorReason? {
-        when(val failure = getFindApiRootFailure(error)) {
+        when (val failure = getFindApiRootFailure(error)) {
             is FindApiRootFailure.FetchHomepage -> return extract(failure.error)
             else -> {}
         }
 
-        when(val failure = getFetchAndParseApiRootFailure(error)) {
+        when (val failure = getFetchAndParseApiRootFailure(error)) {
             is FetchAndParseApiRootFailure.FetchApiRoot -> return extract(failure.error)
             else -> {}
         }
@@ -284,7 +333,7 @@ class ApiUrlDiscoveryTest {
     }
 
     private fun extract(error: RequestExecutionException): RequestExecutionErrorReason? {
-        return when(error) {
+        return when (error) {
             is RequestExecutionException.RequestExecutionFailed -> error.reason
             else -> null
         }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -277,9 +277,8 @@ class ApiUrlDiscoveryTest {
     fun testInvalidHttpsWithExceptionWorks() = runTest {
         val httpClient = WpHttpClient.DefaultHttpClient()
         val executor = WpRequestExecutor(httpClient)
-        httpClient.addAllowedAlternativeNameForHostname(
-            "wordpress-1315525-4803651.cloudwaysapps.com", "vanilla.wpmt.co"
-        )
+        httpClient.addAllowedHostname("wordpress-1315525-4803651.cloudwaysapps.com")
+        httpClient.addAllowedHostname("vanilla.wpmt.co")
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MockRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MockRequestExecutor.kt
@@ -9,8 +9,6 @@ import uniffi.wp_api.WpNetworkRequest
 import uniffi.wp_api.WpNetworkResponse
 import java.net.URI
 
-// Future improvement idea: This class could probably go in a Test Helpers package or something
-
 class Stub(val evaluator: (WpNetworkRequest) -> Boolean, val response: WpNetworkResponse) {
     companion object {
         fun forHost(host: String, response: WpNetworkResponse): Stub {

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/MockRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/MockRequestExecutor.kt
@@ -1,0 +1,100 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.delay
+import okio.FileNotFoundException
+import uniffi.wp_api.MediaUploadRequest
+import uniffi.wp_api.RequestExecutor
+import uniffi.wp_api.WpNetworkHeaderMap
+import uniffi.wp_api.WpNetworkRequest
+import uniffi.wp_api.WpNetworkResponse
+import java.net.URI
+
+// Future improvement idea: This class could probably go in a Test Helpers package or something
+
+class Stub(val evaluator: (WpNetworkRequest) -> Boolean, val response: WpNetworkResponse) {
+    companion object {
+        fun forHost(host: String, response: WpNetworkResponse): Stub {
+            return Stub(evaluator = { request ->
+                URI(request.url()).host == host
+            }, response = response)
+        }
+
+        fun forUrl(url: String, response: WpNetworkResponse): Stub {
+            return Stub({ request -> request.url() == url }, response)
+        }
+    }
+}
+
+class NoStubFoundException(message: String) : Exception(message)
+
+// A class used for testing the request executor.
+class MockRequestExecutor(private var stubs: List<Stub> = listOf()) : RequestExecutor {
+
+    override suspend fun execute(request: WpNetworkRequest): WpNetworkResponse {
+        val stub = stubs.firstOrNull {
+            it.evaluator(request)
+        }
+
+        if (stub != null) {
+            return stub.response
+        }
+
+        throw NoStubFoundException("No stub found for ${request.url()}")
+    }
+
+    override suspend fun uploadMedia(mediaUploadRequest: MediaUploadRequest): WpNetworkResponse {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun sleep(millis: ULong) {
+        delay(millis.toLong())
+    }
+}
+
+val WpNetworkResponse.Companion.empty: WpNetworkResponse
+    get() = WpNetworkResponse(
+        ByteArray(0),
+        200u,
+        WpNetworkHeaderMap.empty,
+        "",
+        WpNetworkHeaderMap.empty
+    )
+
+val WpNetworkHeaderMap.Companion.empty: WpNetworkHeaderMap
+    get() = WpNetworkHeaderMap.fromMap(mapOf())
+
+fun WpNetworkResponse.Companion.withApiRoot(url: String): WpNetworkResponse {
+    return WpNetworkResponse(
+        ByteArray(0),
+        200u,
+        WpNetworkHeaderMap.fromMap(mapOf("Link" to "<$url>; rel=\"https://api.w.org/\"")),
+        "",
+        WpNetworkHeaderMap.empty
+    )
+}
+
+fun WpNetworkResponse.Companion.jsonResponse(name: String): WpNetworkResponse {
+    val data = {}.javaClass.getResource(name)?.readText()
+
+    if (data == null) {
+        throw FileNotFoundException("No resource found for $name")
+    }
+
+    return WpNetworkResponse(
+        data.toByteArray(),
+        200u,
+        WpNetworkHeaderMap.fromMap(mapOf("Content-Type" to "application/json")),
+        "",
+        WpNetworkHeaderMap.empty
+    )
+}
+
+fun WpNetworkResponse.Companion.retryResponse(delay: ULong): WpNetworkResponse {
+    return WpNetworkResponse(
+        ByteArray(0),
+        429u,
+        WpNetworkHeaderMap.fromMap(mapOf("Retry-After" to delay.toString())),
+        "",
+        WpNetworkHeaderMap.empty
+    )
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -43,7 +43,7 @@ sealed class WpHttpClient {
 
 private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) :
     HostnameVerifier {
-    override fun verify(p0: String?, p1: SSLSession?): Boolean {
-        return p1?.isValid == true || allowedHostnames.contains(p0)
+    override fun verify(hostname: String?, session: SSLSession?): Boolean {
+        return session?.isValid == true || hostname?.let { allowedHostnames.contains(it) } ?: false
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -13,8 +13,8 @@ sealed class WpHttpClient {
 
         private var allowedHostnames: List<String> = emptyList()
 
-        fun addAllowedAlternativeNameForHostname(alternativeName: String, hostname: String) {
-            allowedHostnames = allowedHostnames.plus(alternativeName).plus(hostname)
+        fun addAllowedHostname(hostname: String) {
+            allowedHostnames = allowedHostnames.plus(hostname)
             updateClient()
         }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -44,6 +44,6 @@ sealed class WpHttpClient {
 private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) :
     HostnameVerifier {
     override fun verify(p0: String?, p1: SSLSession?): Boolean {
-        return allowedHostnames.contains(p0)
+        return p1?.isValid == true || allowedHostnames.contains(p0)
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -1,7 +1,6 @@
 package rs.wordpress.api.kotlin
 
 import okhttp3.OkHttpClient
-import okhttp3.tls.HandshakeCertificates
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSession
 
@@ -11,25 +10,16 @@ sealed class WpHttpClient {
     class DefaultHttpClient : WpHttpClient() {
         private var client: OkHttpClient = OkHttpClient()
 
-        private var allowedHostnames: List<String> = emptyList()
+        private var allowedHostnames: Map<String, String> = emptyMap()
 
-        fun addAllowedHostname(hostname: String) {
-            allowedHostnames = allowedHostnames.plus(hostname)
+        fun addAllowedAlternativeNameForHostname(hostname: String, alternativeName: String) {
+            allowedHostnames = allowedHostnames.plus(Pair(hostname, alternativeName))
             updateClient()
         }
 
         private fun updateClient() {
-            val clientCertificates = HandshakeCertificates.Builder()
-                .addPlatformTrustedCertificates()
-                .addInsecureHost(allowedHostnames.first())
-                .build()
-
             client = client.newBuilder()
                 .hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
-                .sslSocketFactory(
-                    clientCertificates.sslSocketFactory(),
-                    clientCertificates.trustManager
-                )
                 .build()
         }
 
@@ -41,9 +31,11 @@ sealed class WpHttpClient {
     }
 }
 
-private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) :
+private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: Map<String, String>) :
     HostnameVerifier {
-    override fun verify(hostname: String?, session: SSLSession?): Boolean {
-        return session?.isValid == true || hostname?.let { allowedHostnames.contains(it) } ?: false
-    }
+    override fun verify(hostname: String?, session: SSLSession?): Boolean =
+        session?.let {
+            val name = it.peerPrincipal.name.replace("CN=", "")
+            name == hostname || allowedHostnames[hostname]?.let { alternativeName -> name == alternativeName } ?: false
+        } ?: false
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -10,10 +10,12 @@ sealed class WpHttpClient {
     class DefaultHttpClient : WpHttpClient() {
         private var client: OkHttpClient = OkHttpClient()
 
-        private var allowedHostnames: Map<String, String> = emptyMap()
+        private var allowedHostnames: Map<String, List<String>> = emptyMap()
 
-        fun addAllowedAlternativeNameForHostname(hostname: String, alternativeName: String) {
-            allowedHostnames = allowedHostnames.plus(Pair(hostname, alternativeName))
+        fun addAllowedAlternativeNamesForHostname(hostname: String, allowedNames: List<String>) {
+            // Preserve the previous records for this key
+            val previousList = allowedHostnames[hostname].orEmpty()
+            allowedHostnames = allowedHostnames.plus(Pair(hostname, allowedNames.plus(previousList)))
             updateClient()
         }
 
@@ -31,11 +33,11 @@ sealed class WpHttpClient {
     }
 }
 
-private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: Map<String, String>) :
+private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: Map<String, List<String>>) :
     HostnameVerifier {
     override fun verify(hostname: String?, session: SSLSession?): Boolean =
         session?.let {
-            val name = it.peerPrincipal.name.replace("CN=", "")
-            name == hostname || allowedHostnames[hostname]?.let { alternativeName -> name == alternativeName } ?: false
+            val peerPrincipalName = it.peerPrincipal.name.replace("CN=", "")
+            peerPrincipalName == hostname || allowedHostnames[peerPrincipalName]?.contains(hostname) ?: false
         } ?: false
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -1,0 +1,49 @@
+package rs.wordpress.api.kotlin
+
+import okhttp3.OkHttpClient
+import okhttp3.tls.HandshakeCertificates
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLSession
+
+sealed class WpHttpClient {
+    abstract fun getClient(): OkHttpClient
+
+    class DefaultHttpClient : WpHttpClient() {
+        private var client: OkHttpClient = OkHttpClient()
+
+        private var allowedHostnames: List<String> = emptyList()
+
+        fun addAllowedAlternativeNameForHostname(alternativeName: String, hostname: String) {
+            allowedHostnames = allowedHostnames.plus(alternativeName).plus(hostname)
+            updateClient()
+        }
+
+        private fun updateClient() {
+            val clientCertificates = HandshakeCertificates.Builder()
+                .addPlatformTrustedCertificates()
+                .addInsecureHost(allowedHostnames.first())
+                .build()
+
+            client = client.newBuilder()
+                .hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+                .sslSocketFactory(
+                    clientCertificates.sslSocketFactory(),
+                    clientCertificates.trustManager
+                )
+                .build()
+        }
+
+        override fun getClient() = client
+    }
+
+    data class CustomOkHttpClient(private val client: OkHttpClient) : WpHttpClient() {
+        override fun getClient() = client
+    }
+}
+
+private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) :
+    HostnameVerifier {
+    override fun verify(p0: String?, p1: SSLSession?): Boolean {
+        return allowedHostnames.contains(p0)
+    }
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -19,4 +19,8 @@ class WpLoginClient(
     suspend fun apiDiscovery(siteUrl: String): AutoDiscoveryAttemptSuccess = withContext(dispatcher) {
         internalClient.apiDiscovery(siteUrl)
     }
+
+    suspend fun loginUrl(siteUrl: String): String? = withContext(dispatcher) {
+        internalClient.apiDiscovery(siteUrl).apiDetails.findApplicationPasswordsAuthenticationUrl()
+    }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -7,11 +7,9 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.tls.HandshakeCertificates
 import uniffi.wp_api.MediaUploadRequest
 import uniffi.wp_api.MediaUploadRequestExecutionException
 import uniffi.wp_api.RequestExecutionErrorReason
@@ -23,22 +21,13 @@ import uniffi.wp_api.WpNetworkResponse
 import uniffi.wp_api.parseCertificate
 import java.io.File
 import java.net.UnknownHostException
-import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLPeerUnverifiedException
-import javax.net.ssl.SSLSession
 
 class WpRequestExecutor(
-    private var okHttpClient: OkHttpClient = OkHttpClient(),
+    private val httpClient: WpHttpClient = WpHttpClient.DefaultHttpClient(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : RequestExecutor {
-
-    private var allowedHostnames: List<String> = emptyList()
-
-    fun addAllowedAlternativeNameForHostname(altname: String, hostname: String) {
-        allowedHostnames = allowedHostnames.plus(altname).plus(hostname)
-    }
-
     override suspend fun execute(request: WpNetworkRequest): WpNetworkResponse =
         withContext(dispatcher) {
             val requestBuilder = Request.Builder().url(request.url())
@@ -55,7 +44,7 @@ class WpRequestExecutor(
             val urlRequest = requestBuilder.build()
 
             try {
-                getClient().newCall(urlRequest).execute().use { response ->
+                httpClient.getClient().newCall(urlRequest).execute().use { response ->
                     return@withContext WpNetworkResponse(
                         body = response.body?.bytes() ?: ByteArray(0),
                         statusCode = response.code.toUShort(),
@@ -66,9 +55,7 @@ class WpRequestExecutor(
                 }
             } catch (e: SSLPeerUnverifiedException) {
                 throw requestExecutionFailedWith(
-                    RequestExecutionErrorReason.invalidSSLError(
-                        urlRequest.url
-                    )
+                    RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
                 )
             } catch (e: UnknownHostException) {
                 throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
@@ -105,7 +92,7 @@ class WpRequestExecutor(
                 }
             }
 
-            okHttpClient.newCall(requestBuilder.build()).execute().use { response ->
+            httpClient.getClient().newCall(requestBuilder.build()).execute().use { response ->
                 return@withContext WpNetworkResponse(
                     body = response.body?.bytes() ?: ByteArray(0),
                     statusCode = response.code.toUShort(),
@@ -119,28 +106,6 @@ class WpRequestExecutor(
     override suspend fun sleep(millis: ULong) {
         delay(millis.toLong())
     }
-
-    private fun getClient(): OkHttpClient {
-        if (allowedHostnames.isEmpty()) {
-            return okHttpClient
-        }
-
-        val clientCertificates = HandshakeCertificates.Builder()
-            .addPlatformTrustedCertificates()
-            .addInsecureHost(allowedHostnames.first())
-            .build()
-
-        return okHttpClient.newBuilder()
-            .hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
-            .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
-            .build()
-    }
-}
-
-class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) : HostnameVerifier {
-    override fun verify(p0: String?, p1: SSLSession?): Boolean {
-        return allowedHostnames.contains(p0)
-    }
 }
 
 private fun RequestExecutionErrorReason.Companion.unknownHost(e: UnknownHostException) =
@@ -149,7 +114,11 @@ private fun RequestExecutionErrorReason.Companion.unknownHost(e: UnknownHostExce
         suggestedAction = "Check that the URL is valid and try again"
     )
 
-private fun RequestExecutionErrorReason.Companion.invalidSSLError(requestUrl: HttpUrl): RequestExecutionErrorReason {
+@Suppress("UNUSED_PARAMETER")
+private fun RequestExecutionErrorReason.Companion.invalidSSLError(
+    e: SSLPeerUnverifiedException, // To avoid `SwallowedException` from Detekt
+    requestUrl: HttpUrl
+): RequestExecutionErrorReason {
     // It's kind of weird and annoying that we need to make a second request to get
     // this data, but it doesn't seem like we can get it from the response or the
     // `SSLPeerUnverifiedException` directly.

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -10,18 +10,33 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.tls.HandshakeCertificates
 import uniffi.wp_api.MediaUploadRequest
 import uniffi.wp_api.MediaUploadRequestExecutionException
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.RequestExecutionException
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.WpNetworkHeaderMap
 import uniffi.wp_api.WpNetworkRequest
 import uniffi.wp_api.WpNetworkResponse
+import uniffi.wp_api.parseCertificate
 import java.io.File
+import java.net.UnknownHostException
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.SSLSession
 
 class WpRequestExecutor(
-    private val okHttpClient: OkHttpClient = OkHttpClient(),
+    private var okHttpClient: OkHttpClient = OkHttpClient(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : RequestExecutor {
+
+    private var allowedHostnames: List<String> = emptyList()
+
+    fun addAllowedAlternativeNameForHostname(altname: String, hostname: String) {
+        allowedHostnames = allowedHostnames.plus(altname).plus(hostname)
+    }
 
     override suspend fun execute(request: WpNetworkRequest): WpNetworkResponse =
         withContext(dispatcher) {
@@ -36,15 +51,25 @@ class WpRequestExecutor(
                 }
             }
 
-            okHttpClient.newCall(requestBuilder.build()).execute().use { response ->
-                return@withContext WpNetworkResponse(
-                    body = response.body?.bytes() ?: ByteArray(0),
-                    statusCode = response.code.toUShort(),
-                    responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
-                    requestUrl = request.url(),
-                    requestHeaderMap = request.headerMap()
-                )
+            val urlRequest = requestBuilder.build()
+
+            try {
+                getClient().newCall(urlRequest).execute().use { response ->
+                    return@withContext WpNetworkResponse(
+                        body = response.body?.bytes() ?: ByteArray(0),
+                        statusCode = response.code.toUShort(),
+                        responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
+                        requestUrl = request.url(),
+                        requestHeaderMap = request.headerMap()
+                    )
+                }
+            } catch (e: SSLPeerUnverifiedException) {
+                handleInvalidSSLError(e, urlRequest)
+            } catch (e: UnknownHostException) {
+                handleUnknownHostException(e, urlRequest)
             }
+
+            error("Unknown Error occurred")
         }
 
     override suspend fun uploadMedia(mediaUploadRequest: MediaUploadRequest): WpNetworkResponse =
@@ -90,5 +115,84 @@ class WpRequestExecutor(
 
     override suspend fun sleep(millis: ULong) {
         delay(millis.toLong())
+    }
+
+    private fun getClient(): OkHttpClient {
+        if (allowedHostnames.isEmpty()) {
+            return okHttpClient
+        }
+
+        val clientCertificates = HandshakeCertificates.Builder()
+            .addPlatformTrustedCertificates()
+            .addInsecureHost(allowedHostnames.first())
+            .build()
+
+        return okHttpClient.newBuilder()
+            .hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+            .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+            .build()
+    }
+
+    @Suppress("UnusedParameter")
+    private fun handleInvalidSSLError(e: SSLPeerUnverifiedException, request: Request) {
+        // It's kind of weird and annoying that we need to make a second request to get
+        // this data, but it doesn't seem like we can get it from the response or the
+        // `SSLPeerUnverifiedException` directly.
+        val url = request.url.toUrl()
+
+        // We spin up a new connection that'll accept any certificate. The connection will then
+        // contain all the details we need for the error.
+        val newConnection = url.openConnection() as HttpsURLConnection
+        newConnection.setHostnameVerifier { _, _ -> return@setHostnameVerifier true }
+        newConnection.connect()
+
+        // Certificate is parsed by the Rust shared implementation.
+        val certificates = newConnection.serverCertificates.map { parseCertificate(it.encoded) }
+
+        if (certificates.isEmpty()) {
+            val error = RequestExecutionErrorReason.InvalidSslError(
+                siteCertificate = null,
+                certificateChain = emptyList(),
+                errorMessage = "Invalid certificate for domain",
+                suggestedAction = null
+            )
+
+            throwExceptionFor(error)
+        }
+
+        val siteCertificate = certificates.first()
+
+        val error = RequestExecutionErrorReason.InvalidSslError(
+            siteCertificate = siteCertificate,
+            certificateChain = certificates.mapNotNull { it },
+            errorMessage = "Invalid certificate for domain",
+            suggestedAction = null
+        )
+
+        throwExceptionFor(error)
+    }
+
+    @Suppress("UnusedParameter")
+    private fun handleUnknownHostException(e: UnknownHostException, request: Request) {
+        val error = RequestExecutionErrorReason.NonExistentSiteError(
+            errorMessage = e.localizedMessage,
+            suggestedAction = "Check that the URL is valid and try again"
+        )
+
+        throwExceptionFor(error)
+    }
+
+    private fun throwExceptionFor(reason: RequestExecutionErrorReason) {
+        throw RequestExecutionException.RequestExecutionFailed(
+            statusCode = null,
+            redirects = null,
+            reason = reason
+        )
+    }
+}
+
+class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) : HostnameVerifier {
+    override fun verify(p0: String?, p1: SSLSession?): Boolean {
+        return allowedHostnames.contains(p0)
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -64,12 +65,14 @@ class WpRequestExecutor(
                     )
                 }
             } catch (e: SSLPeerUnverifiedException) {
-                handleInvalidSSLError(e, urlRequest)
+                throw requestExecutionFailedWith(
+                    RequestExecutionErrorReason.invalidSSLError(
+                        urlRequest.url
+                    )
+                )
             } catch (e: UnknownHostException) {
-                handleUnknownHostException(e, urlRequest)
+                throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
             }
-
-            error("Unknown Error occurred")
         }
 
     override suspend fun uploadMedia(mediaUploadRequest: MediaUploadRequest): WpNetworkResponse =
@@ -132,63 +135,6 @@ class WpRequestExecutor(
             .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
             .build()
     }
-
-    @Suppress("UnusedParameter")
-    private fun handleInvalidSSLError(e: SSLPeerUnverifiedException, request: Request) {
-        // It's kind of weird and annoying that we need to make a second request to get
-        // this data, but it doesn't seem like we can get it from the response or the
-        // `SSLPeerUnverifiedException` directly.
-        val url = request.url.toUrl()
-
-        // We spin up a new connection that'll accept any certificate. The connection will then
-        // contain all the details we need for the error.
-        val newConnection = url.openConnection() as HttpsURLConnection
-        newConnection.setHostnameVerifier { _, _ -> return@setHostnameVerifier true }
-        newConnection.connect()
-
-        // Certificate is parsed by the Rust shared implementation.
-        val certificates = newConnection.serverCertificates.map { parseCertificate(it.encoded) }
-
-        if (certificates.isEmpty()) {
-            val error = RequestExecutionErrorReason.InvalidSslError(
-                siteCertificate = null,
-                certificateChain = emptyList(),
-                errorMessage = "Invalid certificate for domain",
-                suggestedAction = null
-            )
-
-            throwExceptionFor(error)
-        }
-
-        val siteCertificate = certificates.first()
-
-        val error = RequestExecutionErrorReason.InvalidSslError(
-            siteCertificate = siteCertificate,
-            certificateChain = certificates.mapNotNull { it },
-            errorMessage = "Invalid certificate for domain",
-            suggestedAction = null
-        )
-
-        throwExceptionFor(error)
-    }
-
-    @Suppress("UnusedParameter")
-    private fun handleUnknownHostException(e: UnknownHostException, request: Request) {
-        val error = RequestExecutionErrorReason.NonExistentSiteError(
-            errorMessage = e.localizedMessage,
-            suggestedAction = "Check that the URL is valid and try again"
-        )
-
-        throwExceptionFor(error)
-    }
-
-    private fun throwExceptionFor(reason: RequestExecutionErrorReason) {
-        throw RequestExecutionException.RequestExecutionFailed(
-            statusCode = null,
-            redirects = null,
-            reason = reason
-        )
-    }
 }
 
 class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<String>) : HostnameVerifier {
@@ -196,3 +142,37 @@ class WpRequestExecutorHostnameVerifier(private val allowedHostnames: List<Strin
         return allowedHostnames.contains(p0)
     }
 }
+
+private fun RequestExecutionErrorReason.Companion.unknownHost(e: UnknownHostException) =
+    RequestExecutionErrorReason.NonExistentSiteError(
+        errorMessage = e.localizedMessage,
+        suggestedAction = "Check that the URL is valid and try again"
+    )
+
+private fun RequestExecutionErrorReason.Companion.invalidSSLError(requestUrl: HttpUrl): RequestExecutionErrorReason {
+    // It's kind of weird and annoying that we need to make a second request to get
+    // this data, but it doesn't seem like we can get it from the response or the
+    // `SSLPeerUnverifiedException` directly.
+    //
+    // We spin up a new connection that'll accept any certificate. The connection will then
+    // contain all the details we need for the error.
+    val newConnection = requestUrl.toUrl().openConnection() as HttpsURLConnection
+    newConnection.setHostnameVerifier { _, _ -> return@setHostnameVerifier true }
+    newConnection.connect()
+
+    // Certificate is parsed by the Rust shared implementation.
+    val certificates = newConnection.serverCertificates.map { parseCertificate(it.encoded) }
+    return RequestExecutionErrorReason.InvalidSslError(
+        siteCertificate = certificates.firstOrNull(),
+        certificateChain = certificates.mapNotNull { it },
+        errorMessage = "Invalid certificate for domain",
+        suggestedAction = null
+    )
+}
+
+private fun requestExecutionFailedWith(reason: RequestExecutionErrorReason) =
+    RequestExecutionException.RequestExecutionFailed(
+        statusCode = null,
+        redirects = null,
+        reason = reason
+    )

--- a/native/kotlin/build.gradle.kts
+++ b/native/kotlin/build.gradle.kts
@@ -94,6 +94,12 @@ fun setupJniAndBindings() {
         from("$cargoProjectRoot/test_media.jpg")
         into(generatedTestResourcesPath)
     }
+
+    tasks.register<Copy>("copySampleJSON") {
+        dependsOn(tasks.named("deleteTestResources"))
+        from("$cargoProjectRoot/native/swift/Tests/wordpress-api/Resources/Responses/localhost-json-root.json")
+        into(generatedTestResourcesPath)
+    }
 }
 
 fun getNativeLibraryExtension(): String {

--- a/native/kotlin/gradle/libs.versions.toml
+++ b/native/kotlin/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
 navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okHttp" }
+okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okHttp" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -68,13 +68,6 @@ public actor WordPressAPI {
         self.requestBuilder.siteSettings()
     }
 
-    public struct Helpers {
-        public static func extractLoginDetails(from url: URL) throws -> WpApiApplicationPasswordDetails? {
-            let parsedUrl = try ParsedUrl.from(url: url)
-            return try extractLoginDetailsFromUrl(url: parsedUrl)
-        }
-    }
-
     enum ParseError: Error {
         case invalidUrl
         case invalidHtml

--- a/native/swift/Tests/wordpress-api/Resources/Responses/localhost-json-root.json
+++ b/native/swift/Tests/wordpress-api/Resources/Responses/localhost-json-root.json
@@ -1,0 +1,26 @@
+{
+  "name": "my-test-site",
+  "description": "",
+  "url": "http:\/\/localhost",
+  "home": "http:\/\/localhost",
+  "gmt_offset": -5,
+  "timezone_string": "America\/New_York",
+  "namespaces": [
+    "oembed\/1.0",
+    "wp\/v2",
+    "wp-site-health\/v1",
+    "wp-block-editor\/v1"
+  ],
+  "authentication": {},
+  "routes": {},
+  "site_logo": 0,
+  "site_icon": 0,
+  "site_icon_url": "",
+  "_links": {
+    "help": [
+      {
+        "href": "https:\/\/developer.wordpress.org\/rest-api\/"
+      }
+    ]
+  }
+}

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -27,7 +27,14 @@ pub struct WpRestApiUrls {
 // embedded as query params. This function parses that URL and extracts the login details as an object.
 #[uniffi::export]
 pub fn extract_login_details_from_url(
-    url: Arc<ParsedUrl>,
+    url: String,
+) -> Result<WpApiApplicationPasswordDetails, OAuthResponseUrlError> {
+    let url = ParsedUrl::parse(&url).map_err(|_| OAuthResponseUrlError::InvalidUrl)?;
+    extract_login_details_from_parsed_url(url)
+}
+
+pub fn extract_login_details_from_parsed_url(
+    url: ParsedUrl,
 ) -> Result<WpApiApplicationPasswordDetails, OAuthResponseUrlError> {
     let f = |key| {
         url.inner
@@ -186,6 +193,7 @@ pub struct WpApiApplicationPasswordDetails {
     Debug, PartialEq, Eq, PartialOrd, Ord, thiserror::Error, uniffi::Error, WpDeriveLocalizable,
 )]
 pub enum OAuthResponseUrlError {
+    InvalidUrl,
     MissingSiteUrl,
     MissingUsername,
     MissingPassword,
@@ -203,6 +211,7 @@ impl WpSupportsLocalization for OAuthResponseUrlError {
             OAuthResponseUrlError::UnsuccessfulLogin => {
                 WpMessages::oauth_response_url_error_unsuccessful_login()
             }
+            OAuthResponseUrlError::InvalidUrl => WpMessages::oauth_response_url_error_url_invalid(),
         }
     }
 }

--- a/wp_api/src/parsed_url.rs
+++ b/wp_api/src/parsed_url.rs
@@ -161,6 +161,12 @@ impl From<Url> for ParsedUrl {
     }
 }
 
+impl From<ParsedUrl> for String {
+    fn from(input: ParsedUrl) -> Self {
+        input.url()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wp_api_integration_tests/tests/test_login_err.rs
+++ b/wp_api_integration_tests/tests/test_login_err.rs
@@ -5,9 +5,7 @@ use wp_api::{
     RequestExecutionError, RequestExecutionErrorReason,
     login::{
         login_client::WpLoginClient,
-        url_discovery::{
-            AutoDiscoveryAttemptFailure, AutoDiscoveryAttemptType, FindApiRootFailure,
-        },
+        url_discovery::{AutoDiscoveryAttemptFailure, FindApiRootFailure},
     },
     middleware::{ApiDiscoveryAuthenticationMiddleware, WpApiMiddleware, WpApiMiddlewarePipeline},
     reqwest_request_executor::ReqwestRequestExecutor,
@@ -116,9 +114,7 @@ async fn login_flow_err_helper(
     )
     .api_discovery(site_url.to_string())
     .await
-    .attempts
-    .remove(&AutoDiscoveryAttemptType::UserInput)
-    .unwrap()
-    .api_discovery_result
+    .combined_result()
     .unwrap_err()
+    .clone()
 }


### PR DESCRIPTION
This PR extracts the Kotlin and (tiny) Rust changes from #532 and adds some minor improvements/fixes on top of it. The first commit is the extraction and it mostly keeps things as is from #532 except addressing a merge conflict due to the changes from #652.

The only major change/fix is in 4c557219e90a68b2edbfe08c831735d0cca1f6fa which introduces `WpHttpClient`. In the original PR, the request executor accepts an `OkHttpClient` as an argument, but then if an allowed host is added, it modifies it. This can result in unexpected behavior. In this commit, I've introduced a sealed class, so the clients can either use their own `OkHttpClient` and have to implement the allowed hostnames themselves or they have to use the one we implement.

I also squeezed in a tiny Rust change in 9f131cb973584cdb2822f75ffe1ea3be90b24cee while I was double checking the behavior from [this comment](https://github.com/Automattic/wordpress-rs/pull/532#discussion_r2030322431).