### PR TITLE
Use Xcode 16.3-v2 image

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,7 +3,7 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-XCODE_VERSION="16.3"
+XCODE_VERSION="16.3-v2"
 CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
 TEST_COLLECTOR_VERSION="v1.10.2"
 


### PR DESCRIPTION
Updates to the latest Xcode 16 image in our Mac CI to potentially help with intermittent S3 failures.