### PR TITLE
Kotlin integration tests for `/templates`

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TemplatesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TemplatesEndpointTest.kt
@@ -1,0 +1,120 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.TemplateCreateParams
+import uniffi.wp_api.TemplateListParams
+import uniffi.wp_api.TemplateUpdateParams
+import uniffi.wp_api.SparseTemplateFieldWithEditContext
+import uniffi.wp_api.SparseTemplateTitle
+import uniffi.wp_api.SparseTemplateTitleWrapper
+import uniffi.wp_api.WpErrorCode
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private const val TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE_SLUG: String = "single"
+private const val TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE: String =
+    "twentytwentyfour//$TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE_SLUG"
+
+class TemplatesEndpointTest {
+    private val client = defaultApiClient()
+
+    @Test
+    fun testTemplateListRequest() = runTest {
+        val templateList = client.request { requestBuilder ->
+            requestBuilder.templates().listWithEditContext(params = TemplateListParams())
+        }.assertSuccessAndRetrieveData().data
+        assert(templateList.isNotEmpty())
+    }
+
+    @Test
+    fun testFilterTemplateListRequest() = runTest {
+        val templateList = client.request { requestBuilder ->
+            requestBuilder.templates().filterListWithEditContext(
+                params = TemplateListParams(),
+                fields = listOf(
+                    SparseTemplateFieldWithEditContext.AUTHOR,
+                    SparseTemplateFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assert(templateList.isNotEmpty())
+        assertNull(templateList.first().description)
+    }
+
+    @Test
+    fun testRetrieveTemplateRequest() = runTest {
+        val template = client.request { requestBuilder ->
+            requestBuilder.templates().retrieveWithEditContext(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE)
+        }.assertSuccessAndRetrieveData().data
+        assertEquals(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE_SLUG, template.slug)
+    }
+
+    @Test
+    fun testFilterRetrieveTemplateRequest() = runTest {
+        val template = client.request { requestBuilder ->
+            requestBuilder.templates().filterRetrieveWithEditContext(
+                TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE,
+                fields = listOf(
+                    SparseTemplateFieldWithEditContext.AUTHOR,
+                    SparseTemplateFieldWithEditContext.SLUG
+                )
+            )
+        }.assertSuccessAndRetrieveData().data
+        assertEquals(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE_SLUG, template.slug)
+        assertNull(template.description)
+    }
+
+    @Test
+    fun createTemplateRequest() = runTest {
+        val createdTemplate = client.request { requestBuilder ->
+            requestBuilder.templates()
+                .create(TemplateCreateParams(slug = "created_slug", title = "new_title"))
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("created_slug", createdTemplate.slug)
+        assertEquals(
+            expected = SparseTemplateTitleWrapper.Object(
+                SparseTemplateTitle(
+                    raw = "new_title",
+                    rendered = "new_title"
+                )
+            ),
+            actual = createdTemplate.title
+        )
+        restoreTestServer()
+    }
+
+    @Test
+    fun deleteTemplateRequest() = runTest {
+        val deletedTemplate = client.request { requestBuilder ->
+            requestBuilder.templates()
+                .delete(templateId = TestCredentials.INSTANCE.integrationTestCustomTemplateId)
+        }.assertSuccessAndRetrieveData().data
+        assert(deletedTemplate.deleted)
+        restoreTestServer()
+    }
+
+    @Test
+    fun updateTemplateRequest() = runTest {
+        val updatedTemplate = client.request { requestBuilder ->
+            requestBuilder.templates()
+                .update(
+                    templateId = TestCredentials.INSTANCE.integrationTestCustomTemplateId,
+                    TemplateUpdateParams(
+                        description = "new_description",
+                    )
+                )
+        }.assertSuccessAndRetrieveData().data
+        assertEquals("new_description", updatedTemplate.description)
+        restoreTestServer()
+    }
+
+    @Test
+    fun testDeleteTemplateErrInvalidTemplate() = runTest {
+        val result =
+            client.request { requestBuilder ->
+                requestBuilder.templates().delete(TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE)
+            }
+        assert(result.wpErrorCode() is WpErrorCode.InvalidTemplate)
+    }
+}

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
@@ -24,8 +24,30 @@ data class TestCredentials(
     val subscriberPassword: String,
     @SerialName("subscriber_password_uuid")
     val subscriberPasswordUuid: String,
+    @SerialName("author_username")
+    val authorUsername: String,
+    @SerialName("author_password")
+    val authorPassword: String,
+    @SerialName("password_protected_post_id")
+    val passwordProtectedPostId: Long,
+    @SerialName("password_protected_post_password")
+    val passwordProtectedPostPassword: String,
+    @SerialName("password_protected_post_title")
+    val passwordProtectedPostTitle: String,
+    @SerialName("password_protected_comment_id")
+    val passwordProtectedCommentId: Long,
+    @SerialName("password_protected_comment_author")
+    val passwordProtectedCommentAuthor: String,
+    @SerialName("trashed_post_id")
+    val trashedPostId: Long,
     @SerialName("first_post_date_gmt")
-    val firstPostDateGmt: String
+    val firstPostDateGmt: String,
+    @SerialName("wordpress_core_version")
+    val wordpressCoreVersion: String,
+    @SerialName("integration_test_custom_template_id")
+    val integrationTestCustomTemplateId: String,
+    @SerialName("revisioned_post_id")
+    val revisionedPostId: Long,
 ) {
     companion object {
         private val json by lazy {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -194,6 +194,8 @@ pub enum WpErrorCode {
     CannotListApplicationPasswords,
     #[serde(rename = "rest_cannot_manage_plugins")]
     CannotManagePlugins,
+    #[serde(rename = "rest_cannot_manage_templates")]
+    CannotManageTemplates,
     #[serde(rename = "rest_cannot_read_application_password")]
     CannotReadApplicationPassword,
     #[serde(rename = "rest_cannot_read")]
@@ -280,10 +282,6 @@ pub enum WpErrorCode {
     RevisionInvalidOffsetNumber,
     #[serde(rename = "rest_taxonomy_invalid")]
     TaxonomyInvalid,
-    #[serde(rename = "rest_template_already_trashed")]
-    TemplateAlreadyTrashed,
-    #[serde(rename = "rest_template_insert_error")]
-    TemplateInsertError,
     #[serde(rename = "rest_template_not_found")]
     TemplateNotFound,
     #[serde(rename = "rest_term_invalid")]
@@ -363,6 +361,8 @@ pub enum WpErrorCode {
     SearchInvalidPageNumber,
     #[serde(rename = "rest_search_invalid_type")]
     SearchInvalidType,
+    #[serde(rename = "rest_template_insert_error")]
+    TemplateInsertError,
     #[serde(rename = "rest_upload_file_error")]
     UploadFileError,
     #[serde(rename = "rest_upload_file_too_big")]
@@ -422,6 +422,9 @@ pub enum WpErrorCode {
     // `parent` argument
     #[serde(rename = "rest_taxonomy_not_hierarchical")]
     TaxonomyNotHierarchical,
+    // If the template is already trashed, the server returns `rest_template_not_found`
+    #[serde(rename = "rest_template_already_trashed")]
+    TemplateAlreadyTrashed,
     // If `force=true` is missing from delete user request.
     // If trash is not supported for the post type: https://github.com/WordPress/WordPress/blob/6.6.2/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1011-L1029
     #[serde(rename = "rest_trash_not_supported")]

--- a/wp_api_integration_tests/tests/test_templates_err.rs
+++ b/wp_api_integration_tests/tests/test_templates_err.rs
@@ -34,6 +34,43 @@ async fn delete_template_err_template_not_found() {
 
 #[tokio::test]
 #[parallel]
+async fn update_template_err_cannot_manage_templates() {
+    api_client_as_subscriber()
+        .templates()
+        .update(
+            &TemplateId(
+                TestCredentials::instance()
+                    .integration_test_custom_template_id
+                    .to_string(),
+            ),
+            &TemplateUpdateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageTemplates)
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_template_err_invalid_author() {
+    api_client()
+        .templates()
+        .update(
+            &TemplateId(
+                TestCredentials::instance()
+                    .integration_test_custom_template_id
+                    .to_string(),
+            ),
+            &TemplateUpdateParams {
+                author: Some(UserId(99999999)),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidAuthor);
+}
+
+#[tokio::test]
+#[parallel]
 async fn update_template_err_template_not_found() {
     api_client()
         .templates()


### PR DESCRIPTION
Follows established patterns to implement Kotlin integration tests for `/templates`.