### PR TITLE
Update `/templates` endpoint

### DIFF
--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -16,6 +16,8 @@ enum TemplatesRequest {
     Delete,
     #[delete(url = "/templates/<template_id>", output = crate::templates::TemplateWithEditContext)]
     Trash,
+    #[post(url = "/templates/<template_id>", params = &crate::templates::TemplateUpdateParams, output = crate::templates::TemplateWithEditContext)]
+    Update,
 }
 
 impl DerivedRequest for TemplatesRequest {
@@ -188,6 +190,14 @@ mod tests {
         validate_wp_v2_endpoint(
             endpoint.trash(&TemplateId("foo".to_string())),
             "/templates/foo?force=false",
+        );
+    }
+
+    #[rstest]
+    fn update_template(endpoint: TemplatesRequestEndpoint) {
+        validate_wp_v2_endpoint(
+            endpoint.update(&TemplateId("foo".to_string())),
+            "/templates/foo",
         );
     }
 

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -175,14 +175,14 @@ pub struct SparseTemplate {
     pub original_source: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum SparseTemplateContentWrapper {
     Object(SparseTemplateContent),
     String(String),
 }
 
-#[derive(Debug, Serialize, wp_derive::WpDeserialize, uniffi::Record)]
+#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, wp_derive::WpDeserialize, uniffi::Record)]
 pub struct SparseTemplateContent {
     pub raw: Option<String>,
     pub rendered: Option<String>,
@@ -190,14 +190,14 @@ pub struct SparseTemplateContent {
     pub block_version: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum SparseTemplateTitleWrapper {
     Object(SparseTemplateTitle),
     String(String),
 }
 
-#[derive(Debug, Serialize, wp_derive::WpDeserialize, uniffi::Record)]
+#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, wp_derive::WpDeserialize, uniffi::Record)]
 pub struct SparseTemplateTitle {
     pub raw: Option<String>,
     pub rendered: Option<String>,
@@ -207,4 +207,28 @@ pub struct SparseTemplateTitle {
 pub struct TemplateDeleteResponse {
     pub deleted: bool,
     pub previous: TemplateWithEditContext,
+}
+
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct TemplateUpdateParams {
+    // Content of template.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    // Title of template.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    // Description of template.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    // The ID for the author of the template.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    // https://developer.wordpress.org/rest-api/reference/wp_templates/#update-a-template
+    // The documentation includes `slug`, `status`, `theme` & `type` parameters, but the updates
+    // don't seem to take place when they are included in the request. So, we decided not to
+    // include them until we figure out under which conditions they'll be allowed to update.
 }

--- a/wp_api_integration_tests/tests/test_templates_err.rs
+++ b/wp_api_integration_tests/tests/test_templates_err.rs
@@ -1,5 +1,8 @@
 use serial_test::parallel;
-use wp_api::{WpErrorCode, templates::TemplateId};
+use wp_api::{
+    WpErrorCode,
+    templates::{TemplateId, TemplateUpdateParams},
+};
 use wp_api_integration_tests::{AssertWpError, TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE, api_client};
 
 #[tokio::test]
@@ -18,6 +21,19 @@ async fn delete_template_err_template_not_found() {
     api_client()
         .templates()
         .delete(&TemplateId("foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::TemplateNotFound)
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_template_err_template_not_found() {
+    api_client()
+        .templates()
+        .update(
+            &TemplateId("foo".to_string()),
+            &TemplateUpdateParams::default(),
+        )
         .await
         .assert_wp_error(WpErrorCode::TemplateNotFound)
 }

--- a/wp_api_integration_tests/tests/test_templates_mut.rs
+++ b/wp_api_integration_tests/tests/test_templates_mut.rs
@@ -1,6 +1,13 @@
+use macro_helper::generate_update_test;
 use serial_test::serial;
-use wp_api::templates::{TemplateId, TemplateStatus};
-use wp_api_integration_tests::{TestCredentials, api_client, backend::RestoreServer};
+use wp_api::templates::{
+    SparseTemplateContent, SparseTemplateContentWrapper, SparseTemplateTitle,
+    SparseTemplateTitleWrapper, TemplateId, TemplateStatus, TemplateUpdateParams,
+    TemplateWithEditContext,
+};
+use wp_api_integration_tests::{
+    AssertResponse, SECOND_USER_ID, TestCredentials, api_client, backend::RestoreServer,
+};
 
 #[tokio::test]
 #[serial]
@@ -45,4 +52,88 @@ async fn trash_template() {
     );
 
     RestoreServer::db().await;
+}
+
+generate_update_test!(
+    update_content,
+    content,
+    "new_content".to_string(),
+    |updated_template| {
+        assert_eq!(
+            updated_template.content,
+            SparseTemplateContentWrapper::Object(SparseTemplateContent {
+                raw: Some("new_content".to_string()),
+                rendered: None,
+                protected: None,
+                block_version: Some(0)
+            })
+        );
+    }
+);
+generate_update_test!(
+    update_title,
+    title,
+    "new_title".to_string(),
+    |updated_template| {
+        assert_eq!(
+            updated_template.title,
+            SparseTemplateTitleWrapper::Object(SparseTemplateTitle {
+                raw: Some("new_title".to_string()),
+                rendered: Some("new_title".to_string())
+            })
+        );
+    }
+);
+generate_update_test!(
+    update_description,
+    description,
+    "new_description".to_string(),
+    |updated_template| {
+        assert_eq!(updated_template.description, "new_description");
+    }
+);
+generate_update_test!(update_author, author, SECOND_USER_ID, |updated_template| {
+    assert_eq!(updated_template.author, SECOND_USER_ID);
+});
+
+async fn test_update_template<F>(params: &TemplateUpdateParams, assert: F)
+where
+    F: Fn(TemplateWithEditContext),
+{
+    let response = api_client()
+        .templates()
+        .update(
+            &TemplateId(
+                TestCredentials::instance()
+                    .integration_test_custom_template_id
+                    .to_string(),
+            ),
+            params,
+        )
+        .await
+        .assert_response();
+    assert(response.data);
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_template(
+                        &TemplateUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
 }


### PR DESCRIPTION
Follows established patterns to implement [update `/templates` endpoint.](https://developer.wordpress.org/rest-api/reference/wp_templates/#update-a-template)