### PR TITLE
Cancelling uploadMedia task should cancel underlying HTTP request

### DIFF
--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -111,6 +111,8 @@ public typealias MediaUploadRequest = WordPressAPIInternal.MediaUploadRequest
 public typealias MediaWithEditContext = WordPressAPIInternal.MediaWithEditContext
 public typealias MediaWithViewContext = WordPressAPIInternal.MediaWithViewContext
 public typealias MediaWithEmbedContext = WordPressAPIInternal.MediaWithEmbedContext
+public typealias MediaCreateParams = WordPressAPIInternal.MediaCreateParams
+public typealias MediaUpdateParams = WordPressAPIInternal.MediaUpdateParams
 public typealias MediaListParams = WordPressAPIInternal.MediaListParams
 public typealias MediaRequestExecutor = WordPressAPIInternal.MediaRequestExecutor
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -64,3 +64,12 @@ extension CommentType: ExpressibleByStringLiteral {
         self.init(stringLiteral)
     }
 }
+
+extension WpApiError {
+    public var isCancellationError: Bool {
+        if case .RequestExecutionFailed(statusCode: _, redirects: _, reason: .cancellationError) = self {
+            return true
+        }
+        return false
+    }
+}

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -97,6 +97,14 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 return handleDeviceIsOfflineError(error)
             }
 
+            if let urlError = error as? URLError, urlError.code == .cancelled {
+                return .failure(.RequestExecutionFailed(
+                    statusCode: nil,
+                    redirects: nil,
+                    reason: .cancellationError
+                ))
+            }
+
             return .failure(.RequestExecutionFailed(
                 statusCode: nil,
                 redirects: nil,

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -138,6 +138,7 @@ public actor WordPressAPI {
     ) async throws -> MediaRequestCreateResponse {
         precondition(localFileURL.isFileURL)
         precondition(progress.completedUnitCount == 0 && progress.totalUnitCount > 0)
+        precondition(progress.cancellationHandler == nil)
 
         let requestId = WpUuid()
 
@@ -168,13 +169,18 @@ public actor WordPressAPI {
             )
         }
 
-        if progress.cancellationHandler == nil {
-            progress.cancellationHandler = {
-                uploadTask.cancel()
-            }
+        progress.cancellationHandler = {
+            uploadTask.cancel()
         }
 
-        return try await uploadTask.value
+        return try await withTaskCancellationHandler {
+            try await uploadTask.value
+        } onCancel: {
+            // Please note: for some reason calling `uploadTask.cancel()` here does not actually cancel
+            // the HTTP request. But calling `progress.cancel()` does, even though `progress.cancel()` eventually
+            // calls `uploadTask.cancel()`.
+            progress.cancel()
+        }
     }
 #endif
 

--- a/native/swift/Tests/integration-tests/MediaTests.swift
+++ b/native/swift/Tests/integration-tests/MediaTests.swift
@@ -39,5 +39,56 @@ struct MediaTests {
 
         try await restoreTestServer()
     }
-    #endif
+
+    @Test
+    func cancelProgress() async throws {
+        let progress = Progress.discreteProgress(totalUnitCount: 100)
+        #expect(progress.fractionCompleted == 0)
+
+        let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
+        await #expect(throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError), performing: {
+            let task = Task {
+                let _ = try await api.uploadMedia(
+                    params: .init(),
+                    fromLocalFileURL: file,
+                    fulfilling: progress
+                )
+            }
+
+            let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
+                progress.cancel()
+            }
+            defer { cancellable.cancel() }
+
+            try await task.value
+        })
+
+        try await restoreTestServer()
+    }
+
+    @Test
+    func cancelTask() async throws {
+        let progress = Progress.discreteProgress(totalUnitCount: 100)
+        #expect(progress.fractionCompleted == 0)
+        let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
+        await #expect(throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError), performing: {
+            let task = Task {
+                let _ = try await api.uploadMedia(
+                    params: .init(),
+                    fromLocalFileURL: file,
+                    fulfilling: progress
+                )
+            }
+
+            let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
+                task.cancel()
+            }
+            defer { cancellable.cancel() }
+
+            try await task.value
+        })
+
+        try await restoreTestServer()
+    }
+#endif
 }

