### PR TITLE
Adds missing fields to subscribers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ test_credentials.json
 /logs
 dump.sql
 
+# WP_COM Testing
+wp_com_test_credentials.json
+
 # CI Cache
 .cargo/*
 /vendor

--- a/wp_api/src/wp_com/endpoint/subscribers.rs
+++ b/wp_api/src/wp_com/endpoint/subscribers.rs
@@ -4,8 +4,9 @@ use crate::{
         WpComNamespace, WpComSiteId,
         subscribers::{
             AddSubscribersParams, AddSubscribersResponse, GetSubscriberQuery,
-            ListSubscribersResponse, SubscriberImportJob, SubscriberImportJobsListParams,
-            SubscriberStatsResponse, SubscribersListParams, UploadId,
+            ListSubscribersResponse, Subscriber, SubscriberImportJob,
+            SubscriberImportJobsListParams, SubscriberStatsResponse, SubscribersListParams,
+            UploadId,
         },
     },
 };
@@ -15,7 +16,7 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum SubscribersRequest {
     #[get(url = "/sites/<wp_com_site_id>/subscribers", params = &SubscribersListParams, output = ListSubscribersResponse)]
     ListSubscribers,
-    #[get(url = "/sites/<wp_com_site_id>/subscribers/individual", params = &GetSubscriberQuery, output = SubscriberImportJob)]
+    #[get(url = "/sites/<wp_com_site_id>/subscribers/individual", params = &GetSubscriberQuery, output = Subscriber)]
     GetSubscriber,
     #[get(url = "/sites/<wp_com_site_id>/subscribers/import", params = &SubscriberImportJobsListParams, output = Vec<SubscriberImportJob>)]
     ListSubscriberImportJobs,

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -13,12 +13,15 @@ use wp_serde_helper::deserialize_u64_or_string;
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct Subscriber {
     pub user_id: UserId,
+    pub subscription_id: u64,
     pub display_name: String,
     pub email_address: String,
+    pub is_email_subscriber: bool,
     pub email_subscription_id: Option<u64>,
     pub date_subscribed: WpGmtDateTime,
     pub subscription_status: String,
     pub avatar: String,
+    pub url: Option<String>,
 }
 
 #[derive(

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -22,6 +22,7 @@ pub struct Subscriber {
     pub subscription_status: String,
     pub avatar: String,
     pub url: Option<String>,
+    pub country: Option<SubscriberCountry>,
 }
 
 #[derive(
@@ -70,6 +71,12 @@ pub enum SubscriptionStatus {
     #[serde(untagged)]
     #[strum(default)]
     Custom(String),
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct SubscriberCountry {
+    code: String,
+    name: String,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -134,7 +134,9 @@ impl AppendUrlQueryPairs for SubscribersListParams {
 #[strum(serialize_all = "snake_case")]
 pub enum ListSubscribersSortField {
     DateSubscribed,
+    #[strum(serialize = "email")]
     EmailAddress,
+    #[strum(serialize = "name")]
     DisplayName,
     Plan,
     SubscriptionStatus,

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -23,6 +23,7 @@ pub struct Subscriber {
     pub avatar: String,
     pub url: Option<String>,
     pub country: Option<SubscriberCountry>,
+    pub plans: Option<Vec<SubscriptionPlan>>,
 }
 
 #[derive(
@@ -77,6 +78,21 @@ pub enum SubscriptionStatus {
 pub struct SubscriberCountry {
     code: String,
     name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct SubscriptionPlan {
+    pub is_gift: bool,
+    pub gift_id: Option<u64>,
+    pub paid_subscription_id: Option<String>,
+    pub status: String,
+    pub title: String,
+    pub currency: String,
+    pub renew_interval: String,
+    pub inactive_renew_interval: Option<String>,
+    pub renewal_price: f64,
+    pub start_date: WpGmtDateTime,
+    pub end_date: WpGmtDateTime,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
@@ -538,5 +554,16 @@ mod tests {
             serde_json::from_reader(file).expect("Unable to parse JSON");
         assert_eq!(response.counts.email_subscribers, 26);
         assert_eq!(response.aggregate.len(), 60);
+    }
+
+    #[test]
+    fn test_get_subscriber_with_paid_plans_response_deserialization() {
+        let json_file_path = "tests/wpcom/subscribers/subscriber-with-paid-plans.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let subscriber: Subscriber = serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let plans = subscriber.plans.expect("JSON file includes plans");
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].start_date.to_string(), "2025-01-13T18:51:55+00:00");
     }
 }

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -13,13 +13,13 @@ use wp_serde_helper::deserialize_u64_or_string;
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct Subscriber {
     pub user_id: UserId,
-    pub subscription_id: u64,
+    pub subscription_id: SubscriptionId,
     pub display_name: String,
     pub email_address: String,
     pub is_email_subscriber: bool,
     pub email_subscription_id: Option<u64>,
     pub date_subscribed: WpGmtDateTime,
-    pub subscription_status: String,
+    pub subscription_status: Option<String>,
     pub avatar: String,
     pub url: Option<String>,
     pub country: Option<SubscriberCountry>,
@@ -165,10 +165,10 @@ pub struct ListSubscribersResponse {
 #[derive(Debug, uniffi::Enum)]
 pub enum GetSubscriberQuery {
     // Return subscribers that receive notifications via WordPress.com for new posts.
-    WpCom(u64),
+    WpCom(UserId),
 
     // Return subscribers that receive notifications via email for new posts.
-    Email(u64),
+    Email(SubscriptionId),
 }
 
 impl AppendUrlQueryPairs for GetSubscriberQuery {
@@ -279,6 +279,25 @@ impl AppendUrlQueryPairs for SubscriberImportJobsListParams {
         if let Some(status) = &self.status {
             query_pairs_mut.append_pair("status", &status.to_string());
         }
+    }
+}
+
+impl_as_query_value_for_new_type!(SubscriptionId);
+uniffi::custom_newtype!(SubscriptionId, u64);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionId(pub u64);
+
+impl std::str::FromStr for SubscriptionId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl std::fmt::Display for SubscriptionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -429,7 +429,7 @@ mod tests {
         .expect("Failed to parse url");
 
         let mut query_pairs = url.query_pairs_mut();
-        GetSubscriberQuery::WpCom(123).append_query_pairs(&mut query_pairs);
+        GetSubscriberQuery::WpCom(UserId(123)).append_query_pairs(&mut query_pairs);
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/wpcom/v2/sites/1234/subscribers/individual?user_id=123&type=wpcom"
@@ -444,7 +444,7 @@ mod tests {
         .expect("Failed to parse url");
 
         let mut query_pairs = url.query_pairs_mut();
-        GetSubscriberQuery::Email(123).append_query_pairs(&mut query_pairs);
+        GetSubscriberQuery::Email(SubscriptionId(123)).append_query_pairs(&mut query_pairs);
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/wpcom/v2/sites/1234/subscribers/individual?subscription_id=123&type=email"

--- a/wp_api/tests/wpcom/subscribers/subscriber-with-paid-plans.json
+++ b/wp_api/tests/wpcom/subscribers/subscriber-with-paid-plans.json
@@ -1,0 +1,43 @@
+{
+    "user_id": 123,
+    "subscription_id": 123,
+    "email_address": "test@example.com",
+    "date_subscribed": "2025-04-17T14:40:00+00:00",
+    "is_email_subscriber": false,
+    "subscription_status": "Subscribed",
+    "avatar": "https://example.com/avatar",
+    "display_name": "Foo",
+    "url": "http://example.wordpress.com",
+    "country": {
+        "code": "US",
+        "name": "United States"
+    },
+    "plans": [
+        {
+            "is_gift": false,
+            "gift_id": null,
+            "paid_subscription_id": "12422686",
+            "status": "active",
+            "title": "Newsletter Tier",
+            "currency": "USD",
+            "renew_interval": "1 month",
+            "inactive_renew_interval": null,
+            "renewal_price": 0.5,
+            "start_date": "2025-01-13T18:51:55+00:00",
+            "end_date": "2025-02-13T18:51:55+00:00"
+        },
+        {
+            "is_gift": true,
+            "gift_id": 31,
+            "paid_subscription_id": null,
+            "status": "active",
+            "title": "Newsletter Tier 3",
+            "currency": "USD",
+            "renew_interval": "one-time",
+            "inactive_renew_interval": null,
+            "renewal_price": 0,
+            "start_date": "2025-05-08T14:50:28+00:00",
+            "end_date": "2025-06-07T14:50:28+00:00"
+        }
+    ]
+}

--- a/wp_api_integration_tests/build.rs
+++ b/wp_api_integration_tests/build.rs
@@ -7,39 +7,49 @@ use std::{
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
-    generate_test_credentials_file()
-}
-
-fn generate_test_credentials_file() -> Result<(), Box<dyn Error>> {
-    // Tell Cargo to rerun if the test credentials file changes
-    println!("cargo::rerun-if-changed=../test_credentials");
-
     let out_dir = env::var("OUT_DIR")?;
     let dest_path = Path::new(&out_dir).join("generated_test_credentials.rs");
     let mut buf_writer = BufWriter::new(File::create(dest_path)?);
 
-    let instance = if let Ok(file) = fs::File::open("../test_credentials.json") {
+    generate_test_credentials("test_credentials", "TestCredentials", &mut buf_writer)?;
+    generate_test_credentials(
+        "wp_com_test_credentials",
+        "WpComTestCredentials",
+        &mut buf_writer,
+    )
+}
+
+fn generate_test_credentials(
+    file_name: &str,
+    test_credentials_type: &str,
+    buf_writer: &mut BufWriter<File>,
+) -> Result<(), Box<dyn Error>> {
+    let test_credential_json_file_path = format!("../{file_name}.json");
+    // Tell Cargo to rerun if the test credentials file changes
+    println!("cargo::rerun-if-changed={test_credential_json_file_path}");
+
+    let instance = if let Ok(file) = fs::File::open(&test_credential_json_file_path) {
         let fields = serde_json::from_reader::<File, serde_json::Value>(file)
-            .expect("test_credentials.json should be a valid JSON file")
+            .expect("{test_credential_json_file_path} should be a valid JSON file")
             .as_object()
-            .expect("test_credentials.json should be a valid JSON Object")
+            .expect("{test_credential_json_file_path} should be a valid JSON Object")
             .into_iter()
             .map(|(k, v)| format!("{}: {},", k, v))
             .collect::<Vec<String>>()
             .join("\n");
-        format!("TestCredentials {{ {} }}", fields)
+        format!("{test_credentials_type} {{ {} }}", fields)
     } else {
-        "TestCredentials::default()".to_string()
+        format!("{test_credentials_type}::default()")
     };
     let generated_content = format!(
         r#"
-            impl TestCredentials {{
+            impl {} {{
                 pub fn instance() -> Self {{
                     {}
                 }}
             }}
         "#,
-        instance
+        test_credentials_type, instance
     );
 
     write!(buf_writer, "{}", generated_content)?;

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,3 +1,5 @@
+use wp_api::wp_com::{WpComSiteId, client::WpComApiClient};
+
 use crate::prelude::*;
 
 pub mod mock;
@@ -71,6 +73,14 @@ pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
 
+// We currently don't have the necessary infrastructure to test wp_com endpoints in CI. We are also
+// not separating the wp_com tests at the moment. So consider this to be temporary.
+//
+// If you need to test a wp_com endpoint, you can temporarily add your token, but do not check it
+// into the repo! Don't forget to change the site id as well!
+pub const WP_COM_BEARER_TOKEN: &str = "DON_T_CHECK_INTO_REPO!";
+pub const WP_COM_SITE_ID: WpComSiteId = WpComSiteId(0);
+
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(
         test_site_api_url_resolver(),
@@ -126,6 +136,18 @@ pub fn api_client_with_auth_provider(auth_provider: Arc<WpAuthenticationProvider
             app_notifier: Arc::new(EmptyAppNotifier),
         },
     )
+}
+
+pub fn wp_com_client() -> WpComApiClient {
+    WpComApiClient::new(WpApiClientDelegate {
+        auth_provider: WpAuthenticationProvider::static_with_auth(WpAuthentication::Bearer {
+            token: WP_COM_BEARER_TOKEN.to_string(),
+        })
+        .into(),
+        request_executor: Arc::new(ReqwestRequestExecutor::default()),
+        middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
+        app_notifier: Arc::new(EmptyAppNotifier),
+    })
 }
 
 pub fn test_site_url() -> ParsedUrl {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -1,6 +1,5 @@
-use wp_api::wp_com::{WpComSiteId, client::WpComApiClient};
-
 use crate::prelude::*;
+use wp_api::wp_com::client::WpComApiClient;
 
 pub mod mock;
 pub mod prelude;
@@ -35,6 +34,14 @@ impl TestCredentials {
     pub fn date_format() -> &'static str {
         "%Y-%m-%d %H:%M:%S"
     }
+}
+
+#[derive(Debug, Default)]
+pub struct WpComTestCredentials {
+    pub bearer_token: &'static str,
+    pub site_id: u64,
+    pub wp_com_subscriber_user_id: i64,
+    pub email_subscriber_subscription_id: u64,
 }
 
 pub mod backend;
@@ -72,14 +79,6 @@ pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
-
-// We currently don't have the necessary infrastructure to test wp_com endpoints in CI. We are also
-// not separating the wp_com tests at the moment. So consider this to be temporary.
-//
-// If you need to test a wp_com endpoint, you can temporarily add your token, but do not check it
-// into the repo! Don't forget to change the site id as well!
-pub const WP_COM_BEARER_TOKEN: &str = "DON_T_CHECK_INTO_REPO!";
-pub const WP_COM_SITE_ID: WpComSiteId = WpComSiteId(0);
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(
@@ -141,7 +140,7 @@ pub fn api_client_with_auth_provider(auth_provider: Arc<WpAuthenticationProvider
 pub fn wp_com_client() -> WpComApiClient {
     WpComApiClient::new(WpApiClientDelegate {
         auth_provider: WpAuthenticationProvider::static_with_auth(WpAuthentication::Bearer {
-            token: WP_COM_BEARER_TOKEN.to_string(),
+            token: WpComTestCredentials::instance().bearer_token.to_string(),
         })
         .into(),
         request_executor: Arc::new(ReqwestRequestExecutor::default()),

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,12 +1,13 @@
-use wp_api::wp_com::subscribers::SubscribersListParams;
+use wp_api::wp_com::subscribers::{ListSubscribersSortField, SubscribersListParams};
 use wp_api_integration_tests::{WP_COM_SITE_ID, prelude::*, wp_com_client};
 
 #[tokio::test]
+#[apply(list_cases)]
 #[parallel]
-async fn list_subscribers() {
+async fn list_subscribers(#[case] params: SubscribersListParams) {
     let subscribers = wp_com_client()
         .subscribers()
-        .list_subscribers(&WP_COM_SITE_ID, &SubscribersListParams::default())
+        .list_subscribers(&WP_COM_SITE_ID, &params)
         .await
         .assert_response();
     assert!(
@@ -15,3 +16,13 @@ async fn list_subscribers() {
         subscribers
     );
 }
+
+#[template]
+#[rstest]
+#[case::default(SubscribersListParams::default())]
+#[case::sort_date_subscribed(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::DateSubscribed))))]
+#[case::sort_email_address(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::EmailAddress))))]
+#[case::sort_display_name(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::DisplayName))))]
+#[case::sort_plan(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::Plan))))]
+#[case::sort_subscription_status(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::SubscriptionStatus))))]
+pub fn list_cases(#[case] params: SubscribersListParams) {}

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -11,8 +11,6 @@ use wp_api_integration_tests::{WpComTestCredentials, prelude::*, wp_com_client};
 #[parallel]
 #[ignore]
 async fn list_subscribers(#[case] params: SubscribersListParams) {
-    use wp_api::wp_com::WpComSiteId;
-
     let subscribers = wp_com_client()
         .subscribers()
         .list_subscribers(

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,19 +1,23 @@
-use wp_api::wp_com::subscribers::{
-    GetSubscriberQuery, ListSubscribersSortField, SubscribersListParams, SubscriptionId,
+use wp_api::wp_com::{
+    WpComSiteId,
+    subscribers::{
+        GetSubscriberQuery, ListSubscribersSortField, SubscribersListParams, SubscriptionId,
+    },
 };
-use wp_api_integration_tests::{WP_COM_SITE_ID, prelude::*, wp_com_client};
-
-// TODO: Update these for your test site
-const WP_COM_SUBSCRIBER_USER_ID: i64 = 0;
-const EMAIL_SUBSCRIBER_SUBSCRIPTION_ID: u64 = 0;
+use wp_api_integration_tests::{WpComTestCredentials, prelude::*, wp_com_client};
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
 async fn list_subscribers(#[case] params: SubscribersListParams) {
+    use wp_api::wp_com::WpComSiteId;
+
     let subscribers = wp_com_client()
         .subscribers()
-        .list_subscribers(&WP_COM_SITE_ID, &params)
+        .list_subscribers(
+            &WpComSiteId(WpComTestCredentials::instance().site_id),
+            &params,
+        )
         .await
         .assert_response();
     assert!(
@@ -29,7 +33,10 @@ async fn list_subscribers(#[case] params: SubscribersListParams) {
 async fn retrieve_subscriber(#[case] query: GetSubscriberQuery) {
     wp_com_client()
         .subscribers()
-        .get_subscriber(&WP_COM_SITE_ID, &query)
+        .get_subscriber(
+            &WpComSiteId(WpComTestCredentials::instance().site_id),
+            &query,
+        )
         .await
         .assert_response();
 }
@@ -46,8 +53,8 @@ pub fn list_cases(#[case] params: SubscribersListParams) {}
 
 #[template]
 #[rstest]
-#[case::wp_com_subscriber(GetSubscriberQuery::WpCom(UserId(WP_COM_SUBSCRIBER_USER_ID)))]
+#[case::wp_com_subscriber(GetSubscriberQuery::WpCom(UserId(WpComTestCredentials::instance().wp_com_subscriber_user_id)))]
 #[case::email_subscriber(GetSubscriberQuery::Email(SubscriptionId(
-    EMAIL_SUBSCRIBER_SUBSCRIPTION_ID
+    WpComTestCredentials::instance().email_subscriber_subscription_id
 )))]
 pub fn retrieve_cases(#[case] query: GetSubscriberQuery) {}

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,0 +1,17 @@
+use wp_api::wp_com::subscribers::SubscribersListParams;
+use wp_api_integration_tests::{WP_COM_SITE_ID, prelude::*, wp_com_client};
+
+#[tokio::test]
+#[parallel]
+async fn list_subscribers() {
+    let subscribers = wp_com_client()
+        .subscribers()
+        .list_subscribers(&WP_COM_SITE_ID, &SubscribersListParams::default())
+        .await
+        .assert_response();
+    assert!(
+        subscribers.data.total > 0,
+        "Retrieved no subscribers: {:#?}",
+        subscribers
+    );
+}

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -9,6 +9,7 @@ use wp_api_integration_tests::{WpComTestCredentials, prelude::*, wp_com_client};
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
+#[ignore]
 async fn list_subscribers(#[case] params: SubscribersListParams) {
     use wp_api::wp_com::WpComSiteId;
 
@@ -30,6 +31,7 @@ async fn list_subscribers(#[case] params: SubscribersListParams) {
 #[tokio::test]
 #[apply(retrieve_cases)]
 #[parallel]
+#[ignore]
 async fn retrieve_subscriber(#[case] query: GetSubscriberQuery) {
     wp_com_client()
         .subscribers()

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,5 +1,11 @@
-use wp_api::wp_com::subscribers::{ListSubscribersSortField, SubscribersListParams};
+use wp_api::wp_com::subscribers::{
+    GetSubscriberQuery, ListSubscribersSortField, SubscribersListParams, SubscriptionId,
+};
 use wp_api_integration_tests::{WP_COM_SITE_ID, prelude::*, wp_com_client};
+
+// TODO: Update these for your test site
+const WP_COM_SUBSCRIBER_USER_ID: i64 = 0;
+const EMAIL_SUBSCRIBER_SUBSCRIPTION_ID: u64 = 0;
 
 #[tokio::test]
 #[apply(list_cases)]
@@ -17,6 +23,17 @@ async fn list_subscribers(#[case] params: SubscribersListParams) {
     );
 }
 
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_subscriber(#[case] query: GetSubscriberQuery) {
+    wp_com_client()
+        .subscribers()
+        .get_subscriber(&WP_COM_SITE_ID, &query)
+        .await
+        .assert_response();
+}
+
 #[template]
 #[rstest]
 #[case::default(SubscribersListParams::default())]
@@ -26,3 +43,11 @@ async fn list_subscribers(#[case] params: SubscribersListParams) {
 #[case::sort_plan(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::Plan))))]
 #[case::sort_subscription_status(generate!(SubscribersListParams, (sort, Some(ListSubscribersSortField::SubscriptionStatus))))]
 pub fn list_cases(#[case] params: SubscribersListParams) {}
+
+#[template]
+#[rstest]
+#[case::wp_com_subscriber(GetSubscriberQuery::WpCom(UserId(WP_COM_SUBSCRIBER_USER_ID)))]
+#[case::email_subscriber(GetSubscriberQuery::Email(SubscriptionId(
+    EMAIL_SUBSCRIBER_SUBSCRIPTION_ID
+)))]
+pub fn retrieve_cases(#[case] query: GetSubscriberQuery) {}

--- a/wp_com_test_credentials.json-example
+++ b/wp_com_test_credentials.json-example
@@ -1,0 +1,6 @@
+{
+   "bearer_token": "replace_with_your_oauth2_token",
+   "site_id": 0,
+   "wp_com_subscriber_user_id": 0,
+   "email_subscriber_subscription_id": 0
+}


### PR DESCRIPTION
## Why

The current `Subscriber` type is missing several fields that are returned by the WordPress.com API, causing incomplete data representation and potential parsing failures. This PR ensures we can properly handle all subscriber data fields.

## What Changed

### New Fields Added to `Subscriber`
- `subscription_id` - Unique identifier for the subscription
- `is_email_subscriber` - Boolean flag for email-only subscribers  
- `url` - Subscriber's website URL
- `country` - Subscriber's country information
- `plans` - List of subscription plans

### New Types
- `SubscriberCountry` - Represents country data with code and name
- `SubscriptionPlan` - Contains plan details including ID and name

### Bug Fixes
- Fixed serialization values for `EmailAddress` & `DisplayName` in `ListSubscribersSortField`
- Updated `/sites/<wp_com_site_id>/subscribers/individual` endpoint to properly return `Subscriber` type

### Type Safety Improvements
- Made appropriate `Subscriber` fields optional to match API responses
- Updated `GetSubscriberQuery` to use strongly-typed `UserId` & `SubscriptionId`

## Testing

We don't have an infrastructure to run integration tests for WordPress.com endpoints. This makes it very difficult to ensure that the implementation is correct and introduces a lot of manual testing overhead during development. To improve this situation, this PR introduces a basic setup that allows a developer to copy the `wp_com_test_credentials.json-example` as `wp_com_test_credentials.json` to run relevant tests.

The PR introduces a few tests for subscribers endpoint, however they all have the `#[ignore]` flag and won't be run by default. If a developer has the correct credentials & ids in `wp_com_test_credentials.json`, they can run the tests with:

```bash
cargo test -p wp_api_integration_tests --test 'test_wp_com_subscribers_immut' -- --ignored
```

I have considered adding instructions for this in the `README`, but I'd like this to be a temporary solution and I have some concerns about having WordPress.com specific instructions, so at least for this PR, I decided to skip this step.

### Additional Test Changes
- Added unit tests for parsing subscribers with plans

## Breaking Changes

- Some `Subscriber` fields are now `Option<T>` - existing code may need updates
- `GetSubscriberQuery` now uses typed IDs instead of raw strings
