### PR TITLE
Add `WpContextualExcludeFromFields` attribute

### DIFF
--- a/wp_contextual/Cargo.toml
+++ b/wp_contextual/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 autotests = false
 
+[features]
+integration-tests = []
+
 [lib]
 proc-macro = true
 

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -268,6 +268,45 @@
 //! ```
 //! ---
 //!
+//! In some cases, you might want to exclude certain fields from the generated field enums (like
+//! `SparseFooFieldWithEditContext`). This is particularly useful for fields that are not suitable for
+//! field filtering, such as catch-all fields for additional data or serde flattened fields. The
+//! `WpContextualExcludeFromFields` attribute can be used for this purpose:
+//!
+//! ```
+//! # use wp_contextual::WpContextual;
+//! #[derive(WpContextual)]
+//! pub struct SparseComment {
+//!     #[WpContext(edit, embed, view)]
+//!     pub id: Option<u32>,
+//!     #[WpContext(edit, embed, view)]
+//!     #[WpContextualExcludeFromFields]
+//!     pub additional_fields: Option<String>,
+//! }
+//! # // We need these 2 lines for UniFFI
+//! # uniffi::setup_scaffolding!();
+//! # fn main() {}
+//! ```
+//!
+//! This will generate the contextual types as usual, but the field enums will exclude the `additional_fields` field:
+//!
+//! ```
+//! pub enum SparseCommentFieldWithEditContext {
+//!     Id,
+//!     // Note: additional_fields is excluded from field filtering
+//! }
+//! pub enum SparseCommentFieldWithEmbedContext {
+//!     Id,
+//!     // Note: additional_fields is excluded from field filtering
+//! }
+//! pub enum SparseCommentFieldWithViewContext {
+//!     Id,
+//!     // Note: additional_fields is excluded from field filtering
+//! }
+//! ```
+//!
+//! ---
+//!
 //! Most endpoints support filtering the fields by `_fields` argument which means some of the
 //! fields might be missing from the response. In these cases, we want to use the `Sparse` type.
 //! In order to make it easier to combine `context` & `_fields` arguments, and get the most useful
@@ -342,6 +381,8 @@ mod wp_contextual;
 ///   type with the appropriate contextual type: `BazWithEditContext`, `BazWithEmbedContext` or
 ///   `BazWithViewContext`.
 /// * `[WpContextualOption]` is used to tell the compiler to keep the field's `Option` type.
+/// * `[WpContextualExcludeFromFields]` is used to exclude a field from the generated field enums
+///   (`SparseFooFieldWithEditContext`, etc.) while still including it in the contextual types.
 /// * Generated types will have the following derive macros:
 ///   `#[derive(Debug, serde::Serialize, serde::Deserialize, uniffi::Record)]`. These types are meant
 ///   to be used for the
@@ -453,7 +494,12 @@ mod wp_contextual;
 ///   `#[WpContextualOption]`.
 #[proc_macro_derive(
     WpContextual,
-    attributes(WpContext, WpContextualField, WpContextualOption)
+    attributes(
+        WpContext,
+        WpContextualField,
+        WpContextualOption,
+        WpContextualExcludeFromFields
+    )
 )]
 pub fn derive(input: TokenStream) -> TokenStream {
     wp_contextual::wp_contextual(parse_macro_input!(input))

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -148,6 +148,9 @@ fn parse_fields(
                     if is_wp_contextual_option_ident(segment_ident) {
                         return Ok(WpParsedAttr::ParsedWpContextualOption);
                     }
+                    if is_wp_contextual_exclude_from_fields_ident(segment_ident) {
+                        return Ok(WpParsedAttr::ParsedWpContextualExcludeFromFields);
+                    }
                     if is_wp_context_ident(segment_ident) {
                         if let syn::Meta::List(meta_list) = &attr.meta {
                             let contexts = parse_contexts_from_tokens(meta_list.tokens.clone())?;
@@ -228,6 +231,9 @@ fn generate_sparse_field_type(
     let mut variant_idents = Vec::with_capacity(fields.len());
     let mut as_field_names = Vec::with_capacity(fields.len());
     for f in fields {
+        if f.is_wp_contextual_exclude_from_fields {
+            continue;
+        }
         if let Some(f_ident) = &f.field.ident {
             let field_name = f_ident.to_string();
             let variant_ident = format_ident!("{}", field_name.to_case(Case::UpperCamel));
@@ -335,6 +341,7 @@ fn generate_integration_test_helper(
 struct GeneratedContextualField {
     field: syn::Field,
     is_wp_contextual_option: bool,
+    is_wp_contextual_exclude_from_fields: bool,
 }
 
 impl GeneratedContextualField {
@@ -364,6 +371,10 @@ impl GeneratedContextualField {
                 let is_wp_contextual_option = pf
                     .parsed_attrs
                     .contains(&WpParsedAttr::ParsedWpContextualOption);
+
+                let is_wp_contextual_exclude_from_fields = pf
+                    .parsed_attrs
+                    .contains(&WpParsedAttr::ParsedWpContextualExcludeFromFields);
 
                 let new_type = if is_wp_contextual_option {
                     f.ty.clone()
@@ -411,6 +422,7 @@ impl GeneratedContextualField {
                 Ok(Self {
                     field: new_field,
                     is_wp_contextual_option,
+                    is_wp_contextual_exclude_from_fields,
                 })
             })
             .collect()
@@ -667,6 +679,10 @@ fn is_wp_contextual_option_ident(ident: &Ident) -> bool {
     ident.to_string().eq("WpContextualOption")
 }
 
+fn is_wp_contextual_exclude_from_fields_ident(ident: &Ident) -> bool {
+    ident.to_string().eq("WpContextualExcludeFromFields")
+}
+
 // ```
 // #[WpContextual]
 // pub struct SparseFoo {
@@ -716,6 +732,7 @@ struct WpParsedField {
 enum WpParsedAttr {
     ParsedWpContextualField,
     ParsedWpContextualOption,
+    ParsedWpContextualExcludeFromFields,
     ParsedWpContext { contexts: Vec<WpContextAttr> },
     ExternalAttr { attr: Box<syn::Attribute> },
 }


### PR DESCRIPTION
## Summary
- Add `WpContextualExcludeFromFields` attribute to exclude fields from generated field enums
- Fix integration-tests feature warning in wp_contextual crate

## Use Case
Useful for fields like `additional_fields` that should be included in contextual types but excluded from field filtering enums (e.g., for serde flattened catch-all fields).

## Testing Instructions
1. Add a test field to `comments::SparseComment`:
   ```rust
   #[WpContext(edit, embed, view)]
   #[WpContextualExcludeFromFields]
   pub test_field: Option<String>,
   ```
2. Run: `cargo expand -p wp_api comments > generated_comments.rs`
3. Verify `test_field` appears in contextual types but NOT in `SparseCommentFieldWithEditContext` enum