### PR TITLE
Map api discovery result to a Kotlin sealed class

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.ApplicationPasswordsDisabledForHttpSite
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.SiteIsLocalDevelopmentEnvironment
-import uniffi.wp_api.AutoDiscoveryAttemptFailure
 import uniffi.wp_api.AutoDiscoveryAttemptSuccess
 import uniffi.wp_api.FetchAndParseApiRootFailure
 import uniffi.wp_api.FindApiRootFailure

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -10,15 +10,16 @@ import uniffi.wp_api.RetryAfterMiddleware
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpNetworkResponse
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.ApplicationPasswordsDisabledForHttpSite
 import uniffi.wp_api.ApplicationPasswordsNotSupportedReason.SiteIsLocalDevelopmentEnvironment
 import uniffi.wp_api.AutoDiscoveryAttemptFailure
+import uniffi.wp_api.AutoDiscoveryAttemptSuccess
 import uniffi.wp_api.FetchAndParseApiRootFailure
 import uniffi.wp_api.FindApiRootFailure
 import uniffi.wp_api.InvalidSslErrorReason
+import uniffi.wp_api.ParseUrlException
 import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.RequestExecutionException
 import kotlin.test.assertContains
@@ -31,7 +32,8 @@ class ApiUrlDiscoveryTest {
     fun testValidSiteWorksCorrectly() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://vanilla.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -58,25 +60,24 @@ class ApiUrlDiscoveryTest {
             )
         )
 
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            val client = WpLoginClient(executor)
-            client.apiDiscovery("http://localhost").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getApplicationPasswordsNotSupportedReason(e)
-            assertInstanceOf(SiteIsLocalDevelopmentEnvironment::class.java, reason)
-        }
+        val client = WpLoginClient(executor)
+        val reason = client.apiDiscovery("http://localhost").assertFailureFetchAndParseApiRoot()
+            .getApplicationPasswordsNotSupportedReason()
+        assertInstanceOf(SiteIsLocalDevelopmentEnvironment::class.java, reason)
     }
 
     @Test // Spec Example 3
     fun testAdminUrlProvided() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-login.php").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-login.php")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-admin").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://vanilla.wpmt.co/wp-admin")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -84,25 +85,24 @@ class ApiUrlDiscoveryTest {
     fun testAutoHttpsSupport() = runTest {
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("http://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("http://vanilla.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 5
     fun testHttpOnlySite() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("http://no-https.wpmt.co").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getApplicationPasswordsNotSupportedReason(e)
-            assertInstanceOf(ApplicationPasswordsDisabledForHttpSite::class.java, reason)
-        }
+        val reason = loginClient.apiDiscovery("http://no-https.wpmt.co").assertFailureFetchAndParseApiRoot()
+            .getApplicationPasswordsNotSupportedReason()
+        assertInstanceOf(ApplicationPasswordsDisabledForHttpSite::class.java, reason)
     }
 
     @Test // Spec Example 6
     fun testHttpOnlySiteWithApplicationPasswordsEnabled() = runTest {
         assertEquals(
             "http://no-https-with-application-passwords.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("http://no-https-with-application-passwords.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("http://no-https-with-application-passwords.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -110,42 +110,37 @@ class ApiUrlDiscoveryTest {
     fun testAggressivelyCachedSiteWithNoLinkHeader() = runTest {
         assertEquals(
             "https://aggressive-caching.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://aggressive-caching.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://aggressive-caching.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 8
     fun testSiteWithApplicationPasswordsDisabledByWordFence() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("https://wordfence.wpmt.co").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getApplicationPasswordsNotSupportedReason(e)
-            assertInstanceOf(
-                ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin::class.java,
-                reason
-            )
-
-            val plugin =
-                (reason as ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin).plugin
-            assertEquals(plugin.name, "Wordfence")
-        }
+        val reason = loginClient.apiDiscovery("https://wordfence.wpmt.co")
+            .assertFailureFetchAndParseApiRoot()
+            .getApplicationPasswordsNotSupportedReason()
+        assertInstanceOf(
+            ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin::class.java,
+            reason
+        )
+        val plugin =
+            (reason as ApplicationPasswordsNotSupportedReason.ApplicationPasswordBlockedByPlugin).plugin
+        assertEquals(plugin.name, "Wordfence")
     }
 
     @Test // Spec Example 9
     fun testNotWordPressSite() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("https://google.com").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getFindApiRootFailure(e)
-            assertInstanceOf(FindApiRootFailure.ProbablyNotAWordPressSite::class.java, reason)
-        }
+        val reason = loginClient.apiDiscovery("https://google.com").assertFailureFindApiRoot()
+        assertInstanceOf(FindApiRootFailure.ProbablyNotAWordPressSite::class.java, reason)
     }
 
     @Test // Spec Example 10
     fun testWordPressSubdirectoryWithLinkHeader() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?link_header=true").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?link_header=true")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -153,7 +148,8 @@ class ApiUrlDiscoveryTest {
     fun testWordPressSubdirectoryWithLinkTag() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://subdirectory.wpmt.co?link_tag=true").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co?link_tag=true")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -161,21 +157,20 @@ class ApiUrlDiscoveryTest {
     fun testWordPressSubdirectoryWithRedirect() = runTest {
         assertEquals(
             "https://subdirectory.wpmt.co/wordpress/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?redirect=true").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://subdirectory.wpmt.co/index.php?redirect=true")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
     @Test // Spec Example 13 (with no credentials)
     fun testWordPressHttpBasicWithMissingCredentials() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(
-                RequestExecutionErrorReason.HttpAuthenticationRequiredError::class.java,
-                reason
-            )
-        }
+        val reason =
+            loginClient.apiDiscovery("https://basic-auth.wpmt.co").assertFailureFindApiRoot()
+                .getRequestExecutionErrorReason()
+        assertInstanceOf(
+            RequestExecutionErrorReason.HttpAuthenticationRequiredError::class.java,
+            reason
+        )
     }
 
     @Test // Spec Example 13 (with invalid credentials)
