### PR TITLE
Adds Kotlin `JetpackApiClient` and `WpComApiClient` wrappers

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
@@ -1,0 +1,41 @@
+package rs.wordpress.api.kotlin
+
+import uniffi.wp_api.WpApiException
+
+fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequestResult<T> =
+    when (apiException) {
+        is WpApiException.InvalidHttpStatusCode -> WpRequestResult.InvalidHttpStatusCode<T>(
+            statusCode = apiException.statusCode,
+        )
+
+        is WpApiException.RequestExecutionFailed -> WpRequestResult.RequestExecutionFailed<T>(
+            statusCode = apiException.statusCode,
+            redirects = apiException.redirects,
+            reason = apiException.reason
+        )
+
+        is WpApiException.MediaFileNotFound -> WpRequestResult.MediaFileNotFound<T>(
+            filePath = apiException.filePath
+        )
+
+        is WpApiException.ResponseParsingException -> WpRequestResult.ResponseParsingError<T>(
+            reason = apiException.reason,
+            response = apiException.response,
+        )
+
+        is WpApiException.SiteUrlParsingException -> WpRequestResult.SiteUrlParsingError<T>(
+            reason = apiException.reason,
+        )
+
+        is WpApiException.UnknownException -> WpRequestResult.UnknownError<T>(
+            statusCode = apiException.statusCode,
+            response = apiException.response,
+        )
+
+        is WpApiException.WpException -> WpRequestResult.WpError<T>(
+            errorCode = apiException.errorCode,
+            errorMessage = apiException.errorMessage,
+            statusCode = apiException.statusCode,
+            response = apiException.response,
+        )
+    }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/EmptyAppNotifier.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/EmptyAppNotifier.kt
@@ -1,0 +1,9 @@
+package rs.wordpress.api.kotlin
+
+import uniffi.wp_api.WpAppNotifier
+
+class EmptyAppNotifier : WpAppNotifier {
+    override suspend fun requestedWithInvalidAuthentication() {
+        // no-op
+    }
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -5,14 +5,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
+import uniffi.wp_api.UniffiJetpackApiClient
 import uniffi.wp_api.UniffiWpApiClient
+import uniffi.wp_api.UniffiWpComApiClient
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAppNotifier
 import uniffi.wp_api.WpAuthenticationProvider
 
-class WpApiClient(
+class JetpackApiClient(
     apiRootUrl: ParsedUrl,
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor = WpRequestExecutor(),
@@ -21,7 +23,7 @@ class WpApiClient(
 ) {
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
     private val requestBuilder by lazy {
-        UniffiWpApiClient(
+        UniffiJetpackApiClient(
             apiRootUrl,
             WpApiClientDelegate(
                 authProvider,
@@ -39,7 +41,7 @@ class WpApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
-        executeRequest: suspend (UniffiWpApiClient) -> T
+        executeRequest: suspend (UniffiJetpackApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
             WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
@@ -48,4 +50,3 @@ class WpApiClient(
         }
     }
 }
-

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.withContext
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiJetpackApiClient
-import uniffi.wp_api.UniffiWpApiClient
-import uniffi.wp_api.UniffiWpComApiClient
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpApiMiddlewarePipeline

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -48,4 +48,3 @@ class WpApiClient(
         }
     }
 }
-

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -3,9 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
-import uniffi.wp_api.UniffiWpApiClient
 import uniffi.wp_api.UniffiWpComApiClient
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiException

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -6,14 +6,14 @@ import kotlinx.coroutines.withContext
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpApiClient
+import uniffi.wp_api.UniffiWpComApiClient
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAppNotifier
 import uniffi.wp_api.WpAuthenticationProvider
 
-class WpApiClient(
-    apiRootUrl: ParsedUrl,
+class WpComApiClient(
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor = WpRequestExecutor(),
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
@@ -21,8 +21,7 @@ class WpApiClient(
 ) {
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
     private val requestBuilder by lazy {
-        UniffiWpApiClient(
-            apiRootUrl,
+        UniffiWpComApiClient(
             WpApiClientDelegate(
                 authProvider,
                 requestExecutor = requestExecutor,
@@ -39,7 +38,7 @@ class WpApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
-        executeRequest: suspend (UniffiWpApiClient) -> T
+        executeRequest: suspend (UniffiWpComApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
             WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
@@ -48,4 +47,3 @@ class WpApiClient(
         }
     }
 }
-

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/login/LoginScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/login/LoginScreen.kt
@@ -24,7 +24,7 @@ fun LoginScreen(authenticateSite: (String) -> Unit) {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxSize(),
         ) {
-            var siteUrl by remember { mutableStateOf("magnificent-funnel.jurassic.ninja") }
+            var siteUrl by remember { mutableStateOf("vanilla.wpmt.co") }
             TextField(value = siteUrl, onValueChange = { siteUrl = it })
             Button(onClick = { authenticateSite(siteUrl) }) {
                 Text("Login")

--- a/wp_api/src/jetpack/client.rs
+++ b/wp_api/src/jetpack/client.rs
@@ -40,9 +40,9 @@ struct UniffiJetpackApiClient {
 #[uniffi::export]
 impl UniffiJetpackApiClient {
     #[uniffi::constructor]
-    fn new(site_url: Arc<ParsedUrl>, delegate: WpApiClientDelegate) -> Self {
+    fn new(api_root_url: Arc<ParsedUrl>, delegate: WpApiClientDelegate) -> Self {
         Self {
-            inner: JetpackApiClient::new(site_url, delegate),
+            inner: JetpackApiClient::new(api_root_url, delegate),
         }
     }
 }


### PR DESCRIPTION
Adds Kotlin `JetpackApiClient` and `WpComApiClient` wrappers which uses the same structure as `WpApiClient`. It adds `mapWpApiExceptionToWpRequestResult` which moves the existing code from `WpApiClient`, so there are no functional changes.