### PR TITLE
Rename CommentStatus::Approve to CommentStatus::Approved

### DIFF
--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -78,6 +78,9 @@ wp user create test_author test_author@example.com --role=author
 # This is used in `/posts` integration tests that updates the `template` field
 wp theme activate twentytwentyfour
 
+wp comment trash 22
+wp comment spam 23
+
 create_test_credentials () {
   local SITE_URL
   local ADMIN_USERNAME

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -569,7 +569,7 @@ pub enum CommentAuthorAvatarUrlSize {
 pub enum CommentStatus {
     Hold,
     #[default]
-    Approve,
+    Approved,
     Spam,
     Trash,
     #[serde(untagged)]
@@ -640,7 +640,7 @@ mod tests {
     #[case(generate!(CommentListParams, (parent_exclude, vec![CommentId(55555), CommentId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(CommentListParams, (post, vec![PostId(66666), PostId(66667)])), "post=66666%2C66667")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Hold))), "status=hold")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approve))), "status=approve")]
+    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approved))), "status=approved")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Spam))), "status=spam")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Trash))), "status=trash")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Custom("foo".to_string())))), "status=foo")]

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -108,7 +108,7 @@ mod tests {
     #[case(generate!(CommentListParams, (parent_exclude, vec![CommentId(55555), CommentId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(CommentListParams, (post, vec![PostId(66666), PostId(66667)])), "post=66666%2C66667")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Hold))), "status=hold")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approve))), "status=approve")]
+    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approved))), "status=approved")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Spam))), "status=spam")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Trash))), "status=trash")]
     #[case(generate!(CommentListParams, (status, Some(CommentStatus::Custom("foo".to_string())))), "status=foo")]

--- a/wp_api_integration_tests/tests/test_comments_err.rs
+++ b/wp_api_integration_tests/tests/test_comments_err.rs
@@ -187,7 +187,7 @@ async fn create_err_comment_invalid_post_id() {
 #[parallel]
 async fn create_err_comment_invalid_status(
     #[values(
-        CommentStatus::Approve,
+        CommentStatus::Approved,
         CommentStatus::Hold,
         CommentStatus::Spam,
         CommentStatus::Trash

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -232,7 +232,7 @@ async fn list_comments_with_edit_context_parse_author_avatar_urls(
 #[case::parent_exclude(generate!(CommentListParams, (parent, vec![CommentId(1), CommentId(2)])))]
 #[case::post(generate!(CommentListParams, (post, vec![PostId(1), PostId(2)])))]
 #[case::status_hold(generate!(CommentListParams, (status, Some(CommentStatus::Hold))))]
-#[case::status_approve(generate!(CommentListParams, (status, Some(CommentStatus::Approve))))]
+#[case::status_approve(generate!(CommentListParams, (status, Some(CommentStatus::Approved))))]
 #[case::status_spam(generate!(CommentListParams, (status, Some(CommentStatus::Spam))))]
 #[case::status_trash(generate!(CommentListParams, (status, Some(CommentStatus::Trash))))]
 #[case::comment_type_comment(generate!(CommentListParams, (comment_type, Some(CommentType::Comment))))]
@@ -384,7 +384,7 @@ mod filter {
     }
 
     #[rstest]
-    #[case(1, CommentStatus::Approve)]
+    #[case(1, CommentStatus::Approved)]
     #[case(6, CommentStatus::Hold)]
     #[case(22, CommentStatus::Trash)]
     #[case(23, CommentStatus::Spam)]

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -382,4 +382,21 @@ mod filter {
             .data;
         comment.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
+
+    #[rstest]
+    #[case(1, CommentStatus::Approve)]
+    #[case(6, CommentStatus::Hold)]
+    #[case(22, CommentStatus::Trash)]
+    #[case(23, CommentStatus::Spam)]
+    #[tokio::test]
+    #[parallel]
+    async fn parse_status(#[case] id: i64, #[case] status: CommentStatus) {
+        let comment = api_client()
+            .comments()
+            .retrieve_with_edit_context(&CommentId(id), &CommentRetrieveParams::default())
+            .await
+            .assert_response()
+            .data;
+        assert_eq!(comment.status, status);
+    }
 }


### PR DESCRIPTION
The "approved" comment status string is `approved`. See this comment on the test site:

```
curl -su 'test@example.com:KYMx5TAaDyoc5sF6I0ONxCFJ' http://localhost/wp-json/wp/v2/comments/1
```