### PR TITLE
Allow passing WP.com base url

### DIFF
--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -14,16 +14,18 @@ pub mod support_bots_endpoint;
 #[derive(uniffi::Object)]
 pub struct WpComDotOrgApiUrlResolver {
     pub base_url: ParsedUrl,
-    pub site_url: String,
+    pub site_id: String,
 }
 
 #[uniffi::export]
 impl WpComDotOrgApiUrlResolver {
     #[uniffi::constructor]
-    pub fn new(site_url: String) -> Self {
+    pub fn new(base_url: Option<String>, site_id: String) -> Self {
         Self {
-            base_url: wp_com_base_url(),
-            site_url,
+            base_url: base_url
+                .and_then(|url| ParsedUrl::parse(&url).ok())
+                .unwrap_or_else(wp_com_base_url),
+            site_id,
         }
     }
 }
@@ -43,7 +45,7 @@ impl ApiUrlResolver for WpComDotOrgApiUrlResolver {
         Arc::new(
             self.base_url
                 .by_extending_and_splitting_by_forward_slash(
-                    vec![namespace, "sites".to_string(), self.site_url.to_string()]
+                    vec![namespace, "sites".to_string(), self.site_id.to_string()]
                         .into_iter()
                         .chain(endpoint_segments),
                 )
@@ -109,7 +111,7 @@ mod tests {
         #[case] endpoint_segments: Vec<String>,
         #[case] expected_url: &str,
     ) {
-        let resolver = WpComDotOrgApiUrlResolver::new("example.wordpress.com".to_string());
+        let resolver = WpComDotOrgApiUrlResolver::new(None, "example.wordpress.com".to_string());
         assert_eq!(
             resolver
                 .resolve(namespace.to_string(), endpoint_segments)

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -1,10 +1,10 @@
 use crate::{
     parsed_url::ParsedUrl,
     request::endpoint::{ApiUrlResolver, AsNamespace, WpNamespace},
+    wp_com::WpComBaseUrl,
 };
 use std::sync::Arc;
 use strum::IntoEnumIterator;
-use url::Url;
 
 pub mod jetpack_connection_endpoint;
 pub mod oauth2;
@@ -20,11 +20,9 @@ pub struct WpComDotOrgApiUrlResolver {
 #[uniffi::export]
 impl WpComDotOrgApiUrlResolver {
     #[uniffi::constructor]
-    pub fn new(base_url: Option<String>, site_id: String) -> Self {
+    pub fn new(site_id: String, base_url: WpComBaseUrl) -> Self {
         Self {
-            base_url: base_url
-                .and_then(|url| ParsedUrl::parse(&url).ok())
-                .unwrap_or_else(wp_com_base_url),
+            base_url: base_url.parsed_url(),
             site_id,
         }
     }
@@ -62,7 +60,7 @@ pub(crate) struct WpComApiClientInternalUrlResolver {
 impl WpComApiClientInternalUrlResolver {
     fn new() -> Self {
         Self {
-            base_url: wp_com_base_url(),
+            base_url: WpComBaseUrl::Production.parsed_url(),
         }
     }
 }
@@ -93,12 +91,6 @@ impl ApiUrlResolver for WpComApiClientInternalUrlResolver {
     }
 }
 
-fn wp_com_base_url() -> ParsedUrl {
-    Url::parse("https://public-api.wordpress.com")
-        .expect("This is a valid URL")
-        .into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,7 +103,10 @@ mod tests {
         #[case] endpoint_segments: Vec<String>,
         #[case] expected_url: &str,
     ) {
-        let resolver = WpComDotOrgApiUrlResolver::new(None, "example.wordpress.com".to_string());
+        let resolver = WpComDotOrgApiUrlResolver::new(
+            "example.wordpress.com".to_string(),
+            WpComBaseUrl::Production,
+        );
         assert_eq!(
             resolver
                 .resolve(namespace.to_string(), endpoint_segments)

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
 use crate::{impl_as_query_value_for_new_type, request::endpoint::AsNamespace};
 use serde::{Deserialize, Serialize};
-use std::{num::ParseIntError, str::FromStr};
+use std::{num::ParseIntError, str::FromStr, sync::Arc};
 
 pub mod client;
 pub mod endpoint;
@@ -38,6 +39,24 @@ impl AsNamespace for WpComNamespace {
         match self {
             WpComNamespace::Oauth2 => "/oauth2",
             WpComNamespace::V2 => "/wpcom/v2",
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Enum)]
+pub enum WpComBaseUrl {
+    #[default]
+    Production,
+    Custom(Arc<ParsedUrl>),
+}
+
+impl WpComBaseUrl {
+    pub fn parsed_url(&self) -> ParsedUrl {
+        match self {
+            WpComBaseUrl::Production => url::Url::parse("https://public-api.wordpress.com")
+                .expect("This is a valid URL")
+                .into(),
+            WpComBaseUrl::Custom(url) => (**url).clone(),
         }
     }
 }


### PR DESCRIPTION
This is to support the app's UI tests, by allowing the app to swap the real WP.com public API URL with a mock server URL.