### PR TITLE
Add middleware support to the rest api client types

### DIFF
--- a/jetpack/src/client.rs
+++ b/jetpack/src/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use wp_api::{
     ParsedUrl, WpAuthentication, api_client_generate_api_client, api_client_generate_endpoint_impl,
-    request::RequestExecutor,
+    middleware::WpApiMiddlewarePipeline, request::RequestExecutor,
 };
 
 use super::endpoint::connection_endpoint::{ConnectionRequestBuilder, ConnectionRequestExecutor};
@@ -47,9 +47,15 @@ impl UniffiJetpackApiClient {
         site_url: Arc<ParsedUrl>,
         authentication: WpAuthentication,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     ) -> Self {
         Self {
-            inner: JetpackApiClient::new(site_url, authentication, request_executor),
+            inner: JetpackApiClient::new(
+                site_url,
+                authentication,
+                request_executor,
+                middleware_pipeline,
+            ),
         }
     }
 }
@@ -64,11 +70,13 @@ impl JetpackApiClient {
         api_root_url: Arc<ParsedUrl>,
         authentication: WpAuthentication,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     ) -> Self {
         api_client_generate_api_client!(
             api_root_url,
             authentication,
-            request_executor;
+            request_executor,
+            middleware_pipeline;
             connection
         )
     }