--- a/native/swift/Tests/integration-tests/MediaTests.swift
+++ b/native/swift/Tests/integration-tests/MediaTests.swift
@@ -46,22 +46,25 @@ struct MediaTests {
         #expect(progress.fractionCompleted == 0)
 
         let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
-        await #expect(throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError), performing: {
-            let task = Task {
-                let _ = try await api.uploadMedia(
-                    params: .init(),
-                    fromLocalFileURL: file,
-                    fulfilling: progress
-                )
-            }
+        await #expect(
+            throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError),
+            performing: {
+                let task = Task {
+                    _ = try await api.uploadMedia(
+                        params: .init(),
+                        fromLocalFileURL: file,
+                        fulfilling: progress
+                    )
+                }
 
-            let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
-                progress.cancel()
-            }
-            defer { cancellable.cancel() }
+                let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
+                    progress.cancel()
+                }
+                defer { cancellable.cancel() }
 
-            try await task.value
-        })
+                try await task.value
+            }
+        )
 
         try await restoreTestServer()
     }
@@ -71,22 +74,25 @@ struct MediaTests {
         let progress = Progress.discreteProgress(totalUnitCount: 100)
         #expect(progress.fractionCompleted == 0)
         let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
-        await #expect(throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError), performing: {
-            let task = Task {
-                let _ = try await api.uploadMedia(
-                    params: .init(),
-                    fromLocalFileURL: file,
-                    fulfilling: progress
-                )
-            }
+        await #expect(
+            throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError),
+            performing: {
+                let task = Task {
+                    _ = try await api.uploadMedia(
+                        params: .init(),
+                        fromLocalFileURL: file,
+                        fulfilling: progress
+                    )
+                }
 
-            let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
-                task.cancel()
-            }
-            defer { cancellable.cancel() }
+                let cancellable = progress.publisher(for: \.fractionCompleted).first { $0 > 0 }.sink { _ in
+                    task.cancel()
+                }
+                defer { cancellable.cancel() }
 
-            try await task.value
-        })
+                try await task.value
+            }
+        )
 
         try await restoreTestServer()
     }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -566,6 +566,7 @@ pub enum RequestExecutionErrorReason {
     DeviceIsOfflineError {
         error_message: String,
     },
+    CancellationError,
     HttpError {
         reason: String,
     },
@@ -656,6 +657,7 @@ impl WpSupportsLocalization for RequestExecutionErrorReason {
                 WpMessages::just(error_message)
             }
             RequestExecutionErrorReason::HttpTimeoutError => WpMessages::http_timeout_error(),
+            RequestExecutionErrorReason::CancellationError => WpMessages::http_cancellation_error(),
         }
     }
 }

--- a/wp_localization/localization/en-US/main.ftl
+++ b/wp_localization/localization/en-US/main.ftl
@@ -22,6 +22,7 @@ non_existent_site_error = A server with the specified hostname could not be foun
 http_authentication_required_error = The server at {$url} requires authentication. Please provide your username and password.
 http_forbidden_error = The server at {$url} denied access to the requested resource. Please check your site's configuration.
 http_timeout_error = The connection timed out
+http_cancellation_error = The request was cancelled.
 
 http_authentication_rejected_error = The server at {$url} rejected your credentials. Please provide a valid username and password.
 


### PR DESCRIPTION
There are two main changes in this PR:
1. Add `RequestExecutionErrorReason::CancellationError`. Currently, cancelling an HTTP API call results in `RequestExecutionErrorReason::GenericError { message: "cancelled" }`, which is not specific enough. Adding a `CancellationError` would help developers to distinguish errors due to the user cancelling operations from other unexpected errors.
2. I initially thought the `try await uploadTask.value` call would handle cancellation, but turns out [it does not](https://forums.swift.org/t/understanding-task-cancellation/75329). I have addressed this issue in this PR and added a couple of unit tests to cover it.