### PR TITLE
Fix `login_spec_16_invalid_url`

### DIFF
--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -228,6 +228,17 @@ impl From<reqwest::Error> for RequestExecutionError {
             };
         }
 
+        if error.is_connect() {
+            return RequestExecutionError::RequestExecutionFailed {
+                status_code,
+                redirects: None,
+                reason: RequestExecutionErrorReason::NonExistentSiteError {
+                    error_message: Some(error.to_string()),
+                    suggested_action: None,
+                },
+            };
+        }
+
         RequestExecutionError::RequestExecutionFailed {
             status_code,
             redirects: None,


### PR DESCRIPTION
reqwest was recently updated. It's likely that its internal implementation changes lead to it now reports a different error when connecting to an non-existing domain. The casting to `ResolveError` (`as_dns_error`) no longer works.

This commit add a final check to see whether the error is a connecting error, and report the error as 'NonExistingSiteError' accordingly.