### PR TITLE
Parse videopress media details

### DIFF
--- a/wp_api/src/jetpack/mod.rs
+++ b/wp_api/src/jetpack/mod.rs
@@ -3,6 +3,7 @@ use crate::request::endpoint::AsNamespace;
 pub mod client;
 pub mod connection;
 pub mod endpoint;
+pub mod videopress;
 
 pub(crate) struct JetpackNamespace();
 

--- a/wp_api/src/jetpack/videopress.rs
+++ b/wp_api/src/jetpack/videopress.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use crate::media::MediaDetails;
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct VideoPressMediaDetails {
+    pub width: u32,
+    pub height: u32,
+    pub videopress: VideoPressDetails,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct VideoPressDetails {
+    pub duration: u64,
+    pub poster: String,
+}
+
+#[uniffi::export(with_foreign)]
+pub trait VideoPressMediaDetailsExtension: Send + Sync {
+    fn parse_videopress(&self, mime_type: String) -> Option<VideoPressMediaDetails>;
+}
+
+#[uniffi::export]
+impl VideoPressMediaDetailsExtension for MediaDetails {
+    fn parse_videopress(&self, mime_type: String) -> Option<VideoPressMediaDetails> {
+        if mime_type != "video/videopress" {
+            return None;
+        }
+
+        serde_json::from_str::<VideoPressMediaDetails>(self.payload.get()).ok()
+    }
+}

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -544,7 +544,7 @@ pub struct SparseMedia {
 #[derive(Debug, Serialize, Deserialize, uniffi::Object)]
 #[serde(transparent)]
 pub struct MediaDetails {
-    payload: Box<RawValue>,
+    pub payload: Box<RawValue>,
 }
 
 #[uniffi::export]


### PR DESCRIPTION
Atomic sites (maybe all sites with Jetpack Videopress enabled) returns a `media_details` JSON object that is not compatible with the one in core. That means the `parse_as_mime_type` function does not return `VideoMediaDetails`.

We want to add a dedicated function to parse the `media_details` values provide by the VideoPress plugin.