### PR TITLE
Experiment: Add support for fetch-post to wp_rs_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ name = "wordpress-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "colored",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4808,6 +4808,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "url",
  "wp_api",
 ]
 

--- a/wp_rs_cli/Cargo.toml
+++ b/wp_rs_cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 wp_api = { path = "../wp_api", features = [ "reqwest-request-executor" ] }
+async-trait = { workspace = true }
 
 [[bin]]
 name = "wp_rs_cli"

--- a/wp_rs_cli/Cargo.toml
+++ b/wp_rs_cli/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 wp_api = { path = "../wp_api", features = [ "reqwest-request-executor" ] }
 async-trait = { workspace = true }
+url = { workspace = true }
 
 [[bin]]
 name = "wp_rs_cli"

--- a/wp_rs_cli/README.md
+++ b/wp_rs_cli/README.md
@@ -37,14 +37,27 @@ wp_rs_cli --help
 ### fetch-post examples
 
 ```bash
-# WordPress.com (Bearer)
+# WordPress.com (Bearer) by post URL (auto derive site)
+wp_rs_cli fetch-post \
+  --url https://example.wordpress.com/2024/07/01/my-post \
+  --bearer "$WP_BEARER_TOKEN" \
+  --pretty
+
+# WordPress.com (Bearer) by explicit site and post id
 wp_rs_cli fetch-post \
   --wpcom-site example.wordpress.com \
   --post-id 123 \
   --bearer "$WP_BEARER_TOKEN" \
   --pretty
 
-# WordPress.org/Jetpack (Application Password)
+# WordPress.org/Jetpack (Application Password) by post URL (auto-discover /wp-json)
+wp_rs_cli fetch-post \
+  --url https://yoursite.com/blog/2024/07/01/my-post \
+  --username "$WP_USERNAME" \
+  --password "$WP_APP_PASSWORD" \
+  --pretty
+
+# WordPress.org/Jetpack (Application Password) by explicit API root and post id
 wp_rs_cli fetch-post \
   --api-root https://yoursite.com/wp-json \
   --post-id 123 \

--- a/wp_rs_cli/README.md
+++ b/wp_rs_cli/README.md
@@ -32,6 +32,26 @@ wp_rs_cli --help
 ## Commands
 
 - `discover-login-url`: Tries connecting to the given URL, and prints the library's relevant error message if unable to.
+- `fetch-post`: Fetch a post and its comments, supporting WordPress.com (Bearer token) and WordPress.org/Jetpack (Application Password) sites.
+
+### fetch-post examples
+
+```bash
+# WordPress.com (Bearer)
+wp_rs_cli fetch-post \
+  --wpcom-site example.wordpress.com \
+  --post-id 123 \
+  --bearer "$WP_BEARER_TOKEN" \
+  --pretty
+
+# WordPress.org/Jetpack (Application Password)
+wp_rs_cli fetch-post \
+  --api-root https://yoursite.com/wp-json \
+  --post-id 123 \
+  --username "$WP_USERNAME" \
+  --password "$WP_APP_PASSWORD" \
+  --pretty
+```
 
 ## License
 

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -420,7 +420,7 @@ async fn resolve_post_id(client: &WpApiClient, post_url: &str) -> Result<PostId>
     let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid url: {e}"))?;
     let slug_candidate = url
         .path_segments()
-        .and_then(|segs| segs.filter(|s| !s.is_empty()).last())
+        .and_then(|segs| segs.rev().find(|s| !s.is_empty()))
         .map(|s| s.trim_end_matches('/'))
         .unwrap_or("")
         .to_string();
@@ -431,11 +431,13 @@ async fn resolve_post_id(client: &WpApiClient, post_url: &str) -> Result<PostId>
 
     // Query posts by slug; returns an array, take first match.
     // Using view context to ensure public content shape.
-    let mut params = wp_api::posts::PostListParams::default();
-    params.slug = vec![slug_candidate.clone()];
-    params.per_page = Some(1);
+    let params = wp_api::posts::PostListParams {
+        slug: vec![slug_candidate.clone()],
+        per_page: Some(1),
+        ..Default::default()
+    };
     let resp = client.posts().list_with_view_context(&params).await?;
-    if let Some(p) = resp.data.into_iter().find_map(|sp| Some(sp.id)) {
+    if let Some(p) = resp.data.into_iter().map(|sp| sp.id).next() {
         return Ok(p);
     }
 

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -64,6 +64,42 @@ struct AuthArgs {
     password: Option<String>,
 }
 
+#[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("site_type")
+        .args(["wpcom_site", "api_root", "url"]),
+), group(
+    ArgGroup::new("post_ref")
+        .required(true)
+        .args(["post_id", "url"]),
+))]
+struct FetchPostArgs {
+    /// Common authentication parameters
+    #[command(flatten)]
+    auth: AuthArgs,
+
+    /// Full post URL (alternative to --post-id)
+    /// When provided, this URL is used to infer the site (wp.com) or autodiscover the API root (wp.org/Jetpack).
+    #[arg(long)]
+    url: Option<String>,
+
+    /// The post ID to fetch
+    #[arg(long, value_parser = parse_post_id)]
+    post_id: Option<PostId>,
+
+    /// Password for the post if it is password-protected
+    #[arg(long)]
+    post_password: Option<String>,
+
+    /// Max items per page when fetching comments
+    #[arg(long, default_value_t = 100)]
+    per_page: u32,
+
+    /// Output pretty-printed JSON
+    #[arg(long, default_value_t = false)]
+    pretty: bool,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -365,7 +401,7 @@ fn env_or_arg(value: &Option<String>, var: &str) -> Option<String> {
 async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
     let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
     let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
-    // Determine target and auth
+    // Determine resolver and auth provider
     let api_type = SiteApiType::detect_from_args(args, url, &request_executor).await?;
     let resolver: Arc<dyn ApiUrlResolver> = api_type.api_url_resolver();
     let auth_provider: Arc<WpAuthenticationProvider> = api_type.auth_provider(args)?;
@@ -391,42 +427,6 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
             app_notifier: Arc::new(CliAppNotifier),
         },
     ))
-}
-
-#[derive(Debug, Parser)]
-#[command(group(
-    ArgGroup::new("target")
-        .args(["wpcom_site", "api_root", "url"]),
-), group(
-    ArgGroup::new("post_ref")
-        .required(true)
-        .args(["post_id", "url"]),
-))]
-struct FetchPostArgs {
-    /// Common authentication and target parameters
-    #[command(flatten)]
-    auth: AuthArgs,
-
-    /// Full post URL (alternative to --post-id)
-    /// When provided, this URL is used to infer the site (wp.com) or autodiscover the API root (wp.org/Jetpack).
-    #[arg(long)]
-    url: Option<String>,
-
-    /// The post ID to fetch
-    #[arg(long, value_parser = parse_post_id)]
-    post_id: Option<PostId>,
-
-    /// Password for the post if it is password-protected
-    #[arg(long)]
-    post_password: Option<String>,
-
-    /// Max items per page when fetching comments
-    #[arg(long, default_value_t = 100)]
-    per_page: u32,
-
-    /// Output pretty-printed JSON
-    #[arg(long, default_value_t = false)]
-    pretty: bool,
 }
 
 fn parse_post_id(s: &str) -> Result<PostId, String> {

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -1,9 +1,16 @@
-use anyhow::Result;
-use clap::{Parser, Subcommand};
+use anyhow::{Result, anyhow};
+use clap::{ArgGroup, Parser, Subcommand};
 use colored::Colorize;
 use csv::Writer;
 use futures::stream::StreamExt;
 use std::{fmt::Display, fs::File, sync::Arc, time::Duration};
+use wp_api::{
+    comments::CommentListParams,
+    parsed_url::ParsedUrl,
+    posts::{PostId, PostRetrieveParams},
+    request::endpoint::WpOrgSiteApiUrlResolver,
+    wp_com::{WpComBaseUrl, endpoint::WpComDotOrgApiUrlResolver},
+};
 use wp_api::{
     login::url_discovery::{
         AutoDiscoveryAttemptFailure, FetchAndParseApiRootFailure, FindApiRootFailure,
@@ -29,6 +36,8 @@ enum Commands {
         input_file: String,
         output_file: String,
     },
+    /// Fetch a single post and its comments
+    FetchPost(FetchPostArgs),
 }
 
 #[tokio::main]
@@ -45,6 +54,9 @@ async fn main() -> Result<()> {
             output_file,
         } => {
             batch_test_autodiscovery(&login_client, input_file.as_str(), output_file).await?;
+        }
+        Commands::FetchPost(args) => {
+            fetch_post_and_comments(args).await?;
         }
     }
 
@@ -121,6 +133,180 @@ async fn perform_api_discovery(
 fn build_login_client() -> WpLoginClient {
     let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
     WpLoginClient::new_with_default_middleware_pipeline(request_executor)
+}
+
+#[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("target")
+        .required(true)
+        .args(["wpcom_site", "api_root"]),
+))]
+struct FetchPostArgs {
+    /// The post ID to fetch
+    #[arg(long, value_parser = parse_post_id)]
+    post_id: PostId,
+
+    /// For WordPress.com: site identifier (e.g. example.wordpress.com or numeric site id)
+    #[arg(long)]
+    wpcom_site: Option<String>,
+
+    /// For WordPress.org/Jetpack: full API root URL (must end with /wp-json)
+    #[arg(long)]
+    api_root: Option<String>,
+
+    /// Bearer token for WordPress.com (fallback env: WP_BEARER_TOKEN)
+    #[arg(long)]
+    bearer: Option<String>,
+
+    /// Application Password username for wp.org/Jetpack (fallback env: WP_USERNAME)
+    #[arg(long)]
+    username: Option<String>,
+
+    /// Application Password for wp.org/Jetpack (fallback env: WP_APP_PASSWORD)
+    #[arg(long)]
+    password: Option<String>,
+
+    /// Password for the post if it is password-protected
+    #[arg(long)]
+    post_password: Option<String>,
+
+    /// Max items per page when fetching comments
+    #[arg(long, default_value_t = 100)]
+    per_page: u32,
+
+    /// Output pretty-printed JSON
+    #[arg(long, default_value_t = false)]
+    pretty: bool,
+}
+
+fn parse_post_id(s: &str) -> Result<PostId, String> {
+    s.parse::<i64>()
+        .map(PostId)
+        .map_err(|e| format!("Invalid post id '{s}': {e}"))
+}
+
+#[derive(Debug)]
+enum TargetSiteResolver {
+    WpCom { site: String },
+    WpOrg { api_root: Arc<ParsedUrl> },
+}
+
+fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
+    // Determine target and auth
+    let target = if let Some(site) = &args.wpcom_site {
+        TargetSiteResolver::WpCom { site: site.clone() }
+    } else if let Some(api_root) = &args.api_root {
+        let parsed = ParsedUrl::try_from(api_root.as_str()).map_err(|_| {
+            anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json")
+        })?;
+        TargetSiteResolver::WpOrg {
+            api_root: Arc::new(parsed),
+        }
+    } else {
+        return Err(anyhow!(
+            "Either --wpcom-site or --api-root must be provided"
+        ));
+    };
+
+    fn env_or_arg(value: &Option<String>, var: &str) -> Option<String> {
+        value.clone().or_else(|| std::env::var(var).ok())
+    }
+
+    let (resolver, auth_provider): (Arc<dyn ApiUrlResolver>, Arc<WpAuthenticationProvider>) =
+        match target {
+            TargetSiteResolver::WpCom { site } => {
+                let token = env_or_arg(&args.bearer, "WP_BEARER_TOKEN").ok_or_else(|| {
+                    anyhow!("Missing bearer token. Provide --bearer or set WP_BEARER_TOKEN")
+                })?;
+                let resolver: Arc<dyn ApiUrlResolver> = Arc::new(WpComDotOrgApiUrlResolver::new(
+                    site,
+                    WpComBaseUrl::Production,
+                ));
+                let auth_provider = Arc::new(WpAuthenticationProvider::static_with_auth(
+                    WpAuthentication::Bearer { token },
+                ));
+                (resolver, auth_provider)
+            }
+            TargetSiteResolver::WpOrg { api_root } => {
+                let username = env_or_arg(&args.username, "WP_USERNAME").ok_or_else(|| {
+                    anyhow!("Missing username. Provide --username or set WP_USERNAME")
+                })?;
+                let password = env_or_arg(&args.password, "WP_APP_PASSWORD").ok_or_else(|| {
+                    anyhow!(
+                        "Missing application password. Provide --password or set WP_APP_PASSWORD"
+                    )
+                })?;
+                let resolver: Arc<dyn ApiUrlResolver> =
+                    Arc::new(WpOrgSiteApiUrlResolver::new(api_root));
+                let auth_provider = Arc::new(
+                    WpAuthenticationProvider::static_with_username_and_password(username, password),
+                );
+                (resolver, auth_provider)
+            }
+        };
+
+    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
+    let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
+
+    #[derive(Debug)]
+    struct NoopNotifier;
+    #[async_trait::async_trait]
+    impl WpAppNotifier for NoopNotifier {
+        async fn requested_with_invalid_authentication(&self) {}
+    }
+
+    Ok(WpApiClient::new(
+        resolver,
+        WpApiClientDelegate {
+            auth_provider,
+            request_executor,
+            middleware_pipeline,
+            app_notifier: Arc::new(NoopNotifier),
+        },
+    ))
+}
+
+async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
+    let client = build_api_client(&args)?;
+
+    let post = client
+        .posts()
+        .retrieve_with_view_context(
+            &args.post_id,
+            &PostRetrieveParams {
+                password: args.post_password.clone(),
+            },
+        )
+        .await?;
+
+    let mut all_comments = Vec::new();
+    let mut page = client
+        .comments()
+        .list_with_view_context(&CommentListParams {
+            post: vec![args.post_id],
+            per_page: Some(args.per_page),
+            ..Default::default()
+        })
+        .await?;
+    all_comments.extend(page.data);
+    while let Some(next_params) = page.next_page_params.take() {
+        page = client
+            .comments()
+            .list_with_view_context(&next_params)
+            .await?;
+        all_comments.extend(page.data);
+    }
+
+    let out = serde_json::json!({
+        "post": post,
+        "comments": all_comments,
+    });
+    if args.pretty {
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("{}", serde_json::to_string(&out)?);
+    }
+    Ok(())
 }
 
 fn parse_input_file(input_file: &str) -> Result<Vec<BatchTestRow>> {

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use clap::{ArgGroup, Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use colored::Colorize;
 use csv::Writer;
 use futures::stream::StreamExt;
@@ -68,7 +68,7 @@ async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<P
     if let Some(id) = args.post_id {
         return Ok(id);
     }
-    let Some(post_url) = &args.post_url else {
+    let Some(post_url) = &args.url else {
         return Err(anyhow!("Either --post-id or --post-url must be provided"));
     };
 
@@ -179,40 +179,25 @@ fn build_login_client() -> WpLoginClient {
 #[derive(Debug, Parser)]
 #[command(group(
     ArgGroup::new("target")
-        .args(["wpcom_site", "api_root"]),
+        .args(["wpcom_site", "api_root", "url"]),
 ), group(
     ArgGroup::new("post_ref")
         .required(true)
-        .args(["post_id", "post_url"]),
+        .args(["post_id", "url"]),
 ))]
 struct FetchPostArgs {
+    /// Common authentication and target parameters
+    #[command(flatten)]
+    auth: AuthArgs,
+
+    /// Full post URL (alternative to --post-id)
+    /// When provided, this URL is used to infer the site (wp.com) or autodiscover the API root (wp.org/Jetpack).
+    #[arg(long)]
+    url: Option<String>,
+
     /// The post ID to fetch
     #[arg(long, value_parser = parse_post_id)]
     post_id: Option<PostId>,
-
-    /// Full post URL (alternative to --post-id)
-    #[arg(long)]
-    post_url: Option<String>,
-
-    /// For WordPress.com: site identifier (e.g. example.wordpress.com or numeric site id)
-    #[arg(long)]
-    wpcom_site: Option<String>,
-
-    /// For WordPress.org/Jetpack: full API root URL (must end with /wp-json)
-    #[arg(long)]
-    api_root: Option<String>,
-
-    /// Bearer token for WordPress.com (fallback env: WP_BEARER_TOKEN)
-    #[arg(long)]
-    bearer: Option<String>,
-
-    /// Application Password username for wp.org/Jetpack (fallback env: WP_USERNAME)
-    #[arg(long)]
-    username: Option<String>,
-
-    /// Application Password for wp.org/Jetpack (fallback env: WP_APP_PASSWORD)
-    #[arg(long)]
-    password: Option<String>,
 
     /// Password for the post if it is password-protected
     #[arg(long)]
@@ -239,7 +224,30 @@ enum TargetSiteResolver {
     WpOrg { api_root: Arc<ParsedUrl> },
 }
 
-async fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
+#[derive(Debug, Args, Clone)]
+struct AuthArgs {
+    /// WordPress.com site (e.g. example.wordpress.com or numeric ID)
+    #[arg(long)]
+    wpcom_site: Option<String>,
+
+    /// WordPress.org/Jetpack API root (must end with /wp-json)
+    #[arg(long)]
+    api_root: Option<String>,
+
+    /// Bearer token for WordPress.com (fallback env: WP_BEARER_TOKEN)
+    #[arg(long)]
+    bearer: Option<String>,
+
+    /// Application Password username for wp.org/Jetpack (fallback env: WP_USERNAME)
+    #[arg(long)]
+    username: Option<String>,
+
+    /// Application Password for wp.org/Jetpack (fallback env: WP_APP_PASSWORD)
+    #[arg(long)]
+    password: Option<String>,
+}
+
+async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
     let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
     let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
     // Determine target and auth
@@ -248,38 +256,46 @@ async fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
         TargetSiteResolver::WpCom { site: site.clone() }
     } else if let Some(api_root) = &args.api_root {
         // Explicit api_root takes priority for wp.org/Jetpack
-        let parsed = ParsedUrl::try_from(api_root.as_str())
-            .map_err(|_| anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json"))?;
-        TargetSiteResolver::WpOrg { api_root: Arc::new(parsed) }
-    } else if let Some(post_url) = &args.post_url {
-        // Derive from post_url if possible
-        if let Ok(u) = Url::parse(post_url) {
+        let parsed = ParsedUrl::try_from(api_root.as_str()).map_err(|_| {
+            anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json")
+        })?;
+        TargetSiteResolver::WpOrg {
+            api_root: Arc::new(parsed),
+        }
+    } else if let Some(url) = url {
+        // Derive from URL if possible
+        if let Ok(u) = Url::parse(url.as_str()) {
             let host = u.host_str().unwrap_or("");
             if host.ends_with(".wordpress.com") {
-                TargetSiteResolver::WpCom { site: host.to_string() }
+                TargetSiteResolver::WpCom {
+                    site: host.to_string(),
+                }
             } else {
-                // Attempt autodiscovery of API root from post URL
-                let login_client = WpLoginClient::new_with_default_middleware_pipeline(request_executor.clone());
+                // Attempt autodiscovery of API root from URL
+                let login_client =
+                    WpLoginClient::new_with_default_middleware_pipeline(request_executor.clone());
                 match login_client
-                    .api_discovery(post_url.clone())
+                    .api_discovery(url.clone())
                     .await
                     .combined_result()
                     .cloned()
                 {
-                    Ok(success) => TargetSiteResolver::WpOrg { api_root: success.api_root_url },
+                    Ok(success) => TargetSiteResolver::WpOrg {
+                        api_root: success.api_root_url,
+                    },
                     Err(_) => {
                         return Err(anyhow!(
-                            "Could not autodiscover API root from --post-url. Please provide --api-root explicitly."
+                            "Could not autodiscover API root from URL. Please provide --api-root explicitly."
                         ));
                     }
                 }
             }
         } else {
-            return Err(anyhow!("Invalid --post-url; could not parse URL"));
+            return Err(anyhow!("Invalid URL; could not parse"));
         }
     } else {
         return Err(anyhow!(
-            "Provide either --wpcom-site, or --api-root, or a wordpress.com --post-url"
+            "Provide either --wpcom-site, or --api-root, or a wordpress.com URL"
         ));
     };
 
@@ -339,7 +355,7 @@ async fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
 }
 
 async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
-    let client = build_api_client(&args).await?;
+    let client = build_api_client(&args.auth, &args.url).await?;
 
     let post_id = resolve_post_id(&client, &args).await?;
 

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -179,7 +179,6 @@ fn build_login_client() -> WpLoginClient {
 #[derive(Debug, Parser)]
 #[command(group(
     ArgGroup::new("target")
-        .required(true)
         .args(["wpcom_site", "api_root"]),
 ), group(
     ArgGroup::new("post_ref")
@@ -240,20 +239,47 @@ enum TargetSiteResolver {
     WpOrg { api_root: Arc<ParsedUrl> },
 }
 
-fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
+async fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
+    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
+    let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
     // Determine target and auth
     let target = if let Some(site) = &args.wpcom_site {
+        // Explicit WordPress.com site takes priority
         TargetSiteResolver::WpCom { site: site.clone() }
     } else if let Some(api_root) = &args.api_root {
-        let parsed = ParsedUrl::try_from(api_root.as_str()).map_err(|_| {
-            anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json")
-        })?;
-        TargetSiteResolver::WpOrg {
-            api_root: Arc::new(parsed),
+        // Explicit api_root takes priority for wp.org/Jetpack
+        let parsed = ParsedUrl::try_from(api_root.as_str())
+            .map_err(|_| anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json"))?;
+        TargetSiteResolver::WpOrg { api_root: Arc::new(parsed) }
+    } else if let Some(post_url) = &args.post_url {
+        // Derive from post_url if possible
+        if let Ok(u) = Url::parse(post_url) {
+            let host = u.host_str().unwrap_or("");
+            if host.ends_with(".wordpress.com") {
+                TargetSiteResolver::WpCom { site: host.to_string() }
+            } else {
+                // Attempt autodiscovery of API root from post URL
+                let login_client = WpLoginClient::new_with_default_middleware_pipeline(request_executor.clone());
+                match login_client
+                    .api_discovery(post_url.clone())
+                    .await
+                    .combined_result()
+                    .cloned()
+                {
+                    Ok(success) => TargetSiteResolver::WpOrg { api_root: success.api_root_url },
+                    Err(_) => {
+                        return Err(anyhow!(
+                            "Could not autodiscover API root from --post-url. Please provide --api-root explicitly."
+                        ));
+                    }
+                }
+            }
+        } else {
+            return Err(anyhow!("Invalid --post-url; could not parse URL"));
         }
     } else {
         return Err(anyhow!(
-            "Either --wpcom-site or --api-root must be provided"
+            "Provide either --wpcom-site, or --api-root, or a wordpress.com --post-url"
         ));
     };
 
@@ -294,9 +320,6 @@ fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
             }
         };
 
-    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
-    let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
-
     #[derive(Debug)]
     struct NoopNotifier;
     #[async_trait::async_trait]
@@ -316,7 +339,7 @@ fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
 }
 
 async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
-    let client = build_api_client(&args)?;
+    let client = build_api_client(&args).await?;
 
     let post_id = resolve_post_id(&client, &args).await?;
 

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -413,14 +413,7 @@ fn parse_post_id(s: &str) -> Result<PostId, String> {
         .map_err(|e| format!("Invalid post id '{s}': {e}"))
 }
 
-async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<PostId> {
-    if let Some(id) = args.post_id {
-        return Ok(id);
-    }
-    let Some(post_url) = &args.url else {
-        return Err(anyhow!("Either --post-id or --url must be provided"));
-    };
-
+async fn resolve_post_id(client: &WpApiClient, post_url: &str) -> Result<PostId> {
     // Strategy: retrieve by slug via posts list API when possible.
     // For wp.com, the resolver requires site context; for wp.org, api_root is given.
     // We'll try to parse the URL and extract a last path segment as potential slug.
@@ -456,7 +449,15 @@ async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<P
 async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
     let client = build_api_client(&args.auth, &args.url).await?;
 
-    let post_id = resolve_post_id(&client, &args).await?;
+    let post_id = if let Some(id) = args.post_id {
+        id
+    } else {
+        let post_url = args
+            .url
+            .as_ref()
+            .ok_or_else(|| anyhow!("Either --post-id or --url must be provided"))?;
+        resolve_post_id(&client, post_url.as_str()).await?
+    };
 
     let post = client
         .posts()

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 use csv::Writer;
 use futures::stream::StreamExt;
 use std::{fmt::Display, fs::File, sync::Arc, time::Duration};
+use url::Url;
 use wp_api::{
     comments::CommentListParams,
     parsed_url::ParsedUrl,
@@ -61,6 +62,46 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<PostId> {
+    if let Some(id) = args.post_id {
+        return Ok(id);
+    }
+    let Some(post_url) = &args.post_url else {
+        return Err(anyhow!("Either --post-id or --post-url must be provided"));
+    };
+
+    // Strategy: retrieve by slug via posts list API when possible.
+    // For wp.com, the resolver requires site context; for wp.org, api_root is given.
+    // We'll try to parse the URL and extract a last path segment as potential slug.
+    let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid --post-url: {e}"))?;
+    let slug_candidate = url
+        .path_segments()
+        .and_then(|segs| segs.filter(|s| !s.is_empty()).last())
+        .map(|s| s.trim_end_matches('/'))
+        .unwrap_or("")
+        .to_string();
+
+    if slug_candidate.is_empty() {
+        return Err(anyhow!("Could not parse a slug from --post-url"));
+    }
+
+    // Query posts by slug; returns an array, take first match.
+    // Using view context to ensure public content shape.
+    let mut params = wp_api::posts::PostListParams::default();
+    params.slug = vec![slug_candidate.clone()];
+    params.per_page = Some(1);
+    let resp = client.posts().list_with_view_context(&params).await?;
+    if let Some(p) = resp.data.into_iter().find_map(|sp| Some(sp.id)) {
+        return Ok(p);
+    }
+
+    Err(anyhow!(
+        "No post found for slug '{slug}' parsed from URL '{url}'",
+        slug = slug_candidate,
+        url = post_url
+    ))
 }
 
 async fn discover_login_url(login_client: &WpLoginClient, site: String) {
@@ -140,11 +181,19 @@ fn build_login_client() -> WpLoginClient {
     ArgGroup::new("target")
         .required(true)
         .args(["wpcom_site", "api_root"]),
+), group(
+    ArgGroup::new("post_ref")
+        .required(true)
+        .args(["post_id", "post_url"]),
 ))]
 struct FetchPostArgs {
     /// The post ID to fetch
     #[arg(long, value_parser = parse_post_id)]
-    post_id: PostId,
+    post_id: Option<PostId>,
+
+    /// Full post URL (alternative to --post-id)
+    #[arg(long)]
+    post_url: Option<String>,
 
     /// For WordPress.com: site identifier (e.g. example.wordpress.com or numeric site id)
     #[arg(long)]
@@ -269,10 +318,12 @@ fn build_api_client(args: &FetchPostArgs) -> Result<WpApiClient> {
 async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
     let client = build_api_client(&args)?;
 
+    let post_id = resolve_post_id(&client, &args).await?;
+
     let post = client
         .posts()
         .retrieve_with_view_context(
-            &args.post_id,
+            &post_id,
             &PostRetrieveParams {
                 password: args.post_password.clone(),
             },
@@ -283,7 +334,7 @@ async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
     let mut page = client
         .comments()
         .list_with_view_context(&CommentListParams {
-            post: vec![args.post_id],
+            post: vec![post_id],
             per_page: Some(args.per_page),
             ..Default::default()
         })

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -258,35 +258,41 @@ fn csv_error_type(failure: &AutoDiscoveryAttemptFailure) -> String {
     }
 }
 
-async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
-    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
-    let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
-    #[derive(Debug)]
-    enum TargetSiteResolver {
-        WpCom { site: String },
-        WpOrg { api_root: Arc<ParsedUrl> },
-    }
-    // Determine target and auth
-    let target = if let Some(site) = &args.wpcom_site {
-        // Explicit WordPress.com site takes priority
-        TargetSiteResolver::WpCom { site: site.clone() }
-    } else if let Some(api_root) = &args.api_root {
-        // Explicit api_root takes priority for wp.org/Jetpack
-        let parsed = ParsedUrl::try_from(api_root.as_str()).map_err(|_| {
-            anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json")
-        })?;
-        TargetSiteResolver::WpOrg {
-            api_root: Arc::new(parsed),
+#[derive(Debug)]
+enum SiteApiType {
+    WpCom { site: String },
+    WpOrg { api_root: Arc<ParsedUrl> },
+}
+
+impl SiteApiType {
+    async fn detect_from_args(
+        args: &AuthArgs,
+        url: &Option<String>,
+        request_executor: &Arc<ReqwestRequestExecutor>,
+    ) -> Result<Self> {
+        if let Some(site) = &args.wpcom_site {
+            // Explicit WordPress.com site takes priority
+            return Ok(SiteApiType::WpCom { site: site.clone() });
         }
-    } else if let Some(url) = url {
-        // Derive from URL if possible
-        if let Ok(u) = Url::parse(url.as_str()) {
-            let host = u.host_str().unwrap_or("");
-            if host.ends_with(".wordpress.com") {
-                TargetSiteResolver::WpCom {
-                    site: host.to_string(),
+        if let Some(api_root) = &args.api_root {
+            // Explicit api_root takes priority for wp.org/Jetpack
+            let parsed = ParsedUrl::try_from(api_root.as_str()).map_err(|_| {
+                anyhow!("Invalid api_root URL: must be a valid URL ending with /wp-json")
+            })?;
+            return Ok(SiteApiType::WpOrg {
+                api_root: Arc::new(parsed),
+            });
+        }
+        if let Some(url) = url {
+            // Derive from URL if possible
+            if let Ok(u) = Url::parse(url.as_str()) {
+                let host = u.host_str().unwrap_or("");
+                if host.ends_with(".wordpress.com") {
+                    return Ok(SiteApiType::WpCom {
+                        site: host.to_string(),
+                    });
                 }
-            } else {
+
                 // Attempt autodiscovery of API root from URL
                 let login_client =
                     WpLoginClient::new_with_default_middleware_pipeline(request_executor.clone());
@@ -296,45 +302,44 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
                     .combined_result()
                     .cloned()
                 {
-                    Ok(success) => TargetSiteResolver::WpOrg {
+                    Ok(success) => Ok(SiteApiType::WpOrg {
                         api_root: success.api_root_url,
-                    },
-                    Err(_) => {
-                        return Err(anyhow!(
-                            "Could not autodiscover API root from URL. Please provide --api-root explicitly."
-                        ));
-                    }
+                    }),
+                    Err(_) => Err(anyhow!(
+                        "Could not autodiscover API root from URL. Please provide --api-root explicitly."
+                    )),
                 }
+            } else {
+                Err(anyhow!("Invalid URL; could not parse"))
             }
         } else {
-            return Err(anyhow!("Invalid URL; could not parse"));
+            Err(anyhow!(
+                "Provide either --wpcom-site, or --api-root, or a wordpress.com URL"
+            ))
         }
-    } else {
-        return Err(anyhow!(
-            "Provide either --wpcom-site, or --api-root, or a wordpress.com URL"
-        ));
-    };
-
-    fn env_or_arg(value: &Option<String>, var: &str) -> Option<String> {
-        value.clone().or_else(|| std::env::var(var).ok())
     }
 
-    let (resolver, auth_provider): (Arc<dyn ApiUrlResolver>, Arc<WpAuthenticationProvider>) =
-        match target {
-            TargetSiteResolver::WpCom { site } => {
+    fn api_url_resolver(&self) -> Arc<dyn ApiUrlResolver> {
+        match self {
+            SiteApiType::WpCom { site } => Arc::new(WpComDotOrgApiUrlResolver::new(
+                site.clone(),
+                WpComBaseUrl::Production,
+            )),
+            SiteApiType::WpOrg { api_root } => Arc::new(WpOrgSiteApiUrlResolver::new(api_root.clone())),
+        }
+    }
+
+    fn auth_provider(&self, args: &AuthArgs) -> Result<Arc<WpAuthenticationProvider>> {
+        match self {
+            SiteApiType::WpCom { .. } => {
                 let token = env_or_arg(&args.bearer, "WP_BEARER_TOKEN").ok_or_else(|| {
                     anyhow!("Missing bearer token. Provide --bearer or set WP_BEARER_TOKEN")
                 })?;
-                let resolver: Arc<dyn ApiUrlResolver> = Arc::new(WpComDotOrgApiUrlResolver::new(
-                    site,
-                    WpComBaseUrl::Production,
-                ));
-                let auth_provider = Arc::new(WpAuthenticationProvider::static_with_auth(
+                Ok(Arc::new(WpAuthenticationProvider::static_with_auth(
                     WpAuthentication::Bearer { token },
-                ));
-                (resolver, auth_provider)
+                )))
             }
-            TargetSiteResolver::WpOrg { api_root } => {
+            SiteApiType::WpOrg { .. } => {
                 let username = env_or_arg(&args.username, "WP_USERNAME").ok_or_else(|| {
                     anyhow!("Missing username. Provide --username or set WP_USERNAME")
                 })?;
@@ -343,14 +348,27 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
                         "Missing application password. Provide --password or set WP_APP_PASSWORD"
                     )
                 })?;
-                let resolver: Arc<dyn ApiUrlResolver> =
-                    Arc::new(WpOrgSiteApiUrlResolver::new(api_root));
-                let auth_provider = Arc::new(
-                    WpAuthenticationProvider::static_with_username_and_password(username, password),
-                );
-                (resolver, auth_provider)
+                Ok(Arc::new(
+                    WpAuthenticationProvider::static_with_username_and_password(
+                        username, password,
+                    ),
+                ))
             }
-        };
+        }
+    }
+}
+
+fn env_or_arg(value: &Option<String>, var: &str) -> Option<String> {
+    value.clone().or_else(|| std::env::var(var).ok())
+}
+
+async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
+    let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
+    let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
+    // Determine target and auth
+    let api_type = SiteApiType::detect_from_args(args, url, &request_executor).await?;
+    let resolver: Arc<dyn ApiUrlResolver> = api_type.api_url_resolver();
+    let auth_provider: Arc<WpAuthenticationProvider> = api_type.auth_provider(args)?;
 
     #[derive(Debug)]
     struct CliAppNotifier;

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -41,6 +41,29 @@ enum Commands {
     FetchPost(FetchPostArgs),
 }
 
+#[derive(Debug, Args, Clone)]
+struct AuthArgs {
+    /// WordPress.com site (e.g. example.wordpress.com or numeric ID)
+    #[arg(long)]
+    wpcom_site: Option<String>,
+
+    /// WordPress.org/Jetpack API root (must end with /wp-json)
+    #[arg(long)]
+    api_root: Option<String>,
+
+    /// Bearer token for WordPress.com (fallback env: WP_BEARER_TOKEN)
+    #[arg(long)]
+    bearer: Option<String>,
+
+    /// Application Password username for wp.org/Jetpack (fallback env: WP_USERNAME)
+    #[arg(long)]
+    username: Option<String>,
+
+    /// Application Password for wp.org/Jetpack (fallback env: WP_APP_PASSWORD)
+    #[arg(long)]
+    password: Option<String>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -62,46 +85,6 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
-}
-
-async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<PostId> {
-    if let Some(id) = args.post_id {
-        return Ok(id);
-    }
-    let Some(post_url) = &args.url else {
-        return Err(anyhow!("Either --post-id or --post-url must be provided"));
-    };
-
-    // Strategy: retrieve by slug via posts list API when possible.
-    // For wp.com, the resolver requires site context; for wp.org, api_root is given.
-    // We'll try to parse the URL and extract a last path segment as potential slug.
-    let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid --post-url: {e}"))?;
-    let slug_candidate = url
-        .path_segments()
-        .and_then(|segs| segs.filter(|s| !s.is_empty()).last())
-        .map(|s| s.trim_end_matches('/'))
-        .unwrap_or("")
-        .to_string();
-
-    if slug_candidate.is_empty() {
-        return Err(anyhow!("Could not parse a slug from --post-url"));
-    }
-
-    // Query posts by slug; returns an array, take first match.
-    // Using view context to ensure public content shape.
-    let mut params = wp_api::posts::PostListParams::default();
-    params.slug = vec![slug_candidate.clone()];
-    params.per_page = Some(1);
-    let resp = client.posts().list_with_view_context(&params).await?;
-    if let Some(p) = resp.data.into_iter().find_map(|sp| Some(sp.id)) {
-        return Ok(p);
-    }
-
-    Err(anyhow!(
-        "No post found for slug '{slug}' parsed from URL '{url}'",
-        slug = slug_candidate,
-        url = post_url
-    ))
 }
 
 async fn discover_login_url(login_client: &WpLoginClient, site: String) {
@@ -176,75 +159,109 @@ fn build_login_client() -> WpLoginClient {
     WpLoginClient::new_with_default_middleware_pipeline(request_executor)
 }
 
-#[derive(Debug, Parser)]
-#[command(group(
-    ArgGroup::new("target")
-        .args(["wpcom_site", "api_root", "url"]),
-), group(
-    ArgGroup::new("post_ref")
-        .required(true)
-        .args(["post_id", "url"]),
-))]
-struct FetchPostArgs {
-    /// Common authentication and target parameters
-    #[command(flatten)]
-    auth: AuthArgs,
-
-    /// Full post URL (alternative to --post-id)
-    /// When provided, this URL is used to infer the site (wp.com) or autodiscover the API root (wp.org/Jetpack).
-    #[arg(long)]
-    url: Option<String>,
-
-    /// The post ID to fetch
-    #[arg(long, value_parser = parse_post_id)]
-    post_id: Option<PostId>,
-
-    /// Password for the post if it is password-protected
-    #[arg(long)]
-    post_password: Option<String>,
-
-    /// Max items per page when fetching comments
-    #[arg(long, default_value_t = 100)]
-    per_page: u32,
-
-    /// Output pretty-printed JSON
-    #[arg(long, default_value_t = false)]
-    pretty: bool,
+fn parse_input_file(input_file: &str) -> Result<Vec<BatchTestRow>> {
+    Ok(csv::Reader::from_path(input_file)?
+        .deserialize::<BatchTestRow>()
+        .filter_map(|r| r.ok())
+        .collect())
 }
 
-fn parse_post_id(s: &str) -> Result<PostId, String> {
-    s.parse::<i64>()
-        .map(PostId)
-        .map_err(|e| format!("Invalid post id '{s}': {e}"))
+#[derive(Debug, serde::Deserialize)]
+struct BatchTestRow {
+    #[serde(rename = "URL")]
+    url: String,
+}
+
+#[derive(Debug)]
+struct SimplifiedDiscoveryResult {
+    attempt_site_url: String,
+    result: Result<LoginUrl, AutoDiscoveryAttemptFailure>,
+}
+
+impl SimplifiedDiscoveryResult {
+    fn success(attempt_site_url: String, login_url: LoginUrl) -> Self {
+        Self {
+            attempt_site_url,
+            result: Ok(login_url),
+        }
+    }
+
+    fn failure(attempt_site_url: String, error: AutoDiscoveryAttemptFailure) -> Self {
+        Self {
+            attempt_site_url,
+            result: Err(error),
+        }
+    }
+
+    fn write_as_csv_record(self, writer: &mut csv::Writer<File>) -> Result<()> {
+        let (error_type, error_message) = self
+            .result
+            .as_ref()
+            .err()
+            .map(|e| (csv_error_type(e), e.to_string()))
+            .unwrap_or(("".to_string(), "".to_string()));
+        Ok(writer.write_record(&[
+            self.result.is_ok().to_string(),
+            self.attempt_site_url,
+            error_type,
+            error_message,
+        ])?)
+    }
+
+    fn log_result(&self) {
+        match &self.result {
+            Ok(login_url) => {
+                println!("{}", format!("Login URL found: {login_url}").green());
+            }
+            Err(error) => {
+                println!("{}", error.to_string().red());
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LoginUrl(Arc<ParsedUrl>);
+
+impl Display for LoginUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+fn csv_error_type(failure: &AutoDiscoveryAttemptFailure) -> String {
+    match failure {
+        AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => "ParseSiteUrl".to_string(),
+        AutoDiscoveryAttemptFailure::FindApiRoot {
+            find_api_root_failure,
+            ..
+        } => match find_api_root_failure {
+            FindApiRootFailure::FetchHomepage { .. } => "FetchHomepage".to_string(),
+            FindApiRootFailure::ProbablyNotAWordPressSite => {
+                "ProbablyNotAWordPressSite".to_string()
+            }
+            FindApiRootFailure::RestApiDisabled => "RestApiDisabled".to_string(),
+        },
+        AutoDiscoveryAttemptFailure::FetchAndParseApiRoot {
+            fetch_and_parse_api_root_failure,
+            ..
+        } => match fetch_and_parse_api_root_failure {
+            FetchAndParseApiRootFailure::FetchApiRoot { .. } => "FetchApiRoot".to_string(),
+            FetchAndParseApiRootFailure::ParseApiRoot { .. } => "ParseApiRoot".to_string(),
+            FetchAndParseApiRootFailure::WpError { error_code, .. } => {
+                format!("WpError-{error_code:#?}")
+            }
+            FetchAndParseApiRootFailure::ApplicationPasswordsNotSupported { reason, .. } => {
+                format!("ApplicationPasswordsNotSupported-{reason:#?}")
+            }
+        },
+    }
 }
 
 #[derive(Debug)]
 enum TargetSiteResolver {
     WpCom { site: String },
     WpOrg { api_root: Arc<ParsedUrl> },
-}
-
-#[derive(Debug, Args, Clone)]
-struct AuthArgs {
-    /// WordPress.com site (e.g. example.wordpress.com or numeric ID)
-    #[arg(long)]
-    wpcom_site: Option<String>,
-
-    /// WordPress.org/Jetpack API root (must end with /wp-json)
-    #[arg(long)]
-    api_root: Option<String>,
-
-    /// Bearer token for WordPress.com (fallback env: WP_BEARER_TOKEN)
-    #[arg(long)]
-    bearer: Option<String>,
-
-    /// Application Password username for wp.org/Jetpack (fallback env: WP_USERNAME)
-    #[arg(long)]
-    username: Option<String>,
-
-    /// Application Password for wp.org/Jetpack (fallback env: WP_APP_PASSWORD)
-    #[arg(long)]
-    password: Option<String>,
 }
 
 async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
@@ -354,6 +371,88 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
     ))
 }
 
+#[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("target")
+        .args(["wpcom_site", "api_root", "url"]),
+), group(
+    ArgGroup::new("post_ref")
+        .required(true)
+        .args(["post_id", "url"]),
+))]
+struct FetchPostArgs {
+    /// Common authentication and target parameters
+    #[command(flatten)]
+    auth: AuthArgs,
+
+    /// Full post URL (alternative to --post-id)
+    /// When provided, this URL is used to infer the site (wp.com) or autodiscover the API root (wp.org/Jetpack).
+    #[arg(long)]
+    url: Option<String>,
+
+    /// The post ID to fetch
+    #[arg(long, value_parser = parse_post_id)]
+    post_id: Option<PostId>,
+
+    /// Password for the post if it is password-protected
+    #[arg(long)]
+    post_password: Option<String>,
+
+    /// Max items per page when fetching comments
+    #[arg(long, default_value_t = 100)]
+    per_page: u32,
+
+    /// Output pretty-printed JSON
+    #[arg(long, default_value_t = false)]
+    pretty: bool,
+}
+
+fn parse_post_id(s: &str) -> Result<PostId, String> {
+    s.parse::<i64>()
+        .map(PostId)
+        .map_err(|e| format!("Invalid post id '{s}': {e}"))
+}
+
+async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<PostId> {
+    if let Some(id) = args.post_id {
+        return Ok(id);
+    }
+    let Some(post_url) = &args.url else {
+        return Err(anyhow!("Either --post-id or --post-url must be provided"));
+    };
+
+    // Strategy: retrieve by slug via posts list API when possible.
+    // For wp.com, the resolver requires site context; for wp.org, api_root is given.
+    // We'll try to parse the URL and extract a last path segment as potential slug.
+    let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid --post-url: {e}"))?;
+    let slug_candidate = url
+        .path_segments()
+        .and_then(|segs| segs.filter(|s| !s.is_empty()).last())
+        .map(|s| s.trim_end_matches('/'))
+        .unwrap_or("")
+        .to_string();
+
+    if slug_candidate.is_empty() {
+        return Err(anyhow!("Could not parse a slug from --post-url"));
+    }
+
+    // Query posts by slug; returns an array, take first match.
+    // Using view context to ensure public content shape.
+    let mut params = wp_api::posts::PostListParams::default();
+    params.slug = vec![slug_candidate.clone()];
+    params.per_page = Some(1);
+    let resp = client.posts().list_with_view_context(&params).await?;
+    if let Some(p) = resp.data.into_iter().find_map(|sp| Some(sp.id)) {
+        return Ok(p);
+    }
+
+    Err(anyhow!(
+        "No post found for slug '{slug}' parsed from URL '{url}'",
+        slug = slug_candidate,
+        url = post_url
+    ))
+}
+
 async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
     let client = build_api_client(&args.auth, &args.url).await?;
 
@@ -397,103 +496,4 @@ async fn fetch_post_and_comments(args: FetchPostArgs) -> Result<()> {
         println!("{}", serde_json::to_string(&out)?);
     }
     Ok(())
-}
-
-fn parse_input_file(input_file: &str) -> Result<Vec<BatchTestRow>> {
-    Ok(csv::Reader::from_path(input_file)?
-        .deserialize::<BatchTestRow>()
-        .filter_map(|r| r.ok())
-        .collect())
-}
-
-#[derive(Debug, serde::Deserialize)]
-struct BatchTestRow {
-    #[serde(rename = "URL")]
-    url: String,
-}
-
-#[derive(Debug)]
-struct SimplifiedDiscoveryResult {
-    attempt_site_url: String,
-    result: Result<LoginUrl, AutoDiscoveryAttemptFailure>,
-}
-
-impl SimplifiedDiscoveryResult {
-    fn success(attempt_site_url: String, login_url: LoginUrl) -> Self {
-        Self {
-            attempt_site_url,
-            result: Ok(login_url),
-        }
-    }
-
-    fn failure(attempt_site_url: String, error: AutoDiscoveryAttemptFailure) -> Self {
-        Self {
-            attempt_site_url,
-            result: Err(error),
-        }
-    }
-
-    fn write_as_csv_record(self, writer: &mut csv::Writer<File>) -> Result<()> {
-        let (error_type, error_message) = self
-            .result
-            .as_ref()
-            .err()
-            .map(|e| (csv_error_type(e), e.to_string()))
-            .unwrap_or(("".to_string(), "".to_string()));
-        Ok(writer.write_record(&[
-            self.result.is_ok().to_string(),
-            self.attempt_site_url,
-            error_type,
-            error_message,
-        ])?)
-    }
-
-    fn log_result(&self) {
-        match &self.result {
-            Ok(login_url) => {
-                println!("{}", format!("Login URL found: {login_url}").green());
-            }
-            Err(error) => {
-                println!("{}", error.to_string().red());
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-struct LoginUrl(Arc<ParsedUrl>);
-
-impl Display for LoginUrl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-fn csv_error_type(failure: &AutoDiscoveryAttemptFailure) -> String {
-    match failure {
-        AutoDiscoveryAttemptFailure::ParseSiteUrl { .. } => "ParseSiteUrl".to_string(),
-        AutoDiscoveryAttemptFailure::FindApiRoot {
-            find_api_root_failure,
-            ..
-        } => match find_api_root_failure {
-            FindApiRootFailure::FetchHomepage { .. } => "FetchHomepage".to_string(),
-            FindApiRootFailure::ProbablyNotAWordPressSite => {
-                "ProbablyNotAWordPressSite".to_string()
-            }
-            FindApiRootFailure::RestApiDisabled => "RestApiDisabled".to_string(),
-        },
-        AutoDiscoveryAttemptFailure::FetchAndParseApiRoot {
-            fetch_and_parse_api_root_failure,
-            ..
-        } => match fetch_and_parse_api_root_failure {
-            FetchAndParseApiRootFailure::FetchApiRoot { .. } => "FetchApiRoot".to_string(),
-            FetchAndParseApiRootFailure::ParseApiRoot { .. } => "ParseApiRoot".to_string(),
-            FetchAndParseApiRootFailure::WpError { error_code, .. } => {
-                format!("WpError-{error_code:#?}")
-            }
-            FetchAndParseApiRootFailure::ApplicationPasswordsNotSupported { reason, .. } => {
-                format!("ApplicationPasswordsNotSupported-{reason:#?}")
-            }
-        },
-    }
 }

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -325,7 +325,9 @@ impl SiteApiType {
                 site.clone(),
                 WpComBaseUrl::Production,
             )),
-            SiteApiType::WpOrg { api_root } => Arc::new(WpOrgSiteApiUrlResolver::new(api_root.clone())),
+            SiteApiType::WpOrg { api_root } => {
+                Arc::new(WpOrgSiteApiUrlResolver::new(api_root.clone()))
+            }
         }
     }
 
@@ -349,9 +351,7 @@ impl SiteApiType {
                     )
                 })?;
                 Ok(Arc::new(
-                    WpAuthenticationProvider::static_with_username_and_password(
-                        username, password,
-                    ),
+                    WpAuthenticationProvider::static_with_username_and_password(username, password),
                 ))
             }
         }

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -418,13 +418,13 @@ async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<P
         return Ok(id);
     }
     let Some(post_url) = &args.url else {
-        return Err(anyhow!("Either --post-id or --post-url must be provided"));
+        return Err(anyhow!("Either --post-id or --url must be provided"));
     };
 
     // Strategy: retrieve by slug via posts list API when possible.
     // For wp.com, the resolver requires site context; for wp.org, api_root is given.
     // We'll try to parse the URL and extract a last path segment as potential slug.
-    let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid --post-url: {e}"))?;
+    let url = Url::parse(post_url).map_err(|e| anyhow!("Invalid url: {e}"))?;
     let slug_candidate = url
         .path_segments()
         .and_then(|segs| segs.filter(|s| !s.is_empty()).last())
@@ -433,7 +433,7 @@ async fn resolve_post_id(client: &WpApiClient, args: &FetchPostArgs) -> Result<P
         .to_string();
 
     if slug_candidate.is_empty() {
-        return Err(anyhow!("Could not parse a slug from --post-url"));
+        return Err(anyhow!("Could not parse a slug from url"));
     }
 
     // Query posts by slug; returns an array, take first match.

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -258,15 +258,14 @@ fn csv_error_type(failure: &AutoDiscoveryAttemptFailure) -> String {
     }
 }
 
-#[derive(Debug)]
-enum TargetSiteResolver {
-    WpCom { site: String },
-    WpOrg { api_root: Arc<ParsedUrl> },
-}
-
 async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApiClient> {
     let request_executor = Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60)));
     let middleware_pipeline = Arc::new(WpApiMiddlewarePipeline::default());
+    #[derive(Debug)]
+    enum TargetSiteResolver {
+        WpCom { site: String },
+        WpOrg { api_root: Arc<ParsedUrl> },
+    }
     // Determine target and auth
     let target = if let Some(site) = &args.wpcom_site {
         // Explicit WordPress.com site takes priority

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -353,10 +353,15 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
         };
 
     #[derive(Debug)]
-    struct NoopNotifier;
+    struct CliAppNotifier;
     #[async_trait::async_trait]
-    impl WpAppNotifier for NoopNotifier {
-        async fn requested_with_invalid_authentication(&self) {}
+    impl WpAppNotifier for CliAppNotifier {
+        async fn requested_with_invalid_authentication(&self) {
+            eprintln!(
+                "Authentication failed. Please verify your credentials or token and try again."
+            );
+            std::process::exit(1);
+        }
     }
 
     Ok(WpApiClient::new(
@@ -365,7 +370,7 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
             auth_provider,
             request_executor,
             middleware_pipeline,
-            app_notifier: Arc::new(NoopNotifier),
+            app_notifier: Arc::new(CliAppNotifier),
         },
     ))
 }


### PR DESCRIPTION
## What

This adds a `fetch-post` subcommand to `wp_rs_cli`

## Why

First, this is obviously a useful feature to have for the CLI

But in particular, as discussed in recent conversations with Oguz in Slack (internal ref: p1754602450419219/1754596820.179099-slack-C08CUT5NT88), this would be especially useful to integrate the CLI into some of our current AI workflows—where we might want to ask our LLM like Claude or Cursor to use the CLI to fetch a post's content and comments and do something with the data (summarize, extract particular info from comments and reformat, etc…)

## How

> [!NOTE]
> This is mostly vibe-coded with cursor-agent and GPT-5 🤖 
> (though I reviewed the code and made some tweaks of my own too)


 - Adds `AuthArgs` struct for common parameters related to authentication needed for this subcommand but that might also be useful to any future subcommand that might require authentication
 - Add a `build_api_client` method to build a `WpApiClient` from the `AuthArgs` and an optional page `url`.
    - `SiteApiType::detect_from_args` will use the  `wpcom_site` (WpCom) or `api_root` (WpOrg) args from `AuthArgs` if explicitly provided
    - But can also try to derive those from the optional `url` parameter if `wpcom_site`/`api_root` are not provided explicitly (extract `wpcom_site` from the host of the `url` if it's a `*.wordpress.com` URL, use `WpLoginClient.api_discovery(url)` to set `api_root` otherwise)
 - Declare a `Commands::FetchPost` subcommand, with its dedicated `FetchPostArgs`, a subset of them coming from `#[command(flatten)] auth: AuthArgs`
 - Implement `resolve_post_id` to find the `post_id` from a post URL / slug.
    - 🗒️  I wonder if that one would make more sense to move into the wp-rs API rather than just in the CLI, as it seems it could be useful for other contexts?
    - Or maybe there is already a method in the API to do that that I (and GPT-5) missed?
    - Or maybe there's a better way to achieve this? (I'm not super familiar with the WP API, but I could imagine there may be some more idiomatic ways to do that, or maybe variants of the API calls accepting the URL or slug directly instead of the ID…?
 - Implement `fetch_post_and_comments` (the core implementation of the `Commands::FetchPosts` command) to call the `WpApiClient`'s `.posts().retrieve_with_view_context()` + `.comments().list_with_view_context(…)` + pagination
    - 🗒️  I'm imagining that the handling of pagination could be probably made more generic in the future, so that one could apply the same trick for any request that has pagination, instead of hardcoding the `while` loop in the `fetch_post_and_comments` method. I didn't want to overcomplicate and try to optimize too early though, and figured the current approach would be ok as a first iteration of the implementation before it could be made more generic later
    - Or maybe there are already some support for auto-paginate at the `WpApiClient`'s level that I missed?

## Testing

```bash
# Obtain a bearer token (going through the OAuth flow if necessary), and set it as env var
$ export WP_BEARER_TOKEN='<your-oauth-token>'

$ cargo run -- fetch-post --url <url-to-a-p2-post>
```

## Future directions

Since this is the first of probably many future CLI subcommands that might require authentication, it'd be nice next to have a subcommand to perform the OAuth flow.

Then once we have automatic handling of OAuth flow (call `/authorize`, obtain the code, exchange it for a token, store the bearer token + refresh token + expiration locally for next CLI calls to reuse, auto-refresh the token on expiration…) by the CLI itself, the `AuthArgs` and friends will likely be adjusted accordingly so that you don't have to pass the bearer token manually.

But all that was out of scope for this spike/experiment, so for now you're just expected to obtain the bearer token on your end and provide it to the CLI, and we can refactor that part around `AuthArgs` later when we get to it or add more subcommands requiring it.