### PR TITLE
[Tooling] Update localization sync to create a PR

### DIFF
--- a/.buildkite/commands/sync-localization.sh
+++ b/.buildkite/commands/sync-localization.sh
@@ -11,10 +11,5 @@ source use-bot-for-git
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :globe_with_meridians: :arrow_up: Generate the source language PO file for GlotPress based on `wp_localization/localization/en-US/main.ftl`"
-bundle exec fastlane generate_source_po_file commit_changes:true
-
-echo "--- :globe_with_meridians: :arrow_down: Download and update translations from GlotPress and update the local Fluent files"
-bundle exec fastlane download_translations commit_changes:true
-
-git push origin
+echo "--- :globe_with_meridians: :arrows_counterclockwise: Synchronizing localization files with GlotPress"
+bundle exec fastlane sync_localization skip_confirm:true

--- a/.buildkite/commands/sync-localization.sh
+++ b/.buildkite/commands/sync-localization.sh
@@ -12,4 +12,4 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :globe_with_meridians: :arrows_counterclockwise: Synchronizing localization files with GlotPress"
-bundle exec fastlane sync_localization skip_confirm:true
+bundle exec fastlane sync_localization

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,7 @@ LANE_VALUE_XCFRAMEWORK_CHECKSUM_PATH = 'WP_XCFRAMEWORK_CHECKSUM_PATH'
 
 GITHUB_REPO = 'automattic/wordpress-rs'
 GIT_REMOTE_NAME = 'origin'
+GIT_BASE_BRANCH = 'trunk'
 
 # Localization constants
 LOCALIZATION_FLUENT_FILES_DIR = File.join(PROJECT_ROOT, 'wp_localization', 'localization')
@@ -179,8 +180,9 @@ end
 # The resulting PO file is saved as the source file (.pot) for translations and is synced to GlotPress.
 #
 # @param commit_changes [Boolean] Whether to commit the generated PO file (default: false)
+# @param skip_date_only_changes [Boolean] Whether to skip commit if only date headers changed (default: true)
 #
-lane :generate_source_po_file do |commit_changes: false|
+lane :generate_source_po_file do |commit_changes: false, skip_date_only_changes: true|
   UI.header('🔄 Converting English Fluent file to PO format')
 
   FileUtils.mkdir_p(File.dirname(LOCALIZATION_PO_SOURCE_FILE))
@@ -202,6 +204,12 @@ lane :generate_source_po_file do |commit_changes: false|
   end
 
   if commit_changes
+    # Check if we should skip commit when only date headers changed
+    if skip_date_only_changes && only_date_headers_changed?(LOCALIZATION_PO_SOURCE_FILE)
+      UI.message('ℹ️ Skipping commit - only date headers changed in PO file')
+      next
+    end
+
     commit_changed_files(
       files: LOCALIZATION_PO_SOURCE_FILE,
       message: 'Update source PO file (en-US.pot) to be synced to GlotPress'
@@ -246,6 +254,56 @@ lane :download_translations do |commit_changes: false|
       )
     end
   end
+end
+
+# Synchronizes localization files with GlotPress and creates a PR
+#
+# This lane performs a complete localization sync:
+# 1. Generates source PO file from English Fluent file
+# 2. Downloads latest translations from GlotPress
+# 3. Creates a PR with the changes instead of pushing directly to trunk
+#
+lane :sync_localization do
+  github_token = ENV['GITHUB_TOKEN'] || UI.user_error!('GITHUB_TOKEN environment variable is required')
+
+  sync_branch = 'localization/sync-translations'
+
+  Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(sync_branch)
+  Fastlane::Helper::GitHelper.create_branch(sync_branch)
+
+  po_result = generate_source_po_file(commit_changes: true, skip_date_only_changes: true)
+  translations_result = download_translations(commit_changes: true)
+
+  # Check if either operation resulted in changes
+  has_changes = !po_result.nil? || !translations_result.nil?
+  unless has_changes
+    UI.important('⚠️ No changes to commit')
+    next
+  end
+
+  Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(sync_branch)
+
+  # Push the localization sync branch to remote
+  push_to_git_remote(set_upstream: true, tags: false)
+
+  pr_result = create_pull_request(
+    repo: GITHUB_REPO,
+    title: 'Sync localization files with GlotPress',
+    body: <<~BODY,
+      This PR synchronizes localization files with GlotPress:
+
+      - **Source PO file**: Updated from English Fluent file for GlotPress sync
+      - **Translations**: Downloaded latest translations from GlotPress and converted to Fluent format
+
+      🔄 This is an automated localization sync.
+    BODY
+    labels: 'Localization',
+    base: GIT_BASE_BRANCH,
+    head: sync_branch,
+    api_token: github_token
+  )
+
+  UI.success("✅ Created pull request: #{pr_result}")
 end
 
 # Downloads PO files from GlotPress for existing project locales
