### PR TITLE
Export `WpNetworkHeaderMap.wp_total`

### DIFF
--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -296,10 +296,6 @@ impl WpNetworkHeaderMap {
         Self { inner: header_map }
     }
 
-    pub fn wp_total(&self) -> Option<u32> {
-        self.header_value_as_u32(HEADER_KEY_WP_TOTAL)
-    }
-
     pub fn wp_total_pages(&self) -> Option<u32> {
         self.header_value_as_u32(HEADER_KEY_WP_TOTAL_PAGES)
     }
@@ -390,6 +386,10 @@ impl WpNetworkHeaderMap {
                 .push(v)
         });
         header_hashmap
+    }
+
+    pub fn wp_total(&self) -> Option<u32> {
+        self.header_value_as_u32(HEADER_KEY_WP_TOTAL)
     }
 }
 


### PR DESCRIPTION
The API can be used to display the total number of posts/pages/media, etc, on the site.