### PR TITLE
Adds delete follower & delete email follower .com endpoints

### DIFF
--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -86,7 +86,7 @@ impl InnerRequestBuilder {
         }
     }
 
-    pub fn post<T>(&self, url: ApiEndpointUrl, json_body: &T) -> WpNetworkRequest
+    pub fn post<T>(&self, url: ApiEndpointUrl, json_body: Option<&T>) -> WpNetworkRequest
     where
         T: ?Sized + Serialize,
     {
@@ -96,9 +96,11 @@ impl InnerRequestBuilder {
             method: RequestMethod::POST,
             url: url.into(),
             header_map: self.header_map_for_post_request().into(),
-            body: serde_json::to_vec(json_body)
-                .ok()
-                .map(|b| Arc::new(WpNetworkRequestBody::new(b))),
+            body: json_body.and_then(|j| {
+                serde_json::to_vec(j)
+                    .ok()
+                    .map(|b| Arc::new(WpNetworkRequestBody::new(b)))
+            }),
         }
     }
 

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -422,6 +422,12 @@ impl std::fmt::Display for UserId {
     }
 }
 
+impl From<i64> for UserId {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseUser {
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -1,4 +1,5 @@
 use super::endpoint::{
+    followers_endpoint::{FollowersRequestBuilder, FollowersRequestExecutor},
     jetpack_connection_endpoint::{
         JetpackConnectionRequestBuilder, JetpackConnectionRequestExecutor,
     },
@@ -30,6 +31,7 @@ impl UniffiWpComApiRequestBuilder {
 }
 
 pub struct WpComApiRequestBuilder {
+    followers: Arc<FollowersRequestBuilder>,
     jetpack_connection: Arc<JetpackConnectionRequestBuilder>,
     oauth2: Arc<Oauth2RequestBuilder>,
     subscribers: Arc<SubscribersRequestBuilder>,
@@ -43,6 +45,7 @@ impl WpComApiRequestBuilder {
         api_client_generate_request_builder!(
             api_url_resolver,
             auth_provider;
+            followers,
             jetpack_connection,
             oauth2,
             subscribers,
@@ -67,6 +70,7 @@ impl UniffiWpComApiClient {
 }
 
 pub struct WpComApiClient {
+    followers: Arc<FollowersRequestExecutor>,
     jetpack_connection: Arc<JetpackConnectionRequestExecutor>,
     oauth2: Arc<Oauth2RequestExecutor>,
     subscribers: Arc<SubscribersRequestExecutor>,
@@ -81,6 +85,7 @@ impl WpComApiClient {
         api_client_generate_api_client!(
             api_url_resolver,
             delegate;
+            followers,
             jetpack_connection,
             oauth2,
             subscribers,
@@ -88,6 +93,7 @@ impl WpComApiClient {
         )
     }
 }
+api_client_generate_endpoint_impl!(WpComApi, followers);
 api_client_generate_endpoint_impl!(WpComApi, jetpack_connection);
 api_client_generate_endpoint_impl!(WpComApi, oauth2);
 api_client_generate_endpoint_impl!(WpComApi, subscribers);

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -6,6 +6,7 @@ use crate::{
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
+pub mod followers_endpoint;
 pub mod jetpack_connection_endpoint;
 pub mod oauth2;
 pub mod subscribers_endpoint;

--- a/wp_api/src/wp_com/endpoint/followers_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/followers_endpoint.rs
@@ -1,0 +1,22 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    users::UserId,
+    wp_com::{
+        WpComNamespace, WpComSiteId, followers::DeleteFollowerResponse, subscribers::SubscriptionId,
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum FollowersRequest {
+    #[post(url = "/sites/<wp_com_site_id>/followers/<user_id>/delete", output = DeleteFollowerResponse)]
+    DeleteFollower,
+    #[post(url = "/sites/<wp_com_site_id>/email-followers/<subscription_id>/delete", output = DeleteFollowerResponse)]
+    DeleteEmailFollower,
+}
+
+impl DerivedRequest for FollowersRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/followers.rs
+++ b/wp_api/src/wp_com/followers.rs
@@ -1,0 +1,10 @@
+use crate::users::UserId;
+use serde::{Deserialize, Serialize};
+use wp_serde_helper::deserialize_i64_or_string_as_t;
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct DeleteFollowerResponse {
+    #[serde(deserialize_with = "deserialize_i64_or_string_as_t")]
+    follower_id: UserId,
+    deleted: bool,
+}

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -5,6 +5,7 @@ use std::{num::ParseIntError, str::FromStr, sync::Arc};
 
 pub mod client;
 pub mod endpoint;
+pub mod followers;
 pub mod jetpack_connection;
 pub mod oauth2;
 pub mod subscribers;
@@ -31,6 +32,7 @@ impl std::fmt::Display for WpComSiteId {
 
 pub(crate) enum WpComNamespace {
     Oauth2,
+    RestV1_1,
     V2,
 }
 
@@ -38,6 +40,7 @@ impl AsNamespace for WpComNamespace {
     fn namespace_value(&self) -> &'static str {
         match self {
             WpComNamespace::Oauth2 => "/oauth2",
+            WpComNamespace::RestV1_1 => "/rest/v1.1",
             WpComNamespace::V2 => "/wpcom/v2",
         }
     }

--- a/wp_api/src/wp_com/subscribers.rs
+++ b/wp_api/src/wp_com/subscribers.rs
@@ -5,7 +5,6 @@ use crate::{
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
     users::UserId,
 };
-
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, ops::Not};
 use wp_serde_helper::deserialize_u64_or_string;

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -370,11 +370,11 @@ pub fn fn_body_build_request_from_url(
         RequestType::Post => {
             if params_type.is_some() {
                 quote! {
-                    self.inner.post(url, params)
+                    self.inner.post(url, Some(params))
                 }
             } else {
                 quote! {
-                    self.inner.post(url)
+                    self.inner.post(url, None::<&()>)
                 }
             }
         }
@@ -1053,11 +1053,15 @@ mod tests {
         RequestType::Delete,
         "self . inner . delete (url)"
     )]
-    #[case(None, RequestType::Post, "self . inner . post (url)")]
+    #[case(
+        None,
+        RequestType::Post,
+        "self . inner . post (url , None :: < & () >)"
+    )]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::Post,
-        "self . inner . post (url , params)"
+        "self . inner . post (url , Some (params))"
     )]
     fn test_fn_body_build_request_from_url(
         #[case] params: Option<ParamsType>,

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -96,6 +96,14 @@ where
     deserializer.deserialize_any(DeserializeU64OrStringVisitor)
 }
 
+pub fn deserialize_i64_or_string_as_t<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: From<i64>,
+{
+    deserialize_i64_or_string(deserializer).map(Into::into)
+}
+
 struct DeserializeU64OrStringVisitor;
 
 impl de::Visitor<'_> for DeserializeU64OrStringVisitor {


### PR DESCRIPTION
Follows established patterns to implement .com endpoints: `/sites/<wp_com_site_id>/followers/<user_id>/delete` & `/sites/<wp_com_site_id>/email-followers/<subscription_id>/delete`.

It updates the json body for `POST` requests to be optional and adds `deserialize_i64_or_string_as_t` so we can parse `String`s as specific ids, such as `UserId`.