### PR TITLE
Delete `/templates` endpoint

### DIFF
--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -95,6 +95,7 @@ create_test_credentials () {
   local PASSWORD_PROTECTED_COMMENT_AUTHOR
   local FIRST_POST_DATE_GMT
   local WORDPRESS_VERSION
+  local INTEGRATION_TEST_CUSTOM_TEMPLATE_ID
   SITE_URL="http://localhost"
   ADMIN_USERNAME="test@example.com"
   ADMIN_PASSWORD="$(wp user application-password create test@example.com test --porcelain)"
@@ -115,8 +116,14 @@ create_test_credentials () {
 
   WORDPRESS_VERSION="$(wp core version)"
 
+  INTEGRATION_TEST_CUSTOM_TEMPLATE_SLUG="integration_test_custom_template"
+
   # Trash the post
   wp post delete "$TRASHED_POST_ID"
+
+  # Create a custom template
+  curl --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d '{"slug":"INTEGRATION_TEST_CUSTOM_TEMPLATE", "content": "Integration test custom template content"}' http://localhost/wp-json/wp/v2/templates
+  INTEGRATION_TEST_CUSTOM_TEMPLATE_ID="twentytwentyfour//integration_test_custom_template"
 
   rm -rf /app/test_credentials.json
   jo -p \
@@ -137,6 +144,7 @@ create_test_credentials () {
     trashed_post_id="$TRASHED_POST_ID" \
     first_post_date_gmt="$FIRST_POST_DATE_GMT" \
     wordpress_core_version="\"$WORDPRESS_VERSION\"" \
+    integration_test_custom_template_id="$INTEGRATION_TEST_CUSTOM_TEMPLATE_ID" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -260,6 +260,8 @@ pub enum WpErrorCode {
     InvalidField,
     #[serde(rename = "rest_invalid_param")]
     InvalidParam,
+    #[serde(rename = "rest_invalid_template")]
+    InvalidTemplate,
     #[serde(rename = "rest_no_search_term_defined")]
     NoSearchTermDefined,
     #[serde(rename = "rest_orderby_include_missing_include")]
@@ -274,6 +276,10 @@ pub enum WpErrorCode {
     PostInvalidPageNumber,
     #[serde(rename = "rest_taxonomy_invalid")]
     TaxonomyInvalid,
+    #[serde(rename = "rest_template_already_trashed")]
+    TemplateAlreadyTrashed,
+    #[serde(rename = "rest_template_not_found")]
+    TemplateNotFound,
     #[serde(rename = "rest_term_invalid")]
     TermInvalid,
     #[serde(rename = "rest_theme_not_found")]

--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -12,9 +12,21 @@ enum TemplatesRequest {
     List,
     #[contextual_get(url = "/templates/<template_id>", output = crate::templates::SparseTemplate, filter_by = crate::templates::SparseTemplateField)]
     Retrieve,
+    #[delete(url = "/templates/<template_id>", output = crate::templates::TemplateDeleteResponse)]
+    Delete,
+    #[delete(url = "/templates/<template_id>", output = crate::templates::TemplateWithEditContext)]
+    Trash,
 }
 
 impl DerivedRequest for TemplatesRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            TemplatesRequest::Delete => vec![("force", true.to_string())],
+            TemplatesRequest::Trash => vec![("force", false.to_string())],
+            _ => vec![],
+        }
+    }
+
     fn namespace() -> impl AsNamespace {
         WpNamespace::WpV2
     }
@@ -160,6 +172,22 @@ mod tests {
         validate_wp_v2_endpoint(
             endpoint.filter_retrieve_with_view_context(&TemplateId("foo".to_string()), fields),
             expected_path,
+        );
+    }
+
+    #[rstest]
+    fn delete_template(endpoint: TemplatesRequestEndpoint) {
+        validate_wp_v2_endpoint(
+            endpoint.delete(&TemplateId("foo".to_string())),
+            "/templates/foo?force=true",
+        );
+    }
+
+    #[rstest]
+    fn trash_template(endpoint: TemplatesRequestEndpoint) {
+        validate_wp_v2_endpoint(
+            endpoint.trash(&TemplateId("foo".to_string())),
+            "/templates/foo?force=false",
         );
     }
 

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -161,7 +161,12 @@ pub struct SparseTemplate {
     #[WpContext(edit, embed, view)]
     pub author: Option<UserId>,
     #[WpContext(edit, view)]
-    pub modified: Option<bool>,
+    #[WpContextualOption]
+    #[serde(
+        default,
+        deserialize_with = "wp_serde_helper::deserialize_false_or_string"
+    )]
+    pub modified: Option<String>,
     #[WpContext(edit, view, embed)]
     pub is_custom: Option<bool>,
     #[WpContext(edit, view, embed)]

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -196,3 +196,9 @@ pub struct SparseTemplateTitle {
     pub raw: Option<String>,
     pub rendered: Option<String>,
 }
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct TemplateDeleteResponse {
+    pub deleted: bool,
+    pub previous: TemplateWithEditContext,
+}

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -45,6 +45,7 @@ pub enum TemplateStatus {
     Private,
     #[default]
     Publish,
+    Trash,
     #[serde(untagged)]
     #[strum(default)]
     Custom(String),

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -40,6 +40,7 @@ pub struct TestCredentials {
     pub trashed_post_id: i64,
     pub first_post_date_gmt: &'static str,
     pub wordpress_core_version: &'static str,
+    pub integration_test_custom_template_id: &'static str,
 }
 
 impl TestCredentials {
@@ -80,7 +81,6 @@ pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
-pub const TEMPLATE_CUSTOM: &str = "CustomTemplateToBeUsedInIntegrationTests";
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -80,6 +80,7 @@ pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
+pub const TEMPLATE_CUSTOM: &str = "CustomTemplateToBeUsedInIntegrationTests";
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(

--- a/wp_api_integration_tests/tests/test_templates_err.rs
+++ b/wp_api_integration_tests/tests/test_templates_err.rs
@@ -1,0 +1,23 @@
+use serial_test::parallel;
+use wp_api::{WpErrorCode, templates::TemplateId};
+use wp_api_integration_tests::{AssertWpError, TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE, api_client};
+
+#[tokio::test]
+#[parallel]
+async fn delete_template_err_invalid_template() {
+    api_client()
+        .templates()
+        .delete(&TemplateId(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE.to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::InvalidTemplate)
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_template_err_template_not_found() {
+    api_client()
+        .templates()
+        .delete(&TemplateId("foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::TemplateNotFound)
+}

--- a/wp_api_integration_tests/tests/test_templates_mut.rs
+++ b/wp_api_integration_tests/tests/test_templates_mut.rs
@@ -1,13 +1,17 @@
 use serial_test::serial;
 use wp_api::templates::TemplateId;
-use wp_api_integration_tests::{TEMPLATE_CUSTOM, api_client, backend::RestoreServer};
+use wp_api_integration_tests::{TestCredentials, api_client, backend::RestoreServer};
 
 #[tokio::test]
 #[serial]
 async fn delete_template() {
     let template_delete_response = api_client()
         .templates()
-        .delete(&TemplateId(TEMPLATE_CUSTOM.to_string()))
+        .delete(&TemplateId(
+            TestCredentials::instance()
+                .integration_test_custom_template_id
+                .to_string(),
+        ))
         .await;
     assert!(
         template_delete_response.is_ok(),

--- a/wp_api_integration_tests/tests/test_templates_mut.rs
+++ b/wp_api_integration_tests/tests/test_templates_mut.rs
@@ -1,5 +1,5 @@
 use serial_test::serial;
-use wp_api::templates::TemplateId;
+use wp_api::templates::{TemplateId, TemplateStatus};
 use wp_api_integration_tests::{TestCredentials, api_client, backend::RestoreServer};
 
 #[tokio::test]
@@ -19,6 +19,30 @@ async fn delete_template() {
         template_delete_response
     );
     assert!(template_delete_response.unwrap().data.deleted);
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn trash_template() {
+    let template_trash_response = api_client()
+        .templates()
+        .trash(&TemplateId(
+            TestCredentials::instance()
+                .integration_test_custom_template_id
+                .to_string(),
+        ))
+        .await;
+    assert!(
+        template_trash_response.is_ok(),
+        "{:#?}",
+        template_trash_response
+    );
+    assert_eq!(
+        template_trash_response.unwrap().data.status,
+        TemplateStatus::Trash
+    );
 
     RestoreServer::db().await;
 }

--- a/wp_api_integration_tests/tests/test_templates_mut.rs
+++ b/wp_api_integration_tests/tests/test_templates_mut.rs
@@ -1,0 +1,20 @@
+use serial_test::serial;
+use wp_api::templates::TemplateId;
+use wp_api_integration_tests::{TEMPLATE_CUSTOM, api_client, backend::RestoreServer};
+
+#[tokio::test]
+#[serial]
+async fn delete_template() {
+    let template_delete_response = api_client()
+        .templates()
+        .delete(&TemplateId(TEMPLATE_CUSTOM.to_string()))
+        .await;
+    assert!(
+        template_delete_response.is_ok(),
+        "{:#?}",
+        template_delete_response
+    );
+    assert!(template_delete_response.unwrap().data.deleted);
+
+    RestoreServer::db().await;
+}


### PR DESCRIPTION
Implements [delete & trash `/templates`](https://developer.wordpress.org/rest-api/reference/wp_templates/#delete-a-template) endpoint following the existing conventions.