### PR TITLE
Add Request URL to `WpAppNotifier` Authentication Failure Method

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/EmptyAppNotifier.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/EmptyAppNotifier.kt
@@ -3,7 +3,7 @@ package rs.wordpress.api.kotlin
 import uniffi.wp_api.WpAppNotifier
 
 class EmptyAppNotifier : WpAppNotifier {
-    override suspend fun requestedWithInvalidAuthentication() {
+    override suspend fun requestedWithInvalidAuthentication(requestUrl: String) {
         // no-op
     }
 }

--- a/native/swift/Sources/wordpress-api/AppNotifier.swift
+++ b/native/swift/Sources/wordpress-api/AppNotifier.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressAPIInternal
 
 class EmptyAppNotifier: @unchecked Sendable, WpAppNotifier {
-    func requestedWithInvalidAuthentication() async {
+    func requestedWithInvalidAuthentication(requestUrl: String) async {
         // no-op
     }
 }

--- a/native/swift/Tests/wordpress-api/Support/Mocks.swift
+++ b/native/swift/Tests/wordpress-api/Support/Mocks.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressAPI
 
 final class MockAppNotifier: WpAppNotifier {
-    func requestedWithInvalidAuthentication() async {
+    func requestedWithInvalidAuthentication(requestUrl: String) async {
         // no-op
     }
 }

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -201,7 +201,7 @@ pub enum IntegerOrString {
 #[uniffi::export(with_foreign)]
 #[async_trait::async_trait]
 pub trait WpAppNotifier: Send + Sync + std::fmt::Debug {
-    async fn requested_with_invalid_authentication(&self);
+    async fn requested_with_invalid_authentication(&self, request_url: String);
 }
 
 #[macro_export]

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -235,7 +235,7 @@ pub struct EmptyAppNotifier;
 
 #[async_trait]
 impl WpAppNotifier for EmptyAppNotifier {
-    async fn requested_with_invalid_authentication(&self) {
+    async fn requested_with_invalid_authentication(&self, _request_url: String) {
         // no-op
     }
 }

--- a/wp_api_integration_tests/tests/test_app_notifier_immut.rs
+++ b/wp_api_integration_tests/tests/test_app_notifier_immut.rs
@@ -84,7 +84,7 @@ impl FooAppNotifier {
 
 #[async_trait]
 impl WpAppNotifier for FooAppNotifier {
-    async fn requested_with_invalid_authentication(&self) {
+    async fn requested_with_invalid_authentication(&self, _request_url: String) {
         let result = (self.requested_with_invalid_authentication_fn)();
         self.has_triggered_notification
             .store(result, Ordering::Relaxed);

--- a/wp_com_e2e/src/main.rs
+++ b/wp_com_e2e/src/main.rs
@@ -28,7 +28,7 @@ pub struct EmptyAppNotifier;
 
 #[async_trait]
 impl WpAppNotifier for EmptyAppNotifier {
-    async fn requested_with_invalid_authentication(&self) {
+    async fn requested_with_invalid_authentication(&self, _request_url: String) {
         // no-op
     }
 }

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -74,31 +74,34 @@ fn generate_async_request_executor(
                 pub async #fn_signature -> Result<#response_type_ident, #error_type> {
                     use #crate_ident::api_error::MaybeWpError;
                     use #crate_ident::middleware::PerformsRequests;
+                    use #crate_ident::request::NetworkRequestAccessor;
                     let perform_request = async || {
                         #request_from_request_builder
+                        let request_url: String = request.url().into();
                         let response = self.perform(std::sync::Arc::new(request)).await?;
                         let response_status_code = response.status_code;
                         let parsed_response = response.parse();
                         let unauthorized = parsed_response.is_unauthorized_error().unwrap_or_default() || (response_status_code == 401 && self.fetch_authentication_state().await.map(|auth_state| auth_state.is_unauthorized()).unwrap_or_default());
 
-                        Ok((parsed_response, unauthorized))
+                        Ok((parsed_response, unauthorized, request_url))
                     };
 
                     let mut parsed_response;
                     let mut unauthorized;
+                    let mut request_url;
 
                     // The Rust compiler has trouble figuring out the return type. The statement below helps it.
                     let result: Result<_, #error_type> = perform_request().await;
-                    (parsed_response, unauthorized) = result?;
+                    (parsed_response, unauthorized, request_url) = result?;
 
                     // If the auth provider successfully refreshed the authentication, we can retry the request.
                     if unauthorized && self.delegate.auth_provider.refresh().await {
                         // The response of the retried request will be returned instead of the original one.
-                        (parsed_response, unauthorized) = perform_request().await?;
+                        (parsed_response, unauthorized, request_url) = perform_request().await?;
                     }
 
                     if unauthorized {
-                        self.delegate.app_notifier.requested_with_invalid_authentication().await;
+                        self.delegate.app_notifier.requested_with_invalid_authentication(request_url).await;
                     }
 
                     parsed_response

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -410,9 +410,10 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
     struct CliAppNotifier;
     #[async_trait::async_trait]
     impl WpAppNotifier for CliAppNotifier {
-        async fn requested_with_invalid_authentication(&self) {
+        async fn requested_with_invalid_authentication(&self, request_url: String) {
             eprintln!(
-                "Authentication failed. Please verify your credentials or token and try again."
+                "Authentication failed for request to: {}. Please verify your credentials or token and try again.",
+                request_url
             );
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary

Enhances the `WpAppNotifier.requested_with_invalid_authentication` method to include the request URL, providing better context when authentication failures occur.

## Why This Change?

When authentication fails, applications need to know which specific request failed and which site it was targeting. The request URL contains valuable information including:
- The specific endpoint that failed authentication
- The site/domain the request was made to
- Context for debugging authentication issues

This enables applications to provide more informative error messages and better handle authentication failures on a per-site basis.

## Breaking Change

This is a breaking change to the `WpAppNotifier` trait interface. All implementations will need to be updated to accept the new parameter.
