### PR TITLE
Automate `SparseField` implementations with serde rename support

### DIFF
--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -573,7 +573,7 @@ mod tests {
         #[case] field: SparseCommentFieldWithEditContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -583,7 +583,7 @@ mod tests {
         #[case] field: SparseCommentFieldWithEmbedContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -593,6 +593,6 @@ mod tests {
         #[case] field: SparseCommentFieldWithViewContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 }

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyJson, UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
+    AnyJson, SparseField, UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
     posts::PostId,
@@ -408,6 +408,33 @@ pub struct SparseComment {
     #[WpContextualExcludeFromFields]
     pub additional_fields: Option<Arc<AnyJson>>,
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/422
+}
+
+impl SparseField for SparseCommentFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::CommentType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseCommentFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::CommentType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseCommentFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::CommentType => "type",
+            _ => self.as_field_name(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -593,4 +593,34 @@ mod tests {
             "page=11&per_page=22&search=s_q&{after}&author=111%2C112&author_exclude=211%2C212&author_email=a_email%40example.com&{before}&exclude=1111%2C1112&include=2111%2C2112&offset=11111&order=desc&orderby=type&parent=44444%2C44445&parent_exclude=55555%2C55556&post=66666%2C66667&status=spam&type=pingback&password=p_q"
         )
     }
+
+    #[rstest]
+    #[case(SparseCommentFieldWithEditContext::Id, "id")]
+    #[case(SparseCommentFieldWithEditContext::CommentType, "type")]
+    fn test_as_mapped_field_name_for_edit_context(
+        #[case] field: SparseCommentFieldWithEditContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseCommentFieldWithEmbedContext::Id, "id")]
+    #[case(SparseCommentFieldWithEmbedContext::CommentType, "type")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparseCommentFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseCommentFieldWithViewContext::Id, "id")]
+    #[case(SparseCommentFieldWithViewContext::CommentType, "type")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparseCommentFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
 }

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyJson, SparseField, UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
+    AnyJson, UserAvatarSize, UserId, WpApiParamOrder, WpResponseString,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
     posts::PostId,
@@ -410,33 +410,6 @@ pub struct SparseComment {
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/422
 }
 
-impl SparseField for SparseCommentFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseCommentFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseCommentFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseCommentContent {
     #[WpContext(edit)]
@@ -509,13 +482,12 @@ fn comment_type_to_string(comment_type: CommentType) -> String {
 mod tests {
     use super::*;
     use crate::{
-        generate,
+        SparseField, generate,
         unit_test_common::{
             assert_expected_and_from_query_pairs, unit_test_example_date_as_option,
             unit_test_example_date_as_query_value,
         },
     };
-
     use rstest::*;
 
     #[rstest]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -91,7 +91,7 @@ pub enum WpApiParamOrder {
 impl_as_query_value_from_to_string!(WpApiParamOrder);
 
 trait SparseField {
-    fn as_str(&self) -> &str;
+    fn as_mapped_field_name(&self) -> &str;
 }
 
 trait OptionFromStr {

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SparseField, UserId, WpApiParamOrder,
+    UserId, WpApiParamOrder,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
     posts::{
@@ -407,35 +407,6 @@ pub struct SparseMedia {
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/381
 }
 
-impl SparseField for SparseMediaFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostId => "post",
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseMediaFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseMediaFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostId => "post",
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, uniffi::Object)]
 #[serde(transparent)]
 pub struct MediaDetails {
@@ -557,7 +528,7 @@ pub struct SparseMediaCaption {
 mod tests {
     use super::*;
     use crate::{
-        generate,
+        SparseField, generate,
         posts::PostId,
         unit_test_common::{
             assert_expected_and_from_query_pairs, unit_test_example_date_as_option,

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -684,7 +684,7 @@ mod tests {
         #[case] field: SparseMediaFieldWithEditContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -694,7 +694,7 @@ mod tests {
         #[case] field: SparseMediaFieldWithEmbedContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -705,6 +705,6 @@ mod tests {
         #[case] field: SparseMediaFieldWithViewContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 }

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -1,5 +1,5 @@
 use crate::{
-    UserId, WpApiParamOrder,
+    SparseField, UserId, WpApiParamOrder,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
     posts::{
@@ -405,6 +405,35 @@ pub struct SparseMedia {
     #[WpContext(edit)]
     pub missing_image_sizes: Option<Vec<String>>,
     // meta field is omitted for now: https://github.com/Automattic/wordpress-rs/issues/381
+}
+
+impl SparseField for SparseMediaFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostId => "post",
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseMediaFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseMediaFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostId => "post",
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Object)]

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -704,4 +704,36 @@ mod tests {
             serde_json::Value::Object(serde_json::Map::new())
         );
     }
+
+    #[rstest]
+    #[case(SparseMediaFieldWithEditContext::Id, "id")]
+    #[case(SparseMediaFieldWithEditContext::PostId, "post")]
+    #[case(SparseMediaFieldWithEditContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_edit_context(
+        #[case] field: SparseMediaFieldWithEditContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseMediaFieldWithEmbedContext::Id, "id")]
+    #[case(SparseMediaFieldWithEmbedContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparseMediaFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseMediaFieldWithViewContext::Id, "id")]
+    #[case(SparseMediaFieldWithViewContext::PostId, "post")]
+    #[case(SparseMediaFieldWithViewContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparseMediaFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
 }

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -651,7 +651,7 @@ mod tests {
         #[case] field: SparsePostFieldWithEditContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -661,7 +661,7 @@ mod tests {
         #[case] field: SparsePostFieldWithEmbedContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -671,7 +671,7 @@ mod tests {
         #[case] field: SparsePostFieldWithViewContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,5 +1,5 @@
 use crate::{
-    UserId, WpApiParamOrder,
+    SparseField, UserId, WpApiParamOrder,
     categories::CategoryId,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
@@ -386,6 +386,33 @@ pub struct SparsePost {
     pub categories: Option<Vec<CategoryId>>,
     #[WpContext(edit, view)]
     pub tags: Option<Vec<TagId>>,
+}
+
+impl SparseField for SparsePostFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparsePostFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparsePostFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::PostType => "type",
+            _ => self.as_field_name(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -671,6 +671,36 @@ mod tests {
         assert_expected_and_from_query_pairs(params, expected_query);
     }
 
+    #[rstest]
+    #[case(SparsePostFieldWithEditContext::Id, "id")]
+    #[case(SparsePostFieldWithEditContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_edit_context(
+        #[case] field: SparsePostFieldWithEditContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparsePostFieldWithEmbedContext::Id, "id")]
+    #[case(SparsePostFieldWithEmbedContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparsePostFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparsePostFieldWithViewContext::Id, "id")]
+    #[case(SparsePostFieldWithViewContext::PostType, "type")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparsePostFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
     fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {
         let after = unit_test_example_date_as_query_value("after");
         let modified_after = unit_test_example_date_as_query_value("modified_after");

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SparseField, UserId, WpApiParamOrder,
+    UserId, WpApiParamOrder,
     categories::CategoryId,
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
@@ -388,33 +388,6 @@ pub struct SparsePost {
     pub tags: Option<Vec<TagId>>,
 }
 
-impl SparseField for SparsePostFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparsePostFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparsePostFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparsePostGuid {
     #[WpContext(edit)]
@@ -606,7 +579,7 @@ impl PostFormat {
 mod tests {
     use super::*;
     use crate::{
-        generate,
+        SparseField, generate,
         unit_test_common::{
             assert_expected_and_from_query_pairs, unit_test_example_date_as_option,
             unit_test_example_date_as_query_value,

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -134,22 +134,6 @@ impl ApiUrlResolver for WpOrgSiteApiUrlResolver {
     }
 }
 
-mod macros {
-    macro_rules! default_sparse_field_implementation_from_field_name {
-        ($ident:ident) => {
-            paste::paste! {
-                impl SparseField for $ident {
-                    fn as_str(&self) -> &str {
-                        self.as_field_name()
-                    }
-                }
-            }
-        };
-    }
-
-    pub(crate) use default_sparse_field_implementation_from_field_name;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wp_api/src/request/endpoint/application_passwords_endpoint.rs
+++ b/wp_api/src/request/endpoint/application_passwords_endpoint.rs
@@ -1,18 +1,18 @@
-use wp_derive_request_builder::WpDerivedRequest;
-
-use crate::SparseField;
-use crate::application_passwords::{
-    ApplicationPasswordCreateParams, ApplicationPasswordDeleteAllResponse,
-    ApplicationPasswordDeleteResponse, ApplicationPasswordUpdateParams, ApplicationPasswordUuid,
-    ApplicationPasswordWithEditContext, ApplicationPasswordWithEmbedContext,
-    ApplicationPasswordWithViewContext, SparseApplicationPasswordFieldWithEditContext,
-    SparseApplicationPasswordFieldWithEmbedContext, SparseApplicationPasswordFieldWithViewContext,
-    SparseApplicationPasswordWithEditContext, SparseApplicationPasswordWithEmbedContext,
-    SparseApplicationPasswordWithViewContext,
-};
-use crate::users::UserId;
-
 use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    application_passwords::{
+        ApplicationPasswordCreateParams, ApplicationPasswordDeleteAllResponse,
+        ApplicationPasswordDeleteResponse, ApplicationPasswordUpdateParams,
+        ApplicationPasswordUuid, ApplicationPasswordWithEditContext,
+        ApplicationPasswordWithEmbedContext, ApplicationPasswordWithViewContext,
+        SparseApplicationPasswordFieldWithEditContext,
+        SparseApplicationPasswordFieldWithEmbedContext,
+        SparseApplicationPasswordFieldWithViewContext, SparseApplicationPasswordWithEditContext,
+        SparseApplicationPasswordWithEmbedContext, SparseApplicationPasswordWithViewContext,
+    },
+    users::UserId,
+};
+use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum ApplicationPasswordsRequest {
@@ -37,16 +37,6 @@ impl DerivedRequest for ApplicationPasswordsRequest {
         WpNamespace::WpV2
     }
 }
-
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseApplicationPasswordFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseApplicationPasswordFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseApplicationPasswordFieldWithViewContext
-);
 
 #[cfg(test)]
 mod tests {

--- a/wp_api/src/request/endpoint/categories_endpoint.rs
+++ b/wp_api/src/request/endpoint/categories_endpoint.rs
@@ -1,11 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    categories::{
-        CategoryId, CategoryListParams, SparseCategoryFieldWithEditContext,
-        SparseCategoryFieldWithEmbedContext, SparseCategoryFieldWithViewContext,
-    },
-};
+use crate::categories::{CategoryId, CategoryListParams};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -37,22 +31,15 @@ impl DerivedRequest for CategoriesRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseCategoryFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseCategoryFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseCategoryFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         WpApiParamOrder,
-        categories::{CategoryId, WpApiParamCategoriesOrderBy},
+        categories::{
+            CategoryId, SparseCategoryFieldWithEditContext, SparseCategoryFieldWithEmbedContext,
+            SparseCategoryFieldWithViewContext, WpApiParamCategoriesOrderBy,
+        },
         generate,
         posts::PostId,
         request::endpoint::{

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -1,8 +1,4 @@
-use crate::SparseField;
-use crate::comments::{
-    CommentId, CommentListParams, CommentUpdateParams, SparseCommentFieldWithEditContext,
-    SparseCommentFieldWithEmbedContext, SparseCommentFieldWithViewContext,
-};
+use crate::comments::{CommentId, CommentListParams, CommentUpdateParams};
 use wp_derive_request_builder::WpDerivedRequest;
 
 use super::{AsNamespace, DerivedRequest, WpNamespace};
@@ -36,33 +32,6 @@ impl DerivedRequest for CommentsRequest {
     }
 }
 
-impl SparseField for SparseCommentFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseCommentFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseCommentFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::CommentType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,7 +39,8 @@ mod tests {
         UserId, WpApiParamOrder,
         comments::{
             CommentDeleteParams, CommentId, CommentRetrieveParams, CommentStatus, CommentType,
-            WpApiParamCommentsOrderBy,
+            SparseCommentFieldWithEditContext, SparseCommentFieldWithEmbedContext,
+            SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy,
         },
         generate,
         posts::PostId,

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -1,12 +1,7 @@
 use super::{AsNamespace, DerivedRequest, WpEndpointUrl, WpNamespace};
 use crate::{
-    SparseField,
     api_error::WpApiError,
-    media::{
-        MediaCreateParams, MediaId, MediaListParams, MediaUpdateParams, MediaWithEditContext,
-        SparseMediaFieldWithEditContext, SparseMediaFieldWithEmbedContext,
-        SparseMediaFieldWithViewContext,
-    },
+    media::{MediaCreateParams, MediaId, MediaListParams, MediaUpdateParams, MediaWithEditContext},
     request::{
         CONTENT_TYPE_MULTIPART, NetworkRequestAccessor, ParsedResponse, RequestMethod,
         WpNetworkHeaderMap, WpNetworkResponse,
@@ -41,35 +36,6 @@ impl DerivedRequest for MediaRequest {
 
     fn namespace() -> impl AsNamespace {
         WpNamespace::WpV2
-    }
-}
-
-impl SparseField for SparseMediaFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostId => "post",
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseMediaFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseMediaFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostId => "post",
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
     }
 }
 
@@ -239,7 +205,10 @@ mod tests {
     use super::*;
     use crate::{
         UserId, WpApiParamOrder, generate,
-        media::{MediaId, MediaStatus, MediaTypeParam},
+        media::{
+            MediaId, MediaStatus, MediaTypeParam, SparseMediaFieldWithEditContext,
+            SparseMediaFieldWithEmbedContext, SparseMediaFieldWithViewContext,
+        },
         posts::{PostId, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn},
         request::endpoint::{
             ApiUrlResolver,

--- a/wp_api/src/request/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/request/endpoint/plugins_endpoint.rs
@@ -1,7 +1,4 @@
-use crate::{
-    PluginSlug, SparseField, SparsePluginFieldWithEditContext, SparsePluginFieldWithEmbedContext,
-    SparsePluginFieldWithViewContext,
-};
+use crate::PluginSlug;
 use wp_derive_request_builder::WpDerivedRequest;
 
 use super::{AsNamespace, DerivedRequest, WpNamespace};
@@ -26,21 +23,12 @@ impl DerivedRequest for PluginsRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePluginFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePluginFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePluginFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         PluginListParams, PluginStatus, generate,
+        plugins::{SparsePluginFieldWithEditContext, SparsePluginFieldWithViewContext},
         request::endpoint::{
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},

--- a/wp_api/src/request/endpoint/post_revisions_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_revisions_endpoint.rs
@@ -1,10 +1,6 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::{
-    SparseField,
-    post_revisions::{
-        PostRevisionId, PostRevisionListParams, SparsePostRevisionFieldWithEditContext,
-        SparsePostRevisionFieldWithEmbedContext, SparsePostRevisionFieldWithViewContext,
-    },
+    post_revisions::{PostRevisionId, PostRevisionListParams},
     posts::PostId,
 };
 use wp_derive_request_builder::WpDerivedRequest;
@@ -32,20 +28,12 @@ impl DerivedRequest for PostRevisionsRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostRevisionFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostRevisionFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostRevisionFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::post_revisions::{PostRevisionId, WpApiParamPostRevisionsOrderBy};
+    use crate::post_revisions::{
+        PostRevisionId, SparsePostRevisionFieldWithEditContext, WpApiParamPostRevisionsOrderBy,
+    };
     use crate::request::endpoint::ApiUrlResolver;
     use crate::{
         WpApiParamOrder, generate,

--- a/wp_api/src/request/endpoint/post_types_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_types_endpoint.rs
@@ -1,9 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::SparseField;
-use crate::post_types::{
-    PostType, SparsePostTypeDetailsFieldWithEditContext,
-    SparsePostTypeDetailsFieldWithEmbedContext, SparsePostTypeDetailsFieldWithViewContext,
-};
+use crate::post_types::PostType;
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -20,22 +16,15 @@ impl DerivedRequest for PostTypesRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostTypeDetailsFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostTypeDetailsFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparsePostTypeDetailsFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::endpoint::{
-        ApiUrlResolver,
-        tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+    use crate::{
+        post_types::SparsePostTypeDetailsFieldWithEmbedContext,
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -1,12 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    posts::{
-        PostId, PostListParams, PostUpdateParams, PostWithEditContext,
-        SparsePostFieldWithEditContext, SparsePostFieldWithEmbedContext,
-        SparsePostFieldWithViewContext,
-    },
-};
+use crate::posts::{PostId, PostListParams, PostUpdateParams, PostWithEditContext};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -39,46 +32,22 @@ impl DerivedRequest for PostsRequest {
     }
 }
 
-impl SparseField for SparsePostFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparsePostFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparsePostFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::PostType => "type",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::endpoint::ApiUrlResolver;
     use crate::{
         UserId, WpApiParamOrder,
         categories::CategoryId,
         generate,
         posts::{
-            PostRetrieveParams, PostStatus, WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn,
-            WpApiParamPostsTaxRelation,
+            PostRetrieveParams, PostStatus, SparsePostFieldWithEditContext,
+            SparsePostFieldWithEmbedContext, SparsePostFieldWithViewContext,
+            WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn, WpApiParamPostsTaxRelation,
         },
-        request::endpoint::tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
         tags::TagId,
         unit_test_common::{
             unit_test_example_date_as_option, unit_test_example_date_as_query_value,

--- a/wp_api/src/request/endpoint/search_endpoint.rs
+++ b/wp_api/src/request/endpoint/search_endpoint.rs
@@ -1,10 +1,4 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    search_results::{
-        SparseSearchResultFieldWithEmbedContext, SparseSearchResultFieldWithViewContext,
-    },
-};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -19,26 +13,6 @@ impl DerivedRequest for SearchRequest {
     }
 }
 
-impl SparseField for SparseSearchResultFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::ObjectType => "type",
-            Self::ObjectSubtype => "subtype",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseSearchResultFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::ObjectType => "type",
-            Self::ObjectSubtype => "subtype",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,7 +22,10 @@ mod tests {
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
         },
-        search_results::{SearchListParams, SearchResultSubtype, SearchResultType},
+        search_results::{
+            SearchListParams, SearchResultSubtype, SearchResultType,
+            SparseSearchResultFieldWithEmbedContext, SparseSearchResultFieldWithViewContext,
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/site_settings_endpoint.rs
+++ b/wp_api/src/request/endpoint/site_settings_endpoint.rs
@@ -1,9 +1,4 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::SparseField;
-use crate::site_settings::{
-    SparseSiteSettingsFieldWithEditContext, SparseSiteSettingsFieldWithEmbedContext,
-    SparseSiteSettingsFieldWithViewContext,
-};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -20,22 +15,15 @@ impl DerivedRequest for SiteSettingsRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseSiteSettingsFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseSiteSettingsFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseSiteSettingsFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::endpoint::{
-        ApiUrlResolver,
-        tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+    use crate::{
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
+        site_settings::SparseSiteSettingsFieldWithEmbedContext,
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/tags_endpoint.rs
+++ b/wp_api/src/request/endpoint/tags_endpoint.rs
@@ -1,11 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    tags::{
-        SparseTagFieldWithEditContext, SparseTagFieldWithEmbedContext,
-        SparseTagFieldWithViewContext, TagId, TagListParams,
-    },
-};
+use crate::tags::{TagId, TagListParams};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -37,10 +31,6 @@ impl DerivedRequest for TagsRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(SparseTagFieldWithEditContext);
-super::macros::default_sparse_field_implementation_from_field_name!(SparseTagFieldWithEmbedContext);
-super::macros::default_sparse_field_implementation_from_field_name!(SparseTagFieldWithViewContext);
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,7 +41,10 @@ mod tests {
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
         },
-        tags::{TagId, WpApiParamTagsOrderBy},
+        tags::{
+            SparseTagFieldWithEditContext, SparseTagFieldWithEmbedContext,
+            SparseTagFieldWithViewContext, TagId, WpApiParamTagsOrderBy,
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/taxonomies_endpoint.rs
+++ b/wp_api/src/request/endpoint/taxonomies_endpoint.rs
@@ -1,9 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::SparseField;
-use crate::taxonomies::{
-    SparseTaxonomyTypeDetailsFieldWithEditContext, SparseTaxonomyTypeDetailsFieldWithEmbedContext,
-    SparseTaxonomyTypeDetailsFieldWithViewContext, TaxonomyListParams, TaxonomyType,
-};
+use crate::taxonomies::{TaxonomyListParams, TaxonomyType};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -19,13 +15,3 @@ impl DerivedRequest for TaxonomiesRequest {
         WpNamespace::WpV2
     }
 }
-
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseTaxonomyTypeDetailsFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseTaxonomyTypeDetailsFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseTaxonomyTypeDetailsFieldWithViewContext
-);

--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -1,9 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::SparseField;
-use crate::templates::{
-    SparseTemplateFieldWithEditContext, SparseTemplateFieldWithEmbedContext,
-    SparseTemplateFieldWithViewContext, TemplateId,
-};
+use crate::templates::TemplateId;
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -36,36 +32,6 @@ impl DerivedRequest for TemplatesRequest {
     }
 }
 
-impl SparseField for SparseTemplateFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseTemplateFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseTemplateFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,7 +43,7 @@ mod tests {
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
         },
-        templates::{TemplateArea, TemplateListParams},
+        templates::{SparseTemplateFieldWithViewContext, TemplateArea, TemplateListParams},
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/themes_endpoint.rs
+++ b/wp_api/src/request/endpoint/themes_endpoint.rs
@@ -1,11 +1,7 @@
-use crate::SparseField;
-use crate::themes::{
-    SparseThemeFieldWithEditContext, SparseThemeFieldWithEmbedContext,
-    SparseThemeFieldWithViewContext, ThemeStylesheet,
-};
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::themes::ThemeStylesheet;
 use wp_derive_request_builder::WpDerivedRequest;
 
-use super::{AsNamespace, DerivedRequest, WpNamespace};
 #[derive(WpDerivedRequest)]
 enum ThemesRequest {
     #[contextual_get(url = "/themes", params = &crate::themes::ThemeListParams, output = Vec<crate::themes::SparseTheme>, filter_by = crate::themes::SparseThemeField)]
@@ -20,16 +16,6 @@ impl DerivedRequest for ThemesRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseThemeFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseThemeFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseThemeFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -39,7 +25,10 @@ mod tests {
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
         },
-        themes::{ThemeListParams, ThemeStatus},
+        themes::{
+            SparseThemeFieldWithEditContext, SparseThemeFieldWithEmbedContext,
+            SparseThemeFieldWithViewContext, ThemeListParams, ThemeStatus,
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/users_endpoint.rs
+++ b/wp_api/src/request/endpoint/users_endpoint.rs
@@ -1,11 +1,9 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
 use crate::{
-    SparseField, SparseUserFieldWithEditContext, SparseUserFieldWithEmbedContext,
-    SparseUserFieldWithViewContext, UserCreateParams, UserDeleteParams, UserDeleteResponse, UserId,
-    UserListParams, UserUpdateParams, UserWithEditContext,
+    UserCreateParams, UserDeleteParams, UserDeleteResponse, UserId, UserListParams,
+    UserUpdateParams, UserWithEditContext,
 };
 use wp_derive_request_builder::WpDerivedRequest;
-
-use super::{AsNamespace, DerivedRequest, WpNamespace};
 
 #[derive(WpDerivedRequest)]
 enum UsersRequest {
@@ -33,19 +31,19 @@ impl DerivedRequest for UsersRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(SparseUserFieldWithEditContext);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseUserFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(SparseUserFieldWithViewContext);
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::endpoint::ApiUrlResolver;
     use crate::{
         WpApiParamUsersHasPublishedPosts,
-        request::endpoint::tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
+        users::{
+            SparseUserFieldWithEditContext, SparseUserFieldWithEmbedContext,
+            SparseUserFieldWithViewContext,
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/widget_types_endpoint.rs
+++ b/wp_api/src/request/endpoint/widget_types_endpoint.rs
@@ -1,11 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    widget_types::{
-        SparseWidgetTypeFieldWithEditContext, SparseWidgetTypeFieldWithEmbedContext,
-        SparseWidgetTypeFieldWithViewContext, WidgetTypeId,
-    },
-};
+use crate::widget_types::WidgetTypeId;
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -22,22 +16,17 @@ impl DerivedRequest for WidgetTypesRequest {
     }
 }
 
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetTypeFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetTypeFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetTypeFieldWithViewContext
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::request::endpoint::ApiUrlResolver;
-    use crate::request::endpoint::tests::{
-        fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint,
+    use crate::{
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
+        widget_types::{
+            SparseWidgetTypeFieldWithEditContext, SparseWidgetTypeFieldWithEmbedContext,
+        },
     };
     use rstest::*;
     use std::sync::Arc;

--- a/wp_api/src/request/endpoint/widgets_endpoint.rs
+++ b/wp_api/src/request/endpoint/widgets_endpoint.rs
@@ -1,11 +1,5 @@
 use super::{AsNamespace, DerivedRequest, WpNamespace};
-use crate::{
-    SparseField,
-    widgets::{
-        SparseWidgetFieldWithEditContext, SparseWidgetFieldWithEmbedContext,
-        SparseWidgetFieldWithViewContext, WidgetId, WidgetListParams, WidgetWithEditContext,
-    },
-};
+use crate::widgets::{WidgetId, WidgetListParams, WidgetWithEditContext};
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
@@ -34,13 +28,3 @@ impl DerivedRequest for WidgetsRequest {
         WpNamespace::WpV2
     }
 }
-
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetFieldWithEditContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetFieldWithEmbedContext
-);
-super::macros::default_sparse_field_implementation_from_field_name!(
-    SparseWidgetFieldWithViewContext
-);

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -143,7 +143,7 @@ mod tests {
         #[case] field: SparseSearchResultFieldWithEmbedContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -154,6 +154,6 @@ mod tests {
         #[case] field: SparseSearchResultFieldWithViewContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 }

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -153,4 +153,26 @@ mod tests {
     fn test_search_result_type_string_conversion(#[case] value: SearchResultType) {
         assert_eq!(value, value.to_string().parse().unwrap());
     }
+
+    #[rstest]
+    #[case(SparseSearchResultFieldWithEmbedContext::Id, "id")]
+    #[case(SparseSearchResultFieldWithEmbedContext::ObjectType, "type")]
+    #[case(SparseSearchResultFieldWithEmbedContext::ObjectSubtype, "subtype")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparseSearchResultFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseSearchResultFieldWithViewContext::Id, "id")]
+    #[case(SparseSearchResultFieldWithViewContext::ObjectType, "type")]
+    #[case(SparseSearchResultFieldWithViewContext::ObjectSubtype, "subtype")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparseSearchResultFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
 }

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -1,5 +1,5 @@
 use crate::{
-    IntegerOrString, impl_as_query_value_from_to_string,
+    IntegerOrString, SparseField, impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
@@ -117,6 +117,26 @@ pub struct SparseSearchResult {
     #[WpContext(edit, embed, view)]
     #[WpContextualOption]
     pub object_subtype: Option<SearchResultSubtype>,
+}
+
+impl SparseField for SparseSearchResultFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::ObjectType => "type",
+            Self::ObjectSubtype => "subtype",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseSearchResultFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::ObjectType => "type",
+            Self::ObjectSubtype => "subtype",
+            _ => self.as_field_name(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/wp_api/src/search_results.rs
+++ b/wp_api/src/search_results.rs
@@ -1,5 +1,5 @@
 use crate::{
-    IntegerOrString, SparseField, impl_as_query_value_from_to_string,
+    IntegerOrString, impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
@@ -119,29 +119,10 @@ pub struct SparseSearchResult {
     pub object_subtype: Option<SearchResultSubtype>,
 }
 
-impl SparseField for SparseSearchResultFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::ObjectType => "type",
-            Self::ObjectSubtype => "subtype",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseSearchResultFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::ObjectType => "type",
-            Self::ObjectSubtype => "subtype",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SparseField;
     use rstest::*;
 
     #[rstest]

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SparseField, UserId, impl_as_query_value_from_to_string,
+    UserId, impl_as_query_value_from_to_string,
     post_types::PostType,
     posts::PostId,
     url_query::{
@@ -141,36 +141,6 @@ pub struct SparseTemplate {
     pub original_source: Option<String>,
 }
 
-impl SparseField for SparseTemplateFieldWithEditContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseTemplateFieldWithEmbedContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
-impl SparseField for SparseTemplateFieldWithViewContext {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::TemplateType => "type",
-            Self::PostId => "wp_id",
-            _ => self.as_field_name(),
-        }
-    }
-}
-
 #[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum SparseTemplateContentWrapper {
@@ -275,6 +245,7 @@ impl TemplateCreateParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SparseField;
     use rstest::*;
 
     #[rstest]

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -256,7 +256,7 @@ mod tests {
         #[case] field: SparseTemplateFieldWithEditContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -267,7 +267,7 @@ mod tests {
         #[case] field: SparseTemplateFieldWithEmbedContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 
     #[rstest]
@@ -278,6 +278,6 @@ mod tests {
         #[case] field: SparseTemplateFieldWithViewContext,
         #[case] expected_mapped_field_name: &str,
     ) {
-        assert_eq!(field.as_str(), expected_mapped_field_name);
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
     }
 }

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -271,3 +271,42 @@ impl TemplateCreateParams {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    #[case(SparseTemplateFieldWithEditContext::Id, "id")]
+    #[case(SparseTemplateFieldWithEditContext::TemplateType, "type")]
+    #[case(SparseTemplateFieldWithEditContext::PostId, "wp_id")]
+    fn test_as_mapped_field_name_for_edit_context(
+        #[case] field: SparseTemplateFieldWithEditContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseTemplateFieldWithEmbedContext::Id, "id")]
+    #[case(SparseTemplateFieldWithEmbedContext::TemplateType, "type")]
+    #[case(SparseTemplateFieldWithEmbedContext::PostId, "wp_id")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparseTemplateFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparseTemplateFieldWithViewContext::Id, "id")]
+    #[case(SparseTemplateFieldWithViewContext::TemplateType, "type")]
+    #[case(SparseTemplateFieldWithViewContext::PostId, "wp_id")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparseTemplateFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_str(), expected_mapped_field_name);
+    }
+}

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -1,5 +1,5 @@
 use crate::{
-    UserId, impl_as_query_value_from_to_string,
+    SparseField, UserId, impl_as_query_value_from_to_string,
     post_types::PostType,
     posts::PostId,
     url_query::{
@@ -139,6 +139,36 @@ pub struct SparseTemplate {
     pub author_text: Option<String>,
     #[WpContext(edit, view, embed)]
     pub original_source: Option<String>,
+}
+
+impl SparseField for SparseTemplateFieldWithEditContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseTemplateFieldWithEmbedContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
+}
+
+impl SparseField for SparseTemplateFieldWithViewContext {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::TemplateType => "type",
+            Self::PostId => "wp_id",
+            _ => self.as_field_name(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]

--- a/wp_api/src/wp_site_health_tests.rs
+++ b/wp_api/src/wp_site_health_tests.rs
@@ -39,7 +39,7 @@ pub enum SparseWpSiteHealthTestField {
 }
 
 impl SparseField for SparseWpSiteHealthTestField {
-    fn as_str(&self) -> &str {
+    fn as_mapped_field_name(&self) -> &str {
         match self {
             Self::Actions => "actions",
             Self::Badge => "badge",
@@ -98,7 +98,7 @@ pub enum SparseWpSiteHealthDirectorySizesField {
 }
 
 impl SparseField for SparseWpSiteHealthDirectorySizesField {
-    fn as_str(&self) -> &str {
+    fn as_mapped_field_name(&self) -> &str {
         match self {
             Self::DatabaseSize => "database_size",
             Self::FontsSize => "fonts_size",

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -344,10 +344,8 @@
 //! Furthermore, it'll generate the `SparseFooFieldWithEditContext`,
 //! `SparseFooFieldWithEmbedContext` & `SparseFooFieldWithViewContext` types as an `enum` which
 //! will include all the fields from their `Sparse` type counterpart as its `enum` variants. It'll
-//! also generate `fn as_field_name(&self) -> &str` function that maps each `enum` variant to its
-//! field name, making it easier to implement functions such as `as_str`. Note that it
-//! intentionally doesn't generate the `as_str` function directly, as the field names might need to
-//! be mapped to a different casing.
+//! also generate `fn as_mapped_field_name(&self) -> &str` function that maps each `enum` variant to
+//! its mapped field name which supports `#[serde(rename = "{mapped_name}")]` attribute.
 //!
 //! So, the above example will also generate the following types:
 //!

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -87,6 +87,8 @@
 //!     pub rendered: Option<String>,
 //! }
 //!
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -123,6 +125,8 @@
 //!     #[WpContext(edit, view)]
 //!     pub rendered: Option<String>,
 //! }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -168,6 +172,8 @@
 //! #     #[WpContext(edit, view)]
 //! #     pub rendered: Option<String>,
 //! # }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -212,6 +218,8 @@
 //! #     #[WpContext(edit, view)]
 //! #     pub rendered: Option<String>,
 //! # }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -253,6 +261,8 @@
 //!     #[WpContextualOption]
 //!     pub avatar_urls: Option<HashMap<String, String>>,
 //! }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -283,6 +293,8 @@
 //!     #[WpContextualExcludeFromFields]
 //!     pub additional_fields: Option<String>,
 //! }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -324,6 +336,8 @@
 //!     #[WpContext(edit, view)]
 //!     pub baz: Option<u32>,
 //! }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 //! # // We need these 2 lines for UniFFI
 //! # uniffi::setup_scaffolding!();
 //! # fn main() {}
@@ -415,6 +429,8 @@ mod wp_contextual;
 ///     #[WpContext(edit)]
 ///     pub qux: Option<Vec<u32>>,
 /// }
+/// # // We need this line because `WpContextual` implements `crate::SparseField`
+/// # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
 /// # // We need these 2 lines for UniFFI
 /// # uniffi::setup_scaffolding!();
 /// # fn main() {}

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -248,7 +248,6 @@ fn generate_sparse_field_type(
     fields: &[GeneratedContextualField],
 ) -> TokenStream {
     let mut variant_idents = Vec::with_capacity(fields.len());
-    let mut as_field_names = Vec::with_capacity(fields.len());
     let mut sparse_field_mappings = Vec::with_capacity(fields.len());
 
     for f in fields {
@@ -264,9 +263,6 @@ fn generate_sparse_field_type(
                 extract_serde_rename(&f.field.attrs).unwrap_or_else(|| field_name.clone());
 
             variant_idents.push(variant_ident.clone());
-            as_field_names.push(quote! {
-                Self::#variant_ident => #field_name
-            });
             sparse_field_mappings.push(quote! {
                 Self::#variant_ident => #api_field_name
             });
@@ -278,7 +274,7 @@ fn generate_sparse_field_type(
 
     let sparse_field_impl = quote! {
         impl crate::SparseField for #type_ident {
-            fn as_str(&self) -> &str {
+            fn as_mapped_field_name(&self) -> &str {
                 match self {
                     #(#sparse_field_mappings,)*
                 }
@@ -290,13 +286,6 @@ fn generate_sparse_field_type(
         #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
         pub enum #type_ident {
             #(#variant_idents,)*
-        }
-        impl #type_ident {
-            pub fn as_field_name(&self) -> &str {
-                match self {
-                    #(#as_field_names,)*
-                }
-            }
         }
         #sparse_field_impl
     }

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -224,12 +224,33 @@ fn parse_fields(
     Ok(parsed_fields)
 }
 
+fn extract_serde_rename(attrs: &[syn::Attribute]) -> Option<String> {
+    attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("serde"))
+        .and_then(|attr| {
+            let mut rename_value = None;
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("rename")
+                    && let Ok(value) = meta.value()
+                    && let Ok(lit_str) = value.parse::<syn::LitStr>()
+                {
+                    rename_value = Some(lit_str.value());
+                }
+                Ok(())
+            });
+            rename_value
+        })
+}
+
 fn generate_sparse_field_type(
     type_ident: &Ident,
     fields: &[GeneratedContextualField],
 ) -> TokenStream {
     let mut variant_idents = Vec::with_capacity(fields.len());
     let mut as_field_names = Vec::with_capacity(fields.len());
+    let mut sparse_field_mappings = Vec::with_capacity(fields.len());
+
     for f in fields {
         if f.is_wp_contextual_exclude_from_fields {
             continue;
@@ -237,17 +258,34 @@ fn generate_sparse_field_type(
         if let Some(f_ident) = &f.field.ident {
             let field_name = f_ident.to_string();
             let variant_ident = format_ident!("{}", field_name.to_case(Case::UpperCamel));
-            let field_name = field_name.as_str();
+
+            // Check for serde rename attribute and use it if present, otherwise use field name
+            let api_field_name =
+                extract_serde_rename(&f.field.attrs).unwrap_or_else(|| field_name.clone());
 
             variant_idents.push(variant_ident.clone());
             as_field_names.push(quote! {
                 Self::#variant_ident => #field_name
+            });
+            sparse_field_mappings.push(quote! {
+                Self::#variant_ident => #api_field_name
             });
         }
     }
     if variant_idents.is_empty() {
         return TokenStream::new();
     }
+
+    let sparse_field_impl = quote! {
+        impl crate::SparseField for #type_ident {
+            fn as_str(&self) -> &str {
+                match self {
+                    #(#sparse_field_mappings,)*
+                }
+            }
+        }
+    };
+
     quote! {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
         pub enum #type_ident {
@@ -260,6 +298,7 @@ fn generate_sparse_field_type(
                 }
             }
         }
+        #sparse_field_impl
     }
     .into()
 }

--- a/wp_contextual/tests/basic_wp_contextual.rs
+++ b/wp_contextual/tests/basic_wp_contextual.rs
@@ -1,5 +1,8 @@
 use wp_contextual::WpContextual;
 
+mod sparse_field_trait;
+pub use sparse_field_trait::SparseField;
+
 #[derive(WpContextual)]
 pub struct SparseFoo {
     #[WpContext(edit, embed, view)]

--- a/wp_contextual/tests/basic_wp_contextual.rs
+++ b/wp_contextual/tests/basic_wp_contextual.rs
@@ -14,11 +14,11 @@ fn main() {
     let _ = SparseFooWithEmbedContext { bar: Some(0) };
     let _ = SparseFooWithViewContext { bar: Some(0) };
     let bar_field_edit_context = SparseFooFieldWithEditContext::Bar;
-    assert_eq!(bar_field_edit_context.as_field_name(), "bar");
+    assert_eq!(bar_field_edit_context.as_mapped_field_name(), "bar");
     let bar_field_embed_context = SparseFooFieldWithEmbedContext::Bar;
-    assert_eq!(bar_field_embed_context.as_field_name(), "bar");
+    assert_eq!(bar_field_embed_context.as_mapped_field_name(), "bar");
     let bar_field_view_context = SparseFooFieldWithViewContext::Bar;
-    assert_eq!(bar_field_view_context.as_field_name(), "bar");
+    assert_eq!(bar_field_view_context.as_mapped_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/basic_wp_contextual_field.rs
+++ b/wp_contextual/tests/basic_wp_contextual_field.rs
@@ -35,7 +35,7 @@ fn main() {
         )])),
     };
     let bar_field = SparseFooFieldWithEditContext::Bar;
-    assert_eq!(bar_field.as_field_name(), "bar");
+    assert_eq!(bar_field.as_mapped_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/basic_wp_contextual_field.rs
+++ b/wp_contextual/tests/basic_wp_contextual_field.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use wp_contextual::WpContextual;
 
+mod sparse_field_trait;
+pub use sparse_field_trait::SparseField;
+
 #[derive(WpContextual)]
 pub struct SparseFoo {
     #[WpContext(edit)]

--- a/wp_contextual/tests/basic_wp_contextual_option.rs
+++ b/wp_contextual/tests/basic_wp_contextual_option.rs
@@ -1,5 +1,8 @@
 use wp_contextual::WpContextual;
 
+mod sparse_field_trait;
+pub use sparse_field_trait::SparseField;
+
 #[derive(WpContextual)]
 pub struct SparseFoo {
     #[WpContext(edit)]

--- a/wp_contextual/tests/basic_wp_contextual_option.rs
+++ b/wp_contextual/tests/basic_wp_contextual_option.rs
@@ -11,7 +11,7 @@ fn main() {
     let _ = FooWithEditContext { bar: None };
     let _ = SparseFooWithEditContext { bar: Some(0) };
     let bar_field = SparseFooFieldWithEditContext::Bar;
-    assert_eq!(bar_field.as_field_name(), "bar");
+    assert_eq!(bar_field.as_mapped_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/sparse_field_trait.rs
+++ b/wp_contextual/tests/sparse_field_trait.rs
@@ -1,0 +1,3 @@
+pub trait SparseField {
+    fn as_mapped_field_name(&self) -> &str;
+}

--- a/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
@@ -33,11 +33,11 @@ fn main() {
     let bar_field = SparseFooFieldWithEditContext::Bar;
     let bar_2_field = SparseFooFieldWithEditContext::Bar2;
     let bar_3_field = SparseFooFieldWithEditContext::Bar3;
-    assert_eq!(bar_field.as_field_name(), "bar");
-    assert_eq!(bar_2_field.as_field_name(), "bar_2");
-    assert_eq!(bar_3_field.as_field_name(), "bar_3");
+    assert_eq!(bar_field.as_mapped_field_name(), "bar");
+    assert_eq!(bar_2_field.as_mapped_field_name(), "bar_2");
+    assert_eq!(bar_3_field.as_mapped_field_name(), "bar_3");
     let baz_field = SparseBarFieldWithEditContext::Baz;
-    assert_eq!(baz_field.as_field_name(), "baz");
+    assert_eq!(baz_field.as_mapped_field_name(), "baz");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_inner_type.rs
@@ -1,5 +1,8 @@
 use wp_contextual::WpContextual;
 
+mod sparse_field_trait;
+pub use sparse_field_trait::SparseField;
+
 #[derive(WpContextual)]
 pub struct SparseFoo {
     #[WpContext(edit)]

--- a/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
@@ -24,7 +24,7 @@ fn main() {
         ),
     };
     let bar_field = SparseFooFieldWithEditContext::Bar;
-    assert_eq!(bar_field.as_field_name(), "bar");
+    assert_eq!(bar_field.as_mapped_field_name(), "bar");
 }
 
 uniffi::setup_scaffolding!();

--- a/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
+++ b/wp_contextual/tests/wp_contextual_field_with_multiple_segments.rs
@@ -1,5 +1,8 @@
 use wp_contextual::WpContextual;
 
+mod sparse_field_trait;
+pub use sparse_field_trait::SparseField;
+
 // This test is validating that we are able to handle `#[WpContextualField]`s if its type
 // has multiple path segments. That's why we use a helper mod and use fully qualified paths
 // rather than the importing the mod.

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -329,7 +329,7 @@ pub fn fn_body_fields_query_pairs(
                 "_fields",
                 fields
                     .iter()
-                    .map(|f| f.as_str())
+                    .map(|f| f.as_mapped_field_name())
                     .collect::<Vec<&str>>()
                     .join(",")
                     .as_str(),


### PR DESCRIPTION
This PR enhances the `WpContextual` derive macro to automatically generate `SparseField` trait implementations, eliminating manual code duplication and adding proper serde rename attribute support.

## Summary

1. **Automated `SparseField` generation**: The `WpContextual` macro now automatically generates `SparseField` trait implementations that extract and use `#[serde(rename = "...")]` attributes for correct API field name mapping.

2. **Comprehensive unit tests**: Added unit tests across all contextual types to verify that field mappings correctly handle both standard field names and serde-renamed fields.

3. **Explicit method naming**: Renamed `SparseField::as_str()` to `as_mapped_field_name()` to clearly indicate the method returns API field names that may differ from Rust field names due to serde renames.

This reduces code duplication by 240+ lines while improving maintainability and ensuring consistent field name mapping throughout the codebase.
