### PR TITLE
Implement uploading media in the Swift wrapper

### DIFF
--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -12,7 +12,7 @@ public extension MiddlewarePipeline {
 }
 
 extension WpNetworkResponse {
-    init(data: Data, request: WpNetworkRequest, response: URLResponse) throws {
+    init(data: Data, request: NetworkRequestContent, response: URLResponse) throws {
         guard let response = response as? HTTPURLResponse else {
             preconditionFailure("We should never wind up here")
         }

--- a/native/swift/Sources/wordpress-api/Middleware.swift
+++ b/native/swift/Sources/wordpress-api/Middleware.swift
@@ -6,7 +6,7 @@ public final class DebugMiddleware: WpApiMiddleware {
         response: WordPressAPIInternal.WpNetworkResponse,
         request: WordPressAPIInternal.WpNetworkRequest
     ) async throws -> WordPressAPIInternal.WpNetworkResponse {
-        debugPrint("Performed request: \(request.asURLRequest())")
+        debugPrint("Performed request: \(String(describing: try? request.buildURLRequest()))")
         debugPrint("Received response: \(response)")
         return response
     }

--- a/native/swift/Sources/wordpress-api/MultipartForm.swift
+++ b/native/swift/Sources/wordpress-api/MultipartForm.swift
@@ -167,7 +167,7 @@ private extension OutputStream {
         guard count > 0 else { return }
 
         _ = data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
-            write(ptr.bindMemory(to: Int8.self).baseAddress!, maxLength: count)
+            write(ptr.bindMemory(to: UInt8.self).baseAddress!, maxLength: count)
         }
     }
 

--- a/native/swift/Sources/wordpress-api/MultipartForm.swift
+++ b/native/swift/Sources/wordpress-api/MultipartForm.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+enum MultipartFormError: Swift.Error, LocalizedError {
+    case inaccessbileFile(underlyingError: Error)
+    case impossible
+
+    var errorDescription: String? {
+        switch self {
+        case let .inaccessbileFile(underlyingError: underlyingError):
+            return underlyingError.localizedDescription
+        case .impossible:
+            return "An unknown error occurred."
+        }
+    }
+}
+
+enum MultipartFormContent {
+    case inMemory(Data)
+    case onDisk(URL)
+
+    func asInputStream() -> InputStream {
+        switch self {
+        case let .inMemory(data):
+            return InputStream(data: data)
+        case let .onDisk(url):
+            precondition(url.isFileURL && FileManager.default.fileExists(atPath: url.path))
+            return InputStream(fileAtPath: url.path)!
+        }
+    }
+}
+
+struct MultipartFormField {
+    let name: String
+    let filename: String?
+    let mimeType: String?
+    let bytes: UInt64
+
+    fileprivate let inputStream: InputStream
+
+    init(text: String, name: String, filename: String? = nil, mimeType: String? = nil) {
+        self.init(data: text.data(using: .utf8)!, name: name, filename: filename, mimeType: mimeType)
+    }
+
+    init(data: Data, name: String, filename: String? = nil, mimeType: String? = nil) {
+        self.inputStream = InputStream(data: data)
+        self.name = name
+        self.filename = filename
+        self.bytes = UInt64(data.count)
+        self.mimeType = mimeType
+    }
+
+    init(fileAtPath path: String, name: String, filename: String? = nil, mimeType: String? = nil) throws {
+        let attrs: [FileAttributeKey: Any]
+        do {
+            attrs = try FileManager.default.attributesOfItem(atPath: path)
+        } catch {
+            throw MultipartFormError.inaccessbileFile(underlyingError: error)
+        }
+
+        guard let inputStream = InputStream(fileAtPath: path),
+              let bytes = (attrs[FileAttributeKey.size] as? NSNumber)?.uint64Value
+        else {
+            // Given we can successfully read the file attributes, the above calls should never fail.
+            throw MultipartFormError.impossible
+        }
+
+        self.inputStream = inputStream
+        self.name = name
+        self.filename = filename ?? path.split(separator: "/").last.flatMap({ String($0) })
+        self.bytes = bytes
+        self.mimeType = mimeType
+    }
+}
+
+extension Array where Element == MultipartFormField {
+    private func multipartFormDestination(forceWriteToFile: Bool) throws -> (outputStream: OutputStream, tempFilePath: String?) {
+        let dest: OutputStream
+        let tempFilePath: String?
+
+        // Build the form data in memory if the content is estimated to be less than 10 MB. Otherwise, use a temporary file.
+        let thresholdBytesForUsingTmpFile = 10_000_000
+        let estimatedFormDataBytes = reduce(0) { $0 + $1.bytes }
+        if forceWriteToFile || estimatedFormDataBytes > thresholdBytesForUsingTmpFile {
+            let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+            guard let stream = OutputStream(toFileAtPath: tempFile, append: false) else {
+                // This error should never occurr, because the `tempFile` is in a temporary directory and is guranteed to be writable.
+                throw MultipartFormError.impossible
+            }
+            dest = stream
+            tempFilePath = tempFile
+        } else {
+            dest = OutputStream.toMemory()
+            tempFilePath = nil
+        }
+
+        return (dest, tempFilePath)
+    }
+
+    func multipartFormDataStream(boundary: String, forceWriteToFile: Bool = false) throws -> MultipartFormContent {
+        guard !isEmpty else {
+            return .inMemory(Data())
+        }
+
+        let (dest, tempFilePath) = try multipartFormDestination(forceWriteToFile: forceWriteToFile)
+
+        // Build the form content
+        do {
+            dest.open()
+            defer { dest.close() }
+
+            writeMultipartFormData(destination: dest, boundary: boundary)
+        }
+
+        // Return the result as `InputStream`
+        if let tempFilePath {
+            return .onDisk(URL(fileURLWithPath: tempFilePath))
+        }
+
+        if let data = dest.property(forKey: .dataWrittenToMemoryStreamKey) as? Data {
+            return .inMemory(data)
+        }
+
+        throw MultipartFormError.impossible
+    }
+
+    private func writeMultipartFormData(destination dest: OutputStream, boundary: String) {
+        for field in self {
+            dest.writeMultipartForm(boundary: boundary, isEnd: false)
+
+            // Write headers
+            var disposition = ["form-data", "name=\"\(field.name)\""]
+            if let filename = field.filename {
+                disposition += ["filename=\"\(filename)\""]
+            }
+            dest.writeMultipartFormHeader(name: "Content-Disposition", value: disposition.joined(separator: "; "))
+
+            if let mimeType = field.mimeType {
+                dest.writeMultipartFormHeader(name: "Content-Type", value: mimeType)
+            }
+
+            // Write a linebreak between header and content
+            dest.writeMultipartFormLineBreak()
+
+            // Write content
+            field.inputStream.open()
+            defer {
+                field.inputStream.close()
+            }
+            let maxLength = 1024
+            var buffer = [UInt8](repeating: 0, count: maxLength)
+            while field.inputStream.hasBytesAvailable {
+                let bytes = field.inputStream.read(&buffer, maxLength: maxLength)
+                dest.write(data: Data(bytesNoCopy: &buffer, count: bytes, deallocator: .none))
+            }
+
+            dest.writeMultipartFormLineBreak()
+        }
+
+        dest.writeMultipartForm(boundary: boundary, isEnd: true)
+    }
+}
+
+private let multipartFormDataLineBreak = "\r\n"
+private extension OutputStream {
+    func write(data: Data) {
+        let count = data.count
+        guard count > 0 else { return }
+
+        _ = data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            write(ptr.bindMemory(to: Int8.self).baseAddress!, maxLength: count)
+        }
+    }
+
+    func writeMultipartForm(lineContent: String) {
+        write(data: "\(lineContent)\(multipartFormDataLineBreak)".data(using: .utf8)!)
+    }
+
+    func writeMultipartFormLineBreak() {
+        write(data: multipartFormDataLineBreak.data(using: .utf8)!)
+    }
+
+    func writeMultipartFormHeader(name: String, value: String) {
+        writeMultipartForm(lineContent: "\(name): \(value)")
+    }
+
+    func writeMultipartForm(boundary: String, isEnd: Bool) {
+        if isEnd {
+            writeMultipartForm(lineContent: "--\(boundary)--")
+        } else {
+            writeMultipartForm(lineContent: "--\(boundary)")
+        }
+    }
+}

--- a/native/swift/Sources/wordpress-api/MultipartForm.swift
+++ b/native/swift/Sources/wordpress-api/MultipartForm.swift
@@ -73,17 +73,21 @@ struct MultipartFormField {
 }
 
 extension Array where Element == MultipartFormField {
-    private func multipartFormDestination(forceWriteToFile: Bool) throws -> (outputStream: OutputStream, tempFilePath: String?) {
+    private func multipartFormDestination(
+        forceWriteToFile: Bool
+    ) throws -> (outputStream: OutputStream, tempFilePath: String?) {
         let dest: OutputStream
         let tempFilePath: String?
 
-        // Build the form data in memory if the content is estimated to be less than 10 MB. Otherwise, use a temporary file.
+        // Build the form data in memory if the content is estimated to be less than 10 MB.
+        // Otherwise, use a temporary file.
         let thresholdBytesForUsingTmpFile = 10_000_000
         let estimatedFormDataBytes = reduce(0) { $0 + $1.bytes }
         if forceWriteToFile || estimatedFormDataBytes > thresholdBytesForUsingTmpFile {
             let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
             guard let stream = OutputStream(toFileAtPath: tempFile, append: false) else {
-                // This error should never occurr, because the `tempFile` is in a temporary directory and is guranteed to be writable.
+                // This error should never occurr, because the `tempFile` is in a temporary directory
+                // and is guranteed to be writable.
                 throw MultipartFormError.impossible
             }
             dest = stream

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -45,7 +45,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         await perform(request)
     }
 
-    public func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
+    public func uploadMedia(
+        mediaUploadRequest: MediaUploadRequest
+    ) async -> Result<WpNetworkResponse, RequestExecutionError> {
         await perform(mediaUploadRequest)
     }
 

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -7,7 +7,9 @@ import FoundationNetworking
 
 public protocol SafeRequestExecutor: RequestExecutor, Sendable {
     func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError>
+    func uploadMedia(
+        mediaUploadRequest: MediaUploadRequest
+    ) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError>
 }
 
 extension SafeRequestExecutor {
@@ -52,7 +54,11 @@ public final class WpRequestExecutor: SafeRequestExecutor {
             .mapError { error in
                 switch error {
                 case let .RequestExecutionFailed(statusCode, redirects, reason):
-                    MediaUploadRequestExecutionError.RequestExecutionFailed(statusCode: statusCode, redirects: redirects, reason: reason)
+                    MediaUploadRequestExecutionError.RequestExecutionFailed(
+                        statusCode: statusCode,
+                        redirects: redirects,
+                        reason: reason
+                    )
                 }
             }
     }

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -7,7 +7,7 @@ import FoundationNetworking
 
 public protocol SafeRequestExecutor: RequestExecutor, Sendable {
     func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
+    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError>
 }
 
 extension SafeRequestExecutor {
@@ -47,8 +47,14 @@ public final class WpRequestExecutor: SafeRequestExecutor {
 
     public func uploadMedia(
         mediaUploadRequest: MediaUploadRequest
-    ) async -> Result<WpNetworkResponse, RequestExecutionError> {
-        await perform(mediaUploadRequest)
+    ) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError> {
+        (await perform(mediaUploadRequest))
+            .mapError { error in
+                switch error {
+                case let .RequestExecutionFailed(statusCode, redirects, reason):
+                    MediaUploadRequestExecutionError.RequestExecutionFailed(statusCode: statusCode, redirects: redirects, reason: reason)
+                }
+            }
     }
 
     func perform(_ request: NetworkRequestContent) async -> Result<WpNetworkResponse, RequestExecutionError> {

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -7,11 +7,17 @@ import FoundationNetworking
 
 public protocol SafeRequestExecutor: RequestExecutor, Sendable {
     func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
+    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError>
 }
 
 extension SafeRequestExecutor {
     public func execute(request: WpNetworkRequest) async throws -> WpNetworkResponse {
         let result = await execute(request)
+        return try result.get()
+    }
+
+    public func uploadMedia(mediaUploadRequest: MediaUploadRequest) async throws -> WpNetworkResponse {
+        let result = await uploadMedia(mediaUploadRequest: mediaUploadRequest)
         return try result.get()
     }
 }
@@ -36,8 +42,16 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     public func execute(_ request: WpNetworkRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
+        await perform(request)
+    }
+
+    public func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
+        await perform(mediaUploadRequest)
+    }
+
+    func perform(_ request: NetworkRequestContent) async -> Result<WpNetworkResponse, RequestExecutionError> {
         do {
-            var urlrequest = request.asURLRequest()
+            var urlrequest = try request.buildURLRequest()
 
             // Set the user agent before `additionalHttpHeadersForAllRequests` so that it can be overridden that way
             urlrequest.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
@@ -80,7 +94,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
 
     private func handleHttpsError(
         _ error: Error,
-        for request: WpNetworkRequest
+        for request: NetworkRequestContent
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
 
         guard
@@ -101,7 +115,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
              redirects: executorDelegate.redirects(for: request.requestId()),
              reason: RequestExecutionErrorReason.invalidSslError(
                 reason: .certificateNotValidForName(
-                    hostname: request.asURLRequest().url?.host ?? "unknown host",
+                    hostname: URL(string: request.url())?.host ?? "unknown host",
                     presentedHostnames: [siteCertificate.commonName()]
                 )
              )
@@ -110,7 +124,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
 
     func handleNonExistentSiteError(
         _ error: Error,
-        for request: WpNetworkRequest
+        for request: NetworkRequestContent
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
         .failure(
             .RequestExecutionFailed(
@@ -122,10 +136,6 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 )
             )
         )
-    }
-
-    public func uploadMedia(mediaUploadRequest: MediaUploadRequest) async throws -> WpNetworkResponse {
-        preconditionFailure("Not implemented yet")
     }
 
     public func sleep(millis: UInt64) async {
@@ -242,4 +252,52 @@ extension URLRequest {
     var requestId: String? {
         allHTTPHeaderFields?["X-REQUEST-ID"]
     }
+}
+
+protocol NetworkRequestContent {
+    func requestId() -> String
+    func method() -> RequestMethod
+    func url() -> WpEndpointUrl
+    func headerMap() -> WpNetworkHeaderMap
+    func encodeBody(into request: inout URLRequest) throws
+}
+
+extension NetworkRequestContent {
+    func buildURLRequest() throws -> URLRequest {
+        let url = URL(string: self.url())!
+        var request = URLRequest(url: url)
+        request.httpMethod = self.method().rawValue
+        request.allHTTPHeaderFields = self.headerMap().toFlatMap()
+        request.allHTTPHeaderFields?["X-REQUEST-ID"] = self.requestId()
+        try self.encodeBody(into: &request)
+        return request
+    }
+}
+
+extension WpNetworkRequest: NetworkRequestContent {
+
+    func encodeBody(into request: inout URLRequest) throws {
+        if let body = self.body()?.contents() {
+            request.httpBody = body
+        }
+    }
+
+}
+
+extension MediaUploadRequest: NetworkRequestContent {
+
+    func encodeBody(into request: inout URLRequest) throws {
+        var form = [MultipartFormField]()
+        for (name, value) in mediaParams() {
+            form.append(.init(text: value, name: name))
+        }
+        try form.append(.init(fileAtPath: filePath(), name: "file"))
+
+        let boundery = String(format: "wordpressrs.%08x", Int.random(in: Int.min..<Int.max))
+        request.setValue("multipart/form-data; boundary=\(boundery)", forHTTPHeaderField: "Content-Type")
+        request.httpBodyStream = try form
+            .multipartFormDataStream(boundary: boundery, forceWriteToFile: false)
+            .asInputStream()
+    }
+
 }

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -111,16 +111,6 @@ public extension WpNetworkHeaderMap {
 
 public extension WpNetworkRequest {
 
-    func asURLRequest() -> URLRequest {
-        let url = URL(string: self.url())!
-        var request = URLRequest(url: url)
-        request.httpMethod = self.method().rawValue
-        request.allHTTPHeaderFields = self.headerMap().toFlatMap()
-        request.allHTTPHeaderFields?["X-REQUEST-ID"] = self.requestId()
-        request.httpBody = self.body()?.contents()
-        return request
-    }
-
     #if DEBUG
     func debugPrint() {
         print("\(method().rawValue) \(self.url())")

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -42,7 +42,9 @@ final class HTTPStubs: SafeRequestExecutor {
         }
     }
 
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError> {
+    func uploadMedia(
+        mediaUploadRequest: MediaUploadRequest
+    ) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError> {
         preconditionFailure("This method is not yet implemented")
     }
 

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -41,7 +41,7 @@ final class HTTPStubs: SafeRequestExecutor {
         }
     }
 
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async throws -> WpNetworkResponse {
+    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
         preconditionFailure("This method is not yet implemented")
     }
 

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressAPI
+import WordPressAPIInternal
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -41,7 +42,7 @@ final class HTTPStubs: SafeRequestExecutor {
         }
     }
 
-    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, RequestExecutionError> {
+    func uploadMedia(mediaUploadRequest: MediaUploadRequest) async -> Result<WpNetworkResponse, MediaUploadRequestExecutionError> {
         preconditionFailure("This method is not yet implemented")
     }
 


### PR DESCRIPTION
The majority of the diff is from `MultipartForm.swift`, which is copied (with a small modification) from [WordPressKit](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/40a984ddc1f6775052f81b82565c1fb01d8198c5/Sources/CoreAPI/MultipartForm.swift).

I have added a `request_id` to the `MediaUploadRequest` struct, to make it consistent with the `WpNetworkRequest`: all HTTP requests should have the `X-Request-Id` header. This property can be useful to track media uploading progress, which will be implemented in a separate PR.