### PR TITLE
Improve error messaging for some connection errors

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -22,6 +22,7 @@ import uniffi.wp_api.WpNetworkRequest
 import uniffi.wp_api.WpNetworkResponse
 import uniffi.wp_api.parseCertificate
 import java.io.File
+import java.net.NoRouteToHostException
 import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLPeerUnverifiedException
@@ -67,6 +68,8 @@ class WpRequestExecutor(
                 )
             } catch (e: UnknownHostException) {
                 throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
+            } catch (e: NoRouteToHostException) {
+                throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
             }
         }
 
@@ -120,6 +123,11 @@ private fun RequestExecutionErrorReason.Companion.unknownHost(e: UnknownHostExce
     RequestExecutionErrorReason.NonExistentSiteError(
         errorMessage = e.localizedMessage,
         suggestedAction = "Check that the URL is valid and try again"
+    )
+
+private fun RequestExecutionErrorReason.Companion.noRouteToHost(e: NoRouteToHostException) =
+    RequestExecutionErrorReason.HttpError(
+        reason = e.localizedMessage
     )
 
 @Suppress("UNUSED_PARAMETER")

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -497,6 +497,9 @@ pub enum RequestExecutionErrorReason {
     DeviceIsOfflineError {
         error_message: String,
     },
+    HttpError {
+        reason: String,
+    },
     GenericError {
         error_message: String,
     },
@@ -576,6 +579,9 @@ impl WpSupportsLocalization for RequestExecutionErrorReason {
             }
             RequestExecutionErrorReason::DeviceIsOfflineError { error_message } => {
                 WpMessages::just(error_message)
+            }
+            RequestExecutionErrorReason::HttpError { reason } => {
+                WpMessages::http_server_error(reason)
             }
             RequestExecutionErrorReason::GenericError { error_message } => {
                 WpMessages::just(error_message)

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -285,12 +285,15 @@ impl From<&ResolveError> for RequestExecutionErrorReason {
 impl From<&HyperError> for RequestExecutionErrorReason {
     fn from(error: &HyperError) -> Self {
         if let Some(http2_error) = error.find::<Http2Error>() {
-            // TODO: We can probably handle more cases here, such as:
-            // - Connection reset
-
-            return RequestExecutionErrorReason::GenericError {
-                error_message: http2_error.to_string(),
-            };
+            if let Some(reason) = http2_error.reason() {
+                return RequestExecutionErrorReason::HttpError {
+                    reason: reason.description().to_string(),
+                };
+            } else {
+                return RequestExecutionErrorReason::GenericError {
+                    error_message: http2_error.to_string(),
+                };
+            }
         }
 
         if error.is_closed() {

--- a/wp_localization/localization/en-US/main.ftl
+++ b/wp_localization/localization/en-US/main.ftl
@@ -25,6 +25,8 @@ http_timeout_error = The connection timed out
 
 http_authentication_rejected_error = The server at {$url} rejected your credentials. Please provide a valid username and password.
 
+http_server_error = Unable to connect to server: {$reason}. Please contact your server provider.
+
 misconfigured_http_authentication_error = The server is sending invalid HTTP authentication information. Please check your site's HTTP authentication configuration.
 
 misconfigured_rate_limit_error = The server is rate limiting requests in a way that will never succeed. Please check your site's rate limit configuration.

--- a/wp_localization/localization/tr-TR/main.ftl
+++ b/wp_localization/localization/tr-TR/main.ftl
@@ -22,6 +22,8 @@ http_authentication_required_error = {$url} adresindeki sunucu kimlik doğrulama
 
 http_authentication_rejected_error = {$url} adresindeki sunucu giriş bilgilerinizi reddetti. Lütfen geçerli bir kullanıcı adı ve şifre girin.
 
+http_server_error = Unable to connect to server: {$reason}. Please contact your server provider.
+
 misconfigured_http_authentication_error = Sunucu geçersiz HTTP kimlik doğrulama bilgileri gönderiyor. Lütfen sitenizin HTTP kimlik doğrulama yapılandırmasını kontrol edin.
 
 misconfigured_rate_limit_error = Sunucu istekleri asla başarılı olmayacak şekilde sınırlıyor. Lütfen sitenizin hız sınırı yapılandırmasını kontrol edin.

--- a/wp_localization/localization/tr-TR/main.ftl
+++ b/wp_localization/localization/tr-TR/main.ftl
@@ -22,8 +22,6 @@ http_authentication_required_error = {$url} adresindeki sunucu kimlik doğrulama
 
 http_authentication_rejected_error = {$url} adresindeki sunucu giriş bilgilerinizi reddetti. Lütfen geçerli bir kullanıcı adı ve şifre girin.
 
-http_server_error = Unable to connect to server: {$reason}. Please contact your server provider.
-
 misconfigured_http_authentication_error = Sunucu geçersiz HTTP kimlik doğrulama bilgileri gönderiyor. Lütfen sitenizin HTTP kimlik doğrulama yapılandırmasını kontrol edin.
 
 misconfigured_rate_limit_error = Sunucu istekleri asla başarılı olmayacak şekilde sınırlıyor. Lütfen sitenizin hız sınırı yapılandırmasını kontrol edin.


### PR DESCRIPTION
Some servers drop the HTTP 2 connection, and we didn't previously give a very helpful message in the web/cli debug tools:

> stream error received: unspecific protocol error detected

This PR handles HTTP 2 connection issues differently and provides an actionable suggestion:

> Unable to connect to server: {$reason}. Please contact your server provider.

For reference, on Apple platforms:
> The network connection was lost.

In Kotlin:
> No route to host