### PR TITLE
Delete `/posts/<post_id>/revisions/<post_revision_id>` endpoint

### DIFF
--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -133,7 +133,7 @@ extension SiteSettingsWithEditContext {
 
 extension PostWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
-        ListViewData(id: self.slug, title: self.title.raw, subtitle: self.slug, fields: [:])
+        ListViewData(id: self.slug, title: self.title.rendered, subtitle: self.slug, fields: [:])
     }
 }
 
@@ -143,7 +143,7 @@ extension MediaWithEditContext: ListViewDataConvertable {
         return ListViewData(
             id: self.slug,
             title: details.emoji + " " + (URL(string: self.sourceUrl)?.lastPathComponent ?? "<invalid-source-url>"),
-            subtitle: self.title.raw,
+            subtitle: self.title.rendered,
             fields: details.fields
         )
     }

--- a/scripts/setup-test-site-custom-plugins/allow-revision-deletion.php
+++ b/scripts/setup-test-site-custom-plugins/allow-revision-deletion.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: Allow Revision Deletion for Integration Tests
+Description: Allows administrators to delete revisions via REST API for integration testing
+Version: 1.0
+*/
+
+add_filter('map_meta_cap', function($caps, $cap, $user_id, $args) {
+    if ($cap === 'delete_post' && !empty($args[0])) {
+        $post = get_post($args[0]);
+        if ($post && $post->post_type === 'revision') {
+            if (current_user_can('delete_posts')) {
+                return ['delete_posts'];
+            }
+        }
+    }
+    return $caps;
+}, 10, 4);

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -71,6 +71,10 @@ wp import /tmp/testdata.xml --authors=create
 wp plugin deactivate wordpress-importer
 wp plugin delete wordpress-importer
 
