### PR TITLE
Remove the user id argument from the application password introspect API

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApplicationPasswordsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApplicationPasswordsEndpointTest.kt
@@ -36,7 +36,7 @@ class ApplicationPasswordsEndpointTest {
     @Test
     fun testApplicationPasswordRetrieveCurrentRequest() = runTest {
         val applicationPasswordList = client.request { requestBuilder ->
-            requestBuilder.applicationPasswords().retrieveCurrentWithEditContext(FIRST_USER_ID)
+            requestBuilder.applicationPasswords().retrieveCurrentWithEditContext()
         }.assertSuccessAndRetrieveData().data
         assertEquals(
             ApplicationPasswordUuid(testCredentials.adminPasswordUuid),

--- a/wp_api/src/request/endpoint/application_passwords_endpoint.rs
+++ b/wp_api/src/request/endpoint/application_passwords_endpoint.rs
@@ -26,7 +26,7 @@ enum ApplicationPasswordsRequest {
     List,
     #[contextual_get(url = "/users/<user_id>/application-passwords/<application_password_uuid>", output = SparseApplicationPassword, filter_by = SparseApplicationPasswordField)]
     Retrieve,
-    #[contextual_get(url = "/users/<user_id>/application-passwords/introspect", output = SparseApplicationPassword, filter_by = SparseApplicationPasswordField)]
+    #[contextual_get(url = "/users/me/application-passwords/introspect", output = SparseApplicationPassword, filter_by = SparseApplicationPasswordField)]
     RetrieveCurrent,
     #[post(url = "/users/<user_id>/application-passwords/<application_password_uuid>", params = &ApplicationPasswordUpdateParams, output = ApplicationPasswordWithEditContext)]
     Update,
@@ -132,21 +132,21 @@ mod tests {
         endpoint: ApplicationPasswordsRequestEndpoint,
     ) {
         validate_wp_v2_endpoint(
-            endpoint.retrieve_current_with_edit_context(&UserId(2)),
-            "/users/2/application-passwords/introspect?context=edit",
+            endpoint.retrieve_current_with_edit_context(),
+            "/users/me/application-passwords/introspect?context=edit",
         );
     }
 
     #[rstest]
-    #[case(&[SparseApplicationPasswordFieldWithViewContext::Uuid], "/users/2/application-passwords/introspect?context=view&_fields=uuid")]
-    #[case(&[SparseApplicationPasswordFieldWithViewContext::Uuid, SparseApplicationPasswordFieldWithViewContext::Name], "/users/2/application-passwords/introspect?context=view&_fields=uuid%2Cname")]
+    #[case(&[SparseApplicationPasswordFieldWithViewContext::Uuid], "/users/me/application-passwords/introspect?context=view&_fields=uuid")]
+    #[case(&[SparseApplicationPasswordFieldWithViewContext::Uuid, SparseApplicationPasswordFieldWithViewContext::Name], "/users/me/application-passwords/introspect?context=view&_fields=uuid%2Cname")]
     fn filter_retrieve_current_application_passwords(
         endpoint: ApplicationPasswordsRequestEndpoint,
         #[case] fields: &[SparseApplicationPasswordFieldWithViewContext],
         #[case] expected_path: &str,
     ) {
         validate_wp_v2_endpoint(
-            endpoint.filter_retrieve_current_with_view_context(&UserId(2), fields),
+            endpoint.filter_retrieve_current_with_view_context(fields),
             expected_path,
         );
     }

--- a/wp_api_integration_tests/tests/test_application_passwords_err.rs
+++ b/wp_api_integration_tests/tests/test_application_passwords_err.rs
@@ -6,8 +6,8 @@ use wp_api::application_passwords::{
 };
 
 use wp_api_integration_tests::{
-    AssertWpError, FIRST_USER_ID, SECOND_USER_ID, TestCredentials, api_client,
-    api_client_as_subscriber, api_client_as_unauthenticated,
+    AssertWpError, FIRST_USER_ID, TestCredentials, api_client, api_client_as_subscriber,
+    api_client_as_unauthenticated,
 };
 
 pub mod reusable_test_cases;
@@ -117,21 +117,9 @@ async fn retrieve_application_password_err_cannot_introspect_app_password_for_no
     // Unauthenticated user can not retrieve the current application password for the second user
     api_client_as_unauthenticated()
         .application_passwords()
-        .retrieve_current_with_edit_context(&SECOND_USER_ID)
+        .retrieve_current_with_edit_context()
         .await
-        .assert_wp_error(WpErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
-}
-
-#[rstest]
-#[tokio::test]
-#[parallel]
-async fn retrieve_application_password_err_cannot_introspect_app_password_for_another_user_403() {
-    // First user can not retrieve the current application password for the second user
-    api_client()
-        .application_passwords()
-        .retrieve_current_with_edit_context(&SECOND_USER_ID)
-        .await
-        .assert_wp_error(WpErrorCode::CannotIntrospectAppPasswordForNonAuthenticatedUser);
+        .assert_wp_error(WpErrorCode::Unauthorized);
 }
 
 #[rstest]

--- a/wp_api_integration_tests/tests/test_application_passwords_immut.rs
+++ b/wp_api_integration_tests/tests/test_application_passwords_immut.rs
@@ -71,7 +71,7 @@ async fn list_application_passwords_ensure_last_ip() {
 async fn retrieve_current_application_passwords_with_edit_context() {
     let a = api_client()
         .application_passwords()
-        .retrieve_current_with_edit_context(&FIRST_USER_ID)
+        .retrieve_current_with_edit_context()
         .await
         .assert_response()
         .data;
@@ -88,7 +88,7 @@ async fn retrieve_current_application_passwords_with_edit_context() {
 async fn retrieve_current_application_passwords_with_embed_context() {
     let a = api_client_as_subscriber()
         .application_passwords()
-        .retrieve_current_with_embed_context(&SECOND_USER_ID)
+        .retrieve_current_with_embed_context()
         .await
         .assert_response()
         .data;
@@ -107,7 +107,7 @@ async fn retrieve_current_application_passwords_with_embed_context() {
 async fn retrieve_current_application_passwords_with_view_context() {
     let a = api_client()
         .application_passwords()
-        .retrieve_current_with_view_context(&FIRST_USER_ID)
+        .retrieve_current_with_view_context()
         .await
         .assert_response()
         .data;
@@ -222,7 +222,7 @@ mod filter {
     ) {
         let p = api_client()
             .application_passwords()
-            .filter_retrieve_current_with_edit_context(&FIRST_USER_ID, fields)
+            .filter_retrieve_current_with_edit_context(fields)
             .await
             .assert_response()
             .data;
@@ -275,7 +275,7 @@ mod filter {
     ) {
         let p = api_client()
             .application_passwords()
-            .filter_retrieve_current_with_embed_context(&FIRST_USER_ID, fields)
+            .filter_retrieve_current_with_embed_context(fields)
             .await
             .assert_response()
             .data;
@@ -328,7 +328,7 @@ mod filter {
     ) {
         let p = api_client()
             .application_passwords()
-            .filter_retrieve_current_with_view_context(&FIRST_USER_ID, fields)
+            .filter_retrieve_current_with_view_context(fields)
             .await
             .assert_response()
             .data;


### PR DESCRIPTION
Since the application password introspect API can only be used on the current user, I think we should remove the user id argument and hard-code the current user instead.