### PR TITLE
`/pages` endpoint

### DIFF
--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -4,6 +4,7 @@ import Combine
 
 private let userListParams = UserListParams(perPage: 5)
 private let postListParams = PostListParams(perPage: 5)
+private let pageListParams = PageListParams(perPage: 5)
 private let mediaListParams = MediaListParams(perPage: 5)
 
 @main
@@ -36,6 +37,10 @@ struct ExampleApp: App {
         }),
         RootListData(name: "Posts", sequence: {
             let sequence = try await WordPressAPI.globalInstance.posts.sequenceWithEditContext(params: postListParams)
+            return ListViewSequence(underlyingSequence: sequence)
+        }),
+        RootListData(name: "Pages", sequence: {
+            let sequence = try await WordPressAPI.globalInstance.pages.sequenceWithEditContext(params: pageListParams)
             return ListViewSequence(underlyingSequence: sequence)
         }),
         RootListData(name: "Media", sequence: {

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -137,6 +137,12 @@ extension PostWithEditContext: ListViewDataConvertable {
     }
 }
 
+extension PageWithEditContext: ListViewDataConvertable {
+    var asListViewData: ListViewData {
+        ListViewData(id: self.slug, title: self.title.rendered, subtitle: "", fields: [:])
+    }
+}
+
 extension MediaWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
         let details = self.mediaDetails.parseAsMimeType(mimeType: self.mimeType)

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -105,6 +105,18 @@ public typealias PostsRequestListWithEditContextResponse = WordPressAPIInternal.
 public typealias PostsRequestListWithViewContextResponse = WordPressAPIInternal.PostsRequestListWithViewContextResponse
 public typealias PostsRequestListWithEmbedContextResponse = WordPressAPIInternal.PostsRequestListWithEmbedContextResponse
 
+// MARK: - Pages
+public typealias SparsePage = WordPressAPIInternal.SparsePage
+public typealias PageWithEditContext = WordPressAPIInternal.PageWithEditContext
+public typealias PageWithViewContext = WordPressAPIInternal.PageWithViewContext
+public typealias PageWithEmbedContext = WordPressAPIInternal.PageWithEmbedContext
+public typealias PageListParams = WordPressAPIInternal.PageListParams
+public typealias PagesRequestExecutor = WordPressAPIInternal.PagesRequestExecutor
+
+public typealias PagesRequestListWithEditContextResponse = WordPressAPIInternal.PagesRequestListWithEditContextResponse
+public typealias PagesRequestListWithViewContextResponse = WordPressAPIInternal.PagesRequestListWithViewContextResponse
+public typealias PagesRequestListWithEmbedContextResponse = WordPressAPIInternal.PagesRequestListWithEmbedContextResponse
+
 // MARK: - Media
 public typealias SparseMedia = WordPressAPIInternal.SparseMedia
 public typealias MediaUploadRequest = WordPressAPIInternal.MediaUploadRequest

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -205,6 +205,28 @@ extension PostsRequestExecutor: PaginationAwareExecutor {
     public typealias EmbedContextResponseType = PostsRequestListWithEmbedContextResponse
 }
 
+// MARK: - Pages
+extension PagesRequestListWithEditContextResponse: PaginatableResponse {
+    public typealias ParamsType = PageListParams
+    public typealias DataType = PageWithEditContext
+}
+
+extension PagesRequestListWithViewContextResponse: PaginatableResponse {
+    public typealias ParamsType = PageListParams
+    public typealias DataType = PageWithViewContext
+}
+
+extension PagesRequestListWithEmbedContextResponse: PaginatableResponse {
+    public typealias ParamsType = PageListParams
+    public typealias DataType = PageWithEmbedContext
+}
+
+extension PagesRequestExecutor: PaginationAwareExecutor {
+    public typealias EditContextResponseType = PagesRequestListWithEditContextResponse
+    public typealias ViewContextResponseType = PagesRequestListWithViewContextResponse
+    public typealias EmbedContextResponseType = PagesRequestListWithEmbedContextResponse
+}
+
 // MARK: - Media
 extension MediaRequestListWithEditContextResponse: PaginatableResponse, @unchecked Sendable {
     public typealias ParamsType = MediaListParams

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -117,6 +117,10 @@ public actor WordPressAPI {
         self.requestBuilder.posts()
     }
 
+    public var pages: PagesRequestExecutor {
+        self.requestBuilder.pages()
+    }
+
     public var comments: CommentsRequestExecutor {
         self.requestBuilder.comments()
     }

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -131,6 +131,11 @@ create_test_credentials () {
   PASSWORD_PROTECTED_POST_ID="$(wp post create --post_type=post --post_password=INTEGRATION_TEST --post_title=Password_Protected --porcelain)"
   TRASHED_POST_ID="$(wp post create --post_type=post --post_title=Trashed_Post --porcelain)"
 
+  # Create test pages
+  PASSWORD_PROTECTED_PAGE_ID="$(wp post create --post_type=page --post_password=INTEGRATION_TEST --post_title=Password_Protected_Page --porcelain)"
+  TRASHED_PAGE_ID="$(wp post create --post_type=page --post_title=Trashed_Page --porcelain)"
+  FIRST_PAGE_ID="$(wp post list --post_type=page --posts_per_page=1 --orderby=ID --order=ASC --format=ids)"
+
   PASSWORD_PROTECTED_COMMENT_AUTHOR="setup-test-site.sh"
   PASSWORD_PROTECTED_COMMENT_ID="$(wp comment create --comment_post_ID="$PASSWORD_PROTECTED_POST_ID" --comment_content="test_comment_for_password_protected_post" --comment_author="$PASSWORD_PROTECTED_COMMENT_AUTHOR" --porcelain)"
 
@@ -140,8 +145,9 @@ create_test_credentials () {
 
   INTEGRATION_TEST_CUSTOM_TEMPLATE_SLUG="integration_test_custom_template"
 
-  # Trash the post
+  # Trash the post and page
   wp post delete "$TRASHED_POST_ID"
+  wp post delete "$TRASHED_PAGE_ID"
 
   echo "Creating a custom template for integration tests.."
   curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d '{"slug":"INTEGRATION_TEST_CUSTOM_TEMPLATE", "content": "Integration test custom template content"}' http://localhost/wp-json/wp/v2/templates > /dev/null
@@ -193,6 +199,11 @@ create_test_credentials () {
     revision_id_for_revisioned_post_id="$REVISION_ID_FOR_REVISIONED_POST_ID" \
     autosaved_post_id="$AUTOSAVED_POST_ID" \
     autosave_id_for_autosaved_post_id="$AUTOSAVE_ID_FOR_AUTOSAVED_POST_ID" \
+    password_protected_page_id="$PASSWORD_PROTECTED_PAGE_ID" \
+    password_protected_page_password="INTEGRATION_TEST" \
+    password_protected_page_title="Password_Protected_Page" \
+    trashed_page_id="$TRASHED_PAGE_ID" \
+    first_page_id="$FIRST_PAGE_ID" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -13,6 +13,7 @@ use crate::{
             categories_endpoint::{CategoriesRequestBuilder, CategoriesRequestExecutor},
             comments_endpoint::{CommentsRequestBuilder, CommentsRequestExecutor},
             media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
+            pages_endpoint::{PagesRequestBuilder, PagesRequestExecutor},
             plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
             post_autosaves_endpoint::{AutosavesRequestBuilder, AutosavesRequestExecutor},
             post_revisions_endpoint::{PostRevisionsRequestBuilder, PostRevisionsRequestExecutor},
@@ -59,6 +60,7 @@ pub struct WpApiRequestBuilder {
     categories: Arc<CategoriesRequestBuilder>,
     comments: Arc<CommentsRequestBuilder>,
     media: Arc<MediaRequestBuilder>,
+    pages: Arc<PagesRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
     post_revisions: Arc<PostRevisionsRequestBuilder>,
     post_types: Arc<PostTypesRequestBuilder>,
@@ -88,6 +90,7 @@ impl WpApiRequestBuilder {
             categories,
             comments,
             media,
+            pages,
             plugins,
             post_revisions,
             post_types,
@@ -127,6 +130,7 @@ pub struct WpApiClient {
     categories: Arc<CategoriesRequestExecutor>,
     comments: Arc<CommentsRequestExecutor>,
     media: Arc<MediaRequestExecutor>,
+    pages: Arc<PagesRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
     post_revisions: Arc<PostRevisionsRequestExecutor>,
     post_types: Arc<PostTypesRequestExecutor>,
@@ -153,6 +157,7 @@ impl WpApiClient {
             categories,
             comments,
             media,
+            pages,
             plugins,
             post_revisions,
             post_types,
@@ -189,6 +194,7 @@ api_client_generate_endpoint_impl!(WpApi, autosaves);
 api_client_generate_endpoint_impl!(WpApi, categories);
 api_client_generate_endpoint_impl!(WpApi, comments);
 api_client_generate_endpoint_impl!(WpApi, media);
+api_client_generate_endpoint_impl!(WpApi, pages);
 api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_revisions);
 api_client_generate_endpoint_impl!(WpApi, post_types);

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -19,6 +19,7 @@ pub mod date;
 pub mod login;
 pub mod media;
 pub mod middleware;
+pub mod pages;
 pub mod parsed_url;
 pub mod plugins;
 pub mod post_revisions;

--- a/wp_api/src/pages.rs
+++ b/wp_api/src/pages.rs
@@ -1,0 +1,617 @@
+use crate::{
+    UserId, WpApiParamOrder,
+    date::WpGmtDateTime,
+    impl_as_query_value_from_to_string,
+    media::MediaId,
+    posts::WpApiParamPostsSearchColumn,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+    wp_content_i64_id,
+};
+use serde::{Deserialize, Serialize};
+use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
+use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum WpApiParamPagesOrderBy {
+    Author,
+    #[default]
+    Date,
+    Id,
+    Include,
+    IncludeSlugs,
+    MenuOrder,
+    Modified,
+    Parent,
+    Relevance,
+    Slug,
+    Title,
+}
+
+impl_as_query_value_from_to_string!(WpApiParamPagesOrderBy);
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
+#[supports_pagination(true)]
+pub struct PageListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    /// Default: `10`
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Limit response to pages published after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub after: Option<WpGmtDateTime>,
+    /// Limit response to pages modified after a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_after: Option<WpGmtDateTime>,
+    /// Limit result set to pages assigned to specific authors.
+    #[uniffi(default = [])]
+    pub author: Vec<UserId>,
+    /// Ensure result set excludes pages assigned to specific authors.
+    #[uniffi(default = [])]
+    pub author_exclude: Vec<UserId>,
+    /// Limit response to pages published before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub before: Option<WpGmtDateTime>,
+    /// Limit response to pages modified before a given ISO8601 compliant date.
+    #[uniffi(default = None)]
+    pub modified_before: Option<WpGmtDateTime>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = [])]
+    pub exclude: Vec<PageId>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = [])]
+    pub include: Vec<PageId>,
+    /// Offset the result set by a specific number of items.
+    #[uniffi(default = None)]
+    pub offset: Option<u32>,
+    /// Order sort attribute ascending or descending.
+    /// Default: desc
+    /// One of: asc, desc
+    #[uniffi(default = None)]
+    pub order: Option<WpApiParamOrder>,
+    /// Sort collection by page attribute.
+    /// Default: date
+    /// One of: author, date, id, include, modified, parent, relevance, slug, include_slugs, title, menu_order
+    #[uniffi(default = None)]
+    #[field_name("orderby")]
+    pub orderby: Option<WpApiParamPagesOrderBy>,
+    /// Array of column names to be searched.
+    #[uniffi(default = [])]
+    pub search_columns: Vec<WpApiParamPostsSearchColumn>,
+    /// Limit result set to pages with one or more specific slugs.
+    #[uniffi(default = [])]
+    pub slug: Vec<String>,
+    /// Limit result set to pages assigned one or more statuses.
+    /// Default: publish
+    #[uniffi(default = [])]
+    pub status: Vec<PageStatus>,
+    /// Limit result set to pages with a specific parent.
+    #[uniffi(default = None)]
+    pub parent: Option<PageId>,
+    /// Limit result set to pages except those of a specific parent.
+    #[uniffi(default = [])]
+    pub parent_exclude: Vec<PageId>,
+    /// Limit result set by menu order.
+    #[uniffi(default = None)]
+    pub menu_order: Option<u32>,
+}
+
+#[derive(Debug, Default, uniffi::Record)]
+pub struct PageRetrieveParams {
+    /// The password for the page if it is password protected.
+    #[uniffi(default = None)]
+    pub password: Option<String>,
+}
+
+impl AppendUrlQueryPairs for PageRetrieveParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair("password", self.password.as_ref());
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PageDeleteResponse {
+    pub deleted: bool,
+    pub previous: PageWithEditContext,
+}
+
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct PageCreateParams {
+    // The date the page was published, in the site's timezone.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    // The date the page was published, as GMT.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_gmt: Option<WpGmtDateTime>,
+    // An alphanumeric identifier for the page unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    // A named status for the page.
+    // One of: publish, future, draft, pending, private
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PageStatus>,
+    // A password to protect access to the content and excerpt.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    // The ID for the parent of the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<PageId>,
+    // The order of the page in relation to other pages.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub menu_order: Option<u32>,
+    // The title for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    // The content for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    // The ID for the author of the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    // The excerpt for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excerpt: Option<String>,
+    // The ID of the featured media for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub featured_media: Option<MediaId>,
+    // Whether or not comments are open on the page.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_status: Option<PageCommentStatus>,
+    // Whether or not the page can be pinged.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ping_status: Option<PagePingStatus>,
+    // Meta fields.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<PageMeta>,
+    // The theme file to use to display the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, uniffi::Record)]
+pub struct PageUpdateParams {
+    // The date the page was published, in the site's timezone.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    // The date the page was published, as GMT.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_gmt: Option<WpGmtDateTime>,
+    // An alphanumeric identifier for the page unique to its type.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    // A named status for the page.
+    // One of: publish, future, draft, pending, private
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PageStatus>,
+    // A password to protect access to the content and excerpt.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    // The ID for the parent of the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<PageId>,
+    // The order of the page in relation to other pages.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub menu_order: Option<u32>,
+    // The title for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    // The content for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    // The ID for the author of the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<UserId>,
+    // The excerpt for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excerpt: Option<String>,
+    // The ID of the featured media for the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub featured_media: Option<MediaId>,
+    // Whether or not comments are open on the page.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_status: Option<PageCommentStatus>,
+    // Whether or not the page can be pinged.
+    // One of: open, closed
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ping_status: Option<PagePingStatus>,
+    // Meta fields.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<PageMeta>,
+    // The theme file to use to display the page.
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+}
+
+wp_content_i64_id!(PageId);
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePage {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<PageId>,
+    #[WpContext(edit, embed, view)]
+    pub date: Option<String>,
+    #[WpContext(edit, view)]
+    pub date_gmt: Option<WpGmtDateTime>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub guid: Option<SparsePageGuid>,
+    #[WpContext(edit, embed, view)]
+    pub link: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified_gmt: Option<WpGmtDateTime>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, view)]
+    pub status: Option<PageStatus>,
+    #[serde(rename = "type")]
+    #[WpContext(edit, embed, view)]
+    pub page_type: Option<String>,
+    #[WpContext(edit)]
+    pub password: Option<String>,
+    #[WpContext(edit)]
+    pub permalink_template: Option<String>,
+    #[WpContext(edit)]
+    pub generated_slug: Option<String>,
+    #[WpContext(edit, view)]
+    pub parent: Option<PageId>,
+    #[WpContext(edit, view)]
+    pub menu_order: Option<u32>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub title: Option<SparsePageTitle>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub content: Option<SparsePageContent>,
+    #[WpContext(edit, embed, view)]
+    pub author: Option<UserId>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub excerpt: Option<SparsePageExcerpt>,
+    #[WpContext(edit, embed, view)]
+    pub featured_media: Option<MediaId>,
+    #[WpContext(edit, view)]
+    pub comment_status: Option<PageCommentStatus>,
+    #[WpContext(edit, view)]
+    pub ping_status: Option<PagePingStatus>,
+    #[WpContext(edit, view)]
+    pub meta: Option<PageMeta>,
+    #[WpContext(edit, view)]
+    pub template: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePageGuid {
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub raw: Option<String>,
+    #[WpContext(edit, view)]
+    pub rendered: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePageTitle {
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub raw: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub rendered: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePageContent {
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub raw: Option<String>,
+    #[WpContext(edit, view)]
+    pub rendered: Option<String>,
+    #[WpContext(edit, view)]
+    #[WpContextualOption]
+    pub protected: Option<bool>,
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub block_version: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparsePageExcerpt {
+    #[WpContext(edit)]
+    #[WpContextualOption]
+    pub raw: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub rendered: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
+    pub protected: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct PageMeta {
+    #[serde(deserialize_with = "deserialize_from_string_of_json_array")]
+    #[serde(serialize_with = "serialize_as_json_string")]
+    pub footnotes: Vec<PageFootnote>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, uniffi::Record)]
+pub struct PageFootnote {
+    pub id: String,
+    pub content: String,
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PageStatus {
+    Draft,
+    Future,
+    Pending,
+    Private,
+    #[default]
+    Publish,
+    #[serde(untagged)]
+    #[strum(default)]
+    Custom(String),
+}
+
+impl_as_query_value_from_to_string!(PageStatus);
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PageCommentStatus {
+    Open,
+    Closed,
+    #[serde(untagged)]
+    #[strum(default)]
+    Custom(String),
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PagePingStatus {
+    Open,
+    Closed,
+    #[serde(untagged)]
+    #[strum(default)]
+    Custom(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        SparseField, generate,
+        unit_test_common::{
+            assert_expected_and_from_query_pairs, unit_test_example_date_as_option,
+            unit_test_example_date_as_query_value,
+        },
+    };
+    use rstest::*;
+
+    #[rstest]
+    #[case(PageListParams::default(), "")]
+    #[case(generate!(PageListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(PageListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(PageListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(PageListParams, (after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PageListParams, (modified_after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_after"))]
+    #[case(generate!(PageListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
+    #[case(generate!(PageListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
+    #[case(generate!(PageListParams, (before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PageListParams, (modified_before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_before"))]
+    #[case(generate!(PageListParams, (exclude, vec![PageId(1), PageId(2)])), "exclude=1%2C2")]
+    #[case(generate!(PageListParams, (include, vec![PageId(1), PageId(2)])), "include=1%2C2")]
+    #[case(generate!(PageListParams, (offset, Some(2))), "offset=2")]
+    #[case(generate!(PageListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(PageListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Author))), "orderby=author")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Date))), "orderby=date")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Id))), "orderby=id")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Include))), "orderby=include")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::IncludeSlugs))), "orderby=include_slugs")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::MenuOrder))), "orderby=menu_order")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Modified))), "orderby=modified")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Parent))), "orderby=parent")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Relevance))), "orderby=relevance")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Slug))), "orderby=slug")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Title))), "orderby=title")]
+    #[case(generate!(PageListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent])), "search_columns=post_content")]
+    #[case(generate!(PageListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostExcerpt])), "search_columns=post_excerpt")]
+    #[case(generate!(PageListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_title")]
+    #[case(generate!(PageListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt, WpApiParamPostsSearchColumn::PostTitle])), "search_columns=post_content%2Cpost_excerpt%2Cpost_title")]
+    #[case(generate!(PageListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Draft])), "status=draft")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Future])), "status=future")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Pending])), "status=pending")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Private])), "status=private")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Publish])), "status=publish")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Custom("foo".to_string())])), "status=foo")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Custom("foo-bar".to_string())])), "status=foo-bar")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Custom("foo_bar".to_string())])), "status=foo_bar")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Custom("FooBar".to_string())])), "status=FooBar")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Draft, PageStatus::Future, PageStatus::Pending, PageStatus::Private, PageStatus::Publish, PageStatus::Custom("foo".to_string())])), "status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(PageListParams, (parent, Some(PageId(1)))), "parent=1")]
+    #[case(generate!(PageListParams, (parent_exclude, vec![PageId(1), PageId(2)])), "parent_exclude=1%2C2")]
+    #[case(generate!(PageListParams, (menu_order, Some(1))), "menu_order=1")]
+    #[case(
+        page_list_params_with_all_fields(),
+        &expected_query_pairs_for_page_list_params_with_all_fields()
+    )]
+    #[trace]
+    fn test_page_list_query_pairs(#[case] params: PageListParams, #[case] expected_query: &str) {
+        assert_expected_and_from_query_pairs(params, expected_query);
+    }
+
+    #[rstest]
+    #[case(SparsePageFieldWithEditContext::Id, "id")]
+    #[case(SparsePageFieldWithEditContext::PageType, "type")]
+    fn test_as_mapped_field_name_for_edit_context(
+        #[case] field: SparsePageFieldWithEditContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparsePageFieldWithEmbedContext::Id, "id")]
+    #[case(SparsePageFieldWithEmbedContext::PageType, "type")]
+    fn test_as_mapped_field_name_for_embed_context(
+        #[case] field: SparsePageFieldWithEmbedContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(SparsePageFieldWithViewContext::Id, "id")]
+    #[case(SparsePageFieldWithViewContext::PageType, "type")]
+    fn test_as_mapped_field_name_for_view_context(
+        #[case] field: SparsePageFieldWithViewContext,
+        #[case] expected_mapped_field_name: &str,
+    ) {
+        assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
+    }
+
+    fn expected_query_pairs_for_page_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!(
+            "page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&parent=1&parent_exclude=1%2C2&menu_order=1"
+        )
+    }
+
+    fn page_list_params_with_all_fields() -> PageListParams {
+        PageListParams {
+            after: unit_test_example_date_as_option(),
+            author: vec![UserId(1), UserId(2)],
+            author_exclude: vec![UserId(1), UserId(2)],
+            before: unit_test_example_date_as_option(),
+            exclude: vec![PageId(1), PageId(2)],
+            include: vec![PageId(1), PageId(2)],
+            modified_after: unit_test_example_date_as_option(),
+            modified_before: unit_test_example_date_as_option(),
+            offset: Some(2),
+            order: Some(WpApiParamOrder::Asc),
+            orderby: Some(WpApiParamPagesOrderBy::Author),
+            page: Some(2),
+            per_page: Some(2),
+            search: Some("foo".to_string()),
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+                WpApiParamPostsSearchColumn::PostTitle,
+            ],
+            slug: vec!["foo".to_string(), "bar".to_string()],
+            status: vec![
+                PageStatus::Draft,
+                PageStatus::Future,
+                PageStatus::Pending,
+                PageStatus::Private,
+                PageStatus::Publish,
+                PageStatus::Custom("foo".to_string()),
+            ],
+            parent: Some(PageId(1)),
+            parent_exclude: vec![PageId(1), PageId(2)],
+            menu_order: Some(1),
+        }
+    }
+}

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -7,6 +7,7 @@ pub mod application_passwords_endpoint;
 pub mod categories_endpoint;
 pub mod comments_endpoint;
 pub mod media_endpoint;
+pub mod pages_endpoint;
 pub mod plugins_endpoint;
 pub mod post_autosaves_endpoint;
 pub mod post_revisions_endpoint;

--- a/wp_api/src/request/endpoint/pages_endpoint.rs
+++ b/wp_api/src/request/endpoint/pages_endpoint.rs
@@ -1,0 +1,351 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::pages::{PageId, PageListParams, PageUpdateParams, PageWithEditContext};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum PagesRequest {
+    #[contextual_paged(url = "/pages", params = &PageListParams, output = Vec<crate::pages::SparsePage>, filter_by = crate::pages::SparsePageField)]
+    List,
+    #[contextual_get(url = "/pages/<page_id>", params = &crate::pages::PageRetrieveParams, output = crate::pages::SparsePage, filter_by = crate::pages::SparsePageField)]
+    Retrieve,
+    #[post(url = "/pages", params = &crate::pages::PageCreateParams, output = crate::pages::PageWithEditContext)]
+    Create,
+    #[delete(url = "/pages/<page_id>", output = crate::pages::PageDeleteResponse)]
+    Delete,
+    #[delete(url = "/pages/<page_id>", output = crate::pages::PageWithEditContext)]
+    Trash,
+    #[post(url = "/pages/<page_id>", params = &PageUpdateParams, output = PageWithEditContext)]
+    Update,
+}
+
+impl DerivedRequest for PagesRequest {
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            PagesRequest::Delete => vec![("force", true.to_string())],
+            PagesRequest::Trash => vec![("force", false.to_string())],
+            _ => vec![],
+        }
+    }
+
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        UserId, WpApiParamOrder, generate,
+        pages::{
+            PageRetrieveParams, PageStatus, SparsePageFieldWithEditContext,
+            SparsePageFieldWithEmbedContext, SparsePageFieldWithViewContext,
+            WpApiParamPagesOrderBy,
+        },
+        posts::WpApiParamPostsSearchColumn,
+        request::endpoint::{
+            ApiUrlResolver,
+            tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+        },
+        unit_test_common::{
+            unit_test_example_date_as_option, unit_test_example_date_as_query_value,
+        },
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    fn create_page(endpoint: PagesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.create(), "/pages");
+    }
+
+    #[rstest]
+    fn delete_page(endpoint: PagesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.delete(&PageId(54)), "/pages/54?force=true");
+    }
+
+    #[rstest]
+    #[case(PageListParams::default(), "")]
+    #[case(generate!(PageListParams, (page, Some(2))), "page=2")]
+    #[case(generate!(PageListParams, (per_page, Some(2))), "per_page=2")]
+    #[case(generate!(PageListParams, (search, Some("foo".to_string()))), "search=foo")]
+    #[case(generate!(PageListParams, (after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("after"))]
+    #[case(generate!(PageListParams, (modified_after, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_after"))]
+    #[case(generate!(PageListParams, (author, vec![UserId(1), UserId(2)])), "author=1%2C2")]
+    #[case(generate!(PageListParams, (author_exclude, vec![UserId(1), UserId(2)])), "author_exclude=1%2C2")]
+    #[case(generate!(PageListParams, (before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("before"))]
+    #[case(generate!(PageListParams, (modified_before, unit_test_example_date_as_option())), &unit_test_example_date_as_query_value("modified_before"))]
+    #[case(generate!(PageListParams, (exclude, vec![PageId(1), PageId(2)])), "exclude=1%2C2")]
+    #[case(generate!(PageListParams, (include, vec![PageId(1), PageId(2)])), "include=1%2C2")]
+    #[case(generate!(PageListParams, (offset, Some(2))), "offset=2")]
+    #[case(generate!(PageListParams, (order, Some(WpApiParamOrder::Asc))), "order=asc")]
+    #[case(generate!(PageListParams, (order, Some(WpApiParamOrder::Desc))), "order=desc")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Author))), "orderby=author")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Date))), "orderby=date")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Id))), "orderby=id")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Include))), "orderby=include")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::IncludeSlugs))), "orderby=include_slugs")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::MenuOrder))), "orderby=menu_order")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Modified))), "orderby=modified")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Parent))), "orderby=parent")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Relevance))), "orderby=relevance")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Slug))), "orderby=slug")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Title))), "orderby=title")]
+    #[case(generate!(PageListParams, (slug, vec!["foo".to_string(), "bar".to_string()])), "slug=foo%2Cbar")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Draft])), "status=draft")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Future])), "status=future")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Pending])), "status=pending")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Private])), "status=private")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Publish])), "status=publish")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Custom("foo".to_string())])), "status=foo")]
+    #[case(generate!(PageListParams, (status, vec![PageStatus::Draft, PageStatus::Future, PageStatus::Pending, PageStatus::Private, PageStatus::Publish, PageStatus::Custom("foo".to_string())])), "status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo")]
+    #[case(generate!(PageListParams, (parent, Some(PageId(1)))), "parent=1")]
+    #[case(generate!(PageListParams, (parent_exclude, vec![PageId(1), PageId(2)])), "parent_exclude=1%2C2")]
+    #[case(generate!(PageListParams, (menu_order, Some(1))), "menu_order=1")]
+    #[case(
+        page_list_params_with_all_fields(),
+        &expected_query_pairs_for_page_list_params_with_all_fields()
+    )]
+    fn list_pages(
+        endpoint: PagesRequestEndpoint,
+        #[case] params: PageListParams,
+        #[case] expected_additional_params: &str,
+    ) {
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/pages?context={context}")
+            } else {
+                format!("/pages?context={context}&{expected_additional_params}")
+            }
+        };
+        validate_wp_v2_endpoint(
+            endpoint.list_with_edit_context(&params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(&params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(&params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(PageListParams::default(), &[], "/pages?context=edit&_fields=")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Author))), &[SparsePageFieldWithEditContext::Author], "/pages?context=edit&orderby=author&_fields=author")]
+    #[case(page_list_params_with_all_fields(), ALL_SPARSE_PAGE_FIELDS_WITH_EDIT_CONTEXT, &format!("/pages?context=edit&{}&{}", expected_query_pairs_for_page_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_EDIT_CONTEXT))]
+    fn filter_list_page_with_edit_context(
+        endpoint: PagesRequestEndpoint,
+        #[case] params: PageListParams,
+        #[case] fields: &[SparsePageFieldWithEditContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_edit_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(PageListParams::default(), &[], "/pages?context=embed&_fields=")]
+    #[case(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Author))), &[SparsePageFieldWithEmbedContext::Author], "/pages?context=embed&orderby=author&_fields=author")]
+    #[case(page_list_params_with_all_fields(), ALL_SPARSE_PAGE_FIELDS_WITH_EMBED_CONTEXT, &format!("/pages?context=embed&{}&{}", expected_query_pairs_for_page_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_EMBED_CONTEXT))]
+    fn filter_list_page_with_embed_context(
+        endpoint: PagesRequestEndpoint,
+        #[case] params: PageListParams,
+        #[case] fields: &[SparsePageFieldWithEmbedContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_list_with_embed_context(&params, fields),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    #[case(None, "")]
+    #[case(Some("foo"), "password=foo")]
+    fn retrieve_page(
+        endpoint: PagesRequestEndpoint,
+        #[case] password: Option<&str>,
+        #[case] expected_additional_params: &str,
+    ) {
+        let page_id = PageId(54);
+        let expected_path = |context: &str| {
+            if expected_additional_params.is_empty() {
+                format!("/pages/54?context={context}")
+            } else {
+                format!("/pages/54?context={context}&{expected_additional_params}")
+            }
+        };
+        let params = PageRetrieveParams {
+            password: password.map(|p| p.to_string()),
+        };
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(&page_id, &params),
+            &expected_path("edit"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(&page_id, &params),
+            &expected_path("embed"),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(&page_id, &params),
+            &expected_path("view"),
+        );
+    }
+
+    #[rstest]
+    #[case(None, &[], "/pages/54?context=view&_fields=")]
+    #[case(Some("foo"), &[SparsePageFieldWithViewContext::Author], "/pages/54?context=view&password=foo&_fields=author")]
+    #[case(Some("foo"), ALL_SPARSE_PAGE_FIELDS_WITH_VIEW_CONTEXT, &format!("/pages/54?context=view&password=foo&{EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_VIEW_CONTEXT}"))]
+    fn filter_retrieve_page_with_view_context(
+        endpoint: PagesRequestEndpoint,
+        #[case] password: Option<&str>,
+        #[case] fields: &[SparsePageFieldWithViewContext],
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_v2_endpoint(
+            endpoint.filter_retrieve_with_view_context(
+                &PageId(54),
+                &PageRetrieveParams {
+                    password: password.map(|p| p.to_string()),
+                },
+                fields,
+            ),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    fn trash_page(endpoint: PagesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.trash(&PageId(54)), "/pages/54?force=false");
+    }
+
+    #[rstest]
+    fn update_page(endpoint: PagesRequestEndpoint) {
+        validate_wp_v2_endpoint(endpoint.update(&PageId(54)), "/pages/54");
+    }
+
+    fn expected_query_pairs_for_page_list_params_with_all_fields() -> String {
+        let after = unit_test_example_date_as_query_value("after");
+        let modified_after = unit_test_example_date_as_query_value("modified_after");
+        let before = unit_test_example_date_as_query_value("before");
+        let modified_before = unit_test_example_date_as_query_value("modified_before");
+        format!(
+            "page=2&per_page=2&search=foo&{after}&{modified_after}&author=1%2C2&author_exclude=1%2C2&{before}&{modified_before}&exclude=1%2C2&include=1%2C2&offset=2&order=asc&orderby=author&search_columns=post_content%2Cpost_excerpt%2Cpost_title&slug=foo%2Cbar&status=draft%2Cfuture%2Cpending%2Cprivate%2Cpublish%2Cfoo&parent=1&parent_exclude=1%2C2&menu_order=1"
+        )
+    }
+
+    fn page_list_params_with_all_fields() -> PageListParams {
+        PageListParams {
+            after: unit_test_example_date_as_option(),
+            author: vec![UserId(1), UserId(2)],
+            author_exclude: vec![UserId(1), UserId(2)],
+            before: unit_test_example_date_as_option(),
+            exclude: vec![PageId(1), PageId(2)],
+            include: vec![PageId(1), PageId(2)],
+            modified_after: unit_test_example_date_as_option(),
+            modified_before: unit_test_example_date_as_option(),
+            offset: Some(2),
+            order: Some(WpApiParamOrder::Asc),
+            orderby: Some(WpApiParamPagesOrderBy::Author),
+            page: Some(2),
+            per_page: Some(2),
+            search: Some("foo".to_string()),
+            search_columns: vec![
+                WpApiParamPostsSearchColumn::PostContent,
+                WpApiParamPostsSearchColumn::PostExcerpt,
+                WpApiParamPostsSearchColumn::PostTitle,
+            ],
+            slug: vec!["foo".to_string(), "bar".to_string()],
+            status: vec![
+                PageStatus::Draft,
+                PageStatus::Future,
+                PageStatus::Pending,
+                PageStatus::Private,
+                PageStatus::Publish,
+                PageStatus::Custom("foo".to_string()),
+            ],
+            parent: Some(PageId(1)),
+            parent_exclude: vec![PageId(1), PageId(2)],
+            menu_order: Some(1),
+        }
+    }
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_EDIT_CONTEXT: &str = "_fields=id%2Cdate%2Cdate_gmt%2Cguid%2Clink%2Cmodified%2Cmodified_gmt%2Cslug%2Cstatus%2Ctype%2Cparent%2Cmenu_order%2Ctitle%2Ccontent%2Cauthor%2Cexcerpt%2Cfeatured_media%2Ccomment_status%2Cping_status%2Cmeta%2Ctemplate%2Cpassword%2Cpermalink_template%2Cgenerated_slug";
+    const ALL_SPARSE_PAGE_FIELDS_WITH_EDIT_CONTEXT: &[SparsePageFieldWithEditContext; 24] = &[
+        SparsePageFieldWithEditContext::Id,
+        SparsePageFieldWithEditContext::Date,
+        SparsePageFieldWithEditContext::DateGmt,
+        SparsePageFieldWithEditContext::Guid,
+        SparsePageFieldWithEditContext::Link,
+        SparsePageFieldWithEditContext::Modified,
+        SparsePageFieldWithEditContext::ModifiedGmt,
+        SparsePageFieldWithEditContext::Slug,
+        SparsePageFieldWithEditContext::Status,
+        SparsePageFieldWithEditContext::PageType,
+        SparsePageFieldWithEditContext::Parent,
+        SparsePageFieldWithEditContext::MenuOrder,
+        SparsePageFieldWithEditContext::Title,
+        SparsePageFieldWithEditContext::Content,
+        SparsePageFieldWithEditContext::Author,
+        SparsePageFieldWithEditContext::Excerpt,
+        SparsePageFieldWithEditContext::FeaturedMedia,
+        SparsePageFieldWithEditContext::CommentStatus,
+        SparsePageFieldWithEditContext::PingStatus,
+        SparsePageFieldWithEditContext::Meta,
+        SparsePageFieldWithEditContext::Template,
+        SparsePageFieldWithEditContext::Password,
+        SparsePageFieldWithEditContext::PermalinkTemplate,
+        SparsePageFieldWithEditContext::GeneratedSlug,
+    ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_EMBED_CONTEXT: &str =
+        "_fields=id%2Cdate%2Clink%2Cslug%2Ctype%2Ctitle%2Cauthor%2Cexcerpt%2Cfeatured_media";
+    const ALL_SPARSE_PAGE_FIELDS_WITH_EMBED_CONTEXT: &[SparsePageFieldWithEmbedContext; 9] = &[
+        SparsePageFieldWithEmbedContext::Id,
+        SparsePageFieldWithEmbedContext::Date,
+        SparsePageFieldWithEmbedContext::Link,
+        SparsePageFieldWithEmbedContext::Slug,
+        SparsePageFieldWithEmbedContext::PageType,
+        SparsePageFieldWithEmbedContext::Title,
+        SparsePageFieldWithEmbedContext::Author,
+        SparsePageFieldWithEmbedContext::Excerpt,
+        SparsePageFieldWithEmbedContext::FeaturedMedia,
+    ];
+
+    const EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_PAGE_FIELDS_WITH_VIEW_CONTEXT: &str = "_fields=id%2Cdate%2Cdate_gmt%2Cguid%2Clink%2Cmodified%2Cmodified_gmt%2Cslug%2Cstatus%2Ctype%2Cparent%2Cmenu_order%2Ctitle%2Ccontent%2Cauthor%2Cexcerpt%2Cfeatured_media%2Ccomment_status%2Cping_status%2Cmeta%2Ctemplate";
+    const ALL_SPARSE_PAGE_FIELDS_WITH_VIEW_CONTEXT: &[SparsePageFieldWithViewContext; 21] = &[
+        SparsePageFieldWithViewContext::Id,
+        SparsePageFieldWithViewContext::Date,
+        SparsePageFieldWithViewContext::DateGmt,
+        SparsePageFieldWithViewContext::Guid,
+        SparsePageFieldWithViewContext::Link,
+        SparsePageFieldWithViewContext::Modified,
+        SparsePageFieldWithViewContext::ModifiedGmt,
+        SparsePageFieldWithViewContext::Slug,
+        SparsePageFieldWithViewContext::Status,
+        SparsePageFieldWithViewContext::PageType,
+        SparsePageFieldWithViewContext::Parent,
+        SparsePageFieldWithViewContext::MenuOrder,
+        SparsePageFieldWithViewContext::Title,
+        SparsePageFieldWithViewContext::Content,
+        SparsePageFieldWithViewContext::Author,
+        SparsePageFieldWithViewContext::Excerpt,
+        SparsePageFieldWithViewContext::FeaturedMedia,
+        SparsePageFieldWithViewContext::CommentStatus,
+        SparsePageFieldWithViewContext::PingStatus,
+        SparsePageFieldWithViewContext::Meta,
+        SparsePageFieldWithViewContext::Template,
+    ];
+
+    #[fixture]
+    fn endpoint(
+        fixture_wp_org_site_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> PagesRequestEndpoint {
+        PagesRequestEndpoint::new(fixture_wp_org_site_api_url_resolver)
+    }
+}

--- a/wp_api_integration_tests/src/backend.rs
+++ b/wp_api_integration_tests/src/backend.rs
@@ -1,9 +1,11 @@
 use serde::{Serialize, de::DeserializeOwned};
 use wp_api::{
-    categories::CategoryId, comments::CommentId, posts::PostId, tags::TagId, users::UserId,
+    categories::CategoryId, comments::CommentId, pages::PageId, posts::PostId, tags::TagId,
+    users::UserId,
 };
 use wp_cli::{
-    WpCliCategory, WpCliComment, WpCliPost, WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta,
+    WpCliCategory, WpCliComment, WpCliPage, WpCliPost, WpCliSiteSettings, WpCliTag, WpCliUser,
+    WpCliUserMeta,
 };
 
 const BACKEND_ADDRESS: &str = "http://127.0.0.1:4000";
@@ -13,6 +15,8 @@ const BACKEND_PATH_CATEGORIES: &str = "/wp-cli/categories";
 const BACKEND_PATH_COMMENT: &str = "/wp-cli/comment";
 const BACKEND_PATH_COMMENTS: &str = "/wp-cli/comments";
 const BACKEND_PATH_SITE_SETTINGS: &str = "/wp-cli/site-settings";
+const BACKEND_PATH_PAGE: &str = "/wp-cli/page";
+const BACKEND_PATH_PAGES: &str = "/wp-cli/pages";
 const BACKEND_PATH_POST: &str = "/wp-cli/post";
 const BACKEND_PATH_POSTS: &str = "/wp-cli/posts";
 const BACKEND_PATH_TAG: &str = "/wp-cli/tag";
@@ -56,6 +60,21 @@ impl Backend {
     }
     pub async fn site_settings() -> Result<WpCliSiteSettings, reqwest::Error> {
         Self::get(BACKEND_PATH_SITE_SETTINGS).await
+    }
+    pub async fn page(page_id: &PageId) -> WpCliPage {
+        Self::get(format!("{BACKEND_PATH_PAGE}?page_id={page_id}"))
+            .await
+            .expect("Failed to parse fetched page from wp_cli")
+    }
+    pub async fn pages(post_status: Option<&str>) -> Vec<WpCliPage> {
+        let url = if let Some(post_status) = post_status {
+            format!("{BACKEND_PATH_PAGES}?post_status={post_status}")
+        } else {
+            BACKEND_PATH_PAGES.to_string()
+        };
+        Self::get(url)
+            .await
+            .expect("Failed to parse fetched pages from wp_cli")
     }
     pub async fn post(post_id: &PostId) -> WpCliPost {
         Self::get(format!("{BACKEND_PATH_POST}?post_id={post_id}"))

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -31,6 +31,11 @@ pub struct TestCredentials {
     pub revision_id_for_revisioned_post_id: i64,
     pub autosaved_post_id: i64,
     pub autosave_id_for_autosaved_post_id: i64,
+    pub password_protected_page_id: i64,
+    pub password_protected_page_password: &'static str,
+    pub password_protected_page_title: &'static str,
+    pub trashed_page_id: i64,
+    pub first_page_id: i64,
 }
 
 impl TestCredentials {
@@ -80,6 +85,7 @@ pub const TAG_ID_100: TagId = TagId(100);
 pub const TAG_ID_INVALID: TagId = TagId(99999999);
 pub const TEMPLATE_TWENTY_TWENTY_FOUR_SINGLE: &str = "twentytwentyfour//single";
 pub const POST_TEMPLATE_SINGLE_WITH_SIDEBAR: &str = "single-with-sidebar";
+pub const PAGE_TEMPLATE_WITH_SIDEBAR: &str = "page-with-sidebar";
 pub const THEME_TWENTY_TWENTY_FIVE: &str = "twentytwentyfive";
 pub const THEME_TWENTY_TWENTY_FOUR: &str = "twentytwentyfour";
 pub const THEME_TWENTY_TWENTY_THREE: &str = "twentytwentythree";

--- a/wp_api_integration_tests/src/prelude.rs
+++ b/wp_api_integration_tests/src/prelude.rs
@@ -22,6 +22,6 @@ pub use std::sync::Arc;
 pub use url::Url;
 pub use wp_api::{
     categories::CategoryId, comments::CommentId, date::WpGmtDateTime, media::MediaId,
-    posts::PostId, prelude::*, reqwest_request_executor::ReqwestRequestExecutor, tags::TagId,
-    users::UserId,
+    pages::PageId, posts::PostId, prelude::*, reqwest_request_executor::ReqwestRequestExecutor,
+    tags::TagId, users::UserId,
 };

--- a/wp_api_integration_tests/tests/test_pages_err.rs
+++ b/wp_api_integration_tests/tests/test_pages_err.rs
@@ -1,0 +1,191 @@
+use wp_api::{
+    pages::{
+        PageCreateParams, PageId, PageListParams, PageRetrieveParams, PageUpdateParams,
+        WpApiParamPagesOrderBy,
+    },
+    users::UserId,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn create_page_err_cannot_create() {
+    api_client_as_subscriber()
+        .pages()
+        .create(&PageCreateParams {
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::CannotCreate);
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_page_err_cannot_create2() {
+    api_client_as_subscriber()
+        .pages()
+        .create(&PageCreateParams {
+            title: Some("foo".to_string()),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::CannotCreate);
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_page_err_cannot_delete() {
+    api_client_as_subscriber()
+        .pages()
+        .delete(&PageId(TestCredentials::instance().first_page_id))
+        .await
+        .assert_wp_error(WpErrorCode::CannotDelete);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_no_search_term_defined() {
+    api_client()
+        .pages()
+        .list_with_edit_context(&PageListParams {
+            orderby: Some(WpApiParamPagesOrderBy::Relevance),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::NoSearchTermDefined);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_order_by_include_missing_include() {
+    api_client()
+        .pages()
+        .list_with_edit_context(&PageListParams {
+            orderby: Some(WpApiParamPagesOrderBy::Include),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::OrderbyIncludeMissingInclude);
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_post_invalid_page_number() {
+    api_client()
+        .pages()
+        .list_with_edit_context(&PageListParams {
+            page: Some(99999999),
+            ..Default::default()
+        })
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidPageNumber);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_page_err_wrong_password() {
+    api_client()
+        .pages()
+        .retrieve_with_view_context(
+            &PageId(TestCredentials::instance().password_protected_page_id),
+            &PageRetrieveParams {
+                password: Some("wrong_password".to_string()),
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostIncorrectPassword);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_page_err_forbidden_context() {
+    api_client_as_subscriber()
+        .pages()
+        .retrieve_with_edit_context(
+            &PageId(TestCredentials::instance().first_page_id),
+            &PageRetrieveParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::ForbiddenContext);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_page_err_post_invalid_id() {
+    api_client()
+        .pages()
+        .retrieve_with_edit_context(&PageId(99999999), &PageRetrieveParams::default())
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId);
+}
+
+#[tokio::test]
+#[parallel]
+async fn trash_page_err_already_trashed() {
+    api_client()
+        .pages()
+        .trash(&PageId(TestCredentials::instance().trashed_page_id))
+        .await
+        .assert_wp_error(WpErrorCode::AlreadyTrashed);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_page_err_cannot_edit() {
+    api_client_as_author()
+        .pages()
+        .update(
+            &PageId(TestCredentials::instance().first_page_id),
+            &PageUpdateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotEdit);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_page_err_invalid_author() {
+    api_client()
+        .pages()
+        .update(
+            &PageId(TestCredentials::instance().first_page_id),
+            &PageUpdateParams {
+                author: Some(UserId(99999999)),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidAuthor);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_page_err_invalid_parent() {
+    api_client()
+        .pages()
+        .update(
+            &PageId(TestCredentials::instance().first_page_id),
+            &PageUpdateParams {
+                parent: Some(PageId(99999999)),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId);
+}
+
+#[tokio::test]
+#[parallel]
+async fn update_page_err_invalid_param() {
+    api_client()
+        .pages()
+        .update(
+            &PageId(TestCredentials::instance().first_page_id),
+            &PageUpdateParams {
+                template: Some("nonexistent-template".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::InvalidParam);
+}

--- a/wp_api_integration_tests/tests/test_pages_immut.rs
+++ b/wp_api_integration_tests/tests/test_pages_immut.rs
@@ -1,0 +1,360 @@
+use wp_api::{
+    pages::{
+        PageId, PageListParams, PageRetrieveParams, PageStatus, SparsePageFieldWithEditContext,
+        SparsePageFieldWithEmbedContext, SparsePageFieldWithViewContext, WpApiParamPagesOrderBy,
+    },
+    posts::WpApiParamPostsSearchColumn,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: PageListParams) {
+    api_client()
+        .pages()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: PageListParams) {
+    api_client()
+        .pages()
+        .list_with_embed_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: PageListParams) {
+    api_client()
+        .pages()
+        .list_with_view_context(&params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    let test_credentials = TestCredentials::instance();
+    api_client()
+        .pages()
+        .retrieve_with_edit_context(
+            &PageId(test_credentials.first_page_id),
+            &PageRetrieveParams::default(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context(#[case] params: PageRetrieveParams) {
+    let test_credentials = TestCredentials::instance();
+    api_client()
+        .pages()
+        .retrieve_with_embed_context(
+            &PageId(test_credentials.first_page_id),
+            &PageRetrieveParams::default(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context(#[case] params: PageRetrieveParams) {
+    let test_credentials = TestCredentials::instance();
+    api_client()
+        .pages()
+        .retrieve_with_view_context(
+            &PageId(test_credentials.first_page_id),
+            &PageRetrieveParams::default(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_edit_context() {
+    let test_credentials = TestCredentials::instance();
+    let page = api_client()
+        .pages()
+        .retrieve_with_edit_context(
+            &PageId(test_credentials.password_protected_page_id),
+            &PageRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_page_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        page.title.rendered,
+        test_credentials.password_protected_page_title
+    );
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_embed_context() {
+    let test_credentials = TestCredentials::instance();
+    let page = api_client()
+        .pages()
+        .retrieve_with_embed_context(
+            &PageId(test_credentials.password_protected_page_id),
+            &PageRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_page_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        page.title.rendered,
+        test_credentials.password_protected_page_title
+    );
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_password_protected_with_view_context() {
+    let test_credentials = TestCredentials::instance();
+    let page = api_client()
+        .pages()
+        .retrieve_with_view_context(
+            &PageId(test_credentials.password_protected_page_id),
+            &PageRetrieveParams {
+                password: Some(
+                    test_credentials
+                        .password_protected_page_password
+                        .to_string(),
+                ),
+            },
+        )
+        .await
+        .assert_response()
+        .data;
+    assert_eq!(
+        page.title.rendered,
+        test_credentials.password_protected_page_title
+    );
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
+#[case(PageListParams { per_page: Some(1), ..Default::default() })]
+#[case(PageListParams { per_page: Some(1), order: Some(WpApiParamOrder::Desc), ..Default::default() })]
+#[case(PageListParams { per_page: Some(1), orderby: Some(WpApiParamPagesOrderBy::Modified), ..Default::default() })]
+async fn paginate_list_pages_with_edit_context(#[case] params: PageListParams) {
+    let first_page_response = api_client()
+        .pages()
+        .list_with_edit_context(&params)
+        .await
+        .assert_response();
+    assert!(!first_page_response.data.is_empty());
+    let next_page_params = first_page_response.next_page_params.unwrap();
+    let next_page_response = api_client()
+        .pages()
+        .list_with_edit_context(&next_page_params)
+        .await
+        .assert_response();
+    assert!(!next_page_response.data.is_empty());
+    let prev_page_params = next_page_response.prev_page_params.unwrap();
+    let prev_page_response = api_client()
+        .pages()
+        .list_with_edit_context(&prev_page_params)
+        .await
+        .assert_response();
+    assert!(!prev_page_response.data.is_empty());
+}
+
+#[template]
+#[rstest]
+#[case::default(PageListParams::default())]
+#[case::page(generate!(PageListParams, (page, Some(1))))]
+#[case::per_page(generate!(PageListParams, (per_page, Some(3))))]
+#[case::search(generate!(PageListParams, (search, Some("foo".to_string()))))]
+#[case::after(generate!(PageListParams, (after, Some(unwrapped_wp_gmt_date_time("2020-08-14T17:00:00+0200")))))]
+#[case::modified_after(generate!(PageListParams, (modified_after, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0200")))))]
+#[case::author(generate!(PageListParams, (author, vec![FIRST_USER_ID, SECOND_USER_ID])))]
+#[case::author_exclude(generate!(PageListParams, (author_exclude, vec![SECOND_USER_ID])))]
+#[case::before(generate!(PageListParams, (before, Some(unwrapped_wp_gmt_date_time("2023-08-14T17:00:00+0000")))))]
+#[case::modified_before(generate!(PageListParams, (modified_before, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0000")))))]
+#[case::exclude(generate!(PageListParams, (exclude, vec![PageId(1), PageId(2)])))]
+#[case::include(generate!(PageListParams, (include, vec![PageId(1)])))]
+#[case::offset(generate!(PageListParams, (offset, Some(2))))]
+#[case::order(generate!(PageListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Id))))]
+#[case::search_columns(generate!(PageListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt])))]
+#[case::slug(generate!(PageListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+#[case::status(generate!(PageListParams, (status, vec![PageStatus::Publish, PageStatus::Pending])))]
+#[case::parent(generate!(PageListParams, (parent, Some(PageId(1)))))]
+#[case::parent_exclude(generate!(PageListParams, (parent_exclude, vec![PageId(1), PageId(2)])))]
+#[case::menu_order(generate!(PageListParams, (menu_order, Some(1))))]
+#[case::orderby_menu_order(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::MenuOrder))))]
+#[case::orderby_parent(generate!(PageListParams, (orderby, Some(WpApiParamPagesOrderBy::Parent))))]
+fn list_cases(#[case] params: PageListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_page_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_page_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_page_field_with_view_context_test_cases!();
+
+    #[apply(sparse_page_field_with_edit_context_test_cases)]
+    #[case(&[SparsePageFieldWithEditContext::Id, SparsePageFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_pages_with_edit_context(
+        #[case] fields: &[SparsePageFieldWithEditContext],
+        #[values(
+            PageListParams::default(),
+            generate!(PageListParams, (status, vec![PageStatus::Draft, PageStatus::Publish])),
+            generate!(PageListParams, (search, Some("foo".to_string())))
+        )]
+        params: PageListParams,
+    ) {
+        api_client()
+            .pages()
+            .filter_list_with_edit_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|page| {
+                page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_page_field_with_edit_context_test_cases)]
+    #[case(&[SparsePageFieldWithEditContext::Id, SparsePageFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_pages_with_edit_context(
+        #[case] fields: &[SparsePageFieldWithEditContext],
+    ) {
+        let test_credentials = TestCredentials::instance();
+        let page = api_client()
+            .pages()
+            .filter_retrieve_with_edit_context(
+                &PageId(test_credentials.first_page_id),
+                &PageRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_page_field_with_embed_context_test_cases)]
+    #[case(&[SparsePageFieldWithEmbedContext::Id, SparsePageFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_pages_with_embed_context(
+        #[case] fields: &[SparsePageFieldWithEmbedContext],
+        #[values(
+            PageListParams::default(),
+            generate!(PageListParams, (status, vec![PageStatus::Draft, PageStatus::Publish])),
+            generate!(PageListParams, (search, Some("foo".to_string())))
+        )]
+        params: PageListParams,
+    ) {
+        api_client()
+            .pages()
+            .filter_list_with_embed_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|page| {
+                page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_page_field_with_embed_context_test_cases)]
+    #[case(&[SparsePageFieldWithEmbedContext::Id, SparsePageFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_pages_with_embed_context(
+        #[case] fields: &[SparsePageFieldWithEmbedContext],
+    ) {
+        let test_credentials = TestCredentials::instance();
+        let page = api_client()
+            .pages()
+            .filter_retrieve_with_embed_context(
+                &PageId(test_credentials.first_page_id),
+                &PageRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+
+    #[apply(sparse_page_field_with_view_context_test_cases)]
+    #[case(&[SparsePageFieldWithViewContext::Id, SparsePageFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_pages_with_view_context(
+        #[case] fields: &[SparsePageFieldWithViewContext],
+        #[values(
+            PageListParams::default(),
+            generate!(PageListParams, (status, vec![PageStatus::Draft, PageStatus::Publish])),
+            generate!(PageListParams, (search, Some("foo".to_string())))
+        )]
+        params: PageListParams,
+    ) {
+        api_client()
+            .pages()
+            .filter_list_with_view_context(&params, fields)
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|page| {
+                page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_page_field_with_view_context_test_cases)]
+    #[case(&[SparsePageFieldWithViewContext::Id, SparsePageFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_pages_with_view_context(
+        #[case] fields: &[SparsePageFieldWithViewContext],
+    ) {
+        let test_credentials = TestCredentials::instance();
+        let page = api_client()
+            .pages()
+            .filter_retrieve_with_view_context(
+                &PageId(test_credentials.first_page_id),
+                &PageRetrieveParams::default(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data;
+        page.assert_that_instance_fields_nullability_match_provided_fields(fields)
+    }
+}

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -1,0 +1,450 @@
+use macro_helper::{generate_update_page_status_test, generate_update_test};
+use wp_api::pages::{
+    PageCommentStatus, PageCreateParams, PageFootnote, PageMeta, PagePingStatus, PageStatus,
+    PageUpdateParams, PageWithEditContext,
+};
+use wp_api_integration_tests::{PAGE_TEMPLATE_WITH_SIDEBAR, prelude::*};
+use wp_cli::WpCliPage;
+
+#[tokio::test]
+#[serial]
+async fn create_page_with_just_title() {
+    test_create_page(
+        &PageCreateParams {
+            title: Some("foo".to_string()),
+            ..Default::default()
+        },
+        |created_page, page_from_wp_cli| {
+            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(page_from_wp_cli.title, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_page_with_title_and_meta() {
+    test_create_page(
+        &PageCreateParams {
+            title: Some("foo".to_string()),
+            meta: Some(PageMeta {
+                footnotes: vec![PageFootnote {
+                    id: "bar".to_string(),
+                    content: "baz".to_string(),
+                }],
+            }),
+            ..Default::default()
+        },
+        |created_page, page_from_wp_cli| {
+            let footnote = created_page.meta.footnotes.first().unwrap();
+            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(page_from_wp_cli.title, "foo");
+            assert_eq!(footnote.id, "bar");
+            assert_eq!(footnote.content, "baz");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_page_with_just_content() {
+    test_create_page(
+        &PageCreateParams {
+            content: Some("foo".to_string()),
+            ..Default::default()
+        },
+        |created_page, page_from_wp_cli| {
+            assert_eq!(created_page.content.raw, Some("foo".to_string()));
+            assert_eq!(page_from_wp_cli.content, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_page_with_just_excerpt() {
+    test_create_page(
+        &PageCreateParams {
+            excerpt: Some("foo".to_string()),
+            ..Default::default()
+        },
+        |created_page, page_from_wp_cli| {
+            assert_eq!(created_page.excerpt.raw, Some("foo".to_string()));
+            assert_eq!(page_from_wp_cli.excerpt, "foo");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_page_with_title_content_and_excerpt() {
+    test_create_page(
+        &PageCreateParams {
+            title: Some("foo".to_string()),
+            content: Some("bar".to_string()),
+            excerpt: Some("baz".to_string()),
+            ..Default::default()
+        },
+        |created_page, page_from_wp_cli| {
+            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(page_from_wp_cli.title, "foo");
+            assert_eq!(created_page.content.raw, Some("bar".to_string()));
+            assert_eq!(page_from_wp_cli.content, "bar");
+            assert_eq!(created_page.excerpt.raw, Some("baz".to_string()));
+            assert_eq!(page_from_wp_cli.excerpt, "baz");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn delete_page() {
+    // Delete the page using the API and ensure it's successful
+    let page_delete_response = api_client()
+        .pages()
+        .delete(&PageId(TestCredentials::instance().first_page_id))
+        .await;
+    assert!(page_delete_response.is_ok(), "{page_delete_response:#?}");
+    assert!(page_delete_response.unwrap().data.deleted);
+
+    // Assert that the page was deleted
+    assert!(
+        !Backend::pages(None)
+            .await
+            .into_iter()
+            .any(|p| p.id == PageId(TestCredentials::instance().first_page_id).0),
+        "Page wasn't deleted"
+    );
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn trash_page() {
+    // Trash the page using the API and ensure it's successful
+    let page_trash_response = api_client()
+        .pages()
+        .trash(&PageId(TestCredentials::instance().first_page_id))
+        .await;
+    assert!(page_trash_response.is_ok(), "{page_trash_response:#?}");
+
+    // Assert that the page was trashed
+    let trashed_page = Backend::pages(Some("trash"))
+        .await
+        .into_iter()
+        .find(|p| p.id == PageId(TestCredentials::instance().first_page_id).0);
+    assert!(trashed_page.is_some(), "Can't find the trashed page");
+    assert_eq!(
+        trashed_page.unwrap().post_status,
+        "trash",
+        "Page wasn't trashed"
+    );
+
+    RestoreServer::db().await;
+}
+
+generate_update_test!(
+    update_date,
+    date,
+    "2024-09-09T12:00:00".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.date, "2024-09-09T12:00:00");
+        assert_eq!(updated_page_from_wp_cli.date, "2024-09-09 12:00:00");
+    }
+);
+
+generate_update_test!(
+    update_date_gmt,
+    date_gmt,
+    unwrapped_wp_gmt_date_time("2024-09-09T12:00:00+0000"),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(
+            updated_page.date_gmt,
+            unwrapped_wp_gmt_date_time("2024-09-09T12:00:00+0000")
+        );
+        assert_eq!(updated_page_from_wp_cli.date_gmt, "2024-09-09 12:00:00");
+    }
+);
+
+generate_update_test!(
+    update_slug,
+    slug,
+    "new_slug".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.slug, "new_slug");
+        assert_eq!(updated_page_from_wp_cli.slug, "new_slug");
+    }
+);
+
+generate_update_test!(
+    update_password,
+    password,
+    "new_password".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.password, "new_password");
+        assert_eq!(updated_page_from_wp_cli.password, "new_password");
+    }
+);
+
+generate_update_test!(
+    update_title,
+    title,
+    "new_title".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.title.raw, Some("new_title".to_string()));
+        assert_eq!(updated_page_from_wp_cli.title, "new_title");
+    }
+);
+
+generate_update_test!(
+    update_content,
+    content,
+    "new_content".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.content.raw, Some("new_content".to_string()));
+        assert_eq!(updated_page_from_wp_cli.content, "new_content");
+    }
+);
+
+generate_update_test!(
+    update_author,
+    author,
+    SECOND_USER_ID,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.author, SECOND_USER_ID);
+        assert_eq!(updated_page_from_wp_cli.author, SECOND_USER_ID.0);
+    }
+);
+
+generate_update_test!(
+    update_excerpt,
+    excerpt,
+    "new_excerpt".to_string(),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.excerpt.raw, Some("new_excerpt".to_string()));
+        assert_eq!(updated_page_from_wp_cli.excerpt, "new_excerpt");
+    }
+);
+
+generate_update_test!(
+    update_featured_media,
+    featured_media,
+    MEDIA_ID_611,
+    |updated_page, _| {
+        assert_eq!(updated_page.featured_media, MEDIA_ID_611);
+    }
+);
+
+generate_update_test!(
+    update_comment_status_to_open,
+    comment_status,
+    PageCommentStatus::Open,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.comment_status, PageCommentStatus::Open);
+        assert_eq!(
+            updated_page_from_wp_cli.comment_status,
+            PageCommentStatus::Open.to_string()
+        );
+    }
+);
+
+generate_update_test!(
+    update_comment_status_to_closed,
+    comment_status,
+    PageCommentStatus::Closed,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.comment_status, PageCommentStatus::Closed);
+        assert_eq!(
+            updated_page_from_wp_cli.comment_status,
+            PageCommentStatus::Closed.to_string()
+        );
+    }
+);
+
+generate_update_test!(
+    update_ping_status_to_open,
+    ping_status,
+    PagePingStatus::Open,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.ping_status, PagePingStatus::Open);
+        assert_eq!(
+            updated_page_from_wp_cli.ping_status,
+            PagePingStatus::Open.to_string()
+        );
+    }
+);
+
+generate_update_test!(
+    update_ping_status_to_closed,
+    ping_status,
+    PagePingStatus::Closed,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.ping_status, PagePingStatus::Closed);
+        assert_eq!(
+            updated_page_from_wp_cli.ping_status,
+            PagePingStatus::Closed.to_string()
+        );
+    }
+);
+
+generate_update_test!(
+    update_parent,
+    parent,
+    PageId(TestCredentials::instance().password_protected_page_id),
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(
+            updated_page.parent,
+            PageId(TestCredentials::instance().password_protected_page_id)
+        );
+        assert_eq!(
+            updated_page_from_wp_cli.parent,
+            PageId(TestCredentials::instance().password_protected_page_id).0
+        );
+    }
+);
+
+generate_update_test!(
+    update_menu_order,
+    menu_order,
+    5u32,
+    |updated_page, updated_page_from_wp_cli| {
+        assert_eq!(updated_page.menu_order, 5);
+        assert_eq!(updated_page_from_wp_cli.menu_order, 5);
+    }
+);
+
+generate_update_test!(
+    update_template,
+    template,
+    PAGE_TEMPLATE_WITH_SIDEBAR.to_string(),
+    |updated_page, _| {
+        assert_eq!(updated_page.template, PAGE_TEMPLATE_WITH_SIDEBAR);
+    }
+);
+
+generate_update_test!(
+    update_meta_to_add_footnote,
+    meta,
+    PageMeta {
+        footnotes: vec![PageFootnote {
+            id: "foo".to_string(),
+            content: "bar".to_string()
+        }]
+    },
+    |updated_page, _| {
+        let footnote = updated_page.meta.footnotes.first().unwrap();
+        assert_eq!(footnote.id, "foo");
+        assert_eq!(footnote.content, "bar");
+    }
+);
+
+#[tokio::test]
+#[serial]
+async fn update_status_to_future() {
+    test_update_page(
+        &PageUpdateParams {
+            status: Some(PageStatus::Future),
+            // Publish date has to be in the future
+            date: Some("2026-09-09T12:00:00".to_string()),
+            ..Default::default()
+        },
+        |updated_page, updated_page_from_wp_cli| {
+            assert_eq!(updated_page.status, PageStatus::Future);
+            assert_eq!(
+                updated_page_from_wp_cli.post_status,
+                PageStatus::Future.to_string()
+            );
+        },
+    )
+    .await;
+}
+
+// See `update_status_to_future` test case for `PageStatus::Future`
+generate_update_page_status_test!(Draft);
+generate_update_page_status_test!(Pending);
+generate_update_page_status_test!(Private);
+generate_update_page_status_test!(Publish);
+
+async fn test_create_page<F>(params: &PageCreateParams, assert: F)
+where
+    F: Fn(PageWithEditContext, WpCliPage),
+{
+    let created_page = api_client()
+        .pages()
+        .create(params)
+        .await
+        .assert_response()
+        .data;
+    let created_page_from_wp_cli = Backend::page(&created_page.id).await;
+    assert(created_page, created_page_from_wp_cli);
+    RestoreServer::db().await;
+}
+
+async fn test_update_page<F>(params: &PageUpdateParams, assert: F)
+where
+    F: Fn(PageWithEditContext, WpCliPage),
+{
+    let updated_page = api_client()
+        .pages()
+        .update(&PageId(TestCredentials::instance().first_page_id), params)
+        .await
+        .assert_response()
+        .data;
+    let updated_page_from_wp_cli =
+        Backend::page(&PageId(TestCredentials::instance().first_page_id)).await;
+    assert(updated_page, updated_page_from_wp_cli);
+    RestoreServer::db().await;
+}
+
+mod macro_helper {
+    macro_rules! generate_update_test {
+        ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn $ident() {
+                    let updated_value = $new_value;
+                    test_update_page(
+                        &PageUpdateParams {
+                            $field: Some(updated_value),
+                            ..Default::default()
+                        }, $assertion)
+                    .await;
+                }
+            }
+        };
+    }
+
+    macro_rules! generate_update_page_status_test {
+        ($status:ident) => {
+            paste::paste! {
+                #[tokio::test]
+                #[serial]
+                async fn [<update_page_status_to_ $status:lower>]() {
+                    test_update_page(
+                        &PageUpdateParams {
+                            status: Some(PageStatus::$status),
+                            ..Default::default()
+                        },
+                        |updated_page, updated_page_from_wp_cli| {
+                            assert_eq!(updated_page.status, PageStatus::$status);
+                            assert_eq!(
+                                updated_page_from_wp_cli.post_status,
+                                PageStatus::$status.to_string()
+                            );
+                        }
+                    ).await;
+                }
+            }
+        };
+    }
+
+    pub(super) use generate_update_page_status_test;
+    pub(super) use generate_update_test;
+}

--- a/wp_api_integration_tests_backend/src/main.rs
+++ b/wp_api_integration_tests_backend/src/main.rs
@@ -6,8 +6,8 @@ use std::fs::metadata;
 use std::io;
 use std::path::Path;
 use wp_cli::{
-    WpCliCategory, WpCliComment, WpCliCommentListArguments, WpCliPost, WpCliPostListArguments,
-    WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta,
+    WpCliCategory, WpCliComment, WpCliCommentListArguments, WpCliPage, WpCliPageListArguments,
+    WpCliPost, WpCliPostListArguments, WpCliSiteSettings, WpCliTag, WpCliUser, WpCliUserMeta,
 };
 
 pub(crate) const TEST_SITE_WP_CONTENT_PATH: &str = "/var/www/html/wp-content";
@@ -63,6 +63,20 @@ fn wp_cli_post(post_id: i64) -> Result<Json<WpCliPost>, Error> {
 #[get("/posts?<post_status>")]
 fn wp_cli_posts(post_status: Option<String>) -> Result<Json<Vec<WpCliPost>>, Error> {
     WpCliPost::list(Some(WpCliPostListArguments { post_status }))
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
+}
+
+#[get("/page?<page_id>")]
+fn wp_cli_page(page_id: i64) -> Result<Json<WpCliPage>, Error> {
+    WpCliPage::get(page_id)
+        .map(Json)
+        .map_err(|e| Error::AsString(e.to_string()))
+}
+
+#[get("/pages?<post_status>")]
+fn wp_cli_pages(post_status: Option<String>) -> Result<Json<Vec<WpCliPage>>, Error> {
+    WpCliPage::list(Some(WpCliPageListArguments { post_status }))
         .map(Json)
         .map_err(|e| Error::AsString(e.to_string()))
 }
@@ -127,6 +141,8 @@ fn rocket() -> _ {
         .mount("/wp-cli/", routes![wp_cli_comment])
         .mount("/wp-cli/", routes![wp_cli_comments])
         .mount("/wp-cli/", routes![wp_cli_site_settings])
+        .mount("/wp-cli/", routes![wp_cli_page])
+        .mount("/wp-cli/", routes![wp_cli_pages])
         .mount("/wp-cli/", routes![wp_cli_post])
         .mount("/wp-cli/", routes![wp_cli_posts])
         .mount("/wp-cli/", routes![wp_cli_tag])

--- a/wp_cli/src/lib.rs
+++ b/wp_cli/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 mod wp_cli_categories;
 mod wp_cli_comments;
+mod wp_cli_pages;
 mod wp_cli_posts;
 mod wp_cli_settings;
 mod wp_cli_tags;
@@ -14,6 +15,7 @@ mod wp_cli_users;
 
 pub use wp_cli_categories::*;
 pub use wp_cli_comments::*;
+pub use wp_cli_pages::*;
 pub use wp_cli_posts::*;
 pub use wp_cli_settings::*;
 pub use wp_cli_tags::*;

--- a/wp_cli/src/wp_cli_pages.rs
+++ b/wp_cli/src/wp_cli_pages.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use wp_serde_helper::deserialize_i64_or_string;
 
-const POST_FIELDS_ARG: &str = "--fields=ID,post_name,post_title,post_date,post_status,post_author,post_date_gmt,post_content,post_excerpt,comment_status,ping_status,post_password,post_modified,post_modified_gmt,guid,post_type";
+const PAGE_FIELDS_ARG: &str = "--fields=ID,post_name,post_title,post_date,post_status,post_author,post_date_gmt,post_content,post_excerpt,comment_status,ping_status,post_password,post_modified,post_modified_gmt,guid,post_type,post_parent,menu_order";
 
 #[derive(Debug, Default)]
-pub struct WpCliPostListArguments {
+pub struct WpCliPageListArguments {
     pub post_status: Option<String>,
 }
 
-impl AsWpCliArguments for WpCliPostListArguments {
+impl AsWpCliArguments for WpCliPageListArguments {
     fn as_wp_cli_arguments(&self) -> Option<String> {
         let mut map = HashMap::new();
         if let Some(post_status) = &self.post_status {
@@ -22,7 +22,7 @@ impl AsWpCliArguments for WpCliPostListArguments {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WpCliPost {
+pub struct WpCliPage {
     #[serde(rename = "ID")]
     #[serde(deserialize_with = "deserialize_i64_or_string")]
     pub id: i64,
@@ -39,10 +39,16 @@ pub struct WpCliPost {
     #[serde(rename = "post_excerpt")]
     pub excerpt: String,
     pub guid: String,
+    #[serde(rename = "menu_order")]
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub menu_order: i64,
     #[serde(rename = "post_modified")]
     pub modified: String,
     #[serde(rename = "post_modified_gmt")]
     pub modified_gmt: String,
+    #[serde(rename = "post_parent")]
+    #[serde(deserialize_with = "deserialize_i64_or_string")]
+    pub parent: i64,
     #[serde(rename = "post_password")]
     pub password: String,
     pub ping_status: String,
@@ -54,23 +60,30 @@ pub struct WpCliPost {
     pub title: String,
 }
 
-impl WpCliPost {
-    pub fn get(post_id: i64) -> Result<Self> {
+impl WpCliPage {
+    pub fn get(page_id: i64) -> Result<Self> {
         // Some `wp` commands return different fields/information for `get` or `list`. To avoid
-        // this, always use `wp post list` and then find the post we are interested in.
+        // this, always use `wp post list --post_type=page` and then find the page we are interested in.
         Self::list(None).and_then(|v| {
             v.into_iter()
-                .find(|u| u.id == post_id)
-                .ok_or(anyhow!("Can't find the post with post_id: {}", post_id,))
+                .find(|u| u.id == page_id)
+                .ok_or(anyhow!("Can't find the page with page_id: {}", page_id,))
         })
     }
-    pub fn list(arguments: Option<WpCliPostListArguments>) -> Result<Vec<Self>> {
+    pub fn list(arguments: Option<WpCliPageListArguments>) -> Result<Vec<Self>> {
         let output = if let Some(cli_arguments) = arguments.and_then(|a| a.as_wp_cli_arguments()) {
-            run_wp_cli_command(["post", "list", POST_FIELDS_ARG, cli_arguments.as_str()])
+            run_wp_cli_command([
+                "post",
+                "list",
+                "--post_type=page",
+                PAGE_FIELDS_ARG,
+                cli_arguments.as_str(),
+            ])
         } else {
-            run_wp_cli_command(["post", "list", POST_FIELDS_ARG])
+            run_wp_cli_command(["post", "list", "--post_type=page", PAGE_FIELDS_ARG])
         };
-        serde_json::from_slice::<Vec<Self>>(&output.stdout)
-            .with_context(|| "Failed to parse `wp post list --format=json` into Vec<WpCliPost>")
+        serde_json::from_slice::<Vec<Self>>(&output.stdout).with_context(
+            || "Failed to parse `wp post list --post_type=page --format=json` into Vec<WpCliPage>",
+        )
     }
 }


### PR DESCRIPTION
Follows established patterns to implement [`/pages` endpoint.](https://developer.wordpress.org/rest-api/reference/pages/)