--- a/jetpack/src/connection.rs
+++ b/jetpack/src/connection.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use wp_api::{
-    ParsedUrl, WpApiError, WpAuthentication, WpErrorCode, request::RequestExecutor, users::UserId,
+    ParsedUrl, WpApiError, WpAuthentication, WpErrorCode, middleware::WpApiMiddlewarePipeline,
+    request::RequestExecutor, users::UserId,
 };
 use wp_com::{
     WpComSiteId, client::WpComApiClient, jetpack_connection::JetpackRemoteConnectionParams,
@@ -87,6 +88,7 @@ pub struct JetpackConnectionCheck {
 #[derive(Debug, uniffi::Object)]
 pub struct JetpackConnectionClient {
     request_executor: Arc<dyn RequestExecutor>,
+    middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     jetpack_client: JetpackApiClient,
 }
 
@@ -96,14 +98,17 @@ impl JetpackConnectionClient {
     pub fn new(
         api_root_url: Arc<ParsedUrl>,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
         site_authentication: WpAuthentication,
     ) -> Self {
         Self {
             request_executor: request_executor.clone(),
+            middleware_pipeline: middleware_pipeline.clone(),
             jetpack_client: JetpackApiClient::new(
                 api_root_url,
                 site_authentication,
                 request_executor,
+                middleware_pipeline,
             ),
         }
     }
@@ -187,8 +192,11 @@ impl JetpackConnectionClient {
             .map_err(JetpackConnectionClientError::Unhandled)?
             .data;
 
-        let wp_com_client =
-            WpComApiClient::new(wp_com_authentication, self.request_executor.clone());
+        let wp_com_client = WpComApiClient::new(
+            wp_com_authentication,
+            self.request_executor.clone(),
+            self.middleware_pipeline.clone(),
+        );
         let params = JetpackRemoteConnectionParams {
             secret: provision_info.secret,
             scope: provision_info.scope,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -7,6 +7,7 @@ import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpApiClient
 import uniffi.wp_api.WpApiException
+import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAuthentication
 
 class WpApiClient
@@ -19,7 +20,7 @@ constructor(
 ) {
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
     private val requestBuilder by lazy {
-        UniffiWpApiClient(apiRootUrl, authentication, requestExecutor)
+        UniffiWpApiClient(apiRootUrl, authentication, requestExecutor, WpApiMiddlewarePipeline(emptyList()))
     }
 
     // Provides the _only_ way to execute authenticated requests using our Kotlin wrapper.

--- a/native/swift/Sources/wordpress-api/JetpackConnectionClient+Extensions.swift
+++ b/native/swift/Sources/wordpress-api/JetpackConnectionClient+Extensions.swift
@@ -6,7 +6,12 @@ import FoundationNetworking
 #endif
 
 extension JetpackConnectionClient {
-    public convenience init(apiRootUrl: ParsedUrl, urlSession: URLSession, authentication: WpAuthentication, middlewarePipeline: MiddlewarePipeline = .default) {
+    public convenience init(
+        apiRootUrl: ParsedUrl,
+        urlSession: URLSession,
+        authentication: WpAuthentication,
+        middlewarePipeline: MiddlewarePipeline = .default
+    ) {
         self.init(
             apiRootUrl: apiRootUrl,
             requestExecutor: WpRequestExecutor(urlSession: urlSession),

--- a/native/swift/Sources/wordpress-api/JetpackConnectionClient+Extensions.swift
+++ b/native/swift/Sources/wordpress-api/JetpackConnectionClient+Extensions.swift
@@ -6,10 +6,11 @@ import FoundationNetworking
 #endif
 
 extension JetpackConnectionClient {
-    public convenience init(apiRootUrl: ParsedUrl, urlSession: URLSession, authentication: WpAuthentication) {
+    public convenience init(apiRootUrl: ParsedUrl, urlSession: URLSession, authentication: WpAuthentication, middlewarePipeline: MiddlewarePipeline = .default) {
         self.init(
             apiRootUrl: apiRootUrl,
             requestExecutor: WpRequestExecutor(urlSession: urlSession),
+            middlewarePipeline: middlewarePipeline,
             siteAuthentication: authentication
         )
     }

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -25,14 +25,16 @@ public actor WordPressAPI {
     init(
         apiRootUrl: ParsedUrl,
         authenticationStategy: WpAuthentication,
-        executor: SafeRequestExecutor
+        executor: SafeRequestExecutor,
+        middlewarePipeline: MiddlewarePipeline = .default
     ) {
         self.internalExecutor = executor
 
         self.requestBuilder = UniffiWpApiClient(
             apiRootUrl: apiRootUrl,
             authentication: authenticationStategy,
-            requestExecutor: executor
+            requestExecutor: executor,
+            middlewarePipeline: middlewarePipeline
         )
     }
 

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -5,8 +5,7 @@ import Testing
 
 struct WordPressAPITests {
 
-    @Test
-    func testExample() async throws {
+    func createStubs() throws -> HTTPStubs {
         let response = """
           {
             "id": 1,
@@ -35,10 +34,14 @@ struct WordPressAPITests {
             }
           }
         """
-        let stubs = HTTPStubs(stubs: [
+        return HTTPStubs(stubs: [
             HTTPStubs.stub(path: "/wp-json/wp/v2/users/1", with: try .json(response))
         ])
+    }
 
+    @Test
+    func testExample() async throws {
+        let stubs = try createStubs()
         let api = try WordPressAPI(
             apiRootUrl: ParsedUrl.parse(input: "https://wordpress.org/wp-json"),
             authenticationStategy: .none,
@@ -50,38 +53,7 @@ struct WordPressAPITests {
 
     @Test
     func testPipeline() async throws {
-        let response = """
-          {
-            "id": 1,
-            "name": "User Name",
-            "url": "",
-            "description": "",
-            "link": "https://profiles.wordpress.org/user/",
-            "slug": "poliuk",
-            "avatar_urls": {
-              "24": "https://secure.gravatar.com/avatar/uuid?s=24&d=mm&r=g",
-              "48": "https://secure.gravatar.com/avatar/uuid?s=48&d=mm&r=g",
-              "96": "https://secure.gravatar.com/avatar/uuid?s=96&d=mm&r=g"
-            },
-            "meta": [],
-            "_links": {
-              "self": [
-                {
-                  "href": "https://wordpress.org/wp-json/wp/v2/users/1"
-                }
-              ],
-              "collection": [
-                {
-                  "href": "https://wordpress.org/wp-json/wp/v2/users"
-                }
-              ]
-            }
-          }
-        """
-        let stubs = HTTPStubs(stubs: [
-            HTTPStubs.stub(path: "/wp-json/wp/v2/users/1", with: try .json(response))
-        ])
-
+        let stubs = try createStubs()
         let counter = CounterMiddleware()
         let api = try WordPressAPI(
             apiRootUrl: ParsedUrl.parse(input: "https://wordpress.org/wp-json"),
@@ -89,7 +61,7 @@ struct WordPressAPITests {
             executor: stubs,
             middlewarePipeline: .init(middlewares: [counter])
         )
-        let _ = try await api.users.retrieveWithViewContext(userId: 1)
+        _ = try await api.users.retrieveWithViewContext(userId: 1)
         await #expect(counter.count == 1)
     }
 }
@@ -97,7 +69,11 @@ struct WordPressAPITests {
 private actor CounterMiddleware: Middleware {
     var count = 0
 
-    func process(requestExecutor: RequestExecutor, response: WpNetworkResponse, request: WpNetworkRequest) async throws  -> WpNetworkResponse {
+    func process(
+        requestExecutor: RequestExecutor,
+        response: WpNetworkResponse,
+        request: WpNetworkRequest
+    ) async throws -> WpNetworkResponse {
         count += 1
         return response
     }

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import WordPressAPI
+@testable import WordPressAPIInternal
 
 struct WordPressAPITests {
 
@@ -45,5 +46,59 @@ struct WordPressAPITests {
         )
         let user = try await api.users.retrieveWithViewContext(userId: 1)
         #expect(user.data.name == "User Name")
+    }
+
+    @Test
+    func testPipeline() async throws {
+        let response = """
+          {
+            "id": 1,
+            "name": "User Name",
+            "url": "",
+            "description": "",
+            "link": "https://profiles.wordpress.org/user/",
+            "slug": "poliuk",
+            "avatar_urls": {
+              "24": "https://secure.gravatar.com/avatar/uuid?s=24&d=mm&r=g",
+              "48": "https://secure.gravatar.com/avatar/uuid?s=48&d=mm&r=g",
+              "96": "https://secure.gravatar.com/avatar/uuid?s=96&d=mm&r=g"
+            },
+            "meta": [],
+            "_links": {
+              "self": [
+                {
+                  "href": "https://wordpress.org/wp-json/wp/v2/users/1"
+                }
+              ],
+              "collection": [
+                {
+                  "href": "https://wordpress.org/wp-json/wp/v2/users"
+                }
+              ]
+            }
+          }
+        """
+        let stubs = HTTPStubs(stubs: [
+            HTTPStubs.stub(path: "/wp-json/wp/v2/users/1", with: try .json(response))
+        ])
+
+        let counter = CounterMiddleware()
+        let api = try WordPressAPI(
+            apiRootUrl: ParsedUrl.parse(input: "https://wordpress.org/wp-json"),
+            authenticationStategy: .none,
+            executor: stubs,
+            middlewarePipeline: .init(middlewares: [counter])
+        )
+        let _ = try await api.users.retrieveWithViewContext(userId: 1)
+        await #expect(counter.count == 1)
+    }
+}
+
+private actor CounterMiddleware: Middleware {
+    var count = 0
+
+    func process(requestExecutor: RequestExecutor, response: WpNetworkResponse, request: WpNetworkRequest) async throws  -> WpNetworkResponse {
+        count += 1
+        return response
     }
 }

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -116,7 +116,7 @@ create_test_credentials () {
   wp post delete "$TRASHED_POST_ID"
 
   rm -rf /app/test_credentials.json
-  jo -p \
+  jo -p -- \
     site_url="$SITE_URL" \
     admin_username="$ADMIN_USERNAME" \
     admin_password="$ADMIN_PASSWORD" \
@@ -133,7 +133,7 @@ create_test_credentials () {
     password_protected_comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" \
     trashed_post_id="$TRASHED_POST_ID" \
     first_post_date_gmt="$FIRST_POST_DATE_GMT" \
-    wordpress_core_version="$WORDPRESS_VERSION" \
+    -s wordpress_core_version="$WORDPRESS_VERSION" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -1,30 +1,33 @@
-use crate::request::{
-    RequestExecutor,
-    endpoint::{
-        application_passwords_endpoint::{
-            ApplicationPasswordsRequestBuilder, ApplicationPasswordsRequestExecutor,
-        },
-        categories_endpoint::{CategoriesRequestBuilder, CategoriesRequestExecutor},
-        comments_endpoint::{CommentsRequestBuilder, CommentsRequestExecutor},
-        media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
-        plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
-        post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
-        posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
-        search_endpoint::{SearchRequestBuilder, SearchRequestExecutor},
-        site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
-        tags_endpoint::{TagsRequestBuilder, TagsRequestExecutor},
-        taxonomies_endpoint::{TaxonomiesRequestBuilder, TaxonomiesRequestExecutor},
-        templates_endpoint::{TemplatesRequestBuilder, TemplatesRequestExecutor},
-        themes_endpoint::{ThemesRequestBuilder, ThemesRequestExecutor},
-        users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
-        wp_site_health_tests_endpoint::{
-            WpSiteHealthTestsRequestBuilder, WpSiteHealthTestsRequestExecutor,
-        },
-    },
-};
 use crate::{
     ParsedUrl, WpAuthentication, api_client_generate_api_client, api_client_generate_endpoint_impl,
     api_client_generate_request_builder,
+};
+use crate::{
+    middleware::WpApiMiddlewarePipeline,
+    request::{
+        RequestExecutor,
+        endpoint::{
+            application_passwords_endpoint::{
+                ApplicationPasswordsRequestBuilder, ApplicationPasswordsRequestExecutor,
+            },
+            categories_endpoint::{CategoriesRequestBuilder, CategoriesRequestExecutor},
+            comments_endpoint::{CommentsRequestBuilder, CommentsRequestExecutor},
+            media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
+            plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
+            post_types_endpoint::{PostTypesRequestBuilder, PostTypesRequestExecutor},
+            posts_endpoint::{PostsRequestBuilder, PostsRequestExecutor},
+            search_endpoint::{SearchRequestBuilder, SearchRequestExecutor},
+            site_settings_endpoint::{SiteSettingsRequestBuilder, SiteSettingsRequestExecutor},
+            tags_endpoint::{TagsRequestBuilder, TagsRequestExecutor},
+            taxonomies_endpoint::{TaxonomiesRequestBuilder, TaxonomiesRequestExecutor},
+            templates_endpoint::{TemplatesRequestBuilder, TemplatesRequestExecutor},
+            themes_endpoint::{ThemesRequestBuilder, ThemesRequestExecutor},
+            users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
+            wp_site_health_tests_endpoint::{
+                WpSiteHealthTestsRequestBuilder, WpSiteHealthTestsRequestExecutor,
+            },
+        },
+    },
 };
 use std::sync::Arc;
 
@@ -98,9 +101,15 @@ impl UniffiWpApiClient {
         api_root_url: Arc<ParsedUrl>,
         authentication: WpAuthentication,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     ) -> Self {
         Self {
-            inner: WpApiClient::new(api_root_url, authentication, request_executor),
+            inner: WpApiClient::new(
+                api_root_url,
+                authentication,
+                request_executor,
+                middleware_pipeline,
+            ),
         }
     }
 }
@@ -129,11 +138,13 @@ impl WpApiClient {
         api_root_url: Arc<ParsedUrl>,
         authentication: WpAuthentication,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     ) -> Self {
         api_client_generate_api_client!(
             api_root_url,
             authentication,
-            request_executor;
+            request_executor,
+            middleware_pipeline;
             application_passwords,
             categories,
             comments,
@@ -220,13 +231,14 @@ macro_rules! api_client_generate_request_builder {
 
 #[macro_export]
 macro_rules! api_client_generate_api_client {
-    ($api_root_url:ident, $authentication:ident, $request_executor:ident; $($element:expr),*) => {
+    ($api_root_url:ident, $authentication:ident, $request_executor:ident, $middleware_pipeline:ident; $($element:expr),*) => {
         paste::paste! {
             Self {
                 $($element: [<$element:camel RequestExecutor>]::new(
                     $api_root_url.clone(),
                     $authentication.clone(),
                     $request_executor.clone(),
+                    $middleware_pipeline.clone(),
                 )
                 .into(),)*
             }

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use url::Url;
 use wp_api::{
     ParsedUrl, WpApiClient, WpApiError, WpAuthentication, WpErrorCode, categories::CategoryId,
-    comments::CommentId, date::WpGmtDateTime, media::MediaId, posts::PostId,
-    reqwest_request_executor::ReqwestRequestExecutor, tags::TagId, users::UserId,
+    comments::CommentId, date::WpGmtDateTime, media::MediaId, middleware::WpApiMiddlewarePipeline,
+    posts::PostId, reqwest_request_executor::ReqwestRequestExecutor, tags::TagId, users::UserId,
 };
 
 pub mod mock;
@@ -80,6 +80,7 @@ pub fn api_client() -> WpApiClient {
         test_site_url(),
         authentication,
         Arc::new(ReqwestRequestExecutor::default()),
+        Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }
 
@@ -92,6 +93,7 @@ pub fn api_client_as_author() -> WpApiClient {
         test_site_url(),
         authentication,
         Arc::new(ReqwestRequestExecutor::default()),
+        Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }
 
@@ -104,6 +106,7 @@ pub fn api_client_as_subscriber() -> WpApiClient {
         test_site_url(),
         authentication,
         Arc::new(ReqwestRequestExecutor::default()),
+        Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }
 
@@ -112,6 +115,7 @@ pub fn api_client_as_unauthenticated() -> WpApiClient {
         test_site_url(),
         WpAuthentication::None,
         Arc::new(ReqwestRequestExecutor::default()),
+        Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }
 

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -6,6 +6,7 @@ use wp_api::{
     MediaUploadRequestExecutionError, RequestExecutionError, RequestExecutionErrorReason,
     WpApiClient, WpAuthentication, WpErrorCode,
     media::{MediaCreateParams, MediaId, MediaListParams, MediaUpdateParams},
+    middleware::WpApiMiddlewarePipeline,
     posts::WpApiParamPostsOrderBy,
     request::{
         RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
@@ -176,6 +177,7 @@ fn api_client_with_medir_err_networking(test_type: MediaErrNetworkingTestType) -
             TestCredentials::instance().admin_password.to_string(),
         ),
         Arc::new(MediaErrNetworking::new(test_type)),
+        Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }
 

--- a/wp_com/src/client.rs
+++ b/wp_com/src/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use wp_api::{
     ParsedUrl, WpAuthentication, api_client_generate_api_client, api_client_generate_endpoint_impl,
-    request::RequestExecutor,
+    middleware::WpApiMiddlewarePipeline, request::RequestExecutor,
 };
 
 use super::endpoint::jetpack_connection_endpoint::{
@@ -48,9 +48,13 @@ struct UniffiWpComApiClient {
 #[uniffi::export]
 impl UniffiWpComApiClient {
     #[uniffi::constructor]
-    fn new(authentication: WpAuthentication, request_executor: Arc<dyn RequestExecutor>) -> Self {
+    fn new(
+        authentication: WpAuthentication,
+        request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
+    ) -> Self {
         Self {
-            inner: WpComApiClient::new(authentication, request_executor),
+            inner: WpComApiClient::new(authentication, request_executor, middleware_pipeline),
         }
     }
 }
@@ -64,6 +68,7 @@ impl WpComApiClient {
     pub fn new(
         authentication: WpAuthentication,
         request_executor: Arc<dyn RequestExecutor>,
+        middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     ) -> Self {
         let url = url::Url::parse("https://public-api.wordpress.com").expect("This is a valid URL");
         let api_root_url: Arc<ParsedUrl> = ParsedUrl::new(url).into();
@@ -71,7 +76,8 @@ impl WpComApiClient {
         api_client_generate_api_client!(
             api_root_url,
             authentication,
-            request_executor;
+            request_executor,
+            middleware_pipeline;
             jetpack_connection
         )
     }

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -35,7 +35,10 @@ fn generate_async_request_executor(
     let static_api_root_url_type = &config.static_types.api_root_url;
     let static_wp_authentication_type = &config.static_types.wp_authentication;
     let static_request_executor_type = &crate_config.request_executor;
+    let static_middleware_pipeline_type = &config.static_types.middleware_pipeline;
     let static_request_executor_type = quote! { std::sync::Arc<dyn #static_request_executor_type> };
+    let static_middleware_pipeline_type =
+        quote! { std::sync::Arc<#static_middleware_pipeline_type> };
     let error_type = &crate_config.error_type;
     let generated_request_builder_ident = &config.generated_idents.request_builder;
     let generated_request_executor_ident = &config.generated_idents.request_executor;
@@ -73,8 +76,9 @@ fn generate_async_request_executor(
             );
             quote! {
                 pub async #fn_signature -> Result<#response_type_ident, #error_type> {
+                    use #crate_ident::middleware::PerformsRequests;
                     #request_from_request_builder
-                    self.request_executor.execute(std::sync::Arc::new(request)).await?.parse()
+                    self.perform(std::sync::Arc::new(request)).await?.parse()
                }
             }
         })
@@ -166,13 +170,24 @@ fn generate_async_request_executor(
         pub struct #generated_request_executor_ident {
             request_builder: #generated_request_builder_ident,
             request_executor: #static_request_executor_type,
+            middleware_pipeline: #static_middleware_pipeline_type,
         }
         impl #generated_request_executor_ident {
-            pub fn new(api_root_url: #static_api_root_url_type, authentication: #static_wp_authentication_type, request_executor: #static_request_executor_type) -> Self {
+            pub fn new(api_root_url: #static_api_root_url_type, authentication: #static_wp_authentication_type, request_executor: #static_request_executor_type, middleware_pipeline: #static_middleware_pipeline_type) -> Self {
                 Self {
                     request_builder: #generated_request_builder_ident::new(api_root_url, authentication),
                     request_executor,
+                    middleware_pipeline,
                 }
+            }
+        }
+        impl #crate_ident::middleware::PerformsRequests for #generated_request_executor_ident {
+            fn get_middleware_pipeline(&self) -> #static_middleware_pipeline_type {
+                self.middleware_pipeline.clone()
+            }
+
+            fn get_request_executor(&self) -> #static_request_executor_type {
+                self.request_executor.clone()
             }
         }
         #[uniffi::export]
@@ -439,6 +454,7 @@ pub struct ConfigStaticTypes {
     pub inner_request_builder: TokenStream,
     pub wp_authentication: TokenStream,
     pub wp_network_request: TokenStream,
+    pub middleware_pipeline: TokenStream,
 }
 
 impl ConfigStaticTypes {
@@ -449,6 +465,7 @@ impl ConfigStaticTypes {
             inner_request_builder: quote! { #crate_ident::request::InnerRequestBuilder },
             wp_authentication: quote! { #crate_ident::WpAuthentication },
             wp_network_request: quote! { #crate_ident::request::WpNetworkRequest },
+            middleware_pipeline: quote! { #crate_ident::middleware::WpApiMiddlewarePipeline },
         }
     }
 }


### PR DESCRIPTION
This PR adds the middleware support in `WpLoginClient` to other API client types. The purpose of this change is to support using a middleware to handle invalid application passwords, which I plan to implement on the app side, so that the app can show a re-authentication UI if users revokes the application password that the app is using.