### PR TITLE
Speed up generating Swift bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,10 @@ validate-localizations:
 	@# Help: Validate localization files using `wp_localization_validation` crate
 	$(rust_docker_run) /bin/bash -c "cargo run --bin wp_localization_validation -- --localization-folder ./wp_localization/localization/"
 
+format-swift:
+	@# Help: Format the Swift binding code
+	xcrun swift format -i -r native/swift/Sources/wordpress-api-wrapper
+
 help:
 	@printf "%-40s %s\n" "Target" "Description"
 	@printf "%-40s %s\n" "------" "-----------"

--- a/scripts/swift-bindings.sh
+++ b/scripts/swift-bindings.sh
@@ -15,6 +15,7 @@ rm -rf "$output_dir" && mkdir "$output_dir"
 cargo run --release --quiet --bin wp_uniffi_bindgen generate \
     --library "$library_path" \
     --out-dir "$output_dir" \
+    --no-format \
     --language swift
 
 function patch_wp_api {


### PR DESCRIPTION
Skipping formatting of the 80k+ lines of generated Swift code shows a noticeable speed boost. Also, the binding code was not formatted correctly, which might be a bug in uniffi-rs. I have added a command to format the Swift code, which we can use when needed.