### PR TITLE
Adds `application_passwords_authentication_url` field to `AutoDiscoveryAttemptSuccess`

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -31,7 +31,7 @@ class ApiUrlDiscoveryTest {
     fun testValidSiteWorksCorrectly() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://vanilla.wpmt.co")
+            loginClient.apiDiscovery("https://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -60,7 +60,7 @@ class ApiUrlDiscoveryTest {
 
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
             val client = WpLoginClient(executor)
-            client.loginUrl("http://localhost")
+            client.apiDiscovery("http://localhost").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getApplicationPasswordsNotSupportedReason(e)
             assertInstanceOf(SiteIsLocalDevelopmentEnvironment::class.java, reason)
@@ -71,12 +71,12 @@ class ApiUrlDiscoveryTest {
     fun testAdminUrlProvided() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://vanilla.wpmt.co/wp-login.php")
+            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-login.php").applicationPasswordsAuthenticationUrl.url()
         )
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://vanilla.wpmt.co/wp-admin")
+            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-admin").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -84,14 +84,14 @@ class ApiUrlDiscoveryTest {
     fun testAutoHttpsSupport() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("http://vanilla.wpmt.co")
+            loginClient.apiDiscovery("http://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 5
     fun testHttpOnlySite() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("http://no-https.wpmt.co")
+            loginClient.apiDiscovery("http://no-https.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getApplicationPasswordsNotSupportedReason(e)
             assertInstanceOf(ApplicationPasswordsDisabledForHttpSite::class.java, reason)
@@ -102,7 +102,7 @@ class ApiUrlDiscoveryTest {
     fun testHttpOnlySiteWithApplicationPasswordsEnabled() = runTest {
         assertEquals(
             "http://no-https-with-application-passwords.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("http://no-https-with-application-passwords.wpmt.co")
+            loginClient.apiDiscovery("http://no-https-with-application-passwords.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -110,14 +110,14 @@ class ApiUrlDiscoveryTest {
     fun testAggressivelyCachedSiteWithNoLinkHeader() = runTest {
         assertEquals(
             "https://aggressive-caching.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://aggressive-caching.wpmt.co")
+            loginClient.apiDiscovery("https://aggressive-caching.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 8
     fun testSiteWithApplicationPasswordsDisabledByWordFence() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("https://wordfence.wpmt.co")
+            loginClient.apiDiscovery("https://wordfence.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getApplicationPasswordsNotSupportedReason(e)
             assertInstanceOf(
@@ -134,7 +134,7 @@ class ApiUrlDiscoveryTest {
     @Test // Spec Example 9
     fun testNotWordPressSite() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("https://google.com")
+            loginClient.apiDiscovery("https://google.com").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getFindApiRootFailure(e)
             assertInstanceOf(FindApiRootFailure.ProbablyNotAWordPressSite::class.java, reason)
@@ -145,7 +145,7 @@ class ApiUrlDiscoveryTest {
     fun testWordPressSubdirectoryWithLinkHeader() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://subdirectory.wpmt.co/index.php?link_header=true")
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?link_header=true").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -153,7 +153,7 @@ class ApiUrlDiscoveryTest {
     fun testWordPressSubdirectoryWithLinkTag() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://subdirectory.wpmt.co?link_tag=true")
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co?link_tag=true").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -161,14 +161,14 @@ class ApiUrlDiscoveryTest {
     fun testWordPressSubdirectoryWithRedirect() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://subdirectory.wpmt.co/index.php?redirect=true")
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?redirect=true").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 13 (with no credentials)
     fun testWordPressHttpBasicWithMissingCredentials() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("https://basic-auth.wpmt.co")
+            loginClient.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
             assertInstanceOf(
@@ -186,7 +186,7 @@ class ApiUrlDiscoveryTest {
             WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(invalid))
         )
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            client.loginUrl("https://basic-auth.wpmt.co")
+            client.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
             assertInstanceOf(
@@ -209,7 +209,7 @@ class ApiUrlDiscoveryTest {
 
         assertEquals(
             "https://basic-auth.wpmt.co/wp-admin/authorize-application.php",
-            client.loginUrl("https://basic-auth.wpmt.co")
+            client.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -217,7 +217,7 @@ class ApiUrlDiscoveryTest {
     fun testWordPressCustomRestApiPrefix() = runTest {
         assertEquals(
             "https://custom-rest-prefix.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://custom-rest-prefix.wpmt.co")
+            loginClient.apiDiscovery("https://custom-rest-prefix.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -225,7 +225,7 @@ class ApiUrlDiscoveryTest {
     fun testWordPressHeavyRateLimiting() = runTest {
         assertEquals(
             "https://aggressive-rate-limiting.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.loginUrl("https://aggressive-rate-limiting.wpmt.co")
+            loginClient.apiDiscovery("https://aggressive-rate-limiting.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -245,7 +245,7 @@ class ApiUrlDiscoveryTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
             val client =
                 WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
-            client.loginUrl("https://aggressive-rate-limiting.wpmt.co")
+            client.apiDiscovery("https://aggressive-rate-limiting.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
             assertInstanceOf(
@@ -258,7 +258,7 @@ class ApiUrlDiscoveryTest {
     @Test // Spec Example 16
     fun testInvalidUrl() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("https://valid-looking-url-but-not-actually.foo")
+            loginClient.apiDiscovery("https://valid-looking-url-but-not-actually.foo").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
             assertInstanceOf(RequestExecutionErrorReason.NonExistentSiteError::class.java, reason)
@@ -268,7 +268,7 @@ class ApiUrlDiscoveryTest {
     @Test // Spec Example 17
     fun testInvalidHTTPsFails() = runTest {
         assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.loginUrl("https://wordpress-1315525-4803651.cloudwaysapps.com")
+            loginClient.apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com").applicationPasswordsAuthenticationUrl.url()
         }.let { e ->
             val reason = getRequestExecutionErrorReason(e)
             assertInstanceOf(RequestExecutionErrorReason.InvalidSslError::class.java, reason)
@@ -298,7 +298,7 @@ class ApiUrlDiscoveryTest {
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            WpLoginClient(requestExecutor = executor).loginUrl("https://wordpress-1315525-4803651.cloudwaysapps.com")
+            WpLoginClient(requestExecutor = executor).apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com").applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -308,7 +308,7 @@ class ApiUrlDiscoveryTest {
             WpRequestExecutor(httpClient = WpHttpClient.CustomOkHttpClient(client = OkHttpClient()))
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            WpLoginClient(requestExecutor = executor).loginUrl("https://vanilla.wpmt.co")
+            WpLoginClient(requestExecutor = executor).apiDiscovery("https://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
         )
     }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -19,8 +19,4 @@ class WpLoginClient(
     suspend fun apiDiscovery(siteUrl: String): AutoDiscoveryAttemptSuccess = withContext(dispatcher) {
         internalClient.apiDiscovery(siteUrl)
     }
-
-    suspend fun loginUrl(siteUrl: String): String? = withContext(dispatcher) {
-        internalClient.apiDiscovery(siteUrl).apiDetails.findApplicationPasswordsAuthenticationUrl()
-    }
 }

--- a/native/kotlin/example/composeApp/src/androidMain/kotlin/rs/wordpress/example/ui/welcome/WelcomeActivity.kt
+++ b/native/kotlin/example/composeApp/src/androidMain/kotlin/rs/wordpress/example/ui/welcome/WelcomeActivity.kt
@@ -27,7 +27,7 @@ class WelcomeActivity : ComponentActivity() {
     private fun authenticateSite(url: String) {
         val authenticationUrl = runBlocking {
             WpLoginClient().apiDiscovery(url)
-                .getOrThrow().apiDetails.findApplicationPasswordsAuthenticationUrl()
+                .getOrThrow().applicationPasswordsAuthenticationUrl.url()
         }
         val uriBuilder = Uri.parse(authenticationUrl).buildUpon()
 

--- a/native/swift/Example/Example/UI/LoginView.swift
+++ b/native/swift/Example/Example/UI/LoginView.swift
@@ -71,10 +71,9 @@ struct LoginView: View {
 
                 let loginClient = WordPressLoginClient(urlSession: .shared)
                 let details = try await loginClient.details(ofSite: url)
-                let loginUrl = try await details.loginURL(for: application)
 
                 let callbackUrl = try await self.webAuthenticationSession.authenticate(
-                    using: loginUrl,
+                    using: details.loginURL(for: application),
                     callbackURLScheme: "x-wordpress-app"
                 )
 

--- a/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
+++ b/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
@@ -39,8 +39,7 @@ public final class WordPressLoginClient: @unchecked Sendable {
         forSite proposedSiteUrl: String
     ) async throws -> ParsedUrl {
         // All sites should have some form of authentication we can use
-        let discoveryResult = try await client.apiDiscovery(siteUrl: proposedSiteUrl)
-        return discoveryResult.applicationPasswordsAuthenticationUrl
+        try await client.apiDiscovery(siteUrl: proposedSiteUrl).applicationPasswordsAuthenticationUrl
     }
 
     /// Uses the proposed site URL to scan the website it points to and find the Application Passwords login URL,
@@ -65,8 +64,8 @@ public final class WordPressLoginClient: @unchecked Sendable {
 
 extension AutoDiscoveryAttemptSuccess {
 
-    public func loginURL(for application: Application) throws -> URL {
-        return createApplicationPasswordAuthenticationUrl(
+    public func loginURL(for application: Application) -> URL {
+        createApplicationPasswordAuthenticationUrl(
             loginUrl: applicationPasswordsAuthenticationUrl,
             appName: application.name,
             appId: application.id,
@@ -74,7 +73,6 @@ extension AutoDiscoveryAttemptSuccess {
             rejectUrl: application.failureCallbackUrl
         ).asURL()
     }
-
 }
 
 public struct Application {

--- a/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
+++ b/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
@@ -40,7 +40,7 @@ public final class WordPressLoginClient: @unchecked Sendable {
     ) async throws -> ParsedUrl {
         // All sites should have some form of authentication we can use
         let discoveryResult = try await client.apiDiscovery(siteUrl: proposedSiteUrl)
-        return try discoveryResult.applicationPasswordAuthenticationUrl
+        return discoveryResult.applicationPasswordsAuthenticationUrl
     }
 
     /// Uses the proposed site URL to scan the website it points to and find the Application Passwords login URL,
@@ -66,9 +66,8 @@ public final class WordPressLoginClient: @unchecked Sendable {
 extension AutoDiscoveryAttemptSuccess {
 
     public func loginURL(for application: Application) throws -> URL {
-        let loginUrl = try applicationPasswordAuthenticationUrl
         return createApplicationPasswordAuthenticationUrl(
-            loginUrl: loginUrl,
+            loginUrl: applicationPasswordsAuthenticationUrl,
             appName: application.name,
             appId: application.id,
             successUrl: application.successCallbackUrl,

--- a/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
+++ b/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
@@ -76,15 +76,6 @@ extension AutoDiscoveryAttemptSuccess {
         ).asURL()
     }
 
-    var applicationPasswordAuthenticationUrl: ParsedUrl {
-        get throws {
-            guard let passwordAuthUrl = apiDetails.findApplicationPasswordsAuthenticationUrl() else {
-                preconditionFailure("No Auth URL Found")
-            }
-            return try ParsedUrl.parse(input: passwordAuthUrl)
-        }
-    }
-
 }
 
 public struct Application {

--- a/wp_api/src/login/login_client.rs
+++ b/wp_api/src/login/login_client.rs
@@ -191,7 +191,22 @@ impl WpLoginClient {
         };
         let api_details = Self::parse_api_root(&fetch_api_details_response)?;
 
-        if !api_details.has_application_passwords_authentication_url() {
+        if let Some(application_passwords_authentication_url) =
+            api_details.find_application_passwords_authentication_url()
+        {
+            let application_passwords_authentication_url =
+                ParsedUrl::parse(application_passwords_authentication_url.as_str())
+                    .expect(
+                        "Application passwords url returned from the server should be a valid url",
+                    )
+                    .into();
+            Ok(AutoDiscoveryAttemptSuccess {
+                parsed_site_url,
+                api_root_url: Arc::clone(&api_root_url.0),
+                api_details: Arc::new(api_details),
+                application_passwords_authentication_url,
+            })
+        } else {
             let reason = if api_details.has_application_password_blocking_plugin() {
                 let plugins = api_details.application_password_blocking_plugins();
 
@@ -221,12 +236,6 @@ impl WpLoginClient {
                     reason,
                 },
             )
-        } else {
-            Ok(AutoDiscoveryAttemptSuccess {
-                parsed_site_url,
-                api_root_url: Arc::clone(&api_root_url.0),
-                api_details: Arc::new(api_details),
-            })
         }
     }
 

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -360,6 +360,7 @@ pub struct AutoDiscoveryAttemptSuccess {
     pub parsed_site_url: Arc<ParsedUrl>,
     pub api_root_url: Arc<ParsedUrl>,
     pub api_details: Arc<WpApiDetails>,
+    pub application_passwords_authentication_url: Arc<ParsedUrl>,
 }
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -5,6 +5,7 @@ use csv::Writer;
 use futures::stream::StreamExt;
 use std::{fmt::Display, fs::File, sync::Arc, time::Duration};
 use wp_api::{
+    ParsedUrl,
     login::{
         login_client::WpLoginClient,
         url_discovery::{
@@ -114,13 +115,10 @@ async fn perform_api_discovery(
         .await
         .combined_result()
     {
-        Ok(s) => {
-            let login_url = s
-                .api_details
-                .find_application_passwords_authentication_url()
-                .expect("Already confirmed auto discovery was successful");
-            SimplifiedDiscoveryResult::success(url, LoginUrl(login_url))
-        }
+        Ok(s) => SimplifiedDiscoveryResult::success(
+            url,
+            LoginUrl(s.application_passwords_authentication_url.clone()),
+        ),
         Err(e) => SimplifiedDiscoveryResult::failure(url, e.clone()),
     }
 }
@@ -197,7 +195,7 @@ impl SimplifiedDiscoveryResult {
 }
 
 #[derive(Debug)]
-struct LoginUrl(String);
+struct LoginUrl(Arc<ParsedUrl>);
 
 impl Display for LoginUrl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Until now, even though api discovery fails if the application passwords authentication url is missing, we still had to use the `find_application_passwords_authentication_url` function that returns `Option<String>` and manually unwrap it.

This PR adds `application_passwords_authentication_url` as a non-optional field to `AutoDiscoveryAttemptSuccess` to avoid this. This change will also force a compiler error if we decide to change this behavior whereas unwrapping `find_application_passwords_authentication_url` might have resulted in runtime crashes.