### PR TITLE
Disable request timeout for nightly plugin directory tests

### DIFF
--- a/wp_api_integration_tests/tests/test_plugin_directory.rs
+++ b/wp_api_integration_tests/tests/test_plugin_directory.rs
@@ -17,7 +17,7 @@ const TOKIO_STREAM_SIZE: usize = 100;
 
 fn wordpress_org_api_client() -> WordPressOrgApiClient {
     WordPressOrgApiClient::new(
-        Arc::new(ReqwestRequestExecutor::default()),
+        Arc::new(ReqwestRequestExecutor::new(false, None)),
         Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }


### PR DESCRIPTION
We recently added a default timeout for requests. This change brings back the old behavior for these tests and disable timeouts. It should address the recent nightly build failures.