### PR TITLE
Properly handle IO-related HTTP errors

### DIFF
--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -187,26 +187,13 @@ impl From<reqwest::Error> for RequestExecutionError {
 
         if let Some(io_error) = error.as_io_error() {
             match io_error.kind() {
-                std::io::ErrorKind::ConnectionRefused => {
-                    return RequestExecutionError::RequestExecutionFailed {
-                        status_code,
-                        redirects: None,
-                        reason: RequestExecutionErrorReason::NonExistentSiteError {
-                            error_message: Some("Connection refused".to_string()),
-                            suggested_action: None,
-                        },
-                    };
-                }
                 std::io::ErrorKind::UnexpectedEof => {
                     // Server terminated the connection unexpectedly
                     return RequestExecutionError::RequestExecutionFailed {
                         status_code,
                         redirects: None,
-                        reason: RequestExecutionErrorReason::NonExistentSiteError {
-                            error_message: Some(
-                                "The server terminated the connection unexpectedly".to_string(),
-                            ),
-                            suggested_action: None,
+                        reason: RequestExecutionErrorReason::HttpError {
+                            reason: "The server terminated the connection unexpectedly".to_string(),
                         },
                     };
                 }
@@ -214,8 +201,8 @@ impl From<reqwest::Error> for RequestExecutionError {
                     return RequestExecutionError::RequestExecutionFailed {
                         status_code,
                         redirects: None,
-                        reason: RequestExecutionErrorReason::GenericError {
-                            error_message: error.to_string(),
+                        reason: RequestExecutionErrorReason::HttpError {
+                            reason: io_error.to_string(),
                         },
                     };
                 }

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -182,7 +182,7 @@ impl SimplifiedDiscoveryResult {
                 println!("{}", format!("Login URL found: {login_url}").green());
             }
             Err(error) => {
-                println!("{}", format!("Error: {}", error).red());
+                println!("{}", error.to_string().red());
             }
         }
     }


### PR DESCRIPTION
I noticed that HTTP/1.1 requests didn't nicely handle `ConnectionReset` errors – the root issue is that we should be calling `IOError.to_string()` instead of `Error.to_string()` – that digs into the error graph to find the most specific explanation for what went wrong.

It also adopts the new `RequestExecutionErrorReason::HttpError` instead of `RequestExecutionErrorReason::GenericError`, which directs the user to contact their server provider.

**To Test**
The easiest way is to add `.http1_only()` to the CLI tool's `ClientBuilder`, then use the same test URL as #700. Before this PR, the error isn't helpful. After, it is.