### PR TITLE
Add support for the `/oauth2/token-info` endpoint

### DIFF
--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -19,6 +19,8 @@ public typealias MiddlewarePipeline = WordPressAPIInternal.WpApiMiddlewarePipeli
 public typealias MiddlewarePipelineBuilder = WordPressAPIInternal.WpApiMiddlewarePipelineBuilder
 public typealias ApiDiscoveryAuthenticationMiddleware = WordPressAPIInternal.ApiDiscoveryAuthenticationMiddleware
 public typealias RetryAfterMiddleware = WordPressAPIInternal.RetryAfterMiddleware
+public typealias WpApiClientDelegate = WordPressAPIInternal.WpApiClientDelegate
+public typealias WpAppNotifier = WordPressAPIInternal.WpAppNotifier
 
 // MARK: - Login
 
@@ -129,3 +131,7 @@ public typealias WpSiteHealthTestsRequestExecutor = WordPressAPIInternal.WpSiteH
 
 // MARK: - WordPress.org
 public typealias WordPressOrgApiClient = WordPressAPIInternal.WordPressOrgApiClient
+
+// MARK: - WordPress.com
+public typealias WPComApiClient = WordPressAPIInternal.UniffiWpComApiClient
+public typealias TokenValidationParameters = WordPressAPIInternal.TokenValidationParameters

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -133,5 +133,4 @@ public typealias WpSiteHealthTestsRequestExecutor = WordPressAPIInternal.WpSiteH
 public typealias WordPressOrgApiClient = WordPressAPIInternal.WordPressOrgApiClient
 
 // MARK: - WordPress.com
-public typealias WPComApiClient = WordPressAPIInternal.UniffiWpComApiClient
 public typealias TokenValidationParameters = WordPressAPIInternal.TokenValidationParameters

--- a/native/swift/Sources/wordpress-api/WPComApiClient.swift
+++ b/native/swift/Sources/wordpress-api/WPComApiClient.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WordPressAPIInternal
+
+public class WPComApiClient {
+    private let internalClient: WordPressAPIInternal.UniffiWpComApiClient
+    private let delegate: WpApiClientDelegate
+
+    public init(delegate: WpApiClientDelegate) {
+        self.delegate = delegate // We need to retain this ourselves because it's passed to a Rust object
+        self.internalClient = UniffiWpComApiClient(delegate: delegate)
+    }
+
+    public var oauth2: Oauth2RequestExecutor {
+        internalClient.oauth2()
+    }
+
+    public var jetpackConnection: JetpackConnectionRequestExecutor {
+        internalClient.jetpackConnection()
+    }
+}

--- a/native/swift/Tests/wordpress-api/Support/Mocks.swift
+++ b/native/swift/Tests/wordpress-api/Support/Mocks.swift
@@ -1,0 +1,8 @@
+import Foundation
+import WordPressAPI
+
+final class MockAppNotifier: WpAppNotifier {
+    func requestedWithInvalidAuthentication() async {
+        // no-op
+    }
+}

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -2,12 +2,11 @@ use super::endpoint::jetpack_connection_endpoint::{
     JetpackConnectionRequestBuilder, JetpackConnectionRequestExecutor,
 };
 use super::endpoint::oauth2::{Oauth2RequestBuilder, Oauth2RequestExecutor};
-use super::oauth2::{TokenValidationParameters, TokenValidationResponse};
 use crate::{
     ParsedUrl, WpApiClientDelegate, api_client_generate_api_client,
     api_client_generate_endpoint_impl, auth::WpAuthenticationProvider,
 };
-use crate::{WpApiError, api_client_generate_request_builder};
+use crate::{api_client_generate_request_builder};
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -2,11 +2,11 @@ use super::endpoint::jetpack_connection_endpoint::{
     JetpackConnectionRequestBuilder, JetpackConnectionRequestExecutor,
 };
 use super::endpoint::oauth2::{Oauth2RequestBuilder, Oauth2RequestExecutor};
