### PR TITLE
`/widgets` endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,15 @@ Test credentials are configured in:
    - To implement new types, use `wp_api/src/posts.rs` as a reference and follow the same style
    - For a new endpoint, a set of JSONs should be provided to you for each context type, so you can compare them and figure out which field is returned for which contexts.
 
+2. **Error handling for an endpoint**:
+   - The server will return a `crate::WpErrorCode` instance for most error types.
+   - While implementing the errors for a new endpoint, if it's missing from the `crate::WpErrorCode` variants, it needs to be added there. If you need to do this, please add the new variants to the very top of the type and add a comment on top with `// Needs Triage`.
+   - Integration tests for error cases go into `wp_api_integration_tests/tests/test_{endpoint_name}_err.rs` file.
+   - The implementation should follow a similar approach to `wp_api_integration_tests/tests/test_users_err.rs`.
+   - There are several `api_client` helper functions available. The default `api_client` function is authenticated with an admin users. This should be the preferred client if creating the error case doesn't require an inauthenticated or a separate user. There is also `api_client_as_subscriber` function that is authenticated with a subscriber user. Most authentication error types can be triggered using this client type. Another possibility is `api_client_with_auth_provider(WpAuthenticationProvider::none().into())` which doesn't have any authentication headers, so it's useful in specific cases.
+   - Implementing these tests can be difficult without having a full understanding of how to trigger them. So, if you are not sure how to implement it, generate a test function following existing patterns, but leave the implementation empty. Instead, add a comment about what you can find from the implementation related to how one might be able to trigger this error.
+   - The existing tests don't have much documentation, because the test implementation can act as one. However, when you are implementing the test, please add a documentation. This is because we need some context about why you implemented a test in a specific way. If you include a documentation, we can check if what you are trying to do is correct, before reviewing the implementation.
+
 ## Important Files
 
 - `Makefile` - Build automation and platform-specific targets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Rust implementation of the WordPress REST API client library with cross-platform bindings for iOS, Android, and other platforms. The project uses a workspace structure with multiple crates providing modular functionality.
+
+## Build Commands
+
+```bash
+# Start WordPress test instance
+make test-server
+
+# Run unit tests
+cargo test --lib
+
+# Run integration tests
+cargo test -p wp_api_integration_tests
+
+# Run integration tests for a specific file
+cargo test -p wp_api_integration_tests --test '{file_name}'
+
+# Run linting and format checks
+cargo fmt --all -- --check
+cargo clippy --tests --all-targets --all-features -- -D warnings
+
+# Generate API documentation
+cargo doc --no-deps --all-features
+```
+
+## Architecture
+
+### Workspace Structure
+- `wp_api/` - Core REST API implementation
+- `wp_api_integration_tests/` - Integration tests requiring Dockerized WordPress instance
+- `wp_contextual/` - Procedural macro for context-aware types
+- `wp_serde/` - Custom serialization helpers
+- `uniffi-bindgen/` - Cross-platform binding generator
+- `kotlin/` - Kotlin/Android wrapper for generated bindings
+- `native/apple/` - Swift/iOS wrapper for generated bindings
+
+### Testing
+
+Tests require a WordPress instance. Use Docker:
+```bash
+# Start test server (keep running)
+make test-server
+
+# Run the integration tests
+cargo test -p wp_api_integration_tests
+```
+
+Test credentials are configured in:
+- `wp_api_integration_tests/tests/test_credentials.json` (WordPress.org)
+- `wp_api_integration_tests/tests/wp_com_test_credentials.json` (WordPress.com)
+
+### Common Development Tasks
+
+1. **Adding new types that uses WordPress REST API endpoint**:
+   - The API returns different fields depending on the `context` parameter which can be `edit`, `embed` or `view` and defaults to `view`. To support this, we use the `wp_contextual::WpContextual` derive macro and add `#[WpContext(edit, embed, view)]` attribute to each field, using the available contexts.
+   - Each contextual type's name has to start with `Sparse` prefix and all of its fields has to be `Option<T>`. `wp_contextual::WpContextual` derive macro will generate new types from it with the `WithEditContext`, `WithEmbedContext` & `WithViewContext` suffices. These new types will not use `Option<T>` for its fields unless a field in the original `Sparse` type is marked with `#[WpContextualOption]` attribute.
+   - Most types should have the following derive macros `#[derive(Debug, serde::Serialize, serde::Deserialize, uniffi::Record)]`.
+   - To implement new types, use `wp_api/src/posts.rs` as a reference and follow the same style
+   - For a new endpoint, a set of JSONs should be provided to you for each context type, so you can compare them and figure out which field is returned for which contexts.
+
+## Important Files
+
+- `Makefile` - Build automation and platform-specific targets
+- `wp_api/src/lib.rs` - Main library entry point
+- `wp_api/src/request.rs` - Core request/response handling
+- `wp_api/src/wp_error.rs` - Error types and handling
+
+## Development Tips
+
+- Platform bindings are generated automatically - don't edit generated files directly

--- a/api.sh
+++ b/api.sh
@@ -7,4 +7,4 @@ fi
 
 ADMIN_TOKEN=$(jq .admin_password test_credentials.json)
 
-curl --user test@example.com:"$ADMIN_TOKEN" "http://localhost/wp-json$1"
+curl --silent --user test@example.com:"$ADMIN_TOKEN" "http://localhost/wp-json$1" | jq .

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -24,6 +24,7 @@ use crate::{
             templates_endpoint::{TemplatesRequestBuilder, TemplatesRequestExecutor},
             themes_endpoint::{ThemesRequestBuilder, ThemesRequestExecutor},
             users_endpoint::{UsersRequestBuilder, UsersRequestExecutor},
+            widgets_endpoint::{WidgetsRequestBuilder, WidgetsRequestExecutor},
             wp_site_health_tests_endpoint::{
                 WpSiteHealthTestsRequestBuilder, WpSiteHealthTestsRequestExecutor,
             },
@@ -66,6 +67,7 @@ pub struct WpApiRequestBuilder {
     templates: Arc<TemplatesRequestBuilder>,
     themes: Arc<ThemesRequestBuilder>,
     users: Arc<UsersRequestBuilder>,
+    widgets: Arc<WidgetsRequestBuilder>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestBuilder>,
 }
 
@@ -92,6 +94,7 @@ impl WpApiRequestBuilder {
             templates,
             themes,
             users,
+            widgets,
             wp_site_health_tests
         )
     }
@@ -128,6 +131,7 @@ pub struct WpApiClient {
     templates: Arc<TemplatesRequestExecutor>,
     themes: Arc<ThemesRequestExecutor>,
     users: Arc<UsersRequestExecutor>,
+    widgets: Arc<WidgetsRequestExecutor>,
     wp_site_health_tests: Arc<WpSiteHealthTestsRequestExecutor>,
 }
 
@@ -151,6 +155,7 @@ impl WpApiClient {
             templates,
             themes,
             users,
+            widgets,
             wp_site_health_tests
         )
     }
@@ -184,6 +189,7 @@ api_client_generate_endpoint_impl!(WpApi, taxonomies);
 api_client_generate_endpoint_impl!(WpApi, templates);
 api_client_generate_endpoint_impl!(WpApi, themes);
 api_client_generate_endpoint_impl!(WpApi, users);
+api_client_generate_endpoint_impl!(WpApi, widgets);
 api_client_generate_endpoint_impl!(WpApi, wp_site_health_tests);
 
 #[macro_export]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -196,6 +196,8 @@ pub enum WpErrorCode {
     CannotManagePlugins,
     #[serde(rename = "rest_cannot_manage_templates")]
     CannotManageTemplates,
