### PR TITLE
Update code comment about cancelling API calls

### DIFF
--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -188,9 +188,13 @@ public actor WordPressAPI {
         return try await withTaskCancellationHandler {
             try await uploadTask.value
         } onCancel: {
-            // Please note: for some reason calling `uploadTask.cancel()` here does not actually cancel
-            // the HTTP request. But calling `progress.cancel()` does, even though `progress.cancel()` eventually
-            // calls `uploadTask.cancel()`.
+            // Please note: the async functions exported by uniffi-rs _do not_ support cancellation.
+            // That means cancelling an API call like `Task { try await api.users.retrieveMe() }.cancel()`
+            // does not cancel the underlying HTTP request sent by URLSession.
+            //
+            // The `progress.cancel()` in this particular function can cancel the HTTP request, because the
+            // `progress` instance is the parent progress of `URLSessionTask.progress`, and cancelling a parent
+            // progress automatically cancels their child progress, which is the `URLSessionTask` in this case.
             progress.cancel()
         }
     }


### PR DESCRIPTION
I thought that cancelling `Task { try await api.users.retrieveMe() }` would cancel the HTTP request sent by the URLSession, which is part of the `RequestExecutor` implementation. It turns out that that's too magical to be true. uniffi-rs does not support cancellation.

This PR updates a related code comment.