+# Install custom must-use plugins for integration tests
+mkdir -p wp-content/mu-plugins
+cp /app/scripts/setup-test-site-custom-plugins/*.php wp-content/mu-plugins/
+
 # We need an `author` user for some of the integration tests
 wp user create test_author test_author@example.com --role=author
 

--- a/wp_api/src/post_revisions.rs
+++ b/wp_api/src/post_revisions.rs
@@ -188,6 +188,12 @@ pub struct SparsePostRevision {
     pub meta: Option<crate::posts::PostMeta>,
 }
 
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PostRevisionDeleteResponse {
+    pub deleted: bool,
+    pub previous: PostRevisionWithEditContext,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -531,6 +531,7 @@ pub struct SparsePost {
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparsePostGuid {
     #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
     #[WpContext(edit, view)]
     pub rendered: Option<String>,
@@ -539,6 +540,7 @@ pub struct SparsePostGuid {
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparsePostTitle {
     #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
     #[WpContext(edit, embed, view)]
     pub rendered: Option<String>,
@@ -547,6 +549,7 @@ pub struct SparsePostTitle {
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparsePostContent {
     #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
     #[WpContext(edit, view)]
     pub rendered: Option<String>,
@@ -561,6 +564,7 @@ pub struct SparsePostContent {
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparsePostExcerpt {
     #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
     #[WpContext(edit, embed, view)]
     pub rendered: Option<String>,

--- a/wp_api/src/request/endpoint/post_revisions_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_revisions_endpoint.rs
@@ -15,11 +15,20 @@ enum PostRevisionsRequest {
     List,
     #[contextual_get(url = "/posts/<post_id>/revisions/<post_revision_id>", output = crate::post_revisions::SparsePostRevision, filter_by = crate::post_revisions::SparsePostRevisionField)]
     Retrieve,
+    #[delete(url = "/posts/<post_id>/revisions/<post_revision_id>", output = crate::post_revisions::PostRevisionDeleteResponse)]
+    Delete,
 }
 
 impl DerivedRequest for PostRevisionsRequest {
     fn namespace() -> impl AsNamespace {
         WpNamespace::WpV2
+    }
+
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            PostRevisionsRequest::Delete => vec![("force", "true".to_string())],
+            _ => vec![],
+        }
     }
 }
 
@@ -159,6 +168,16 @@ mod tests {
         validate_wp_v2_endpoint(
             endpoint.filter_retrieve_with_edit_context(&PostId(777), &PostRevisionId(888), fields),
             expected_path,
+        );
+    }
+
+    #[rstest]
+    fn delete_post_revision(endpoint: PostRevisionsRequestEndpoint) {
+        let post_id = PostId(777);
+        let revision_id = PostRevisionId(888);
+        validate_wp_v2_endpoint(
+            endpoint.delete(&post_id, &revision_id),
+            &format!("/posts/{post_id}/revisions/{revision_id}?force=true"),
         );
     }
 

--- a/wp_api_integration_tests/tests/test_post_revisions_mut.rs
+++ b/wp_api_integration_tests/tests/test_post_revisions_mut.rs
@@ -1,0 +1,31 @@
+use wp_api::{post_revisions::PostRevisionId, posts::PostId};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[serial]
+async fn delete_post_revision() {
+    let revision_id = revision_id_for_revisioned_post_id();
+    let revision_delete_response = api_client()
+        .post_revisions()
+        .delete(&revisioned_post_id(), &revision_id)
+        .await;
+
+    assert!(
+        revision_delete_response.is_ok(),
+        "{revision_delete_response:#?}"
+    );
+
+    let delete_response = revision_delete_response.unwrap().data;
+    assert!(delete_response.deleted);
+    assert_eq!(delete_response.previous.id, revision_id);
+
+    RestoreServer::db().await;
+}
+
+fn revisioned_post_id() -> PostId {
+    PostId(TestCredentials::instance().revisioned_post_id)
+}
+
+fn revision_id_for_revisioned_post_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().revision_id_for_revisioned_post_id)
+}

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -17,7 +17,7 @@ async fn create_post_with_just_title() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.title.raw, "foo");
+            assert_eq!(created_post.title.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.title, "foo");
         },
     )
@@ -40,7 +40,7 @@ async fn create_post_with_title_and_meta() {
         },
         |created_post, post_from_wp_cli| {
             let footnote = created_post.meta.footnotes.first().unwrap();
-            assert_eq!(created_post.title.raw, "foo");
+            assert_eq!(created_post.title.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.title, "foo");
             assert_eq!(footnote.id, "bar");
             assert_eq!(footnote.content, "baz");
@@ -58,7 +58,7 @@ async fn create_post_with_just_content() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.content.raw, "foo");
+            assert_eq!(created_post.content.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.content, "foo");
         },
     )
@@ -74,7 +74,7 @@ async fn create_post_with_just_excerpt() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.excerpt.raw, "foo");
+            assert_eq!(created_post.excerpt.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.excerpt, "foo");
         },
     )
@@ -92,11 +92,11 @@ async fn create_post_with_title_content_and_excerpt() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.title.raw, "foo");
+            assert_eq!(created_post.title.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.title, "foo");
-            assert_eq!(created_post.content.raw, "bar");
+            assert_eq!(created_post.content.raw, Some("bar".to_string()));
             assert_eq!(post_from_wp_cli.content, "bar");
-            assert_eq!(created_post.excerpt.raw, "baz");
+            assert_eq!(created_post.excerpt.raw, Some("baz".to_string()));
             assert_eq!(post_from_wp_cli.excerpt, "baz");
         },
     )
@@ -193,7 +193,7 @@ generate_update_test!(
     title,
     "new_title".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.title.raw, "new_title");
+        assert_eq!(updated_post.title.raw, Some("new_title".to_string()));
         assert_eq!(updated_post_from_wp_cli.title, "new_title");
     }
 );
@@ -203,7 +203,7 @@ generate_update_test!(
     content,
     "new_content".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.content.raw, "new_content");
+        assert_eq!(updated_post.content.raw, Some("new_content".to_string()));
         assert_eq!(updated_post_from_wp_cli.content, "new_content");
     }
 );
@@ -223,7 +223,7 @@ generate_update_test!(
     excerpt,
     "new_excerpt".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.excerpt.raw, "new_excerpt");
+        assert_eq!(updated_post.excerpt.raw, Some("new_excerpt".to_string()));
         assert_eq!(updated_post_from_wp_cli.excerpt, "new_excerpt");
     }
 );


### PR DESCRIPTION
Adds a plugin to the test site to allow deleting revisions, so we can use that in integration tests. Makes the `raw` field for various post inner types optional - as these are not included for revisions.