+use crate::api_client_generate_request_builder;
 use crate::{
     ParsedUrl, WpApiClientDelegate, api_client_generate_api_client,
     api_client_generate_endpoint_impl, auth::WpAuthenticationProvider,
 };
-use crate::{api_client_generate_request_builder};
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -1,10 +1,13 @@
 use super::endpoint::jetpack_connection_endpoint::{
     JetpackConnectionRequestBuilder, JetpackConnectionRequestExecutor,
 };
+use super::endpoint::oauth2::{Oauth2RequestBuilder, Oauth2RequestExecutor};
+use super::oauth2::{TokenValidationParameters, TokenValidationResponse};
 use crate::{
     ParsedUrl, WpApiClientDelegate, api_client_generate_api_client,
     api_client_generate_endpoint_impl, auth::WpAuthenticationProvider,
 };
+use crate::{WpApiError, api_client_generate_request_builder};
 use std::sync::Arc;
 
 #[derive(uniffi::Object)]
@@ -24,14 +27,17 @@ impl UniffiWpComApiRequestBuilder {
 
 pub struct WpComApiRequestBuilder {
     jetpack_connection: Arc<JetpackConnectionRequestBuilder>,
+    oauth2: Arc<Oauth2RequestBuilder>,
 }
 
 impl WpComApiRequestBuilder {
     pub fn new(api_root_url: Arc<ParsedUrl>, auth_provider: Arc<WpAuthenticationProvider>) -> Self {
-        Self {
-            jetpack_connection: JetpackConnectionRequestBuilder::new(api_root_url, auth_provider)
-                .into(),
-        }
+        api_client_generate_request_builder!(
+            api_root_url,
+            auth_provider;
+            jetpack_connection,
+            oauth2
+        )
     }
 }
 
@@ -52,6 +58,7 @@ impl UniffiWpComApiClient {
 
 pub struct WpComApiClient {
     jetpack_connection: Arc<JetpackConnectionRequestExecutor>,
+    oauth2: Arc<Oauth2RequestExecutor>,
 }
 
 impl WpComApiClient {
@@ -62,8 +69,10 @@ impl WpComApiClient {
         api_client_generate_api_client!(
             api_root_url,
             delegate;
-            jetpack_connection
+            jetpack_connection,
+            oauth2
         )
     }
 }
 api_client_generate_endpoint_impl!(WpComApi, jetpack_connection);
+api_client_generate_endpoint_impl!(WpComApi, oauth2);

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -1,1 +1,2 @@
 pub mod jetpack_connection_endpoint;
+pub mod oauth2;

--- a/wp_api/src/wp_com/endpoint/oauth2.rs
+++ b/wp_api/src/wp_com/endpoint/oauth2.rs
@@ -1,0 +1,18 @@
+use crate::wp_com::oauth2::{TokenValidationParameters, TokenValidationResponse};
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::WpComNamespace,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum Oauth2Request {
+    #[get(url = "/token-info", params = &TokenValidationParameters, output = TokenValidationResponse)]
+    FetchInfo,
+}
+
+impl DerivedRequest for Oauth2Request {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::Oauth2
+    }
+}

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -5,6 +5,7 @@ use std::{num::ParseIntError, str::FromStr};
 pub mod client;
 pub mod endpoint;
 pub mod jetpack_connection;
+pub mod oauth2;
 
 impl_as_query_value_for_new_type!(WpComSiteId);
 uniffi::custom_newtype!(WpComSiteId, u64);
@@ -26,12 +27,14 @@ impl std::fmt::Display for WpComSiteId {
 }
 
 pub(crate) enum WpComNamespace {
+    Oauth2,
     V2,
 }
 
 impl AsNamespace for WpComNamespace {
     fn as_str(&self) -> &str {
         match self {
+            WpComNamespace::Oauth2 => "/oauth2",
             WpComNamespace::V2 => "/wpcom/v2",
         }
     }

--- a/wp_api/src/wp_com/oauth2.rs
+++ b/wp_api/src/wp_com/oauth2.rs
@@ -1,0 +1,74 @@
+use crate::url_query::AppendUrlQueryPairs;
+use crate::url_query::QueryPairs;
+use serde::{Deserialize, Serialize};
+use wp_serde_helper::deserialize_u64_or_string;
+
+#[derive(Debug, Serialize, uniffi::Record)]
+pub struct TokenValidationParameters {
+    pub client_id: String,
+    pub token: String,
+}
+
+impl AppendUrlQueryPairs for TokenValidationParameters {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_pair("client_id", &self.client_id);
+        query_pairs_mut.append_pair("token", &self.token);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct TokenValidationResponse {
+    #[serde(default, deserialize_with = "deserialize_u64_or_string")]
+    pub client_id: u64,
+    #[serde(default, deserialize_with = "deserialize_u64_or_string")]
+    pub user_id: u64,
+    pub blog_id: Option<u64>,
+    pub scope: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use url::{Url, UrlQuery};
+
+    #[test]
+    fn test_token_validation_parameters_append_query_pairs() {
+        let mut url = Url::parse("https://public-api.wordpress.com/oauth2/token-info")
+            .expect("Failed to parse url");
+
+        let params = TokenValidationParameters {
+            client_id: "11".to_string(),
+            token: "test_token".to_string(),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/oauth2/token-info?client_id=11&token=test_token"
+        );
+    }
+
+    #[test]
+    fn test_token_validation_response_deserialization() {
+        let json_str =
+            r#"{"client_id":"11","user_id":"1234567890","blog_id":null,"scope":"global"}"#;
+        let response: TokenValidationResponse = serde_json::from_str(json_str).unwrap();
+
+        assert_eq!(response.client_id, 11);
+        assert_eq!(response.user_id, 1234567890);
+        assert_eq!(response.blog_id, None);
+        assert_eq!(response.scope, "global");
+    }
+
+    #[test]
+    fn test_token_validation_error_response() {
+        let json_str =
+            r#"{"error":"invalid_request","error_description":"The specified token is invalid."}"#;
+        let result = serde_json::from_str::<TokenValidationResponse>(json_str);
+
+        assert!(result.is_err());
+    }
+}

--- a/wp_api/src/wp_com/oauth2.rs
+++ b/wp_api/src/wp_com/oauth2.rs
@@ -29,8 +29,7 @@ pub struct TokenValidationResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-    use url::{Url, UrlQuery};
+    use url::Url;
 
     #[test]
     fn test_token_validation_parameters_append_query_pairs() {

--- a/wp_api/tests/wpcom/oauth2/invalid-token-info.json
+++ b/wp_api/tests/wpcom/oauth2/invalid-token-info.json
@@ -1,0 +1,1 @@
+{"error":"invalid_request","error_description":"The specified token is invalid."}

--- a/wp_api/tests/wpcom/oauth2/token-info.json
+++ b/wp_api/tests/wpcom/oauth2/token-info.json
@@ -1,0 +1,1 @@
+{"client_id":"11","user_id":"1234567890","blog_id":null,"scope":"global"}

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -89,6 +89,37 @@ where
     deserializer.deserialize_any(DeserializeI64OrStringVisitor)
 }
 
+pub fn deserialize_u64_or_string<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(DeserializeU64OrStringVisitor)
+}
+
+struct DeserializeU64OrStringVisitor;
+
+impl de::Visitor<'_> for DeserializeU64OrStringVisitor {
+    type Value = u64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("u64 or a string")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        v.parse::<u64>()
+            .map_err(|_| E::invalid_value(Unexpected::Str(v), &self))
+    }
+}
 pub struct DeserializeOffsetVisitor;
 
 impl de::Visitor<'_> for DeserializeOffsetVisitor {


### PR DESCRIPTION
Adds the ability for the apps to check if a WP.com token is valid or not. 

Tested against the actual endpoint, but that code isn't committed because we don't want to leak the token in question.

The tests should be sufficient for this.