### PR TITLE
Don't allow `None` timeout for `ReqwestRequestExecutor`

### DIFF
--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -15,6 +15,8 @@ use reqwest::multipart::Part;
 use rustls::{CertificateError, Error as TlsError};
 use std::{error::Error, sync::Arc, time::Duration};
 
+const DEFAULT_TIMEOUT: u64 = 10;
+
 #[derive(Debug)]
 pub struct ReqwestRequestExecutor {
     client: reqwest::Client,
@@ -27,23 +29,22 @@ impl Default for ReqwestRequestExecutor {
 }
 
 impl ReqwestRequestExecutor {
-    pub fn new(danger_accept_invalid_certs: bool, timeout: Option<Duration>) -> Self {
+    pub fn new(danger_accept_invalid_certs: bool, timeout: Duration) -> Self {
         Self {
             client: reqwest::Client::builder()
                 .danger_accept_invalid_certs(danger_accept_invalid_certs)
-                .timeout(timeout.unwrap_or(Duration::from_secs(10)))
+                .timeout(timeout)
                 .use_rustls_tls()
                 .build()
                 .expect("We should be able to build the reqwest client with this configuration"),
         }
     }
 
-    pub fn new_with_timeout(danger_accept_invalid_certs: bool, timeout: Duration) -> Self {
-        Self::new(danger_accept_invalid_certs, Some(timeout))
-    }
-
     pub fn new_with_default_timeout(danger_accept_invalid_certs: bool) -> Self {
-        Self::new(danger_accept_invalid_certs, None)
+        Self::new(
+            danger_accept_invalid_certs,
+            Duration::from_secs(DEFAULT_TIMEOUT),
+        )
     }
 }
 

--- a/wp_api_integration_tests/tests/test_plugin_directory.rs
+++ b/wp_api_integration_tests/tests/test_plugin_directory.rs
@@ -1,5 +1,5 @@
 use futures::{FutureExt, StreamExt};
-use std::{env, sync::Arc};
+use std::{env, sync::Arc, time::Duration};
 use wp_api::{
     middleware::WpApiMiddlewarePipeline,
     reqwest_request_executor::ReqwestRequestExecutor,
@@ -17,7 +17,7 @@ const TOKIO_STREAM_SIZE: usize = 100;
 
 fn wordpress_org_api_client() -> WordPressOrgApiClient {
     WordPressOrgApiClient::new(
-        Arc::new(ReqwestRequestExecutor::new(false, None)),
+        Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(120))),
         Arc::new(WpApiMiddlewarePipeline::default()),
     )
 }

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -126,10 +126,7 @@ async fn perform_api_discovery(
 }
 
 fn build_login_client() -> WpLoginClient {
-    let request_executor = Arc::new(ReqwestRequestExecutor::new_with_timeout(
-        false,
-        Duration::from_secs(60),
-    ));
+    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
     WpLoginClient::new(
         request_executor,
         Arc::new(WpApiMiddlewarePipeline {


### PR DESCRIPTION
Previous implementation ignores `None` values and sets it to `10` seconds by default. If we want to have a default value, this is not the correct way to do it.

Since this issue is causing the nightly tests to break, I'd like to admin merge the simple solution, but I'd be happy to implement a default timeout if you'd like @jkmassel.