### PR TITLE
Adding progress listener to kotlin WpRequestExecutor

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ProgressRequestBody.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ProgressRequestBody.kt
@@ -1,0 +1,60 @@
+package rs.wordpress.api.kotlin
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.Buffer
+import okio.BufferedSink
+import okio.ForwardingSink
+import okio.Sink
+import okio.buffer
+import java.io.IOException
+
+class ProgressRequestBody(
+    private val delegate: RequestBody,
+    private val progressListener: ProgressListener
+) : RequestBody() {
+    interface ProgressListener {
+        fun onProgress(bytesWritten: Long, contentLength: Long)
+    }
+
+    override fun contentType(): MediaType? = delegate.contentType()
+
+    override fun contentLength(): Long = delegate.contentLength()
+
+    @Throws(IOException::class)
+    override fun writeTo(sink: BufferedSink) {
+        val contentLength = contentLength()
+        val progressSink = ProgressSink(sink, contentLength, progressListener)
+        val bufferedSink = progressSink.buffer()
+
+        delegate.writeTo(bufferedSink)
+        bufferedSink.flush()
+    }
+
+    private class ProgressSink(
+        delegate: Sink,
+        private val contentLength: Long,
+        private val listener: ProgressListener
+    ) : ForwardingSink(delegate) {
+        private var totalBytesWritten = 0L
+        private var lastProgressTime = 0L
+        
+        // Throttle to 2 calls per second (500ms minimum between calls)
+        private val progressThrottleMs = 500L
+
+        @Throws(IOException::class)
+        override fun write(source: Buffer, byteCount: Long) {
+            super.write(source, byteCount)
+            totalBytesWritten += byteCount
+            
+            val currentTime = System.currentTimeMillis()
+            val isComplete = totalBytesWritten >= contentLength
+            
+            // Always send progress for completion, or if enough time has passed
+            if (isComplete || currentTime - lastProgressTime >= progressThrottleMs) {
+                listener.onProgress(totalBytesWritten, contentLength)
+                lastProgressTime = currentTime
+            }
+        }
+    }
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ProgressRequestBody.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ProgressRequestBody.kt
@@ -9,6 +9,7 @@ import okio.Sink
 import okio.buffer
 import java.io.IOException
 
+private const val PROGRESS_THROTTLE_MS = 500
 class ProgressRequestBody(
     private val delegate: RequestBody,
     private val progressListener: ProgressListener
@@ -38,20 +39,15 @@ class ProgressRequestBody(
     ) : ForwardingSink(delegate) {
         private var totalBytesWritten = 0L
         private var lastProgressTime = 0L
-        
-        // Throttle to 2 calls per second (500ms minimum between calls)
-        private val progressThrottleMs = 500L
 
         @Throws(IOException::class)
         override fun write(source: Buffer, byteCount: Long) {
             super.write(source, byteCount)
             totalBytesWritten += byteCount
-            
             val currentTime = System.currentTimeMillis()
             val isComplete = totalBytesWritten >= contentLength
-            
             // Always send progress for completion, or if enough time has passed
-            if (isComplete || currentTime - lastProgressTime >= progressThrottleMs) {
+            if (isComplete || currentTime - lastProgressTime >= PROGRESS_THROTTLE_MS) {
                 listener.onProgress(totalBytesWritten, contentLength)
                 lastProgressTime = currentTime
             }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -33,7 +33,8 @@ const val USER_AGENT_HEADER_NAME = "User-Agent"
 class WpRequestExecutor(
     private val httpClient: WpHttpClient = WpHttpClient.DefaultHttpClient(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val fileResolver: FileResolver = DefaultFileResolver()
+    private val fileResolver: FileResolver = DefaultFileResolver(),
+    private val uploadProgressListener: ((uploadedBytes: Long, totalBytes: Long) -> Unit)? = null
 ) : RequestExecutor {
     override suspend fun execute(request: WpNetworkRequest): WpNetworkResponse =
         withContext(dispatcher) {
@@ -93,10 +94,21 @@ class WpRequestExecutor(
             if (file == null || !file.canBeUploaded()) {
                 throw MediaUploadRequestExecutionException.MediaFileNotFound(mediaUploadRequest.filePath())
             }
+            val fileRequestBody = file.asRequestBody(mediaUploadRequest.fileContentType().toMediaType())
+            val progressRequestBody = if (uploadProgressListener != null) {
+                ProgressRequestBody(fileRequestBody, object : ProgressRequestBody.ProgressListener {
+                    override fun onProgress(bytesWritten: Long, contentLength: Long) {
+                        uploadProgressListener.invoke(bytesWritten, contentLength)
+                    }
+                })
+            } else {
+                fileRequestBody
+            }
+
             multipartBodyBuilder.addFormDataPart(
                 name = "file",
                 filename = file.name,
-                body = file.asRequestBody(mediaUploadRequest.fileContentType().toMediaType())
+                body = progressRequestBody
             )
             requestBuilder.method(
                 method = mediaUploadRequest.method().toString(),

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -9,6 +9,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttp
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import uniffi.wp_api.InvalidSslErrorReason
@@ -94,20 +95,7 @@ class WpRequestExecutor(
             if (file == null || !file.canBeUploaded()) {
                 throw MediaUploadRequestExecutionException.MediaFileNotFound(mediaUploadRequest.filePath())
             }
-            val fileRequestBody = file.asRequestBody(mediaUploadRequest.fileContentType().toMediaType())
-            val progressRequestBody = if (uploadProgressListener != null) {
-                ProgressRequestBody(
-                    delegate = fileRequestBody,
-                    progressListener = object : ProgressRequestBody.ProgressListener {
-                        override fun onProgress(bytesWritten: Long, contentLength: Long) {
-                            uploadProgressListener.invoke(bytesWritten, contentLength)
-                        }
-                    }
-                )
-            } else {
-                fileRequestBody
-            }
-
+            val progressRequestBody = getRequestBody(file, mediaUploadRequest, uploadProgressListener)
             multipartBodyBuilder.addFormDataPart(
                 name = "file",
                 filename = file.name,
@@ -133,6 +121,26 @@ class WpRequestExecutor(
                 )
             }
         }
+
+    private fun getRequestBody(
+        file: File,
+        mediaUploadRequest: MediaUploadRequest,
+        uploadProgressListener: ((uploadedBytes: Long, totalBytes: Long) -> Unit)?
+    ): RequestBody {
+        val fileRequestBody = file.asRequestBody(mediaUploadRequest.fileContentType().toMediaType())
+        return if (uploadProgressListener != null) {
+            ProgressRequestBody(
+                delegate = fileRequestBody,
+                progressListener = object : ProgressRequestBody.ProgressListener {
+                    override fun onProgress(bytesWritten: Long, contentLength: Long) {
+                        uploadProgressListener.invoke(bytesWritten, contentLength)
+                    }
+                }
+            )
+        } else {
+            fileRequestBody
+        }
+    }
 
     override suspend fun sleep(millis: ULong) {
         delay(millis.toLong())

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -96,11 +96,14 @@ class WpRequestExecutor(
             }
             val fileRequestBody = file.asRequestBody(mediaUploadRequest.fileContentType().toMediaType())
             val progressRequestBody = if (uploadProgressListener != null) {
-                ProgressRequestBody(fileRequestBody, object : ProgressRequestBody.ProgressListener {
-                    override fun onProgress(bytesWritten: Long, contentLength: Long) {
-                        uploadProgressListener.invoke(bytesWritten, contentLength)
+                ProgressRequestBody(
+                    delegate = fileRequestBody,
+                    progressListener = object : ProgressRequestBody.ProgressListener {
+                        override fun onProgress(bytesWritten: Long, contentLength: Long) {
+                            uploadProgressListener.invoke(bytesWritten, contentLength)
+                        }
                     }
-                })
+                )
             } else {
                 fileRequestBody
             }


### PR DESCRIPTION
**Add progress listener support to Kotlin WpRequestExecutor**

This PR adds progress listener functionality to the Kotlin WpRequestExecutor, enabling real-time progress tracking for media upload requests. 

This has been tested on WordPress Android, so we just need to be sure the CI keeps green here.