### PR TITLE
Add Individual Subscriber Stats Endpoint

### DIFF
--- a/wp_api/src/wp_com/endpoint/subscribers.rs
+++ b/wp_api/src/wp_com/endpoint/subscribers.rs
@@ -4,9 +4,9 @@ use crate::{
         WpComNamespace, WpComSiteId,
         subscribers::{
             AddSubscribersParams, AddSubscribersResponse, GetSubscriberQuery,
-            ListSubscribersResponse, Subscriber, SubscriberImportJob,
-            SubscriberImportJobsListParams, SubscriberStatsResponse, SubscribersListParams,
-            UploadId,
+            IndividualSubscriberStats, IndividualSubscriberStatsParams, ListSubscribersResponse,
+            Subscriber, SubscriberImportJob, SubscriberImportJobsListParams,
+            SubscriberStatsResponse, SubscribersListParams, UploadId,
         },
     },
 };
@@ -18,6 +18,8 @@ enum SubscribersRequest {
     ListSubscribers,
     #[get(url = "/sites/<wp_com_site_id>/subscribers/individual", params = &GetSubscriberQuery, output = Subscriber)]
     GetSubscriber,
+    #[get(url = "/sites/<wp_com_site_id>/individual-subscriber-stats", params = &IndividualSubscriberStatsParams, output = IndividualSubscriberStats)]
+    IndividualSubscriberStats,
     #[get(url = "/sites/<wp_com_site_id>/subscribers/import", params = &SubscriberImportJobsListParams, output = Vec<SubscriberImportJob>)]
     ListSubscriberImportJobs,
     #[get(url = "/sites/<wp_com_site_id>/subscribers/import/<upload_id>", output = SubscriberImportJob)]

--- a/wp_api/src/wp_com/endpoint/subscribers.rs
+++ b/wp_api/src/wp_com/endpoint/subscribers.rs
@@ -3,7 +3,7 @@ use crate::{
     wp_com::{
         WpComNamespace, WpComSiteId,
         subscribers::{
-            AddSubscribersParams, AddSubscribersResponse, GetSubscriberQuery,
+            AddSubscribersParams, AddSubscribersResponse, GetSubscriberParams,
             IndividualSubscriberStats, IndividualSubscriberStatsParams, ListSubscribersResponse,
             Subscriber, SubscriberImportJob, SubscriberImportJobsListParams,
             SubscriberStatsResponse, SubscribersListParams, UploadId,
@@ -16,7 +16,7 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum SubscribersRequest {
     #[get(url = "/sites/<wp_com_site_id>/subscribers", params = &SubscribersListParams, output = ListSubscribersResponse)]
     ListSubscribers,
-    #[get(url = "/sites/<wp_com_site_id>/subscribers/individual", params = &GetSubscriberQuery, output = Subscriber)]
+    #[get(url = "/sites/<wp_com_site_id>/subscribers/individual", params = &GetSubscriberParams, output = Subscriber)]
     GetSubscriber,
     #[get(url = "/sites/<wp_com_site_id>/individual-subscriber-stats", params = &IndividualSubscriberStatsParams, output = IndividualSubscriberStats)]
     IndividualSubscriberStats,

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -202,6 +202,27 @@ impl AppendUrlQueryPairs for GetSubscriberQuery {
     }
 }
 
+// MARK: - Individual Subscriber Stats
+
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct IndividualSubscriberStatsParams {
+    pub subscription_id: SubscriptionId,
+}
+
+impl AppendUrlQueryPairs for IndividualSubscriberStatsParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_query_value_pair("subscription_id", &self.subscription_id);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct IndividualSubscriberStats {
+    emails_sent: u64,
+    unique_opens: u64,
+    unique_clicks: u64,
+    blog_registration_date: WpGmtDateTime,
+}
+
 // MARK: - Add Subscribers
 
 #[derive(Debug, Serialize, Deserialize, Default, uniffi::Record)]
@@ -565,5 +586,14 @@ mod tests {
         let plans = subscriber.plans.expect("JSON file includes plans");
         assert_eq!(plans.len(), 2);
         assert_eq!(plans[0].start_date.to_string(), "2025-01-13T18:51:55+00:00");
+    }
+
+    #[test]
+    fn test_individual_subscriber_stats_response_deserialization() {
+        let json_file_path = "tests/wpcom/subscribers/individual-subscriber-stats.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let stats: IndividualSubscriberStats =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(stats.emails_sent, 2);
     }
 }

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -220,7 +220,7 @@ pub struct IndividualSubscriberStats {
     emails_sent: u64,
     unique_opens: u64,
     unique_clicks: u64,
-    blog_registration_date: WpGmtDateTime,
+    blog_registration_date: String,
 }
 
 // MARK: - Add Subscribers

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -179,7 +179,7 @@ pub struct ListSubscribersResponse {
 // MARK: - Get Subscriber
 
 #[derive(Debug, uniffi::Enum)]
-pub enum GetSubscriberQuery {
+pub enum GetSubscriberParams {
     // Return subscribers that receive notifications via WordPress.com for new posts.
     WpCom(UserId),
 
@@ -187,14 +187,14 @@ pub enum GetSubscriberQuery {
     Email(SubscriptionId),
 }
 
-impl AppendUrlQueryPairs for GetSubscriberQuery {
+impl AppendUrlQueryPairs for GetSubscriberParams {
     fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
         match self {
-            GetSubscriberQuery::WpCom(user_id) => {
+            GetSubscriberParams::WpCom(user_id) => {
                 query_pairs_mut.append_pair("user_id", &user_id.to_string());
                 query_pairs_mut.append_pair("type", "wpcom");
             }
-            GetSubscriberQuery::Email(email) => {
+            GetSubscriberParams::Email(email) => {
                 query_pairs_mut.append_pair("subscription_id", &email.to_string());
                 query_pairs_mut.append_pair("type", "email");
             }
@@ -466,7 +466,7 @@ mod tests {
         .expect("Failed to parse url");
 
         let mut query_pairs = url.query_pairs_mut();
-        GetSubscriberQuery::WpCom(UserId(123)).append_query_pairs(&mut query_pairs);
+        GetSubscriberParams::WpCom(UserId(123)).append_query_pairs(&mut query_pairs);
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/wpcom/v2/sites/1234/subscribers/individual?user_id=123&type=wpcom"
@@ -481,7 +481,7 @@ mod tests {
         .expect("Failed to parse url");
 
         let mut query_pairs = url.query_pairs_mut();
-        GetSubscriberQuery::Email(SubscriptionId(123)).append_query_pairs(&mut query_pairs);
+        GetSubscriberParams::Email(SubscriptionId(123)).append_query_pairs(&mut query_pairs);
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/wpcom/v2/sites/1234/subscribers/individual?subscription_id=123&type=email"

--- a/wp_api/tests/wpcom/subscribers/individual-subscriber-stats.json
+++ b/wp_api/tests/wpcom/subscribers/individual-subscriber-stats.json
@@ -1,0 +1,6 @@
+{
+  "emails_sent": 2,
+  "unique_opens": 1,
+  "unique_clicks": 2,
+  "blog_registration_date": "2025-01-21 12:14:50"
+}

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,7 +1,7 @@
 use wp_api::wp_com::{
     WpComSiteId,
     subscribers::{
-        GetSubscriberQuery, IndividualSubscriberStatsParams, ListSubscribersSortField,
+        GetSubscriberParams, IndividualSubscriberStatsParams, ListSubscribersSortField,
         SubscribersListParams, SubscriptionId,
     },
 };
@@ -31,7 +31,7 @@ async fn list_subscribers(#[case] params: SubscribersListParams) {
 #[apply(retrieve_cases)]
 #[parallel]
 #[ignore]
-async fn retrieve_subscriber(#[case] query: GetSubscriberQuery) {
+async fn retrieve_subscriber(#[case] query: GetSubscriberParams) {
     wp_com_client()
         .subscribers()
         .get_subscriber(
@@ -72,8 +72,8 @@ pub fn list_cases(#[case] params: SubscribersListParams) {}
 
 #[template]
 #[rstest]
-#[case::wp_com_subscriber(GetSubscriberQuery::WpCom(UserId(WpComTestCredentials::instance().wp_com_subscriber_user_id)))]
-#[case::email_subscriber(GetSubscriberQuery::Email(SubscriptionId(
+#[case::wp_com_subscriber(GetSubscriberParams::WpCom(UserId(WpComTestCredentials::instance().wp_com_subscriber_user_id)))]
+#[case::email_subscriber(GetSubscriberParams::Email(SubscriptionId(
     WpComTestCredentials::instance().email_subscriber_subscription_id
 )))]
-pub fn retrieve_cases(#[case] query: GetSubscriberQuery) {}
+pub fn retrieve_cases(#[case] query: GetSubscriberParams) {}

--- a/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_subscribers_immut.rs
@@ -1,7 +1,8 @@
 use wp_api::wp_com::{
     WpComSiteId,
     subscribers::{
-        GetSubscriberQuery, ListSubscribersSortField, SubscribersListParams, SubscriptionId,
+        GetSubscriberQuery, IndividualSubscriberStatsParams, ListSubscribersSortField,
+        SubscribersListParams, SubscriptionId,
     },
 };
 use wp_api_integration_tests::{WpComTestCredentials, prelude::*, wp_com_client};
@@ -36,6 +37,24 @@ async fn retrieve_subscriber(#[case] query: GetSubscriberQuery) {
         .get_subscriber(
             &WpComSiteId(WpComTestCredentials::instance().site_id),
             &query,
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+#[ignore]
+async fn individual_subscriber_stats() {
+    wp_com_client()
+        .subscribers()
+        .individual_subscriber_stats(
+            &WpComSiteId(WpComTestCredentials::instance().site_id),
+            &IndividualSubscriberStatsParams {
+                subscription_id: SubscriptionId(
+                    WpComTestCredentials::instance().email_subscriber_subscription_id,
+                ),
+            },
         )
         .await
         .assert_response();


### PR DESCRIPTION
## Summary

This PR adds a new endpoint to retrieve individual subscriber statistics and renames `GetSubscriberQuery` to `GetSubscriberParams` for consistency with other parameter structs in the codebase.

## Changes

### New Features
- **Individual Subscriber Stats Endpoint**: Adds `/sites/<wp_com_site_id>/individual-subscriber-stats` endpoint to retrieve statistics for individual subscribers
  - Returns `emails_sent`, `unique_opens`, `unique_clicks`, and `blog_registration_date`
  - Accepts `subscription_id` as a query parameter

### Refactoring
- **Renamed `GetSubscriberQuery` to `GetSubscriberParams`**: Aligns naming convention with other parameter structs like `SubscribersListParams` and `SubscriberImportJobsListParams`

### Implementation Details
- Added `IndividualSubscriberStats` struct with statistics fields
- Added `IndividualSubscriberStatsParams` struct for query parameters
- Added test JSON fixture and integration test for the new endpoint

## Testing
- Added unit test for deserializing individual subscriber stats response
- Added integration test for the new endpoint (marked as `#[ignore]` for manual execution)
