### PR TITLE
Introduces `NetworkRequestAccessor` trait

### DIFF
--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -173,11 +173,6 @@ pub struct WpNetworkRequest {
 
 #[uniffi::export]
 impl WpNetworkRequest {
-    /// Unique identifier for this request – used for external record-keeping
-    pub fn request_id(&self) -> String {
-        self.uuid.clone()
-    }
-
     /// Clones the request and increments the retry count
     pub fn clone_with_incremented_retry_count(&self) -> Self {
         Self {
@@ -276,6 +271,19 @@ impl Debug for WpNetworkRequest {
         );
         s.pop(); // Remove the new line at the end
         write!(f, "{}", s)
+    }
+}
+
+/// Unique identifier for this request – used for external record-keeping
+#[uniffi::export(with_foreign)]
+pub trait HasNetworkRequestId: Send + Sync {
+    fn request_id(&self) -> String;
+}
+
+#[uniffi::export]
+impl HasNetworkRequestId for WpNetworkRequest {
+    fn request_id(&self) -> String {
+        self.uuid.clone()
     }
 }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -190,18 +190,6 @@ impl WpNetworkRequest {
         self.retry_count
     }
 
-    pub fn method(&self) -> RequestMethod {
-        self.method.clone()
-    }
-
-    pub fn url(&self) -> WpEndpointUrl {
-        self.url.clone()
-    }
-
-    pub fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
-        self.header_map.clone()
-    }
-
     pub fn body(&self) -> Option<Arc<WpNetworkRequestBody>> {
         self.body.clone()
     }
@@ -276,14 +264,29 @@ impl Debug for WpNetworkRequest {
 
 /// Unique identifier for this request – used for external record-keeping
 #[uniffi::export(with_foreign)]
-pub trait HasNetworkRequestId: Send + Sync {
+pub trait NetworkRequestDescriptor: Send + Sync {
     fn request_id(&self) -> String;
+    fn method(&self) -> RequestMethod;
+    fn url(&self) -> WpEndpointUrl;
+    fn header_map(&self) -> Arc<WpNetworkHeaderMap>;
 }
 
 #[uniffi::export]
-impl HasNetworkRequestId for WpNetworkRequest {
+impl NetworkRequestDescriptor for WpNetworkRequest {
     fn request_id(&self) -> String {
         self.uuid.clone()
+    }
+
+    fn method(&self) -> RequestMethod {
+        self.method.clone()
+    }
+
+    fn url(&self) -> WpEndpointUrl {
+        self.url.clone()
+    }
+
+    fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
+        self.header_map.clone()
     }
 }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -264,7 +264,7 @@ impl Debug for WpNetworkRequest {
 
 /// Unique identifier for this request – used for external record-keeping
 #[uniffi::export(with_foreign)]
-pub trait NetworkRequestDescriptor: Send + Sync {
+pub trait NetworkRequestAccessor: Send + Sync {
     fn request_id(&self) -> String;
     fn method(&self) -> RequestMethod;
     fn url(&self) -> WpEndpointUrl;
@@ -272,7 +272,7 @@ pub trait NetworkRequestDescriptor: Send + Sync {
 }
 
 #[uniffi::export]
-impl NetworkRequestDescriptor for WpNetworkRequest {
+impl NetworkRequestAccessor for WpNetworkRequest {
     fn request_id(&self) -> String {
         self.uuid.clone()
     }

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -9,11 +9,12 @@ use crate::{
         SparseMediaFieldWithViewContext,
     },
     request::{
-        CONTENT_TYPE_MULTIPART, ParsedResponse, RequestMethod, WpNetworkHeaderMap,
-        WpNetworkResponse,
+        CONTENT_TYPE_MULTIPART, HasNetworkRequestId, ParsedResponse, RequestMethod,
+        WpNetworkHeaderMap, WpNetworkResponse,
     },
 };
 use http::HeaderValue;
+use uuid::Uuid;
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -119,6 +120,7 @@ fn parse_as_media_request_create_response(
 
 #[derive(uniffi::Object)]
 pub struct MediaUploadRequest {
+    pub(crate) uuid: String,
     pub(crate) method: RequestMethod,
     pub(crate) url: WpEndpointUrl,
     pub(crate) header_map: Arc<WpNetworkHeaderMap>,
@@ -180,6 +182,13 @@ impl std::fmt::Debug for MediaUploadRequest {
 }
 
 #[uniffi::export]
+impl HasNetworkRequestId for MediaUploadRequest {
+    fn request_id(&self) -> String {
+        self.uuid.clone()
+    }
+}
+
+#[uniffi::export]
 impl MediaRequestBuilder {
     pub fn create(
         &self,
@@ -193,6 +202,7 @@ impl MediaRequestBuilder {
             HeaderValue::from_static(CONTENT_TYPE_MULTIPART),
         );
         MediaUploadRequest {
+            uuid: Uuid::new_v4().into(),
             method: RequestMethod::POST,
             url: self.endpoint.create().into(),
             header_map: header_map.into(),

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -9,7 +9,7 @@ use crate::{
         SparseMediaFieldWithViewContext,
     },
     request::{
-        CONTENT_TYPE_MULTIPART, HasNetworkRequestId, ParsedResponse, RequestMethod,
+        CONTENT_TYPE_MULTIPART, NetworkRequestDescriptor, ParsedResponse, RequestMethod,
         WpNetworkHeaderMap, WpNetworkResponse,
     },
 };
@@ -131,18 +131,6 @@ pub struct MediaUploadRequest {
 
 #[uniffi::export]
 impl MediaUploadRequest {
-    pub fn method(&self) -> RequestMethod {
-        self.method.clone()
-    }
-
-    pub fn url(&self) -> WpEndpointUrl {
-        self.url.clone()
-    }
-
-    pub fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
-        self.header_map.clone()
-    }
-
     pub fn file_path(&self) -> String {
         self.file_path.clone()
     }
@@ -182,9 +170,21 @@ impl std::fmt::Debug for MediaUploadRequest {
 }
 
 #[uniffi::export]
-impl HasNetworkRequestId for MediaUploadRequest {
+impl NetworkRequestDescriptor for MediaUploadRequest {
     fn request_id(&self) -> String {
         self.uuid.clone()
+    }
+
+    fn method(&self) -> RequestMethod {
+        self.method.clone()
+    }
+
+    fn url(&self) -> WpEndpointUrl {
+        self.url.clone()
+    }
+
+    fn header_map(&self) -> Arc<WpNetworkHeaderMap> {
+        self.header_map.clone()
     }
 }
 

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -9,7 +9,7 @@ use crate::{
         SparseMediaFieldWithViewContext,
     },
     request::{
-        CONTENT_TYPE_MULTIPART, NetworkRequestDescriptor, ParsedResponse, RequestMethod,
+        CONTENT_TYPE_MULTIPART, NetworkRequestAccessor, ParsedResponse, RequestMethod,
         WpNetworkHeaderMap, WpNetworkResponse,
     },
 };
@@ -170,7 +170,7 @@ impl std::fmt::Debug for MediaUploadRequest {
 }
 
 #[uniffi::export]
-impl NetworkRequestDescriptor for MediaUploadRequest {
+impl NetworkRequestAccessor for MediaUploadRequest {
     fn request_id(&self) -> String {
         self.uuid.clone()
     }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -2,8 +2,9 @@ use crate::{
     MediaUploadRequestExecutionError, RequestExecutionError, RequestExecutionErrorReason,
     api_error::InvalidSslErrorReason,
     request::{
-        RequestExecutor, RequestMethod, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
-        endpoint::media_endpoint::MediaUploadRequest, user_agent,
+        NetworkRequestDescriptor, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
+        WpNetworkRequest, WpNetworkResponse, endpoint::media_endpoint::MediaUploadRequest,
+        user_agent,
     },
 };
 use async_trait::async_trait;

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -2,7 +2,7 @@ use crate::{
     MediaUploadRequestExecutionError, RequestExecutionError, RequestExecutionErrorReason,
     api_error::InvalidSslErrorReason,
     request::{
-        NetworkRequestDescriptor, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
+        NetworkRequestAccessor, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
         WpNetworkRequest, WpNetworkResponse, endpoint::media_endpoint::MediaUploadRequest,
         user_agent,
     },

--- a/wp_api_integration_tests/tests/test_app_notifier_immut.rs
+++ b/wp_api_integration_tests/tests/test_app_notifier_immut.rs
@@ -10,7 +10,7 @@ use wp_api::{
     auth::WpAuthenticationProvider,
     middleware::WpApiMiddlewarePipeline,
     request::{
-        NetworkRequestDescriptor, RequestExecutor, WpNetworkRequest, WpNetworkResponse,
+        NetworkRequestAccessor, RequestExecutor, WpNetworkRequest, WpNetworkResponse,
         endpoint::media_endpoint::MediaUploadRequest,
     },
     reqwest_request_executor::ReqwestRequestExecutor,

--- a/wp_api_integration_tests/tests/test_app_notifier_immut.rs
+++ b/wp_api_integration_tests/tests/test_app_notifier_immut.rs
@@ -10,7 +10,7 @@ use wp_api::{
     auth::WpAuthenticationProvider,
     middleware::WpApiMiddlewarePipeline,
     request::{
-        RequestExecutor, WpNetworkRequest, WpNetworkResponse,
+        NetworkRequestDescriptor, RequestExecutor, WpNetworkRequest, WpNetworkResponse,
         endpoint::media_endpoint::MediaUploadRequest,
     },
     reqwest_request_executor::ReqwestRequestExecutor,

--- a/wp_api_integration_tests/tests/test_login_remote.rs
+++ b/wp_api_integration_tests/tests/test_login_remote.rs
@@ -14,7 +14,7 @@ use wp_api::{
         ApiDiscoveryAuthenticationMiddleware, RetryAfterMiddleware, WpApiMiddleware,
         WpApiMiddlewarePipeline,
     },
-    request::{NetworkRequestDescriptor, RequestExecutor},
+    request::{NetworkRequestAccessor, RequestExecutor},
     reqwest_request_executor::ReqwestRequestExecutor,
 };
 use wp_api_integration_tests::mock::{MockExecutor, response_helpers};

--- a/wp_api_integration_tests/tests/test_login_remote.rs
+++ b/wp_api_integration_tests/tests/test_login_remote.rs
@@ -14,7 +14,7 @@ use wp_api::{
         ApiDiscoveryAuthenticationMiddleware, RetryAfterMiddleware, WpApiMiddleware,
         WpApiMiddlewarePipeline,
     },
-    request::RequestExecutor,
+    request::{NetworkRequestDescriptor, RequestExecutor},
     reqwest_request_executor::ReqwestRequestExecutor,
 };
 use wp_api_integration_tests::mock::{MockExecutor, response_helpers};

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -10,8 +10,8 @@ use wp_api::{
     middleware::WpApiMiddlewarePipeline,
     posts::WpApiParamPostsOrderBy,
     request::{
-        RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest, WpNetworkResponse,
-        endpoint::media_endpoint::MediaUploadRequest,
+        NetworkRequestDescriptor, RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest,
+        WpNetworkResponse, endpoint::media_endpoint::MediaUploadRequest,
     },
     reqwest_request_executor::ReqwestRequestExecutor,
     users::UserId,

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -10,7 +10,7 @@ use wp_api::{
     middleware::WpApiMiddlewarePipeline,
     posts::WpApiParamPostsOrderBy,
     request::{
-        NetworkRequestDescriptor, RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest,
+        NetworkRequestAccessor, RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest,
         WpNetworkResponse, endpoint::media_endpoint::MediaUploadRequest,
     },
     reqwest_request_executor::ReqwestRequestExecutor,


### PR DESCRIPTION
The trait is implemented by both `WpNetworkRequest` and `MediaUploadRequest` to offer a way to generalize some implementation logic in the client/wrapper side. We might end up using it in Rust as well, but I haven't looked into it in detail yet as this PR is mostly to help with Swift.