@@ -185,15 +180,12 @@ class ApiUrlDiscoveryTest {
         val client = WpLoginClient(
             WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(invalid))
         )
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            client.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(
-                RequestExecutionErrorReason.HttpAuthenticationRejectedError::class.java,
-                reason
-            )
-        }
+        val reason = client.apiDiscovery("https://basic-auth.wpmt.co")
+            .assertFailureFindApiRoot().getRequestExecutionErrorReason()
+        assertInstanceOf(
+            RequestExecutionErrorReason.HttpAuthenticationRejectedError::class.java,
+            reason
+        )
     }
 
     @Test // Spec Example 13 (with valid credentials)
@@ -209,7 +201,8 @@ class ApiUrlDiscoveryTest {
 
         assertEquals(
             "https://basic-auth.wpmt.co/wp-admin/authorize-application.php",
-            client.apiDiscovery("https://basic-auth.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            client.apiDiscovery("https://basic-auth.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -217,7 +210,8 @@ class ApiUrlDiscoveryTest {
     fun testWordPressCustomRestApiPrefix() = runTest {
         assertEquals(
             "https://custom-rest-prefix.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://custom-rest-prefix.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://custom-rest-prefix.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -225,7 +219,8 @@ class ApiUrlDiscoveryTest {
     fun testWordPressHeavyRateLimiting() = runTest {
         assertEquals(
             "https://aggressive-rate-limiting.wpmt.co/wp-admin/authorize-application.php",
-            loginClient.apiDiscovery("https://aggressive-rate-limiting.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            loginClient.apiDiscovery("https://aggressive-rate-limiting.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -242,49 +237,40 @@ class ApiUrlDiscoveryTest {
 
         val middleware = RetryAfterMiddleware(maxRetries = 3u, maxRetryWaitSeconds = 1u)
 
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            val client =
-                WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
-            client.apiDiscovery("https://aggressive-rate-limiting.wpmt.co").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(
-                RequestExecutionErrorReason.MisconfiguredRateLimitError::class.java,
-                reason
-            )
-        }
+        val client =
+            WpLoginClient(executor, WpApiMiddlewarePipeline(middlewares = listOf(middleware)))
+        val reason = client.apiDiscovery("https://aggressive-rate-limiting.wpmt.co")
+            .assertFailureFindApiRoot().getRequestExecutionErrorReason()
+        assertInstanceOf(
+            RequestExecutionErrorReason.MisconfiguredRateLimitError::class.java,
+            reason
+        )
     }
 
     @Test // Spec Example 16
     fun testInvalidUrl() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("https://valid-looking-url-but-not-actually.foo").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(RequestExecutionErrorReason.NonExistentSiteError::class.java, reason)
-        }
+        val reason = loginClient.apiDiscovery("https://valid-looking-url-but-not-actually.foo")
+            .assertFailureFindApiRoot().getRequestExecutionErrorReason()
+        assertInstanceOf(RequestExecutionErrorReason.NonExistentSiteError::class.java, reason)
     }
 
     @Test // Spec Example 17
     fun testInvalidHTTPsFails() = runTest {
-        assertFailsWith<AutoDiscoveryAttemptFailure>() {
-            loginClient.apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com").applicationPasswordsAuthenticationUrl.url()
-        }.let { e ->
-            val reason = getRequestExecutionErrorReason(e)
-            assertInstanceOf(RequestExecutionErrorReason.InvalidSslError::class.java, reason)
+        val reason = loginClient.apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com")
+            .assertFailureFindApiRoot().getRequestExecutionErrorReason()
+        assertInstanceOf(RequestExecutionErrorReason.InvalidSslError::class.java, reason)
 
-            val sslError = (reason as RequestExecutionErrorReason.InvalidSslError).reason
-            assertInstanceOf(
-                InvalidSslErrorReason.CertificateNotValidForName::class.java,
-                sslError
-            )
+        val sslError = (reason as RequestExecutionErrorReason.InvalidSslError).reason
+        assertInstanceOf(
+            InvalidSslErrorReason.CertificateNotValidForName::class.java,
+            sslError
+        )
 
-            val hostname = (sslError as InvalidSslErrorReason.CertificateNotValidForName).hostname
-            val presentedHostnames = sslError.presentedHostnames
+        val hostname = (sslError as InvalidSslErrorReason.CertificateNotValidForName).hostname
+        val presentedHostnames = sslError.presentedHostnames
 
-            assertEquals(hostname, "wordpress-1315525-4803651.cloudwaysapps.com")
-            assertContains(presentedHostnames, "vanilla.wpmt.co")
-        }
+        assertEquals(hostname, "wordpress-1315525-4803651.cloudwaysapps.com")
+        assertContains(presentedHostnames, "vanilla.wpmt.co")
     }
 
     @Test // Spec Example 17 (with exception)
@@ -298,7 +284,8 @@ class ApiUrlDiscoveryTest {
 
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            WpLoginClient(requestExecutor = executor).apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com").applicationPasswordsAuthenticationUrl.url()
+            WpLoginClient(requestExecutor = executor).apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
 
@@ -308,50 +295,54 @@ class ApiUrlDiscoveryTest {
             WpRequestExecutor(httpClient = WpHttpClient.CustomOkHttpClient(client = OkHttpClient()))
         assertEquals(
             "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
-            WpLoginClient(requestExecutor = executor).apiDiscovery("https://vanilla.wpmt.co").applicationPasswordsAuthenticationUrl.url()
+            WpLoginClient(requestExecutor = executor).apiDiscovery("https://vanilla.wpmt.co")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
         )
     }
+}
 
-    private fun getApplicationPasswordsNotSupportedReason(error: AutoDiscoveryAttemptFailure): ApplicationPasswordsNotSupportedReason? {
-        return when (val failure = getFetchAndParseApiRootFailure(error)) {
-            is FetchAndParseApiRootFailure.ApplicationPasswordsNotSupported -> failure.reason
-            else -> null
-        }
+private fun ApiDiscoveryResult.assertSuccess(): AutoDiscoveryAttemptSuccess {
+    assert(this is ApiDiscoveryResult.Success)
+    return (this as ApiDiscoveryResult.Success).success
+}
+
+private fun ApiDiscoveryResult.assertFailureParseSiteUrl(): ParseUrlException {
+    assert(this is ApiDiscoveryResult.FailureParseSiteUrl)
+    return (this as ApiDiscoveryResult.FailureParseSiteUrl).error
+}
+
+private fun ApiDiscoveryResult.assertFailureFindApiRoot(): FindApiRootFailure {
+    assert(this is ApiDiscoveryResult.FailureFindApiRoot)
+    return (this as ApiDiscoveryResult.FailureFindApiRoot).findApiRootFailure
+}
+
+private fun ApiDiscoveryResult.assertFailureFetchAndParseApiRoot(): FetchAndParseApiRootFailure {
+    assert(this is ApiDiscoveryResult.FailureFetchAndParseApiRoot)
+    return (this as ApiDiscoveryResult.FailureFetchAndParseApiRoot).fetchAndParseApiRootFailure
+}
+
+private fun FetchAndParseApiRootFailure.getApplicationPasswordsNotSupportedReason(): ApplicationPasswordsNotSupportedReason? {
+    return when (this) {
+        is FetchAndParseApiRootFailure.ApplicationPasswordsNotSupported -> this.reason
+        else -> null
+    }
+}
+
+private fun FindApiRootFailure.getRequestExecutionErrorReason(): RequestExecutionErrorReason? =
+    when (this) {
+        is FindApiRootFailure.FetchHomepage -> this.error.reason()
+        else -> null
     }
 
-    private fun getFetchAndParseApiRootFailure(error: AutoDiscoveryAttemptFailure): FetchAndParseApiRootFailure? {
-        return when (error) {
-            is AutoDiscoveryAttemptFailure.FetchAndParseApiRoot -> error.fetchAndParseApiRootFailure
-            else -> null
-        }
+private fun FetchAndParseApiRootFailure.getRequestExecutionErrorReason(): RequestExecutionErrorReason? =
+    when (this) {
+        is FetchAndParseApiRootFailure.FetchApiRoot -> this.error.reason()
+        else -> null
     }
 
-    private fun getFindApiRootFailure(error: AutoDiscoveryAttemptFailure): FindApiRootFailure? {
-        return when (error) {
-            is AutoDiscoveryAttemptFailure.FindApiRoot -> error.findApiRootFailure
-            else -> null
-        }
+private fun RequestExecutionException.reason(): RequestExecutionErrorReason? {
+    return when (this) {
+        is RequestExecutionException.RequestExecutionFailed -> this.reason
+        else -> null
     }
-
-    private fun getRequestExecutionErrorReason(error: AutoDiscoveryAttemptFailure): RequestExecutionErrorReason? {
-        when (val failure = getFindApiRootFailure(error)) {
-            is FindApiRootFailure.FetchHomepage -> return extract(failure.error)
-            else -> {}
-        }
-
-        when (val failure = getFetchAndParseApiRootFailure(error)) {
-            is FetchAndParseApiRootFailure.FetchApiRoot -> return extract(failure.error)
-            else -> {}
-        }
-
-        return null
-    }
-
-    private fun extract(error: RequestExecutionException): RequestExecutionErrorReason? {
-        return when (error) {
-            is RequestExecutionException.RequestExecutionFailed -> error.reason
-            else -> null
-        }
-    }
-
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiDiscoveryResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiDiscoveryResult.kt
@@ -1,0 +1,23 @@
+package rs.wordpress.api.kotlin
+
+import uniffi.wp_api.AutoDiscoveryAttemptSuccess
+import uniffi.wp_api.FetchAndParseApiRootFailure
+import uniffi.wp_api.FindApiRootFailure
+import uniffi.wp_api.ParseUrlException
+import uniffi.wp_api.ParsedUrl
+
+sealed class ApiDiscoveryResult {
+    data class Success(val success: AutoDiscoveryAttemptSuccess) : ApiDiscoveryResult()
+    data class FailureParseSiteUrl(
+        val error: ParseUrlException
+    ) : ApiDiscoveryResult()
+    data class FailureFindApiRoot(
+        val parsedSiteUrl: ParsedUrl,
+        val findApiRootFailure: FindApiRootFailure
+    ) : ApiDiscoveryResult()
+    data class FailureFetchAndParseApiRoot(
+        val parsedSiteUrl: ParsedUrl,
+        val apiRootUrl: ParsedUrl,
+        val fetchAndParseApiRootFailure: FetchAndParseApiRootFailure
+    ) : ApiDiscoveryResult()
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -3,7 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import uniffi.wp_api.AutoDiscoveryAttemptSuccess
+import uniffi.wp_api.AutoDiscoveryAttemptFailure
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpLoginClient
 import uniffi.wp_api.WpApiMiddlewarePipeline
@@ -16,7 +16,28 @@ class WpLoginClient(
     private val internalClient: UniffiWpLoginClient =
         UniffiWpLoginClient(requestExecutor, middlewarePipeline)
 
-    suspend fun apiDiscovery(siteUrl: String): AutoDiscoveryAttemptSuccess = withContext(dispatcher) {
-        internalClient.apiDiscovery(siteUrl)
+    suspend fun apiDiscovery(
+        siteUrl: String
+    ): ApiDiscoveryResult = withContext(dispatcher) {
+        try {
+            val success = internalClient.apiDiscovery(siteUrl)
+            ApiDiscoveryResult.Success(success)
+        } catch (exception: AutoDiscoveryAttemptFailure) {
+            when (exception) {
+                is AutoDiscoveryAttemptFailure.ParseSiteUrl -> ApiDiscoveryResult.FailureParseSiteUrl(
+                    error = exception.error,
+                )
+                is AutoDiscoveryAttemptFailure.FindApiRoot -> ApiDiscoveryResult.FailureFindApiRoot(
+                    parsedSiteUrl = exception.parsedSiteUrl,
+                    findApiRootFailure = exception.findApiRootFailure,
+                )
+
+                is AutoDiscoveryAttemptFailure.FetchAndParseApiRoot -> ApiDiscoveryResult.FailureFetchAndParseApiRoot(
+                    parsedSiteUrl = exception.parsedSiteUrl,
+                    apiRootUrl = exception.apiRootUrl,
+                    fetchAndParseApiRootFailure = exception.fetchAndParseApiRootFailure
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
Maps api discovery result to a Kotlin sealed class to make it easier to work with it without consulting the documentation. It replaces some of the helpers in the Kotlin api discovery tests with simpler alternatives that's now possible with the new result type.

Note that I am still not quite sure whether we should use a sealed class or a [Kotlin Result type](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-result/) for this. Both approaches have advantages and disadvantages, so my hope is that we'll find what we prefer as we work in clients such as WordPress-Android.