### PR TITLE
Implement `WpDeriveParamsField` macro for automatic enum generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,12 +5092,15 @@ dependencies = [
 name = "wp_derive"
 version = "0.1.0"
 dependencies = [
+ "convert_case",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "rstest",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "syn",
  "thiserror 2.0.16",
  "trybuild",

--- a/wp_api/src/categories.rs
+++ b/wp_api/src/categories.rs
@@ -8,8 +8,8 @@ use crate::{
     wp_content_i64_id,
 };
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 wp_content_i64_id!(CategoryId);
 
@@ -39,7 +39,7 @@ pub enum WpApiParamCategoriesOrderBy {
 
 impl_as_query_value_from_to_string!(WpApiParamCategoriesOrderBy);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct CategoryListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -70,6 +70,7 @@ pub struct CategoryListParams {
     /// Default: `name`
     /// One of: `id`, `include`, `name`, `slug`, `include_slugs`, `term_group`, `description`, `count`
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamCategoriesOrderBy>,
     /// Whether to hide terms not assigned to any posts.
     #[uniffi(default = None)]
@@ -83,34 +84,6 @@ pub struct CategoryListParams {
     /// Limit result set to users with one or more specific slugs.
     #[uniffi(default = [])]
     pub slug: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum CategoryListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "hide_empty")]
-    HideEmpty,
-    #[strum(serialize = "parent")]
-    Parent,
-    #[strum(serialize = "post")]
-    Post,
-    #[strum(serialize = "slug")]
-    Slug,
 }
 
 impl AppendUrlQueryPairs for CategoryListParams {

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr, sync::Arc};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 #[derive(
     Debug,
@@ -69,7 +69,7 @@ pub enum CommentType {
 
 impl_as_query_value_from_to_string!(CommentType);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct CommentListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -115,6 +115,7 @@ pub struct CommentListParams {
     /// Default: date_gmt
     /// One of: date, date_gmt, id, include, post, parent, type
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamCommentsOrderBy>,
     /// Limit result set to comments of specific parent IDs.
     #[uniffi(default = [])]
@@ -132,52 +133,11 @@ pub struct CommentListParams {
     /// Limit result set to comments assigned a specific type. Requires authorization.
     /// Default: comment
     #[uniffi(default = None)]
+    #[field_name("type")]
     pub comment_type: Option<CommentType>,
     /// The password for the post if it is password protected.
     #[uniffi(default = None)]
     pub password: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum CommentListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "after")]
-    After,
-    #[strum(serialize = "author")]
-    Author,
-    #[strum(serialize = "author_exclude")]
-    AuthorExclude,
-    #[strum(serialize = "author_email")]
-    AuthorEmail,
-    #[strum(serialize = "before")]
-    Before,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "parent")]
-    Parent,
-    #[strum(serialize = "parent_exclude")]
-    ParentExclude,
-    #[strum(serialize = "post")]
-    Post,
-    #[strum(serialize = "status")]
-    Status,
-    #[strum(serialize = "type")]
-    CommentType,
-    #[strum(serialize = "password")]
-    Password,
 }
 
 impl AppendUrlQueryPairs for CommentListParams {

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use std::collections::HashMap;
 use std::sync::Arc;
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 wp_content_i64_id!(MediaId);
 
@@ -107,7 +107,7 @@ pub enum MediaStatus {
 
 impl_as_query_value_from_to_string!(MediaStatus);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct MediaListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -156,6 +156,7 @@ pub struct MediaListParams {
     /// Default: date
     /// One of: author, date, id, include, modified, parent, relevance, slug, include_slugs, title
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Limit result set to items with particular parent IDs.
     #[uniffi(default = [])]
@@ -180,52 +181,6 @@ pub struct MediaListParams {
     /// Limit result set to attachments of a particular MIME type.
     #[uniffi(default = None)]
     pub mime_type: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum MediaListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "after")]
-    After,
-    #[strum(serialize = "modified_after")]
-    ModifiedAfter,
-    #[strum(serialize = "author")]
-    Author,
-    #[strum(serialize = "author_exclude")]
-    AuthorExclude,
-    #[strum(serialize = "before")]
-    Before,
-    #[strum(serialize = "modified_before")]
-    ModifiedBefore,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "parent")]
-    Parent,
-    #[strum(serialize = "parent_exclude")]
-    ParentExclude,
-    #[strum(serialize = "search_columns")]
-    SearchColumns,
-    #[strum(serialize = "slug")]
-    Slug,
-    #[strum(serialize = "status")]
-    Status,
-    #[strum(serialize = "media_type")]
-    MediaType,
-    #[strum(serialize = "mime_type")]
-    MimeType,
 }
 
 impl AppendUrlQueryPairs for MediaListParams {

--- a/wp_api/src/post_revisions.rs
+++ b/wp_api/src/post_revisions.rs
@@ -9,8 +9,8 @@ use crate::{
     wp_content_i64_id,
 };
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 wp_content_i64_id!(PostRevisionId);
 
@@ -39,7 +39,7 @@ pub enum WpApiParamPostRevisionsOrderBy {
 
 impl_as_query_value_from_to_string!(WpApiParamPostRevisionsOrderBy);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct PostRevisionListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -69,27 +69,8 @@ pub struct PostRevisionListParams {
     /// Default: date
     /// One of: date, id, include, relevance, slug, include_slugs, title
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamPostRevisionsOrderBy>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum PostRevisionListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
 }
 
 impl AppendUrlQueryPairs for PostRevisionListParams {

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -11,8 +11,8 @@ use crate::{
     wp_content_i64_id,
 };
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 #[derive(
@@ -67,7 +67,7 @@ pub enum WpApiParamPostsSearchColumn {
 
 impl_as_query_value_from_to_string!(WpApiParamPostsSearchColumn);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct PostListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -116,6 +116,7 @@ pub struct PostListParams {
     /// Default: date
     /// One of: author, date, id, include, modified, parent, relevance, slug, include_slugs, title
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamPostsOrderBy>,
     /// Array of column names to be searched.
     #[uniffi(default = [])]
@@ -146,56 +147,6 @@ pub struct PostListParams {
     /// Limit result set to items that are sticky.
     #[uniffi(default = None)]
     pub sticky: Option<bool>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum PostListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "after")]
-    After,
-    #[strum(serialize = "modified_after")]
-    ModifiedAfter,
-    #[strum(serialize = "author")]
-    Author,
-    #[strum(serialize = "author_exclude")]
-    AuthorExclude,
-    #[strum(serialize = "before")]
-    Before,
-    #[strum(serialize = "modified_before")]
-    ModifiedBefore,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "search_columns")]
-    SearchColumns,
-    #[strum(serialize = "slug")]
-    Slug,
-    #[strum(serialize = "status")]
-    Status,
-    #[strum(serialize = "tax_relation")]
-    TaxRelation,
-    #[strum(serialize = "categories")]
-    Categories,
-    #[strum(serialize = "categories_exclude")]
-    CategoriesExclude,
-    #[strum(serialize = "tags")]
-    Tags,
-    #[strum(serialize = "tags_exclude")]
-    TagsExclude,
-    #[strum(serialize = "sticky")]
-    Sticky,
 }
 
 impl AppendUrlQueryPairs for PostListParams {

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -5,8 +5,8 @@ use crate::{
     },
 };
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 #[derive(
     Debug,
@@ -69,7 +69,7 @@ pub enum SearchResultSubtype {
 
 impl_as_query_value_from_to_string!(SearchResultSubtype);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct SearchListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -86,10 +86,12 @@ pub struct SearchListParams {
     /// Default: `post`
     /// One of: `post`, `term`, `post-format`
     #[uniffi(default = None)]
+    #[field_name("type")]
     pub object_type: Option<SearchResultType>,
     /// Limit results to items of one or more object subtypes.
     /// Default: `any`
     #[uniffi(default = None)]
+    #[field_name("subtype")]
     pub object_subtype: Option<SearchResultSubtype>,
     /// Ensure result set excludes specific IDs.
     #[uniffi(default = [])]
@@ -97,24 +99,6 @@ pub struct SearchListParams {
     /// Limit result set to specific IDs.
     #[uniffi(default = [])]
     pub include: Vec<i64>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum SearchListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "type")]
-    ObjectType,
-    #[strum(serialize = "subtype")]
-    ObjectSubtype,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
 }
 
 impl AppendUrlQueryPairs for SearchListParams {

--- a/wp_api/src/tags.rs
+++ b/wp_api/src/tags.rs
@@ -8,8 +8,8 @@ use crate::{
     wp_content_i64_id,
 };
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 wp_content_i64_id!(TagId);
 
@@ -39,7 +39,7 @@ pub enum WpApiParamTagsOrderBy {
 
 impl_as_query_value_from_to_string!(WpApiParamTagsOrderBy);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct TagListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -70,6 +70,7 @@ pub struct TagListParams {
     /// Default: `name`
     /// One of: `id`, `include`, `name`, `slug`, `include_slugs`, `term_group`, `description`, `count`
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamTagsOrderBy>,
     /// Whether to hide terms not assigned to any posts.
     #[uniffi(default = None)]
@@ -80,32 +81,6 @@ pub struct TagListParams {
     /// Limit result set to users with one or more specific slugs.
     #[uniffi(default = [])]
     pub slug: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum TagListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "hide_empty")]
-    HideEmpty,
-    #[strum(serialize = "post")]
-    Post,
-    #[strum(serialize = "slug")]
-    Slug,
 }
 
 impl AppendUrlQueryPairs for TagListParams {

--- a/wp_api/src/taxonomies.rs
+++ b/wp_api/src/taxonomies.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt::Display};
 
 use serde::{Deserialize, Serialize};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 use crate::{
     post_types::PostType,
@@ -90,17 +90,12 @@ pub enum TaxonomyTypeLabels {
     Custom(String),
 }
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct TaxonomyListParams {
     /// Limit results to taxonomies associated with a specific post type.
     #[uniffi(default = None)]
+    #[field_name("type")]
     pub post_type: Option<PostType>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum TaxonomyListParamsField {
-    #[strum(serialize = "type")]
-    PostType,
 }
 
 impl AppendUrlQueryPairs for TaxonomyListParams {

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 uniffi::custom_newtype!(TemplateId, String);
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,10 +80,11 @@ pub enum TemplateArea {
 
 impl_as_query_value_from_to_string!(TemplateArea);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct TemplateListParams {
     /// Limit to the specified post id.
     #[uniffi(default = None)]
+    #[field_name("wp_id")]
     pub post_id: Option<PostId>,
     /// Limit to the specified template part area.
     #[uniffi(default = None)]
@@ -91,16 +92,6 @@ pub struct TemplateListParams {
     /// Post type to get the templates for.
     #[uniffi(default = None)]
     pub post_type: Option<PostType>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum TemplateListParamsField {
-    #[strum(serialize = "wp_id")]
-    PostId,
-    #[strum(serialize = "area")]
-    Area,
-    #[strum(serialize = "post_type")]
-    PostType,
 }
 
 impl AppendUrlQueryPairs for TemplateListParams {

--- a/wp_api/src/themes.rs
+++ b/wp_api/src/themes.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 #[derive(
     Debug,
@@ -35,17 +35,11 @@ pub enum ThemeStatus {
 
 impl_as_query_value_from_to_string!(ThemeStatus);
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct ThemeListParams {
     /// Limit result set to themes assigned one or more statuses.
     #[uniffi(default = None)]
     pub status: Option<ThemeStatus>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum ThemeListParamsField {
-    #[strum(serialize = "status")]
-    Status,
 }
 
 impl AppendUrlQueryPairs for ThemeListParams {

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::Infallible, fmt::Display, str::FromStr};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 #[derive(
     Debug,
@@ -119,7 +119,7 @@ pub enum UserAvatarSize {
     Custom(String),
 }
 
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 pub struct UserListParams {
     /// Current page of the collection.
     /// Default: `1`
@@ -150,6 +150,7 @@ pub struct UserListParams {
     /// Default: `name`
     /// One of: `id`, `include`, `name`, `registered_date`, `slug`, `include_slugs`, `email`, `url`
     #[uniffi(default = None)]
+    #[field_name("orderby")]
     pub orderby: Option<WpApiParamUsersOrderBy>,
     /// Limit result set to users with one or more specific slugs.
     #[uniffi(default = [])]
@@ -167,36 +168,6 @@ pub struct UserListParams {
     /// Limit result set to users who have published posts.
     #[uniffi(default = None)]
     pub has_published_posts: Option<WpApiParamUsersHasPublishedPosts>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum UserListParamsField {
-    #[strum(serialize = "page")]
-    Page,
-    #[strum(serialize = "per_page")]
-    PerPage,
-    #[strum(serialize = "search")]
-    Search,
-    #[strum(serialize = "exclude")]
-    Exclude,
-    #[strum(serialize = "include")]
-    Include,
-    #[strum(serialize = "offset")]
-    Offset,
-    #[strum(serialize = "order")]
-    Order,
-    #[strum(serialize = "orderby")]
-    Orderby,
-    #[strum(serialize = "slug")]
-    Slug,
-    #[strum(serialize = "roles")]
-    Roles,
-    #[strum(serialize = "capabilities")]
-    Capabilities,
-    #[strum(serialize = "who")]
-    Who,
-    #[strum(serialize = "has_published_posts")]
-    HasPublishedPosts,
 }
 
 impl AppendUrlQueryPairs for UserListParams {

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -5,8 +5,8 @@ use crate::url_query::{
 use crate::widget_types::WidgetTypeId;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
-use strum_macros::IntoStaticStr;
 use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
 
 uniffi::custom_newtype!(WidgetId, String);
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,15 +47,9 @@ pub struct WidgetInstance {
     pub raw: Option<HashMap<String, JsonValue>>,
 }
 
-#[derive(Debug, Clone, Default, uniffi::Record)]
+#[derive(Debug, Clone, Default, uniffi::Record, WpDeriveParamsField)]
 pub struct WidgetListParams {
     pub sidebar: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, IntoStaticStr)]
-enum WidgetListParamsField {
-    #[strum(serialize = "sidebar")]
-    Sidebar,
 }
 
 impl AppendUrlQueryPairs for WidgetListParams {

--- a/wp_derive/Cargo.toml
+++ b/wp_derive/Cargo.toml
@@ -12,15 +12,18 @@ name = "tests"
 path = "tests/parser_tests.rs"
 
 [dependencies]
+convert_case = { workspace = true }
 proc-macro-crate = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
+strum_macros = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 trybuild = { workspace = true, features = ["diff"] }
 wp_serde_helper = { path = "../wp_serde_helper" }

--- a/wp_derive/src/lib.rs
+++ b/wp_derive/src/lib.rs
@@ -1,8 +1,14 @@
 use proc_macro::TokenStream;
 
+mod params_field;
 mod wp_deserialize;
 
 #[proc_macro_derive(WpDeserialize)]
-pub fn derive(input: TokenStream) -> TokenStream {
+pub fn derive_wp_deserialize(input: TokenStream) -> TokenStream {
     wp_deserialize::derive(input)
+}
+
+#[proc_macro_derive(WpDeriveParamsField, attributes(field_name))]
+pub fn derive_params_field(input: TokenStream) -> TokenStream {
+    params_field::derive(input)
 }

--- a/wp_derive/src/params_field.rs
+++ b/wp_derive/src/params_field.rs
@@ -1,0 +1,158 @@
+use convert_case::{Case, Casing};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{
+    Attribute, Field, Token, braced,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    token::Comma,
+};
+
+const ATTR_FIELD_NAME: &str = "field_name";
+
+pub(crate) fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let parsed_struct = parse_macro_input!(input as ParsedParamsStruct);
+
+    parsed_struct.generate_params_field_enum().into()
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedParamsStruct {
+    pub struct_ident: Ident,
+    pub fields: Vec<ParsedField>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedField {
+    pub field_ident: Ident,
+    pub _field_type: syn::Type,
+    pub field_name_override: Option<String>,
+}
+
+impl Parse for ParsedParamsStruct {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _vis: syn::Visibility = input.parse()?;
+        let _struct_token: Token![struct] = input.parse()?;
+        let struct_ident: Ident = input.parse()?;
+
+        let content;
+        let _brace_token = braced!(content in input);
+
+        let fields = Self::parse_fields(&content)?;
+
+        Ok(Self {
+            struct_ident,
+            fields,
+        })
+    }
+}
+
+impl ParsedParamsStruct {
+    fn parse_fields(content: ParseStream) -> syn::Result<Vec<ParsedField>> {
+        let fields: Punctuated<Field, Comma> =
+            content.parse_terminated(Field::parse_named, Token![,])?;
+
+        fields
+            .into_iter()
+            .map(|field| {
+                let field_span = field.span();
+                let field_ident = field.ident.ok_or_else(|| {
+                    WpDeriveParamsFieldError::UnnamedField.into_syn_error(field_span)
+                })?;
+
+                // Parse field attributes for #[field_name("...")]
+                let field_name_override = Self::parse_field_name_attribute(&field.attrs)?;
+
+                Ok(ParsedField {
+                    field_ident,
+                    _field_type: field.ty,
+                    field_name_override,
+                })
+            })
+            .collect()
+    }
+
+    fn parse_field_name_attribute(attrs: &[Attribute]) -> syn::Result<Option<String>> {
+        let mut field_name_override = None;
+
+        for attr in attrs {
+            if attr.path().is_ident(ATTR_FIELD_NAME) {
+                if field_name_override.is_some() {
+                    return Err(WpDeriveParamsFieldError::DuplicateFieldNameAttribute
+                        .into_syn_error(attr.span()));
+                }
+
+                let literal: syn::LitStr = attr.parse_args()?;
+                field_name_override = Some(literal.value());
+            }
+        }
+
+        Ok(field_name_override)
+    }
+
+    /// Generate the params field enum from the parsed struct
+    fn generate_params_field_enum(&self) -> TokenStream {
+        let enum_name = self.generate_enum_name();
+        let enum_variants = self.generate_enum_variants();
+
+        quote! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum_macros::IntoStaticStr)]
+            enum #enum_name {
+                #(#enum_variants,)*
+            }
+        }
+    }
+
+    /// Generate the enum name from struct name (e.g., PostListParams -> PostListParamsField)
+    fn generate_enum_name(&self) -> Ident {
+        let struct_name = self.struct_ident.to_string();
+        format_ident!("{}Field", struct_name)
+    }
+
+    /// Generate enum variants with strum attributes
+    fn generate_enum_variants(&self) -> Vec<TokenStream> {
+        self.fields
+            .iter()
+            .map(|field| {
+                let variant_name = self.generate_variant_name(&field.field_ident);
+                let serialize_name = self.generate_serialize_name(field);
+
+                quote! {
+                    #[strum(serialize = #serialize_name)]
+                    #variant_name
+                }
+            })
+            .collect()
+    }
+
+    /// Generate variant name (-> PascalCase)
+    fn generate_variant_name(&self, field_ident: &Ident) -> Ident {
+        let field_name = field_ident.to_string();
+        let pascal_case = field_name.to_case(Case::Pascal);
+        format_ident!("{}", pascal_case)
+    }
+
+    /// Generate serialize name (use override or original field name)
+    fn generate_serialize_name(&self, field: &ParsedField) -> String {
+        field
+            .field_name_override
+            .clone()
+            .unwrap_or_else(|| field.field_ident.to_string())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum WpDeriveParamsFieldError {
+    #[error("Only named fields are supported")]
+    UnnamedField,
+    #[error("Duplicate #[field_name] attribute found")]
+    DuplicateFieldNameAttribute,
+}
+
+impl WpDeriveParamsFieldError {
+    fn into_syn_error(self, span: proc_macro2::Span) -> syn::Error {
+        syn::Error::new(span, self.to_string())
+    }
+}

--- a/wp_derive/tests/parser_tests.rs
+++ b/wp_derive/tests/parser_tests.rs
@@ -1,6 +1,13 @@
 #[test]
-fn tests() {
+fn wp_deserialize_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/wp_deserialize/pass/*.rs");
     t.compile_fail("tests/wp_deserialize/fail/*.rs");
+}
+
+#[test]
+fn wp_derive_params_field_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/wp_derive_params_field/pass/*.rs");
+    t.compile_fail("tests/wp_derive_params_field/fail/*.rs");
 }

--- a/wp_derive/tests/wp_derive_params_field/fail/duplicate_field_name.rs
+++ b/wp_derive/tests/wp_derive_params_field/fail/duplicate_field_name.rs
@@ -1,0 +1,10 @@
+use wp_derive::WpDeriveParamsField;
+
+#[derive(WpDeriveParamsField)]
+pub struct TestParams {
+    #[field_name("per_page")]
+    #[field_name("per_page")] // Duplicate should fail
+    pub per_page: Option<u32>,
+}
+
+fn main() {}

--- a/wp_derive/tests/wp_derive_params_field/fail/duplicate_field_name.stderr
+++ b/wp_derive/tests/wp_derive_params_field/fail/duplicate_field_name.stderr
@@ -1,0 +1,5 @@
+error: Duplicate #[field_name] attribute found
+ --> tests/wp_derive_params_field/fail/duplicate_field_name.rs:6:5
+  |
+6 |     #[field_name("per_page")]  // Duplicate should fail
+  |     ^

--- a/wp_derive/tests/wp_derive_params_field/pass/comprehensive_enum_test.rs
+++ b/wp_derive/tests/wp_derive_params_field/pass/comprehensive_enum_test.rs
@@ -1,0 +1,39 @@
+use wp_derive::WpDeriveParamsField;
+
+#[derive(WpDeriveParamsField)]
+pub struct TestListParams {
+    // Basic field - should serialize to "page"
+    pub page: Option<u32>,
+    // Snake case field - should serialize to "per_page"
+    pub per_page: Option<u32>,
+    // Custom field name override - should serialize to "custom_search"
+    #[field_name("custom_search")]
+    pub search: Option<String>,
+    // Field with different naming convention - should serialize to "authorId" (camelCase)
+    #[field_name("authorId")]
+    pub author_id: Vec<i64>,
+    // Multi-word field - should serialize to "search_columns"
+    pub search_columns: Vec<String>,
+}
+
+fn main() {
+    // Verify basic field serialization
+    let page: &'static str = TestListParamsField::Page.into();
+    assert_eq!("page", page);
+
+    // Verify snake_case field serialization
+    let per_page: &'static str = TestListParamsField::PerPage.into();
+    assert_eq!("per_page", per_page);
+
+    // Verify custom field_name attribute override
+    let search: &'static str = TestListParamsField::Search.into();
+    assert_eq!("custom_search", search);
+
+    // Verify field_name attribute with camelCase (different from snake_case default)
+    let author_id: &'static str = TestListParamsField::AuthorId.into();
+    assert_eq!("authorId", author_id);
+
+    // Verify multi-word field auto snake_case conversion
+    let search_columns: &'static str = TestListParamsField::SearchColumns.into();
+    assert_eq!("search_columns", search_columns);
+}

--- a/wp_derive/tests/wp_derive_params_field/pass/empty_struct.rs
+++ b/wp_derive/tests/wp_derive_params_field/pass/empty_struct.rs
@@ -1,0 +1,6 @@
+use wp_derive::WpDeriveParamsField;
+
+#[derive(WpDeriveParamsField)]
+pub struct EmptyParams {}
+
+fn main() {}


### PR DESCRIPTION
Replace manual `*ListParamsField` enum implementations with a procedural macro that automatically generates field enums from struct definitions. The macro generates enums with:

- Automatic `PascalCase` conversion for variant names
- Support for `#[field_name("custom_name")]` attribute for custom serialization names
- Strum attributes for field serialization