### PR TITLE
Add `/templates` related errors and their integration tests

### DIFF
--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -194,6 +194,8 @@ pub enum WpErrorCode {
     CannotListApplicationPasswords,
     #[serde(rename = "rest_cannot_manage_plugins")]
     CannotManagePlugins,
+    #[serde(rename = "rest_cannot_manage_templates")]
+    CannotManageTemplates,
     #[serde(rename = "rest_cannot_read_application_password")]
     CannotReadApplicationPassword,
     #[serde(rename = "rest_cannot_read")]
@@ -280,10 +282,6 @@ pub enum WpErrorCode {
     RevisionInvalidOffsetNumber,
     #[serde(rename = "rest_taxonomy_invalid")]
     TaxonomyInvalid,
-    #[serde(rename = "rest_template_already_trashed")]
-    TemplateAlreadyTrashed,
-    #[serde(rename = "rest_template_insert_error")]
-    TemplateInsertError,
     #[serde(rename = "rest_template_not_found")]
     TemplateNotFound,
     #[serde(rename = "rest_term_invalid")]
@@ -363,6 +361,8 @@ pub enum WpErrorCode {
     SearchInvalidPageNumber,
     #[serde(rename = "rest_search_invalid_type")]
     SearchInvalidType,
+    #[serde(rename = "rest_template_insert_error")]
+    TemplateInsertError,
     #[serde(rename = "rest_upload_file_error")]
     UploadFileError,
     #[serde(rename = "rest_upload_file_too_big")]
@@ -422,6 +422,9 @@ pub enum WpErrorCode {
     // `parent` argument
     #[serde(rename = "rest_taxonomy_not_hierarchical")]
     TaxonomyNotHierarchical,
+    // If the template is already trashed, the server returns `rest_template_not_found`
+    #[serde(rename = "rest_template_already_trashed")]
+    TemplateAlreadyTrashed,
     // If `force=true` is missing from delete user request.
     // If trash is not supported for the post type: https://github.com/WordPress/WordPress/blob/6.6.2/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1011-L1029
     #[serde(rename = "rest_trash_not_supported")]

--- a/wp_api_integration_tests/tests/test_templates_err.rs
+++ b/wp_api_integration_tests/tests/test_templates_err.rs
@@ -34,6 +34,43 @@ async fn delete_template_err_template_not_found() {
 
 #[tokio::test]
 #[parallel]
+async fn update_template_err_cannot_manage_templates() {
+    api_client_as_subscriber()
+        .templates()
+        .update(
+            &TemplateId(
+                TestCredentials::instance()
+                    .integration_test_custom_template_id
+                    .to_string(),
+            ),
+            &TemplateUpdateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageTemplates)
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_template_err_invalid_author() {
+    api_client()
+        .templates()
+        .update(
+            &TemplateId(
+                TestCredentials::instance()
+                    .integration_test_custom_template_id
+                    .to_string(),
+            ),
+            &TemplateUpdateParams {
+                author: Some(UserId(99999999)),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidAuthor);
+}
+
+#[tokio::test]
+#[parallel]
 async fn update_template_err_template_not_found() {
     api_client()
         .templates()


### PR DESCRIPTION
I had been implementing some of the errors as part of the other `/templates` PRs which is why there aren't as many new tests as usual. However, I still looked into every `WP_Error` instance in the server code just as I usually do.

Note that I moved a couple previously added errors into "Can't test" section.