### PR TITLE
Adds user agent for Rust and Kotlin clients

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3e723a182486c41184079f7daf2551e27a56abba5cfb053ec3d6345fba457f5",
+  "originHash" : "78fdd614b34e94d4f7dfe46ec815ab0e4f6797cf13d890875512c0a83088a922",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",

--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,10 @@ let libwordpressFFI: Target = libwordpressFFIVersion.target
 var package = Package(
     name: "WordPressAPI",
     platforms: [
-        .iOS(.v15),
+        .iOS(.v16),
         .macOS(.v12),
         .tvOS(.v16),
-        .watchOS(.v8)
+        .watchOS(.v9)
     ],
     products: [
         .library(

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -72,7 +72,7 @@ class MediaEndpointTest {
             requestBuilder.media().create(
                 params = MediaCreateParams(title = title),
                 "test_media.jpg",
-                "image/jpg"
+                "image/jpeg"
             )
         }.assertSuccessAndRetrieveData().data
         assertEquals(title, response.title.rendered)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
+import okhttp3.OkHttp
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -25,6 +26,8 @@ import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLPeerUnverifiedException
 
+const val USER_AGENT_HEADER_NAME = "User-Agent"
+
 class WpRequestExecutor(
     private val httpClient: WpHttpClient = WpHttpClient.DefaultHttpClient(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
@@ -41,6 +44,10 @@ class WpRequestExecutor(
                     requestBuilder.addHeader(key, value)
                 }
             }
+            requestBuilder.addHeader(
+                USER_AGENT_HEADER_NAME,
+                uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
+            )
 
             val urlRequest = requestBuilder.build()
 

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -16,24 +16,31 @@ extension SafeRequestExecutor {
     }
 }
 
-final class WpRequestExecutor: SafeRequestExecutor {
+public final class WpRequestExecutor: SafeRequestExecutor {
     private let session: URLSession
     private let executorDelegate: RequestExecutorDelegate
 
     private let additionalHttpHeadersForAllRequests: [String: String]
 
-    init(
+    private let userAgent: String
+
+    public init(
         urlSession: URLSession,
-        additionalHttpHeadersForAllRequests: [String: String] = [:]
+        additionalHttpHeadersForAllRequests: [String: String] = [:],
+        userAgent: String = defaultUserAgent(clientSpecificPostfix: UserAgent.postfix)
     ) {
         self.session = urlSession
         self.executorDelegate = RequestExecutorDelegate()
+        self.userAgent = userAgent
         self.additionalHttpHeadersForAllRequests = additionalHttpHeadersForAllRequests
     }
 
-    func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
+    public func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
         do {
             var urlrequest = request.asURLRequest()
+
+            // Set the user agent before `additionalHttpHeadersForAllRequests` so that it can be overridden that way
+            urlrequest.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
 
             for (key, value) in additionalHttpHeadersForAllRequests {
                 urlrequest.addValue(value, forHTTPHeaderField: key)
@@ -117,11 +124,11 @@ final class WpRequestExecutor: SafeRequestExecutor {
         )
     }
 
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async throws -> WpNetworkResponse {
+    public func uploadMedia(mediaUploadRequest: MediaUploadRequest) async throws -> WpNetworkResponse {
         preconditionFailure("Not implemented yet")
     }
 
-    func sleep(millis: UInt64) async {
+    public func sleep(millis: UInt64) async {
         // swiftlint:disable:next force_try
         try! await Task.sleep(nanoseconds: millis * 1000)
     }

--- a/native/swift/Sources/wordpress-api/UserAgent.swift
+++ b/native/swift/Sources/wordpress-api/UserAgent.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public struct UserAgent{
+    public static var postfix: String {
+        #if canImport(Darwin)
+        "\(bundleName)/\(bundleVersion) \(cfNetworkVersion) \(darwinVersion) \(architecture)"
+        #elseif os(Linux)
+        "Linux/URLSession \(architecture)"
+        #else
+        "unknown"
+        #endif
+    }
+
+    #if canImport(Darwin)
+    static var bundleName: String {
+        Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "application"
+    }
+
+    static var bundleVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    static var cfNetworkVersion: String {
+        guard
+            let bundle = Bundle(identifier: "com.apple.CFNetwork"),
+            let versionAny = bundle.infoDictionary?[kCFBundleVersionKey as String],
+            let version = versionAny as? String
+        else {
+            return "CFNetwork/unknown"
+        }
+
+        return "CFNetwork/\(version)"
+    }
+
+    static var darwinVersion: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let bytes = Data(bytes: &systemInfo.release, count: Int(_SYS_NAMELEN))
+        guard let string = String(bytes: bytes, encoding: .ascii) else {
+            return "Darwin/unknown"
+        }
+
+        return "Darwin/\(string)"
+    }
+
+    static var architecture: String {
+        systemInfo(for: "hw.machine") ?? "unknown"
+    }
+
+    static func systemInfo(for key: String) -> String? {
+        var size = 0
+        sysctlbyname(key, nil, &size, nil, 0)
+        var value = [CChar](repeating: 0,  count: size)
+        sysctlbyname(key, &value, &size, nil, 0)
+        guard let string = String(cString: value, encoding: .ascii) else {
+            return nil
+        }
+
+        return string
+    }
+    #elseif os(Linux)
+    static var architecture: String {
+        do {
+            let process = Process()
+            let pipe = Pipe()
+
+            process.standardOutput = pipe // you can also set stderr and stdin
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/uname") // or any other shell you like
+            process.arguments = ["-m"]
+
+            try process.run()
+            
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+            guard let string = String(data: data, encoding: .ascii) else {
+                return "unknown"
+            }
+
+            return string.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch let err {
+            return "unknown"
+        }
+    }
+    #endif
+}

--- a/native/swift/Sources/wordpress-api/UserAgent.swift
+++ b/native/swift/Sources/wordpress-api/UserAgent.swift
@@ -3,7 +3,11 @@ import Foundation
 public struct UserAgent {
     public static var postfix: String {
         #if canImport(Darwin)
-        "\(bundleName)/\(bundleVersion) \(cfNetworkVersion) \(darwinVersion) \(architecture)"
+        if let bundleName = bundleName, let bundleVersion = bundleVersion {
+            return "\(bundleName)/\(bundleVersion) \(cfNetworkVersion) \(darwinVersion) \(architecture)"
+        } else {
+            return "\(cfNetworkVersion) \(darwinVersion) \(architecture)"
+        }
         #elseif os(Linux)
         "Linux/URLSession \(architecture)"
         #else
@@ -12,12 +16,12 @@ public struct UserAgent {
     }
 
     #if canImport(Darwin)
-    static var bundleName: String {
-        Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "application"
+    static var bundleName: String? {
+        Bundle.main.infoDictionary?["CFBundleName"] as? String
     }
 
-    static var bundleVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    static var bundleVersion: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     }
 
     static var cfNetworkVersion: String {
@@ -35,8 +39,10 @@ public struct UserAgent {
     static var darwinVersion: String {
         var systemInfo = utsname()
         uname(&systemInfo)
-        let bytes = Data(bytes: &systemInfo.release, count: Int(_SYS_NAMELEN))
-        guard let string = String(bytes: bytes, encoding: .ascii) else {
+
+        let bytes = Data(bytes: &systemInfo.release, count: Int(_SYS_NAMELEN)).filter { $0 != 0 }
+
+        guard let string = String(data: bytes, encoding: .ascii) else {
             return "Darwin/unknown"
         }
 

--- a/native/swift/Sources/wordpress-api/UserAgent.swift
+++ b/native/swift/Sources/wordpress-api/UserAgent.swift
@@ -40,7 +40,11 @@ public struct UserAgent {
         var systemInfo = utsname()
         uname(&systemInfo)
 
-        let bytes = Data(bytes: &systemInfo.release, count: Int(_SYS_NAMELEN)).filter { $0 != 0 }
+        // Picking a sensible buffer size manually means the value might be truncated. 8 bytes is enough for a very long
+        // version string – right now we only need 6 bytes for a three-segment code (ex: `24.3.0` ~> 6 bytes). We can
+        // use something like `_SYS_NAMELEN` as a buffer size but that's 256 bytes and it's a big waste of CPU
+        // to `.filter` over.
+        let bytes = Data(bytes: &systemInfo.release, count: 8).filter { $0 != 0 }
 
         guard let string = String(data: bytes, encoding: .ascii) else {
             return "Darwin/unknown"

--- a/native/swift/Sources/wordpress-api/UserAgent.swift
+++ b/native/swift/Sources/wordpress-api/UserAgent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct UserAgent{
+public struct UserAgent {
     public static var postfix: String {
         #if canImport(Darwin)
         "\(bundleName)/\(bundleVersion) \(cfNetworkVersion) \(darwinVersion) \(architecture)"
@@ -50,7 +50,7 @@ public struct UserAgent{
     static func systemInfo(for key: String) -> String? {
         var size = 0
         sysctlbyname(key, nil, &size, nil, 0)
-        var value = [CChar](repeating: 0,  count: size)
+        var value = [CChar](repeating: 0, count: size)
         sysctlbyname(key, &value, &size, nil, 0)
         guard let string = String(cString: value, encoding: .ascii) else {
             return nil
@@ -69,7 +69,7 @@ public struct UserAgent{
             process.arguments = ["-m"]
 
             try process.run()
-            
+
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
 
             guard let string = String(data: data, encoding: .ascii) else {

--- a/native/swift/Tests/wordpress-api/Support/Extensions.swift
+++ b/native/swift/Tests/wordpress-api/Support/Extensions.swift
@@ -41,3 +41,5 @@ func isLinux() -> Bool {
     return false
     #endif
 }
+
+let isXCTest: Bool = Bundle.main.infoDictionary?["CFBundleName"] as? String == "xctest"

--- a/native/swift/Tests/wordpress-api/UserAgentTests.swift
+++ b/native/swift/Tests/wordpress-api/UserAgentTests.swift
@@ -27,7 +27,7 @@ struct UserAgentTests {
     #elseif os(Linux)
     @Test("User agent contains architecture")
     func testThatUserAgentContainsArchitecture() throws {
-        #expect(UserAgent.postfix.contains("aarch64"))
+        #expect(UserAgent.postfix.contains("aarch64") || UserAgent.postfix.contains("x86_64")) // CI is `x86_64`
     }
     #endif
 }

--- a/native/swift/Tests/wordpress-api/UserAgentTests.swift
+++ b/native/swift/Tests/wordpress-api/UserAgentTests.swift
@@ -5,12 +5,12 @@ import WordPressAPI
 @Suite("User Agent Tests")
 struct UserAgentTests {
     #if canImport(Darwin)
-    @Test("User agent contains bundle name and version")
+    @Test("User agent contains bundle name and version", .enabled(if: isXCTest))
     func testThatDefaultUserAgentContainsBundleNameAndVersion() throws {
         #expect(UserAgent.postfix.contains(/xctest\/(\d+.\d+)/))
     }
 
-    @Test("User agent contains CFNetwork version")
+    @Test("User agent contains CFNetwork version", .enabled(if: isXCTest))
     func testThatDefaultUserAgentContainsCFNetworkVersion() throws {
         #expect(UserAgent.postfix.contains(/CFNetwork\/(\d+.\d+.\d+)/))
     }

--- a/native/swift/Tests/wordpress-api/UserAgentTests.swift
+++ b/native/swift/Tests/wordpress-api/UserAgentTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import WordPressAPI
+
+@Suite("User Agent Tests")
+struct UserAgentTests {
+    #if canImport(Darwin)
+    @Test("User agent contains bundle name and version")
+    func testThatDefaultUserAgentContainsBundleNameAndVersion() throws {
+        #expect(UserAgent.postfix.contains(/xctest\/(\d+.\d+)/))
+    }
+
+    @Test("User agent contains CFNetwork version")
+    func testThatDefaultUserAgentContainsCFNetworkVersion() throws {
+        #expect(UserAgent.postfix.contains(/CFNetwork\/(\d+.\d+.\d+)/))
+    }
+
+    @Test("User agent contains Darwin version")
+    func testThatDefaultUserAgentContainsDarwinVersion() throws {
+        #expect(UserAgent.postfix.contains(/Darwin\/(\d+.\d+.\d+)/))
+    }
+
+    @Test("User agent contains architecture")
+    func testThatDefaultUserAgentContainsArchitecture() throws {
+        #expect(UserAgent.postfix.contains("arm64"))
+    }
+    #elseif os(Linux)
+    @Test("User agent contains architecture")
+    func testThatUserAgentContainsArchitecture() throws {
+        #expect(UserAgent.postfix.contains("aarch64"))
+    }
+    #endif
+}

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -133,7 +133,7 @@ create_test_credentials () {
     password_protected_comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" \
     trashed_post_id="$TRASHED_POST_ID" \
     first_post_date_gmt="$FIRST_POST_DATE_GMT" \
-    wordpress_core_version="$WORDPRESS_VERSION" \
+    wordpress_core_version="\"$WORDPRESS_VERSION\"" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -47,6 +47,8 @@ pub mod reqwest_request_executor;
 #[cfg(test)]
 mod unit_test_common;
 
+pub const WORDPRESS_RS_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum WpContext {
     Edit,

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -763,6 +763,74 @@ pub fn is_valid_json(value: impl AsRef<str>) -> bool {
     serde_json::from_str::<serde_json::Value>(value.as_ref()).is_ok()
 }
 
+pub mod user_agent {
+    #[uniffi::export]
+    pub fn default_user_agent(client_specific_postfix: &str) -> String {
+        default_user_agent_with_version(client_specific_postfix, version())
+    }
+
+    fn default_user_agent_with_version(client_specific_postfix: &str, version: &str) -> String {
+        format!(
+            "wordpress-rs/{version} (https://github.com/automattic/wordpress-rs);{client_specific_postfix}"
+        )
+    }
+
+    fn version() -> &'static str {
+        crate::WORDPRESS_RS_VERSION
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_default_user_agent() {
+            assert_eq!(
+                default_user_agent_with_version("reqwest", "1.0"),
+                "wordpress-rs/1.0 (https://github.com/automattic/wordpress-rs);reqwest"
+            );
+        }
+    }
+
+    #[cfg(feature = "reqwest-request-executor")]
+    pub mod reqwest {
+        use super::*;
+        use http::HeaderValue;
+
+        const REQWEST_REQUEST_EXECUTOR_USER_AGENT_POST_FIX: &str = "reqwest";
+
+        pub fn user_agent_for_reqwest_request_executor() -> HeaderValue {
+            user_agent_for_reqwest_request_executor_with_version(version())
+        }
+
+        fn user_agent_for_reqwest_request_executor_with_version(version: &str) -> HeaderValue {
+            HeaderValue::from_str(
+                default_user_agent_with_version(
+                    REQWEST_REQUEST_EXECUTOR_USER_AGENT_POST_FIX,
+                    version,
+                )
+                .as_str(),
+            )
+            .expect("Reqwest user agent is a valid header value as proven by its unit test")
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn test_reqwest_user_agent() {
+                assert_eq!(
+                    user_agent_for_reqwest_request_executor_with_version("1.0")
+                        .to_str()
+                        .expect("Reqwest user agent header value can be converted to str"),
+                    "wordpress-rs/1.0 (https://github.com/automattic/wordpress-rs);reqwest"
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -3,7 +3,7 @@ use crate::{
     api_error::InvalidSslErrorReason,
     request::{
         RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
-        endpoint::media_endpoint::MediaUploadRequest,
+        endpoint::media_endpoint::MediaUploadRequest, user_agent,
     },
 };
 use async_trait::async_trait;
@@ -66,7 +66,7 @@ impl ReqwestRequestExecutor {
         let mut header_map = std::mem::take(response.headers_mut());
         header_map.insert(
             http::header::USER_AGENT,
-            HeaderValue::from_str("wordpress-rs").expect("`wordpress-rs` is a valid header value"),
+            user_agent::reqwest::user_agent_for_reqwest_request_executor(),
         );
 
         let status = response.status();

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -52,22 +52,23 @@ impl ReqwestRequestExecutor {
         &self,
         wp_request: Arc<WpNetworkRequest>,
     ) -> Result<WpNetworkResponse, reqwest::Error> {
+        let mut request_header_map = wp_request.header_map().to_header_map();
+        request_header_map.insert(
+            http::header::USER_AGENT,
+            user_agent::reqwest::user_agent_for_reqwest_request_executor(),
+        );
         let mut request = self
             .client
             .request(
                 Self::request_method(wp_request.method()),
                 wp_request.url().0.as_str(),
             )
-            .headers(wp_request.header_map().to_header_map());
+            .headers(request_header_map);
         if let Some(body) = wp_request.body() {
             request = request.body(body.contents());
         }
         let mut response = request.send().await?;
-        let mut header_map = std::mem::take(response.headers_mut());
-        header_map.insert(
-            http::header::USER_AGENT,
-            user_agent::reqwest::user_agent_for_reqwest_request_executor(),
-        );
+        let response_header_map = std::mem::take(response.headers_mut());
 
         let status = response.status();
         let body = response.bytes().await?;
@@ -75,7 +76,7 @@ impl ReqwestRequestExecutor {
         Ok(WpNetworkResponse {
             status_code: status.as_u16(),
             body: body.to_vec(),
-            response_header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
+            response_header_map: Arc::new(WpNetworkHeaderMap::new(response_header_map)),
             request_url: wp_request.url(),
             request_header_map: wp_request.header_map(),
         })


### PR DESCRIPTION
Also addresses issues in the testing setup due to WordPress `6.8` and fixes an issue related to setting the user is agent for `reqwest` executor.