+    #[serde(rename = "rest_cannot_manage_widgets")]
+    CannotManageWidgets,
     #[serde(rename = "rest_cannot_read_application_password")]
     CannotReadApplicationPassword,
     #[serde(rename = "rest_cannot_read")]
@@ -264,6 +266,8 @@ pub enum WpErrorCode {
     InvalidParam,
     #[serde(rename = "rest_invalid_template")]
     InvalidTemplate,
+    #[serde(rename = "rest_invalid_widget")]
+    InvalidWidget,
     #[serde(rename = "rest_no_search_term_defined")]
     NoSearchTermDefined,
     #[serde(rename = "rest_orderby_include_missing_include")]
@@ -308,6 +312,8 @@ pub enum WpErrorCode {
     UserInvalidRole,
     #[serde(rename = "rest_user_invalid_slug")]
     UserInvalidSlug,
+    #[serde(rename = "rest_widget_not_found")]
+    WidgetNotFound,
     // ------------------------------------------------------------------------------------
     // Untested, because we are unable to create the necessary conditions for them
     // ------------------------------------------------------------------------------------

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -35,6 +35,7 @@ pub mod themes;
 pub mod url_query;
 pub mod users;
 pub mod uuid;
+pub mod widgets;
 pub mod wordpress_org;
 pub mod wp_site_health_tests;
 

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -35,6 +35,7 @@ pub mod themes;
 pub mod url_query;
 pub mod users;
 pub mod uuid;
+pub mod widget_types;
 pub mod widgets;
 pub mod wordpress_org;
 pub mod wp_site_health_tests;
@@ -105,7 +106,7 @@ pub enum EnumFromStrParsingError {
     UnknownVariant { value: String },
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum JsonValue {
     Null,

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -18,6 +18,7 @@ pub mod taxonomies_endpoint;
 pub mod templates_endpoint;
 pub mod themes_endpoint;
 pub mod users_endpoint;
+pub mod widgets_endpoint;
 pub mod wp_site_health_tests_endpoint;
 
 pub const WP_JSON_PATH_SEGMENTS: [&str; 1] = ["wp-json"];

--- a/wp_api/src/request/endpoint/widgets_endpoint.rs
+++ b/wp_api/src/request/endpoint/widgets_endpoint.rs
@@ -20,15 +20,12 @@ enum WidgetsRequest {
     Update,
     #[delete(url = "/widgets/<widget_id>", output = crate::widgets::WidgetDeleteResponse)]
     Delete,
-    #[delete(url = "/widgets/<widget_id>", output = WidgetWithEditContext)]
-    Trash,
 }
 
 impl DerivedRequest for WidgetsRequest {
     fn additional_query_pairs(&self) -> Vec<(&str, String)> {
         match &self {
             Self::Delete => vec![("force", true.to_string())],
-            Self::Trash => vec![("force", false.to_string())],
             _ => vec![],
         }
     }

--- a/wp_api/src/request/endpoint/widgets_endpoint.rs
+++ b/wp_api/src/request/endpoint/widgets_endpoint.rs
@@ -20,13 +20,15 @@ enum WidgetsRequest {
     Update,
     #[delete(url = "/widgets/<widget_id>", output = crate::widgets::WidgetDeleteResponse)]
     Delete,
+    #[delete(url = "/widgets/<widget_id>", output = WidgetWithEditContext)]
+    Trash,
 }
 
 impl DerivedRequest for WidgetsRequest {
     fn additional_query_pairs(&self) -> Vec<(&str, String)> {
         match &self {
-            // TODO: Check if there should be a trash action
             Self::Delete => vec![("force", true.to_string())],
+            Self::Trash => vec![("force", false.to_string())],
             _ => vec![],
         }
     }

--- a/wp_api/src/request/endpoint/widgets_endpoint.rs
+++ b/wp_api/src/request/endpoint/widgets_endpoint.rs
@@ -1,0 +1,47 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    SparseField,
+    widgets::{
+        SparseWidgetFieldWithEditContext, SparseWidgetFieldWithEmbedContext,
+        SparseWidgetFieldWithViewContext, WidgetId, WidgetListParams, WidgetWithEditContext,
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum WidgetsRequest {
+    #[contextual_paged(url = "/widgets", params = &WidgetListParams, output = Vec<crate::widgets::SparseWidget>, filter_by = crate::widgets::SparseWidgetField)]
+    List,
+    #[contextual_get(url = "/widgets/<widget_id>", output = crate::widgets::SparseWidget, filter_by = crate::widgets::SparseWidgetField)]
+    Retrieve,
+    #[post(url = "/widgets", params = &crate::widgets::WidgetCreateParams, output = WidgetWithEditContext)]
+    Create,
+    #[post(url = "/widgets/<widget_id>", params = &crate::widgets::WidgetUpdateParams, output = WidgetWithEditContext)]
+    Update,
+    #[delete(url = "/widgets/<widget_id>", output = crate::widgets::WidgetDeleteResponse)]
+    Delete,
+}
+
+impl DerivedRequest for WidgetsRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match &self {
+            // TODO: Check if there should be a trash action
+            Self::Delete => vec![("force", true.to_string())],
+            _ => vec![],
+        }
+    }
+
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseWidgetFieldWithEditContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseWidgetFieldWithEmbedContext
+);
+super::macros::default_sparse_field_implementation_from_field_name!(
+    SparseWidgetFieldWithViewContext
+);

--- a/wp_api/src/widget_types.rs
+++ b/wp_api/src/widget_types.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+uniffi::custom_newtype!(WidgetTypeId, String);
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WidgetTypeId(pub String);
+
+impl Display for WidgetTypeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -1,0 +1,116 @@
+use crate::{
+    WpApiParamOrder, impl_as_query_value_from_to_string,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Display};
+use strum_macros::IntoStaticStr;
+use wp_contextual::WpContextual;
+
+uniffi::custom_newtype!(WidgetId, String);
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WidgetId(pub String);
+
+impl Display for WidgetId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseWidget {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<WidgetId>,
+    #[WpContext(edit, embed, view)]
+    pub id_base: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub sidebar: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub rendered: Option<String>,
+    #[WpContext(edit)]
+    pub rendered_form: Option<String>,
+    #[WpContext(edit)]
+    pub instance: Option<WidgetInstance>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct WidgetInstance {
+    pub encoded: String,
+    pub hash: String,
+    pub raw: HashMap<String, String>,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum WpApiParamWidgetsOrderBy {
+    Id,
+    Include,
+}
+
+impl_as_query_value_from_to_string!(WpApiParamWidgetsOrderBy);
+
+#[derive(Debug, Clone, Default, uniffi::Record)]
+pub struct WidgetListParams {
+    pub order: Option<WpApiParamOrder>,
+    pub orderby: Option<WpApiParamWidgetsOrderBy>,
+    pub sidebar: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
+enum WidgetListParamsField {
+    #[strum(serialize = "order")]
+    Order,
+    #[strum(serialize = "orderby")]
+    Orderby,
+    #[strum(serialize = "sidebar")]
+    Sidebar,
+}
+
+impl AppendUrlQueryPairs for WidgetListParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair(WidgetListParamsField::Order, self.order.as_ref())
+            .append_option_query_value_pair(WidgetListParamsField::Orderby, self.orderby.as_ref())
+            .append_option_query_value_pair(WidgetListParamsField::Sidebar, self.sidebar.as_ref());
+    }
+}
+impl FromUrlQueryPairs for WidgetListParams {
+    fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
+        Some(Self {
+            order: query_pairs.get(WidgetListParamsField::Order),
+            orderby: query_pairs.get(WidgetListParamsField::Orderby),
+            sidebar: query_pairs.get(WidgetListParamsField::Sidebar),
+        })
+    }
+
+    // TODO: Check if true
+    fn supports_pagination() -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Record, Serialize, Deserialize)]
+pub struct WidgetCreateParams {
+    pub id_base: String,
+    pub sidebar: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct WidgetUpdateParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sidebar: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct WidgetDeleteResponse {
+    pub deleted: bool,
+    pub previous: WidgetWithEditContext,
+}

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -81,28 +81,27 @@ pub struct WidgetCreateParams {
     pub id_base: WidgetTypeId,
     pub sidebar: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance: Option<WidgetInstanceCreateParams>,
+    pub instance: Option<WidgetInstanceParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_data: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
-pub enum WidgetInstanceCreateParams {
+pub enum WidgetInstanceParams {
     Raw { raw: HashMap<String, JsonValue> },
     Encoded { encoded: String, hash: String },
 }
 
 #[derive(Debug, Default, Serialize, uniffi::Record)]
 pub struct WidgetUpdateParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_base: Option<WidgetTypeId>,
+    // Updating widget type's with `id_base` is not supported by the backend even though the field
+    // is listed in the documentation: https://developer.wordpress.org/rest-api/reference/widgets/#update-a-widget
+    // The field is omitted from the type to avoid confusion.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sidebar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance: Option<HashMap<String, String>>,
+    pub instance: Option<WidgetInstanceParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_data: Option<String>,
 }

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -1,8 +1,5 @@
-use crate::{
-    WpApiParamOrder, impl_as_query_value_from_to_string,
-    url_query::{
-        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
-    },
+use crate::url_query::{
+    AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
@@ -33,39 +30,28 @@ pub struct SparseWidget {
     pub rendered_form: Option<String>,
     #[WpContext(edit)]
     pub instance: Option<WidgetInstance>,
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub form_data: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct WidgetInstance {
-    pub encoded: String,
-    pub hash: String,
-    pub raw: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoded: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<HashMap<String, String>>,
 }
-
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum, strum_macros::EnumString, strum_macros::Display,
-)]
-#[strum(serialize_all = "snake_case")]
-pub enum WpApiParamWidgetsOrderBy {
-    Id,
-    Include,
-}
-
-impl_as_query_value_from_to_string!(WpApiParamWidgetsOrderBy);
 
 #[derive(Debug, Clone, Default, uniffi::Record)]
 pub struct WidgetListParams {
-    pub order: Option<WpApiParamOrder>,
-    pub orderby: Option<WpApiParamWidgetsOrderBy>,
     pub sidebar: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
 enum WidgetListParamsField {
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
     #[strum(serialize = "sidebar")]
     Sidebar,
 }
@@ -73,40 +59,47 @@ enum WidgetListParamsField {
 impl AppendUrlQueryPairs for WidgetListParams {
     fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
         query_pairs_mut
-            .append_option_query_value_pair(WidgetListParamsField::Order, self.order.as_ref())
-            .append_option_query_value_pair(WidgetListParamsField::Orderby, self.orderby.as_ref())
             .append_option_query_value_pair(WidgetListParamsField::Sidebar, self.sidebar.as_ref());
     }
 }
 impl FromUrlQueryPairs for WidgetListParams {
     fn from_url_query_pairs(query_pairs: UrlQueryPairsMap) -> Option<Self> {
         Some(Self {
-            order: query_pairs.get(WidgetListParamsField::Order),
-            orderby: query_pairs.get(WidgetListParamsField::Orderby),
             sidebar: query_pairs.get(WidgetListParamsField::Sidebar),
         })
     }
 
-    // TODO: Check if true
     fn supports_pagination() -> bool {
-        true
+        false
     }
 }
 
 #[derive(Debug, Clone, uniffi::Record, Serialize, Deserialize)]
 pub struct WidgetCreateParams {
-    pub id_base: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id_base: Option<String>,
     pub sidebar: String,
+    // TODO: What should this type be?
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form_data: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, uniffi::Record)]
 pub struct WidgetUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id_base: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sidebar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form_data: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -1,6 +1,8 @@
+use crate::JsonValue;
 use crate::url_query::{
     AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
 };
+use crate::widget_types::WidgetTypeId;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 use strum_macros::IntoStaticStr;
@@ -21,7 +23,7 @@ pub struct SparseWidget {
     #[WpContext(edit, embed, view)]
     pub id: Option<WidgetId>,
     #[WpContext(edit, embed, view)]
-    pub id_base: Option<String>,
+    pub id_base: Option<WidgetTypeId>,
     #[WpContext(edit, embed, view)]
     pub sidebar: Option<String>,
     #[WpContext(edit, embed, view)]
@@ -42,7 +44,7 @@ pub struct WidgetInstance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw: Option<HashMap<String, String>>,
+    pub raw: Option<HashMap<String, JsonValue>>,
 }
 
 #[derive(Debug, Clone, Default, uniffi::Record)]
@@ -74,18 +76,21 @@ impl FromUrlQueryPairs for WidgetListParams {
     }
 }
 
-#[derive(Debug, Clone, uniffi::Record, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct WidgetCreateParams {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_base: Option<String>,
+    pub id_base: WidgetTypeId,
     pub sidebar: String,
-    // TODO: What should this type be?
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance: Option<HashMap<String, String>>,
+    pub instance: Option<WidgetInstanceCreateParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_data: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Enum)]
+#[serde(untagged)]
+pub enum WidgetInstanceCreateParams {
+    Raw { raw: HashMap<String, JsonValue> },
+    Encoded { encoded: String, hash: String },
 }
 
 #[derive(Debug, Default, Serialize, uniffi::Record)]
@@ -93,7 +98,7 @@ pub struct WidgetUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_base: Option<String>,
+    pub id_base: Option<WidgetTypeId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sidebar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -80,6 +80,8 @@ pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
 pub const WIDGET_ID_BLOCK_2: &str = "block-2";
+pub const WIDGET_INACTIVE_WIDGETS_SIDEBAR: &str = "wp_inactive_widgets";
+pub const WIDGET_TYPE_TEXT: &str = "text";
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -79,7 +79,7 @@ pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
-pub const WIDGET_ID_1: &str = "archives-1";
+pub const WIDGET_ID_BLOCK_2: &str = "block-2";
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -79,6 +79,7 @@ pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";
+pub const WIDGET_ID_1: &str = "archives-1";
 
 pub fn api_client() -> WpApiClient {
     WpApiClient::new(

--- a/wp_api_integration_tests/tests/test_widgets_err.rs
+++ b/wp_api_integration_tests/tests/test_widgets_err.rs
@@ -1,0 +1,132 @@
+use wp_api::widget_types::WidgetTypeId;
+use wp_api::widgets::{
+    WidgetCreateParams, WidgetId, WidgetInstanceParams, WidgetListParams, WidgetUpdateParams,
+};
+use wp_api_integration_tests::{WIDGET_INACTIVE_WIDGETS_SIDEBAR, WIDGET_TYPE_TEXT, prelude::*};
+
+#[tokio::test]
+#[parallel]
+async fn create_widget_err_cannot_manage_widgets() {
+    api_client_as_subscriber()
+        .widgets()
+        .create(&valid_widget_create_params())
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageWidgets);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_widget_err_invalid_widget() {
+    // Test creating a widget with a non-existent widget type.
+    // The WordPress controller validates that the provided `id_base` corresponds to a registered
+    // widget type.
+    let params = WidgetCreateParams {
+        id_base: WidgetTypeId("non_existent_widget_type".to_string()),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        instance: None,
+        form_data: None,
+    };
+    api_client()
+        .widgets()
+        .create(&params)
+        .await
+        .assert_wp_error(WpErrorCode::InvalidWidget);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_widget_err_invalid_widget_malformed_encoded_instance() {
+    let instance = WidgetInstanceParams::Encoded {
+        encoded: "foo".to_string(),
+        hash: "bar".to_string(),
+    };
+    let params = WidgetCreateParams {
+        id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        instance: Some(instance),
+        form_data: None,
+    };
+    api_client()
+        .widgets()
+        .create(&params)
+        .await
+        .assert_wp_error(WpErrorCode::InvalidWidget);
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_widget_err_cannot_manage_widgets() {
+    // The WordPress widgets controller requires 'edit_theme_options' capability which
+    // subscribers don't have.
+    api_client_as_subscriber()
+        .widgets()
+        .delete(&WidgetId("foo".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageWidgets);
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_widget_err_widget_not_found() {
+    api_client()
+        .widgets()
+        .delete(&WidgetId("non-existent-widget-99999".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::WidgetNotFound);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_widgets_err_cannot_manage_widgets() {
+    api_client_with_auth_provider(WpAuthenticationProvider::none().into())
+        .widgets()
+        .list_with_edit_context(&WidgetListParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageWidgets);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_widget_err_widget_not_found() {
+    api_client()
+        .widgets()
+        .retrieve_with_edit_context(&WidgetId("non-existent-widget-99999".to_string()))
+        .await
+        .assert_wp_error(WpErrorCode::WidgetNotFound);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_widget_err_cannot_manage_widgets() {
+    // The WordPress widgets controller requires 'edit_theme_options' capability which
+    // subscribers don't have.
+    api_client_as_subscriber()
+        .widgets()
+        .update(&WidgetId("foo".to_string()), &WidgetUpdateParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::CannotManageWidgets);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_widget_err_invalid_widget() {
+    api_client()
+        .widgets()
+        .update(
+            &WidgetId("non-existent-widget-99999".to_string()),
+            &WidgetUpdateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidWidget);
+}
+
+// Helpers
+
+fn valid_widget_create_params() -> WidgetCreateParams {
+    WidgetCreateParams {
+        id_base: WidgetTypeId("text".to_string()),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        instance: None,
+        form_data: None,
+    }
+}

--- a/wp_api_integration_tests/tests/test_widgets_immut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_immut.rs
@@ -1,0 +1,207 @@
+use wp_api::widgets::{
+    SparseWidgetFieldWithEditContext, SparseWidgetFieldWithEmbedContext,
+    SparseWidgetFieldWithViewContext, WidgetId, WidgetListParams,
+};
+use wp_api_integration_tests::{WIDGET_ID_1, prelude::*};
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: WidgetListParams) {
+    api_client()
+        .widgets()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: WidgetListParams) {
+    api_client()
+        .widgets()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: WidgetListParams) {
+    api_client()
+        .widgets()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .widgets()
+        .retrieve_with_edit_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .widgets()
+        .retrieve_with_embed_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .widgets()
+        .retrieve_with_view_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .await
+        .assert_response();
+}
+
+#[template]
+#[rstest]
+#[case::default(WidgetListParams::default())]
+#[case::sidebar_wp_inactive_widgets(generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))))]
+#[case::sidebar_primary(generate!(WidgetListParams, (sidebar, Some("primary".to_string()))))]
+#[case::sidebar_secondary(generate!(WidgetListParams, (sidebar, Some("secondary".to_string()))))]
+pub fn list_cases(#[case] params: WidgetListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_widget_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_widget_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_widget_field_with_view_context_test_cases!();
+
+    #[apply(sparse_widget_field_with_edit_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithEditContext::Id, SparseWidgetFieldWithEditContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_edit_context(
+        #[case] fields: &[SparseWidgetFieldWithEditContext],
+        #[values(
+            WidgetListParams::default(),
+            generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
+            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
+        )]
+        params: WidgetListParams,
+    ) {
+        api_client()
+            .widgets()
+            .filter_list_with_edit_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|widget| {
+                widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_widget_field_with_edit_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithEditContext::Id, SparseWidgetFieldWithEditContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_edit_context(
+        #[case] fields: &[SparseWidgetFieldWithEditContext],
+    ) {
+        let widget = api_client()
+            .widgets()
+            .filter_retrieve_with_edit_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .await
+            .assert_response()
+            .data;
+        widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_widget_field_with_embed_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithEmbedContext::Id, SparseWidgetFieldWithEmbedContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseWidgetFieldWithEmbedContext],
+        #[values(
+            WidgetListParams::default(),
+            generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
+            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
+        )]
+        params: WidgetListParams,
+    ) {
+        api_client()
+            .widgets()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|widget| {
+                widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_widget_field_with_embed_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithEmbedContext::Id, SparseWidgetFieldWithEmbedContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_embed_context(
+        #[case] fields: &[SparseWidgetFieldWithEmbedContext],
+    ) {
+        let widget = api_client()
+            .widgets()
+            .filter_retrieve_with_embed_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .await
+            .assert_response()
+            .data;
+        widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_widget_field_with_view_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithViewContext::Id, SparseWidgetFieldWithViewContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseWidgetFieldWithViewContext],
+        #[values(
+            WidgetListParams::default(),
+            generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
+            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
+        )]
+        params: WidgetListParams,
+    ) {
+        api_client()
+            .widgets()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|widget| {
+                widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_widget_field_with_view_context_test_cases)]
+    #[case(&[SparseWidgetFieldWithViewContext::Id, SparseWidgetFieldWithViewContext::IdBase])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_view_context(
+        #[case] fields: &[SparseWidgetFieldWithViewContext],
+    ) {
+        let widget = api_client()
+            .widgets()
+            .filter_retrieve_with_view_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .await
+            .assert_response()
+            .data;
+        widget.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+}

--- a/wp_api_integration_tests/tests/test_widgets_immut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_immut.rs
@@ -2,7 +2,7 @@ use wp_api::widgets::{
     SparseWidgetFieldWithEditContext, SparseWidgetFieldWithEmbedContext,
     SparseWidgetFieldWithViewContext, WidgetId, WidgetListParams,
 };
-use wp_api_integration_tests::{WIDGET_ID_1, prelude::*};
+use wp_api_integration_tests::{WIDGET_ID_BLOCK_2, prelude::*};
 
 #[tokio::test]
 #[apply(list_cases)]
@@ -42,7 +42,7 @@ async fn list_with_view_context(#[case] params: WidgetListParams) {
 async fn retrieve_with_edit_context() {
     api_client()
         .widgets()
-        .retrieve_with_edit_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .retrieve_with_edit_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()))
         .await
         .assert_response();
 }
@@ -52,7 +52,7 @@ async fn retrieve_with_edit_context() {
 async fn retrieve_with_embed_context() {
     api_client()
         .widgets()
-        .retrieve_with_embed_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .retrieve_with_embed_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()))
         .await
         .assert_response();
 }
@@ -62,7 +62,7 @@ async fn retrieve_with_embed_context() {
 async fn retrieve_with_view_context() {
     api_client()
         .widgets()
-        .retrieve_with_view_context(&WidgetId(WIDGET_ID_1.to_string()))
+        .retrieve_with_view_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()))
         .await
         .assert_response();
 }
@@ -71,8 +71,6 @@ async fn retrieve_with_view_context() {
 #[rstest]
 #[case::default(WidgetListParams::default())]
 #[case::sidebar_wp_inactive_widgets(generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))))]
-#[case::sidebar_primary(generate!(WidgetListParams, (sidebar, Some("primary".to_string()))))]
-#[case::sidebar_secondary(generate!(WidgetListParams, (sidebar, Some("secondary".to_string()))))]
 pub fn list_cases(#[case] params: WidgetListParams) {}
 
 mod filter {
@@ -91,7 +89,6 @@ mod filter {
         #[values(
             WidgetListParams::default(),
             generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
-            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
         )]
         params: WidgetListParams,
     ) {
@@ -116,7 +113,7 @@ mod filter {
     ) {
         let widget = api_client()
             .widgets()
-            .filter_retrieve_with_edit_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .filter_retrieve_with_edit_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()), fields)
             .await
             .assert_response()
             .data;
@@ -132,7 +129,6 @@ mod filter {
         #[values(
             WidgetListParams::default(),
             generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
-            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
         )]
         params: WidgetListParams,
     ) {
@@ -157,7 +153,7 @@ mod filter {
     ) {
         let widget = api_client()
             .widgets()
-            .filter_retrieve_with_embed_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .filter_retrieve_with_embed_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()), fields)
             .await
             .assert_response()
             .data;
@@ -173,7 +169,6 @@ mod filter {
         #[values(
             WidgetListParams::default(),
             generate!(WidgetListParams, (sidebar, Some("wp_inactive_widgets".to_string()))),
-            generate!(WidgetListParams, (sidebar, Some("primary".to_string())))
         )]
         params: WidgetListParams,
     ) {
@@ -198,7 +193,7 @@ mod filter {
     ) {
         let widget = api_client()
             .widgets()
-            .filter_retrieve_with_view_context(&WidgetId(WIDGET_ID_1.to_string()), fields)
+            .filter_retrieve_with_view_context(&WidgetId(WIDGET_ID_BLOCK_2.to_string()), fields)
             .await
             .assert_response()
             .data;

--- a/wp_api_integration_tests/tests/test_widgets_mut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_mut.rs
@@ -12,10 +12,6 @@ use wp_api_integration_tests::{
     WIDGET_ID_BLOCK_2, WIDGET_INACTIVE_WIDGETS_SIDEBAR, WIDGET_TYPE_TEXT, prelude::*,
 };
 
-const WIDGET_INSTANCE_ENCODED: &str =
-    "YTozOntzOjU6InRpdGxlIjtzOjM6ImZvbyI7czo0OiJ0ZXh0IjtzOjM6ImJhciI7czo2OiJmaWx0ZXIiO2I6MDt9";
-const WIDGET_INSTANCE_HASH: &str = "617122067917f65822b0f1db144ac92b";
-
 #[tokio::test]
 #[serial]
 async fn create_widget() {
@@ -64,37 +60,6 @@ async fn create_widget_with_raw_instance() {
                 .expect("raw instance expected for this test")
                 .get("title"),
             Some(&JsonValue::String(new_title.to_string()))
-        );
-    })
-    .await;
-}
-
-#[tokio::test]
-#[serial]
-async fn create_widget_with_encoded() {
-    let instance = WidgetInstanceParams::Encoded {
-        encoded: WIDGET_INSTANCE_ENCODED.to_string(),
-        hash: WIDGET_INSTANCE_HASH.to_string(),
-    };
-    let params = WidgetCreateParams {
-        id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
-        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
-        instance: Some(instance),
-        form_data: None,
-    };
-    test_create_widget(&params, |created_widget| {
-        assert_eq!(
-            created_widget.id_base,
-            WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
-        );
-        assert_eq!(created_widget.sidebar, WIDGET_INACTIVE_WIDGETS_SIDEBAR);
-        assert_eq!(
-            created_widget.instance.encoded,
-            Some(WIDGET_INSTANCE_ENCODED.to_string())
-        );
-        assert_eq!(
-            created_widget.instance.hash,
-            Some(WIDGET_INSTANCE_HASH.to_string())
         );
     })
     .await;

--- a/wp_api_integration_tests/tests/test_widgets_mut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_mut.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use wp_api::{
     JsonValue,
     widget_types::WidgetTypeId,
-    widgets::{WidgetCreateParams, WidgetInstanceCreateParams, WidgetWithEditContext},
+    widgets::{WidgetCreateParams, WidgetId, WidgetInstanceCreateParams, WidgetWithEditContext},
 };
-use wp_api_integration_tests::prelude::*;
+use wp_api_integration_tests::{WIDGET_ID_BLOCK_2, prelude::*};
 
 const TEST_SIDEBAR: &str = "wp_inactive_widgets";
 const TEST_WIDGET_TYPE: &str = "text";
@@ -87,157 +87,22 @@ async fn create_widget_with_encoded() {
     .await;
 }
 
-// #[tokio::test]
-// #[serial]
-// async fn delete_widget() {
-//     // First create a widget to delete
-//     let mut instance = HashMap::new();
-//     instance.insert("title".to_string(), "Widget to Delete".to_string());
-//
-//     let create_params = WidgetCreateParams {
-//         id: None,
-//         id_base: Some(TEST_ID_BASE.to_string()),
-//         sidebar: TEST_SIDEBAR.to_string(),
-//         instance: Some(instance),
-//         form_data: None,
-//     };
-//
-//     let created_response = api_client()
-//         .widgets()
-//         .create(&create_params)
-//         .await
-//         .assert_response();
-//
-//     let widget_id = &created_response.data.id;
-//
-//     // Now delete it
-//     let delete_response = api_client().widgets().delete(widget_id).await;
-//
-//     assert!(delete_response.is_ok(), "{:#?}", delete_response);
-//     let delete_data = delete_response.unwrap().data;
-//     assert!(delete_data.deleted);
-//     assert_eq!(delete_data.previous.id, *widget_id);
-//
-//     RestoreServer::db().await;
-// }
-//
-// #[tokio::test]
-// #[serial]
-// async fn trash_widget() {
-//     // First create a widget to trash
-//     let mut instance = HashMap::new();
-//     instance.insert("title".to_string(), "Widget to Trash".to_string());
-//
-//     let create_params = WidgetCreateParams {
-//         id: None,
-//         id_base: Some(TEST_ID_BASE.to_string()),
-//         sidebar: TEST_SIDEBAR.to_string(),
-//         instance: Some(instance),
-//         form_data: None,
-//     };
-//
-//     let created_response = api_client()
-//         .widgets()
-//         .create(&create_params)
-//         .await
-//         .assert_response();
-//
-//     let widget_id = &created_response.data.id;
-//
-//     // Now trash it (move to inactive widgets)
-//     let trash_response = api_client().widgets().trash(widget_id).await;
-//
-//     assert!(trash_response.is_ok(), "{:#?}", trash_response);
-//     let trashed_widget = trash_response.unwrap().data;
-//     assert_eq!(trashed_widget.id, *widget_id);
-//     // When trashing, widgets are typically moved to inactive widgets sidebar
-//     assert_eq!(trashed_widget.sidebar, "wp_inactive_widgets");
-//
-//     RestoreServer::db().await;
-// }
-//
-// generate_update_test!(
-//     update_sidebar,
-//     sidebar,
-//     "sidebar-1".to_string(),
-//     |updated_widget| {
-//         assert_eq!(updated_widget.sidebar, "sidebar-1");
-//     }
-// );
-//
-// generate_update_test!(
-//     update_instance_title,
-//     instance,
-//     {
-//         let mut instance = HashMap::new();
-//         instance.insert("title".to_string(), "Updated Title".to_string());
-//         instance.insert("text".to_string(), "Updated content".to_string());
-//         instance
-//     },
-//     |updated_widget| {
-//         assert!(updated_widget.instance.is_some());
-//         if let Some(widget_instance) = &updated_widget.instance {
-//             assert!(widget_instance.raw.is_some());
-//             if let Some(raw) = &widget_instance.raw {
-//                 assert_eq!(raw.get("title"), Some(&"Updated Title".to_string()));
-//                 assert_eq!(raw.get("text"), Some(&"Updated content".to_string()));
-//             }
-//         }
-//     }
-// );
-//
-// generate_update_test!(
-//     update_with_form_data,
-//     form_data,
-//     "widget-text[2][title]=Form+Updated+Title&widget-text[2][text]=Form+updated+content"
-//         .to_string(),
-//     |updated_widget| {
-//         // The form data should have been processed and reflected in the instance
-//         assert!(updated_widget.instance.is_some());
-//     }
-// );
+#[tokio::test]
+#[serial]
+async fn delete_widget() {
+    let widget_delete_response = api_client()
+        .widgets()
+        .delete(&WidgetId(WIDGET_ID_BLOCK_2.to_string()))
+        .await;
+    assert!(
+        widget_delete_response.is_ok(),
+        "{:#?}",
+        widget_delete_response
+    );
+    assert!(widget_delete_response.unwrap().data.deleted);
 
-// async fn test_update_widget<F>(widget_id: &WidgetId, params: &WidgetUpdateParams, assert: F)
-// where
-//     F: Fn(WidgetWithEditContext),
-// {
-//     let response = api_client()
-//         .widgets()
-//         .update(widget_id, params)
-//         .await
-//         .assert_response();
-//     assert(response.data);
-//     RestoreServer::db().await;
-// }
-
-// async fn test_update_existing_widget<F>(params: &WidgetUpdateParams, assert: F)
-// where
-//     F: Fn(WidgetWithEditContext),
-// {
-//     // Create a widget first
-//     let mut instance = HashMap::new();
-//     instance.insert("title".to_string(), "Initial Title".to_string());
-//     instance.insert("text".to_string(), "Initial content".to_string());
-//
-//     let create_params = WidgetCreateParams {
-//         id: None,
-//         id_base: Some(TEST_ID_BASE.to_string()),
-//         sidebar: TEST_SIDEBAR.to_string(),
-//         instance: Some(instance),
-//         form_data: None,
-//     };
-//
-//     let created_response = api_client()
-//         .widgets()
-//         .create(&create_params)
-//         .await
-//         .assert_response();
-//
-//     let widget_id = &created_response.data.id;
-//
-//     // Now update it
-//     test_update_widget(widget_id, params, assert).await;
-// }
+    RestoreServer::db().await;
+}
 
 async fn test_create_widget<F>(params: &WidgetCreateParams, assert: F)
 where
@@ -252,24 +117,15 @@ where
     RestoreServer::db().await;
 }
 
-// mod macro_helper {
-//     macro_rules! generate_update_test {
-//         ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
-//             paste::paste! {
-//                 #[tokio::test]
-//                 #[serial]
-//                 async fn $ident() {
-//                     let updated_value = $new_value;
-//                     test_update_existing_widget(
-//                         &WidgetUpdateParams {
-//                             $field: Some(updated_value),
-//                             ..Default::default()
-//                         }, $assertion)
-//                     .await;
-//                 }
-//             }
-//         };
-//     }
-//
-//     pub(super) use generate_update_test;
+// async fn test_update_widget<F>(widget_id: &WidgetId, params: &WidgetUpdateParams, assert: F)
+// where
+//     F: Fn(WidgetWithEditContext),
+// {
+//     let response = api_client()
+//         .widgets()
+//         .update(widget_id, params)
+//         .await
+//         .assert_response();
+//     assert(response.data);
+//     RestoreServer::db().await;
 // }

--- a/wp_api_integration_tests/tests/test_widgets_mut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_mut.rs
@@ -8,10 +8,10 @@ use wp_api::{
         WidgetWithEditContext,
     },
 };
-use wp_api_integration_tests::{WIDGET_ID_BLOCK_2, prelude::*};
+use wp_api_integration_tests::{
+    WIDGET_ID_BLOCK_2, WIDGET_INACTIVE_WIDGETS_SIDEBAR, WIDGET_TYPE_TEXT, prelude::*,
+};
 
-const INACTIVE_WIDGETS_SIDEBAR: &str = "wp_inactive_widgets";
-const WIDGET_TYPE_TEXT: &str = "text";
 const WIDGET_INSTANCE_ENCODED: &str =
     "YTozOntzOjU6InRpdGxlIjtzOjM6ImZvbyI7czo0OiJ0ZXh0IjtzOjM6ImJhciI7czo2OiJmaWx0ZXIiO2I6MDt9";
 const WIDGET_INSTANCE_HASH: &str = "617122067917f65822b0f1db144ac92b";
@@ -21,7 +21,7 @@ const WIDGET_INSTANCE_HASH: &str = "617122067917f65822b0f1db144ac92b";
 async fn create_widget() {
     let params = WidgetCreateParams {
         id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
-        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: None,
         form_data: None,
     };
@@ -30,7 +30,7 @@ async fn create_widget() {
             created_widget.id_base,
             WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
+        assert_eq!(created_widget.sidebar, WIDGET_INACTIVE_WIDGETS_SIDEBAR);
     })
     .await;
 }
@@ -47,7 +47,7 @@ async fn create_widget_with_raw_instance() {
     let instance = WidgetInstanceParams::Raw { raw };
     let params = WidgetCreateParams {
         id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
-        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: Some(instance),
         form_data: None,
     };
@@ -56,7 +56,7 @@ async fn create_widget_with_raw_instance() {
             created_widget.id_base,
             WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
+        assert_eq!(created_widget.sidebar, WIDGET_INACTIVE_WIDGETS_SIDEBAR);
         assert_eq!(
             created_widget
                 .instance
@@ -78,7 +78,7 @@ async fn create_widget_with_encoded() {
     };
     let params = WidgetCreateParams {
         id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
-        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
+        sidebar: WIDGET_INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: Some(instance),
         form_data: None,
     };
@@ -87,7 +87,7 @@ async fn create_widget_with_encoded() {
             created_widget.id_base,
             WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
+        assert_eq!(created_widget.sidebar, WIDGET_INACTIVE_WIDGETS_SIDEBAR);
         assert_eq!(
             created_widget.instance.encoded,
             Some(WIDGET_INSTANCE_ENCODED.to_string())

--- a/wp_api_integration_tests/tests/test_widgets_mut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_mut.rs
@@ -1,29 +1,36 @@
+use macro_helper::generate_update_test;
 use std::collections::HashMap;
 use wp_api::{
     JsonValue,
     widget_types::WidgetTypeId,
-    widgets::{WidgetCreateParams, WidgetId, WidgetInstanceCreateParams, WidgetWithEditContext},
+    widgets::{
+        WidgetCreateParams, WidgetId, WidgetInstanceParams, WidgetUpdateParams,
+        WidgetWithEditContext,
+    },
 };
 use wp_api_integration_tests::{WIDGET_ID_BLOCK_2, prelude::*};
 
-const TEST_SIDEBAR: &str = "wp_inactive_widgets";
-const TEST_WIDGET_TYPE: &str = "text";
+const INACTIVE_WIDGETS_SIDEBAR: &str = "wp_inactive_widgets";
+const WIDGET_TYPE_TEXT: &str = "text";
+const WIDGET_INSTANCE_ENCODED: &str =
+    "YTozOntzOjU6InRpdGxlIjtzOjM6ImZvbyI7czo0OiJ0ZXh0IjtzOjM6ImJhciI7czo2OiJmaWx0ZXIiO2I6MDt9";
+const WIDGET_INSTANCE_HASH: &str = "617122067917f65822b0f1db144ac92b";
 
 #[tokio::test]
 #[serial]
 async fn create_widget() {
     let params = WidgetCreateParams {
-        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
-        sidebar: TEST_SIDEBAR.to_string(),
+        id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
+        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: None,
         form_data: None,
     };
     test_create_widget(&params, |created_widget| {
         assert_eq!(
             created_widget.id_base,
-            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+            WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
+        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
     })
     .await;
 }
@@ -31,31 +38,32 @@ async fn create_widget() {
 #[tokio::test]
 #[serial]
 async fn create_widget_with_raw_instance() {
+    let new_title = "foo_title";
     let mut raw = HashMap::new();
     raw.insert(
         "title".to_string(),
-        JsonValue::String("foo_title".to_string()),
+        JsonValue::String(new_title.to_string()),
     );
-    let instance = WidgetInstanceCreateParams::Raw { raw };
+    let instance = WidgetInstanceParams::Raw { raw };
     let params = WidgetCreateParams {
-        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
-        sidebar: TEST_SIDEBAR.to_string(),
+        id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
+        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: Some(instance),
         form_data: None,
     };
     test_create_widget(&params, |created_widget| {
         assert_eq!(
             created_widget.id_base,
-            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+            WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
+        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
         assert_eq!(
             created_widget
                 .instance
                 .raw
                 .expect("raw instance expected for this test")
                 .get("title"),
-            Some(&JsonValue::String("foo_title".to_string()))
+            Some(&JsonValue::String(new_title.to_string()))
         );
     })
     .await;
@@ -64,25 +72,30 @@ async fn create_widget_with_raw_instance() {
 #[tokio::test]
 #[serial]
 async fn create_widget_with_encoded() {
-    let encoded =
-        "YTozOntzOjU6InRpdGxlIjtzOjM6ImZvbyI7czo0OiJ0ZXh0IjtzOjM6ImJhciI7czo2OiJmaWx0ZXIiO2I6MDt9";
-    let instance = WidgetInstanceCreateParams::Encoded {
-        encoded: encoded.to_string(),
-        hash: "617122067917f65822b0f1db144ac92b".to_string(),
+    let instance = WidgetInstanceParams::Encoded {
+        encoded: WIDGET_INSTANCE_ENCODED.to_string(),
+        hash: WIDGET_INSTANCE_HASH.to_string(),
     };
     let params = WidgetCreateParams {
-        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
-        sidebar: TEST_SIDEBAR.to_string(),
+        id_base: WidgetTypeId(WIDGET_TYPE_TEXT.to_string()),
+        sidebar: INACTIVE_WIDGETS_SIDEBAR.to_string(),
         instance: Some(instance),
         form_data: None,
     };
     test_create_widget(&params, |created_widget| {
         assert_eq!(
             created_widget.id_base,
-            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+            WidgetTypeId(WIDGET_TYPE_TEXT.to_string())
         );
-        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
-        assert_eq!(created_widget.instance.encoded, Some(encoded.to_string()));
+        assert_eq!(created_widget.sidebar, INACTIVE_WIDGETS_SIDEBAR);
+        assert_eq!(
+            created_widget.instance.encoded,
+            Some(WIDGET_INSTANCE_ENCODED.to_string())
+        );
+        assert_eq!(
+            created_widget.instance.hash,
+            Some(WIDGET_INSTANCE_HASH.to_string())
+        );
     })
     .await;
 }
@@ -104,6 +117,44 @@ async fn delete_widget() {
     RestoreServer::db().await;
 }
 
+generate_update_test!(
+    update_widget_sidebar,
+    sidebar,
+    "foo".to_string(),
+    |updated_widget| {
+        assert_eq!(updated_widget.sidebar, "foo".to_string());
+    }
+);
+
+#[tokio::test]
+#[serial]
+async fn update_widget_instance() {
+    let new_content = "foo_content";
+    let mut raw = HashMap::new();
+    raw.insert(
+        "content".to_string(),
+        JsonValue::String(new_content.to_string()),
+    );
+    let instance = WidgetInstanceParams::Raw { raw };
+    test_update_widget(
+        &WidgetUpdateParams {
+            instance: Some(instance),
+            ..Default::default()
+        },
+        |updated_widget| {
+            assert_eq!(
+                updated_widget
+                    .instance
+                    .raw
+                    .expect("raw instance expected for this test")
+                    .get("content"),
+                Some(&JsonValue::String(new_content.to_string()))
+            );
+        },
+    )
+    .await;
+}
+
 async fn test_create_widget<F>(params: &WidgetCreateParams, assert: F)
 where
     F: Fn(WidgetWithEditContext),
@@ -117,15 +168,37 @@ where
     RestoreServer::db().await;
 }
 
-// async fn test_update_widget<F>(widget_id: &WidgetId, params: &WidgetUpdateParams, assert: F)
-// where
-//     F: Fn(WidgetWithEditContext),
-// {
-//     let response = api_client()
-//         .widgets()
-//         .update(widget_id, params)
-//         .await
-//         .assert_response();
-//     assert(response.data);
-//     RestoreServer::db().await;
-// }
+async fn test_update_widget<F>(params: &WidgetUpdateParams, assert: F)
+where
+    F: Fn(WidgetWithEditContext),
+{
+    let response = api_client()
+        .widgets()
+        .update(&WidgetId(WIDGET_ID_BLOCK_2.to_string()), params)
+        .await
+        .assert_response();
+    assert(response.data);
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_widget(
+                        &WidgetUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_test;
+}

--- a/wp_api_integration_tests/tests/test_widgets_mut.rs
+++ b/wp_api_integration_tests/tests/test_widgets_mut.rs
@@ -1,0 +1,275 @@
+use std::collections::HashMap;
+use wp_api::{
+    JsonValue,
+    widget_types::WidgetTypeId,
+    widgets::{WidgetCreateParams, WidgetInstanceCreateParams, WidgetWithEditContext},
+};
+use wp_api_integration_tests::prelude::*;
+
+const TEST_SIDEBAR: &str = "wp_inactive_widgets";
+const TEST_WIDGET_TYPE: &str = "text";
+
+#[tokio::test]
+#[serial]
+async fn create_widget() {
+    let params = WidgetCreateParams {
+        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
+        sidebar: TEST_SIDEBAR.to_string(),
+        instance: None,
+        form_data: None,
+    };
+    test_create_widget(&params, |created_widget| {
+        assert_eq!(
+            created_widget.id_base,
+            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+        );
+        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_widget_with_raw_instance() {
+    let mut raw = HashMap::new();
+    raw.insert(
+        "title".to_string(),
+        JsonValue::String("foo_title".to_string()),
+    );
+    let instance = WidgetInstanceCreateParams::Raw { raw };
+    let params = WidgetCreateParams {
+        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
+        sidebar: TEST_SIDEBAR.to_string(),
+        instance: Some(instance),
+        form_data: None,
+    };
+    test_create_widget(&params, |created_widget| {
+        assert_eq!(
+            created_widget.id_base,
+            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+        );
+        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
+        assert_eq!(
+            created_widget
+                .instance
+                .raw
+                .expect("raw instance expected for this test")
+                .get("title"),
+            Some(&JsonValue::String("foo_title".to_string()))
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_widget_with_encoded() {
+    let encoded =
+        "YTozOntzOjU6InRpdGxlIjtzOjM6ImZvbyI7czo0OiJ0ZXh0IjtzOjM6ImJhciI7czo2OiJmaWx0ZXIiO2I6MDt9";
+    let instance = WidgetInstanceCreateParams::Encoded {
+        encoded: encoded.to_string(),
+        hash: "617122067917f65822b0f1db144ac92b".to_string(),
+    };
+    let params = WidgetCreateParams {
+        id_base: WidgetTypeId(TEST_WIDGET_TYPE.to_string()),
+        sidebar: TEST_SIDEBAR.to_string(),
+        instance: Some(instance),
+        form_data: None,
+    };
+    test_create_widget(&params, |created_widget| {
+        assert_eq!(
+            created_widget.id_base,
+            WidgetTypeId(TEST_WIDGET_TYPE.to_string())
+        );
+        assert_eq!(created_widget.sidebar, TEST_SIDEBAR);
+        assert_eq!(created_widget.instance.encoded, Some(encoded.to_string()));
+    })
+    .await;
+}
+
+// #[tokio::test]
+// #[serial]
+// async fn delete_widget() {
+//     // First create a widget to delete
+//     let mut instance = HashMap::new();
+//     instance.insert("title".to_string(), "Widget to Delete".to_string());
+//
+//     let create_params = WidgetCreateParams {
+//         id: None,
+//         id_base: Some(TEST_ID_BASE.to_string()),
+//         sidebar: TEST_SIDEBAR.to_string(),
+//         instance: Some(instance),
+//         form_data: None,
+//     };
+//
+//     let created_response = api_client()
+//         .widgets()
+//         .create(&create_params)
+//         .await
+//         .assert_response();
+//
+//     let widget_id = &created_response.data.id;
+//
+//     // Now delete it
+//     let delete_response = api_client().widgets().delete(widget_id).await;
+//
+//     assert!(delete_response.is_ok(), "{:#?}", delete_response);
+//     let delete_data = delete_response.unwrap().data;
+//     assert!(delete_data.deleted);
+//     assert_eq!(delete_data.previous.id, *widget_id);
+//
+//     RestoreServer::db().await;
+// }
+//
+// #[tokio::test]
+// #[serial]
+// async fn trash_widget() {
+//     // First create a widget to trash
+//     let mut instance = HashMap::new();
+//     instance.insert("title".to_string(), "Widget to Trash".to_string());
+//
+//     let create_params = WidgetCreateParams {
+//         id: None,
+//         id_base: Some(TEST_ID_BASE.to_string()),
+//         sidebar: TEST_SIDEBAR.to_string(),
+//         instance: Some(instance),
+//         form_data: None,
+//     };
+//
+//     let created_response = api_client()
+//         .widgets()
+//         .create(&create_params)
+//         .await
+//         .assert_response();
+//
+//     let widget_id = &created_response.data.id;
+//
+//     // Now trash it (move to inactive widgets)
+//     let trash_response = api_client().widgets().trash(widget_id).await;
+//
+//     assert!(trash_response.is_ok(), "{:#?}", trash_response);
+//     let trashed_widget = trash_response.unwrap().data;
+//     assert_eq!(trashed_widget.id, *widget_id);
+//     // When trashing, widgets are typically moved to inactive widgets sidebar
+//     assert_eq!(trashed_widget.sidebar, "wp_inactive_widgets");
+//
+//     RestoreServer::db().await;
+// }
+//
+// generate_update_test!(
+//     update_sidebar,
+//     sidebar,
+//     "sidebar-1".to_string(),
+//     |updated_widget| {
+//         assert_eq!(updated_widget.sidebar, "sidebar-1");
+//     }
+// );
+//
+// generate_update_test!(
+//     update_instance_title,
+//     instance,
+//     {
+//         let mut instance = HashMap::new();
+//         instance.insert("title".to_string(), "Updated Title".to_string());
+//         instance.insert("text".to_string(), "Updated content".to_string());
+//         instance
+//     },
+//     |updated_widget| {
+//         assert!(updated_widget.instance.is_some());
+//         if let Some(widget_instance) = &updated_widget.instance {
+//             assert!(widget_instance.raw.is_some());
+//             if let Some(raw) = &widget_instance.raw {
+//                 assert_eq!(raw.get("title"), Some(&"Updated Title".to_string()));
+//                 assert_eq!(raw.get("text"), Some(&"Updated content".to_string()));
+//             }
+//         }
+//     }
+// );
+//
+// generate_update_test!(
+//     update_with_form_data,
+//     form_data,
+//     "widget-text[2][title]=Form+Updated+Title&widget-text[2][text]=Form+updated+content"
+//         .to_string(),
+//     |updated_widget| {
+//         // The form data should have been processed and reflected in the instance
+//         assert!(updated_widget.instance.is_some());
+//     }
+// );
+
+// async fn test_update_widget<F>(widget_id: &WidgetId, params: &WidgetUpdateParams, assert: F)
+// where
+//     F: Fn(WidgetWithEditContext),
+// {
+//     let response = api_client()
+//         .widgets()
+//         .update(widget_id, params)
+//         .await
+//         .assert_response();
+//     assert(response.data);
+//     RestoreServer::db().await;
+// }
+
+// async fn test_update_existing_widget<F>(params: &WidgetUpdateParams, assert: F)
+// where
+//     F: Fn(WidgetWithEditContext),
+// {
+//     // Create a widget first
+//     let mut instance = HashMap::new();
+//     instance.insert("title".to_string(), "Initial Title".to_string());
+//     instance.insert("text".to_string(), "Initial content".to_string());
+//
+//     let create_params = WidgetCreateParams {
+//         id: None,
+//         id_base: Some(TEST_ID_BASE.to_string()),
+//         sidebar: TEST_SIDEBAR.to_string(),
+//         instance: Some(instance),
+//         form_data: None,
+//     };
+//
+//     let created_response = api_client()
+//         .widgets()
+//         .create(&create_params)
+//         .await
+//         .assert_response();
+//
+//     let widget_id = &created_response.data.id;
+//
+//     // Now update it
+//     test_update_widget(widget_id, params, assert).await;
+// }
+
+async fn test_create_widget<F>(params: &WidgetCreateParams, assert: F)
+where
+    F: Fn(WidgetWithEditContext),
+{
+    let response = api_client()
+        .widgets()
+        .create(params)
+        .await
+        .assert_response();
+    assert(response.data);
+    RestoreServer::db().await;
+}
+
+// mod macro_helper {
+//     macro_rules! generate_update_test {
+//         ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+//             paste::paste! {
+//                 #[tokio::test]
+//                 #[serial]
+//                 async fn $ident() {
+//                     let updated_value = $new_value;
+//                     test_update_existing_widget(
+//                         &WidgetUpdateParams {
+//                             $field: Some(updated_value),
+//                             ..Default::default()
+//                         }, $assertion)
+//                     .await;
+//                 }
+//             }
+//         };
+//     }
+//
+//     pub(super) use generate_update_test;
+// }


### PR DESCRIPTION
Follows established patterns to implement [`/widgets` endpoint](https://developer.wordpress.org/rest-api/reference/widgets/).

I've been trying out Claude Code and added a work in progress `CLAUDE.md` file. I think it's pretty far from where it needs to be, but I don't want to make it a priority to improve that file and instead have been doing that as I need to. Please note that the generated code will have a lot of issues with the current instructions - probably even after it's improved greatly. So, I suggest carefully reviewing everything generated by AI.