@@ -357,4 +415,34 @@ def commit_changed_files(files:, message:, push: false)
   elsif push
     push_to_git_remote(set_upstream: true, tags: false)
   end
+
+  result
+end
+
+# Checks if only date headers changed in a PO file
+#
+# This method uses git diff to check if the only changes in a PO file
+# are the POT-Creation-Date and PO-Revision-Date headers.
+#
+# @param file_path [String] Path to the PO file to check
+# @return [Boolean] true if only date headers changed, false otherwise
+#
+def only_date_headers_changed?(file_path)
+  begin
+    diff_output = sh('git', 'diff', file_path).strip
+  rescue
+    return false
+  end
+
+  return false if diff_output.empty?
+
+  # Parse diff lines that start with + or - (actual changes)
+  changed_lines = diff_output.split("\n").select do |line|
+    line.start_with?('+') || line.start_with?('-')
+  end.reject do |line|
+    # Exclude diff metadata lines
+    line.start_with?('+++') || line.start_with?('---')
+  end
+
+  changed_lines.all? { |l| l.include?('"POT-Creation-Date:') || l.include?('"PO-Revision-Date:') }
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -298,6 +298,7 @@ lane :sync_localization do
       🔄 This is an automated localization sync.
     BODY
     labels: 'Localization',
+    team_reviewers: ['wordpress-rs'],
     base: GIT_BASE_BRANCH,
     head: sync_branch,
     api_token: github_token

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,6 +278,15 @@ lane :sync_localization do
   has_changes = !po_result.nil? || !translations_result.nil?
   unless has_changes
     UI.important('⚠️ No changes to commit')
+
+    if is_ci
+      buildkite_annotate(
+        context: 'localization-sync-no-changes',
+        style: 'info',
+        message: 'No localization changes to commit. No PR was created.'
+      )
+    end
+
     next
   end
 
@@ -304,7 +313,15 @@ lane :sync_localization do
     api_token: github_token
   )
 
-  UI.success("✅ Created pull request: #{pr_result}")
+  UI.success("✅ Created pull request: #{pr_result}") if pr_result
+
+  if is_ci && pr_result
+    buildkite_annotate(
+      context: 'localization-sync-pr',
+      style: 'info',
+      message: "Localization Sync Pull Request: #{pr_result}"
+    )
+  end
 end
 
 # Downloads PO files from GlotPress for existing project locales


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wordpress-rs/pull/770
Related to [AINFRA-573](https://linear.app/a8c/issue/AINFRA-573)

This PR changes the localization sync job to create a Pull Request when there are localization changes, instead of committing directly to `trunk` (which would fail anyway as the branch is protected and even admins are not allowed to bypass).

### Testing

I've run a couple of builds manually (with `PIPELINE=nightly.yml`) to test this PR:
- Build without changes: https://buildkite.com/automattic/wordpress-rs/builds/3194#0197d000-facf-4251-9a98-272b7c070191/312-332
- Build with one translation update: https://buildkite.com/automattic/wordpress-rs/builds/3196#0197d00b-dfef-4bef-9081-4c6b8b99e2aa/742-746 (resulting in [this PR](https://github.com/Automattic/wordpress-rs/pull/791/files#diff-444b00a617b054b7a9f666725893bcccbd84c09ffe5fa47332a26a12c56ec018R21), which contains the changes from this branch as I ran it in Buildkite directly from this branch)