### PR TITLE
Improve ergonomics for Kotlin wrapper

### DIFF
--- a/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
+++ b/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
@@ -4,14 +4,14 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
-import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.UserListParams
 import uniffi.wp_api.WpAuthenticationProvider
+import java.net.URL
 
 class UsersEndpointAndroidTest {
     // https://developer.android.com/studio/run/emulator-networking
     private val siteUrl = "http://10.0.2.2"
-    private val client = WpApiClient(ParsedUrl.parse(siteUrl), WpAuthenticationProvider.none())
+    private val client = WpApiClient(URL(siteUrl), WpAuthenticationProvider.none())
 
     @Test
     fun testUserListRequest() = runTest {

--- a/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
+++ b/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
@@ -18,6 +18,6 @@ class UsersEndpointAndroidTest {
         val result = client.request { requestBuilder ->
             requestBuilder.users().listWithViewContext(params = UserListParams())
         }
-        assert(result is WpRequestResult.WpRequestSuccess)
+        assert(result is WpRequestResult.Success)
     }
 }

--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 }
 
 java {
+    withJavadocJar()
+    withSourcesJar()
+
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
     toolchain {
@@ -123,6 +126,9 @@ tasks.named("processIntegrationTestResources").configure {
     dependsOn(rootProject.tasks.named("copyTestCredentials"))
     dependsOn(rootProject.tasks.named("copyTestMedia"))
     dependsOn(rootProject.tasks.named("copySampleJSON"))
+}
+tasks.named("sourcesJar").configure {
+    dependsOn(generateUniFFIBindingsTask)
 }
 
 project.afterEvaluate {

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
@@ -25,14 +25,14 @@ fun defaultApiClient(): WpApiClient {
 }
 
 fun <T> WpRequestResult<T>.assertSuccess() {
-    assert(this is WpRequestResult.WpRequestSuccess)
+    assert(this is WpRequestResult.Success)
 }
 
 fun <T> WpRequestResult<T>.assertSuccessAndRetrieveData(): T {
-    assert(this is WpRequestResult.WpRequestSuccess) {
+    assert(this is WpRequestResult.Success) {
         "Request wasn't successful: $this"
     }
-    return (this as WpRequestResult.WpRequestSuccess).data
+    return (this as WpRequestResult.Success).response
 }
 
 fun <T> WpRequestResult<T>.wpErrorCode(): WpErrorCode {

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ManualParserTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ManualParserTest.kt
@@ -2,6 +2,7 @@ package rs.wordpress.api.kotlin
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.UniffiWpApiRequestBuilder
 import uniffi.wp_api.UserListParams
 import uniffi.wp_api.WpAuthenticationProvider
@@ -19,7 +20,7 @@ class ManualParserTest {
     @Test
     fun testUserListManualRequestAndParsing() = runTest {
         val requestBuilder = UniffiWpApiRequestBuilder(
-            apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = testCredentials.apiRootUrl),
+            apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl(testCredentials.apiRootUrl)),
             authProvider
         )
         val userListRequest = requestBuilder.users().listWithEditContext(UserListParams())

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
@@ -3,8 +3,8 @@ package rs.wordpress.api.kotlin
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import uniffi.wp_api.ParsedUrl
 import java.io.File
+import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
@@ -44,5 +44,5 @@ data class TestCredentials(
         }
     }
 
-    val apiRootUrl by lazy { ParsedUrl.parse("$siteUrl/wp-json") }
+    val apiRootUrl by lazy { URL("$siteUrl/wp-json") }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiDiscoveryResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiDiscoveryResult.kt
@@ -4,7 +4,7 @@ import uniffi.wp_api.AutoDiscoveryAttemptSuccess
 import uniffi.wp_api.FetchAndParseApiRootFailure
 import uniffi.wp_api.FindApiRootFailure
 import uniffi.wp_api.ParseUrlException
-import uniffi.wp_api.ParsedUrl
+import java.net.URL
 
 sealed class ApiDiscoveryResult {
     data class Success(val success: AutoDiscoveryAttemptSuccess) : ApiDiscoveryResult()
@@ -12,12 +12,12 @@ sealed class ApiDiscoveryResult {
         val error: ParseUrlException
     ) : ApiDiscoveryResult()
     data class FailureFindApiRoot(
-        val parsedSiteUrl: ParsedUrl,
+        val parsedSiteUrl: URL,
         val findApiRootFailure: FindApiRootFailure
     ) : ApiDiscoveryResult()
     data class FailureFetchAndParseApiRoot(
-        val parsedSiteUrl: ParsedUrl,
-        val apiRootUrl: ParsedUrl,
+        val parsedSiteUrl: URL,
+        val apiRootUrl: URL,
         val fetchAndParseApiRootFailure: FetchAndParseApiRootFailure
     ) : ApiDiscoveryResult()
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -13,6 +13,7 @@ import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAppNotifier
 import uniffi.wp_api.WpAuthenticationProvider
 import uniffi.wp_api.WpOrgSiteApiUrlResolver
+import java.net.URL
 
 class JetpackApiClient(
     apiUrlResolver: ApiUrlResolver,
@@ -22,13 +23,13 @@ class JetpackApiClient(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     constructor(
-        wpOrgSiteApiRootUrl: ParsedUrl,
+        wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
         requestExecutor: RequestExecutor = WpRequestExecutor(),
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : this(
-        apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = wpOrgSiteApiRootUrl),
+        apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
         appNotifier,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -58,7 +58,7 @@ class JetpackApiClient(
         executeRequest: suspend (UniffiJetpackApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
-            WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
+            WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult(exception)
         }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ParsedUrl.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ParsedUrl.kt
@@ -1,0 +1,8 @@
+package rs.wordpress.api.kotlin
+
+import uniffi.wp_api.ParsedUrl
+import java.net.URL
+
+operator fun ParsedUrl.Companion.invoke(url: URL) = parse(url.toString())
+
+fun ParsedUrl.toURL(): URL = URL(this.url())

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -58,7 +58,7 @@ class WpApiClient(
         executeRequest: suspend (UniffiWpApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
-            WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
+            WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult(exception)
         }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -13,6 +13,7 @@ import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAppNotifier
 import uniffi.wp_api.WpAuthenticationProvider
 import uniffi.wp_api.WpOrgSiteApiUrlResolver
+import java.net.URL
 
 class WpApiClient(
     apiUrlResolver: ApiUrlResolver,
@@ -22,13 +23,13 @@ class WpApiClient(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     constructor(
-        wpOrgSiteApiRootUrl: ParsedUrl,
+        wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
         requestExecutor: RequestExecutor = WpRequestExecutor(),
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : this(
-        apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = wpOrgSiteApiRootUrl),
+        apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
         appNotifier,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -39,7 +39,7 @@ class WpComApiClient(
         executeRequest: suspend (UniffiWpComApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         try {
-            WpRequestResult.WpRequestSuccess(data = executeRequest(requestBuilder))
+            WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult(exception)
         }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -28,13 +28,13 @@ class WpLoginClient(
                     error = exception.error,
                 )
                 is AutoDiscoveryAttemptFailure.FindApiRoot -> ApiDiscoveryResult.FailureFindApiRoot(
-                    parsedSiteUrl = exception.parsedSiteUrl,
+                    parsedSiteUrl = exception.parsedSiteUrl.toURL(),
                     findApiRootFailure = exception.findApiRootFailure,
                 )
 
                 is AutoDiscoveryAttemptFailure.FetchAndParseApiRoot -> ApiDiscoveryResult.FailureFetchAndParseApiRoot(
-                    parsedSiteUrl = exception.parsedSiteUrl,
-                    apiRootUrl = exception.apiRootUrl,
+                    parsedSiteUrl = exception.parsedSiteUrl.toURL(),
+                    apiRootUrl = exception.apiRootUrl.toURL(),
                     fetchAndParseApiRootFailure = exception.fetchAndParseApiRootFailure
                 )
             }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -5,7 +5,7 @@ import uniffi.wp_api.WpErrorCode
 import uniffi.wp_api.WpRedirect
 
 sealed class WpRequestResult<T> {
-    data class WpRequestSuccess<T>(val data: T) : WpRequestResult<T>()
+    data class Success<T>(val response: T) : WpRequestResult<T>()
     data class WpError<T>(
         val errorCode: WpErrorCode,
         val errorMessage: String,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -40,4 +40,10 @@ sealed class WpRequestResult<T> {
         val statusCode: UShort,
         val response: String,
     ) : WpRequestResult<T>()
+
+    fun successfulResponse(): T? =
+        when (this) {
+            is Success -> this.response
+            else -> null
+        }
 }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/domain/AuthenticatedSite.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/domain/AuthenticatedSite.kt
@@ -1,5 +1,5 @@
 package rs.wordpress.example.shared.domain
 
-import uniffi.wp_api.ParsedUrl
+import java.net.URL
 
-data class AuthenticatedSite(val name: String, val apiRootUrl: ParsedUrl)
+data class AuthenticatedSite(val name: String, val apiRootUrl: URL)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/repository/AuthenticationRepository.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/repository/AuthenticationRepository.kt
@@ -1,9 +1,9 @@
 package rs.wordpress.example.shared.repository
 
 import rs.wordpress.example.shared.domain.AuthenticatedSite
-import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.WpAuthentication
 import uniffi.wp_api.wpAuthenticationFromUsernameAndPassword
+import java.net.URL
 
 class AuthenticationRepository(
     localTestSiteUrl: String,
@@ -14,16 +14,16 @@ class AuthenticationRepository(
 
     init {
         addAuthenticatedSite(
-            ParsedUrl.parse(localTestSiteUrl),
-            ParsedUrl.parse("$localTestSiteUrl/wp-json"),
+            URL(localTestSiteUrl),
+            URL("$localTestSiteUrl/wp-json"),
             localTestSiteUsername,
             localTestSitePassword
         )
     }
 
-    fun addAuthenticatedSite(siteUrl: ParsedUrl, apiRootUrl: ParsedUrl, username: String, password: String): Boolean {
+    fun addAuthenticatedSite(siteUrl: URL, apiRootUrl: URL, username: String, password: String): Boolean {
         if (username.isNotEmpty() && password.isNotEmpty()) {
-            authenticatedSites[AuthenticatedSite(name = siteUrl.url(), apiRootUrl)] =
+            authenticatedSites[AuthenticatedSite(name = siteUrl.toString(), apiRootUrl)] =
                 wpAuthenticationFromUsernameAndPassword(username, password)
             return true
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
@@ -30,7 +30,7 @@ class PluginListViewModel(private val authRepository: AuthenticationRepository) 
                 }
             }
             return when (pluginsResult) {
-                is WpRequestResult.WpRequestSuccess -> pluginsResult.data.data
+                is WpRequestResult.Success -> pluginsResult.response.data
                 else -> listOf()
             }
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
@@ -30,7 +30,7 @@ class UserListViewModel(private val authRepository: AuthenticationRepository) {
                 }
             }
             return when (usersResult) {
-                is WpRequestResult.WpRequestSuccess -> usersResult.data.data
+                is WpRequestResult.Success -> usersResult.response.data
                 else -> throw IllegalStateException("User list request should succeed: $usersResult")
             }
         }


### PR DESCRIPTION
Improves a few things in the Kotlin wrapper:

* Renames `WpRequestResult.WpRequestSuccess` to `WpRequestResult.Success`
* Renames `WpRequestResult.WpRequestSuccess.data` to `WpRequestResult.WpRequestSuccess.response` because the previous `data` field has another `data` field inside, so in usage, it looked like `success.data.data`.
* Adds a few Kotlin extensions for `ParsedUrl` and in most of the API it replaces it with `java.net.URL` and internally converts it to `ParsedUrl`. I'll take a look to see if we could just lift `ParsedUrl` as `URL` in another PR.
* Publishes Kotlin source files so it's easier to work with from the clients.