### PR TITLE
Add Feature Detection

### DIFF
--- a/test-data/api-details/test-case-01.json
+++ b/test-data/api-details/test-case-01.json
@@ -9,6 +9,7 @@
     "oembed/1.0"
   ],
   "authentication": [],
+  "routes": {},
   "site_logo": 0,
   "site_icon": 26343,
   "site_icon_url": false

--- a/test-data/api-details/test-case-02.json
+++ b/test-data/api-details/test-case-02.json
@@ -9,6 +9,7 @@
     "oembed/1.0"
   ],
   "authentication": [],
+  "routes": {},
   "site_logo": 110703,
   "site_icon": 110706,
   "_links": {

--- a/test-data/api-details/test-case-03.json
+++ b/test-data/api-details/test-case-03.json
@@ -1,0 +1,28575 @@
+{
+  "name": "jetpack.wpmt.co",
+  "description": "",
+  "url": "https:\/\/jetpack.wpmt.co",
+  "home": "https:\/\/jetpack.wpmt.co",
+  "gmt_offset": "0",
+  "timezone_string": "",
+  "page_for_posts": 0,
+  "page_on_front": 0,
+  "show_on_front": "posts",
+  "namespaces": [
+    "oembed\/1.0",
+    "akismet\/v1",
+    "application-password-extras\/v1",
+    "__experimental\/wp-block-editor\/v1",
+    "wp-block-editor\/v1",
+    "jetpack\/v4",
+    "jetpack-boost-ds",
+    "jetpack-boost\/v1",
+    "my-jetpack\/v1",
+    "jetpack\/v4\/explat",
+    "wpcom\/v2",
+    "videopress\/v1",
+    "jetpack\/v4\/stats-app",
+    "jetpack\/v4\/import",
+    "wpcom\/v3",
+    "jetpack\/v4\/blaze-app",
+    "jetpack\/v4\/blaze",
+    "wp\/v2",
+    "wp-site-health\/v1"
+  ],
+  "authentication": {
+    "application-passwords": {
+      "endpoints": {
+        "authorization": "https:\/\/jetpack.wpmt.co\/wp-admin\/authorize-application.php"
+      }
+    }
+  },
+  "routes": {
+    "\/": {
+      "namespace": "",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/"
+          }
+        ]
+      }
+    },
+    "\/batch\/v1": {
+      "namespace": "",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "validation": {
+              "type": "string",
+              "enum": [
+                "require-all-validate",
+                "normal"
+              ],
+              "default": "normal",
+              "required": false
+            },
+            "requests": {
+              "type": "array",
+              "maxItems": 25,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ],
+                    "default": "POST"
+                  },
+                  "path": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "body": {
+                    "type": "object",
+                    "properties": [],
+                    "additionalProperties": true
+                  },
+                  "headers": {
+                    "type": "object",
+                    "properties": [],
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "array"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/batch\/v1"
+          }
+        ]
+      }
+    },
+    "\/oembed\/1.0": {
+      "namespace": "oembed\/1.0",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "oembed\/1.0",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/oembed\/1.0"
+          }
+        ]
+      }
+    },
+    "\/oembed\/1.0\/embed": {
+      "namespace": "oembed\/1.0",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "url": {
+              "description": "The URL of the resource for which to fetch oEmbed data.",
+              "type": "string",
+              "format": "uri",
+              "required": true
+            },
+            "format": {
+              "default": "json",
+              "required": false
+            },
+            "maxwidth": {
+              "default": 600,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/oembed\/1.0\/embed"
+          }
+        ]
+      }
+    },
+    "\/oembed\/1.0\/proxy": {
+      "namespace": "oembed\/1.0",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "url": {
+              "description": "The URL of the resource for which to fetch oEmbed data.",
+              "type": "string",
+              "format": "uri",
+              "required": true
+            },
+            "format": {
+              "description": "The oEmbed format to use.",
+              "type": "string",
+              "default": "json",
+              "enum": [
+                "json",
+                "xml"
+              ],
+              "required": false
+            },
+            "maxwidth": {
+              "description": "The maximum width of the embed frame in pixels.",
+              "type": "integer",
+              "default": 600,
+              "required": false
+            },
+            "maxheight": {
+              "description": "The maximum height of the embed frame in pixels.",
+              "type": "integer",
+              "required": false
+            },
+            "discover": {
+              "description": "Whether to perform an oEmbed discovery request for unsanctioned providers.",
+              "type": "boolean",
+              "default": true,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/oembed\/1.0\/proxy"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "akismet\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1\/key": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "key": {
+              "type": "string",
+              "description": "A 12-character Akismet API key. Available at akismet.com\/get\/",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1\/key"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1\/settings": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "akismet_strictness": {
+              "type": "boolean",
+              "description": "If true, Akismet will automatically discard the worst spam automatically rather than putting it in the spam folder.",
+              "required": false
+            },
+            "akismet_show_user_comments_approved": {
+              "type": "boolean",
+              "description": "If true, show the number of approved comments beside each comment author in the comments list page.",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1\/settings"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1\/stats": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "interval": {
+              "type": "string",
+              "description": "The time period for which to retrieve stats. Options: 60-days, 6-months, all",
+              "default": "all",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1\/stats"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1\/stats\/(?P<interval>[\\w+])": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "interval": {
+              "description": "The time period for which to retrieve stats. Options: 60-days, 6-months, all",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/akismet\/v1\/alert": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "key": {
+              "type": "string",
+              "description": "A 12-character Akismet API key. Available at akismet.com\/get\/",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "key": {
+              "type": "string",
+              "description": "A 12-character Akismet API key. Available at akismet.com\/get\/",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "key": {
+              "type": "string",
+              "description": "A 12-character Akismet API key. Available at akismet.com\/get\/",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1\/alert"
+          }
+        ]
+      }
+    },
+    "\/akismet\/v1\/webhook": {
+      "namespace": "akismet\/v1",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/akismet\/v1\/webhook"
+          }
+        ]
+      }
+    },
+    "\/application-password-extras\/v1": {
+      "namespace": "application-password-extras\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "application-password-extras\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/application-password-extras\/v1"
+          }
+        ]
+      }
+    },
+    "\/application-password-extras\/v1\/capabilities": {
+      "namespace": "application-password-extras\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/application-password-extras\/v1\/capabilities"
+          }
+        ]
+      }
+    },
+    "\/application-password-extras\/v1\/admin-ajax": {
+      "namespace": "application-password-extras\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/application-password-extras\/v1\/admin-ajax"
+          }
+        ]
+      }
+    },
+    "\/application-password-extras\/v1\/post-previews": {
+      "namespace": "application-password-extras\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/application-password-extras\/v1\/post-previews"
+          }
+        ]
+      }
+    },
+    "\/__experimental\/wp-block-editor\/v1": {
+      "namespace": "__experimental\/wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "__experimental\/wp-block-editor\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/__experimental\/wp-block-editor\/v1"
+          }
+        ]
+      }
+    },
+    "\/__experimental\/wp-block-editor\/v1\/editor-assets": {
+      "namespace": "__experimental\/wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/__experimental\/wp-block-editor\/v1\/editor-assets"
+          }
+        ]
+      }
+    },
+    "\/wp-block-editor\/v1": {
+      "namespace": "wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "wp-block-editor\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-block-editor\/v1"
+          }
+        ]
+      }
+    },
+    "\/wp-block-editor\/v1\/export": {
+      "namespace": "wp-block-editor\/v1",
+      "methods": [
+        "GET",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-block-editor\/v1\/export"
+          }
+        ]
+      }
+    },
+    "\/wp-block-editor\/v1\/settings": {
+      "namespace": "wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-block-editor\/v1\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/backup-helper-script": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "helper": {
+              "description": "base64 encoded Backup Helper Script body.",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "path": {
+              "description": "Path to Backup Helper Script",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/backup-helper-script"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/database-object\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "object_type": {
+              "description": "Type of object to fetch from the database",
+              "required": true
+            },
+            "object_id": {
+              "description": "ID of the database object to fetch",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/database-object\/backup"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/options\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "name": {
+              "description": "One or more option names to include in the backup",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/options\/backup"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/comments\/(?P<id>\\d+)\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/posts\/(?P<id>\\d+)\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/terms\/(?P<id>\\d+)\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/users\/(?P<id>\\d+)\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/site\/backup\/undo-event": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/backup\/undo-event"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/orders\/(?P<id>\\d+)\/backup": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/site\/backup\/preflight": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/backup\/preflight"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack-boost-ds",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/dismissed-alerts": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/dismissed-alerts"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/dismissed-alerts\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/dismissed-alerts\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/dismissed-alerts\/merge": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/dismissed-alerts\/merge"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/connection": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/connection"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/pricing": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/pricing"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/product": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/product"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/premium-features": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/premium-features"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/getting-started": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/getting-started"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/getting-started\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/getting-started\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/jetpack-ai-jwt": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/jetpack-ai-jwt"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/plans": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/plans"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/products": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/products"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/marketing\/survey": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/marketing\/survey"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/test": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/test"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/test-wpcom": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/test-wpcom"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/rewind": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/rewind"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/scan": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/scan"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/url": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "from": {
+              "type": "string",
+              "required": false
+            },
+            "redirect": {
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/url"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/tracking\/settings": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "tracks_opt_out": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/tracking\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/features": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/features"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/products": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/products"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/purchases": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/purchases"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/benefits": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/benefits"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/activity": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/activity"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/module\/all": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/module\/all"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/module\/all\/active": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "modules": {
+              "default": "",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": true
+            },
+            "active": {
+              "default": true,
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/module\/all\/active"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/module\/(?P<slug>[a-z\\-]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "context": {
+              "default": "edit",
+              "required": false
+            },
+            "jetpack_blocks_disabled": {
+              "description": "Jetpack Blocks disabled.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "carousel_background_color": {
+              "description": "Color scheme.",
+              "type": "string",
+              "default": "black",
+              "enum": [
+                "black",
+                "white"
+              ],
+              "required": false
+            },
+            "carousel_display_exif": {
+              "description": "Show photo metadata (<a href=\"https:\/\/en.wikipedia.org\/wiki\/Exchangeable_image_file_format\" target=\"_blank\">Exif<\/a>) in carousel, when available.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "carousel_display_comments": {
+              "description": "Show comments area in carousel",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "highlander_comment_form_prompt": {
+              "description": "Greeting Text",
+              "type": "string",
+              "default": "Leave a Reply",
+              "required": false
+            },
+            "jetpack_comment_form_color_scheme": {
+              "description": "Color scheme",
+              "type": "string",
+              "default": "light",
+              "enum": [
+                "light",
+                "dark",
+                "transparent"
+              ],
+              "required": false
+            },
+            "jetpack_portfolio": {
+              "description": "Enable or disable Jetpack portfolio post type.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_portfolio_posts_per_page": {
+              "description": "Number of entries to show at most in Portfolio pages.",
+              "type": "integer",
+              "default": 10,
+              "required": false
+            },
+            "jetpack_testimonial": {
+              "description": "Enable or disable Jetpack testimonial post type.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_testimonial_posts_per_page": {
+              "description": "Number of entries to show at most in Testimonial pages.",
+              "type": "integer",
+              "default": 10,
+              "required": false
+            },
+            "jetpack_waf_automatic_rules": {
+              "description": "Enable automatic rules - Protect your site against untrusted traffic sources with automatic security rules.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "jetpack_waf_ip_block_list_enabled": {
+              "description": "Block list - Block a specific request IP.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_ip_block_list": {
+              "description": "Blocked IP addresses",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_waf_ip_allow_list_enabled": {
+              "description": "Allow list - Allow a specific request IP.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_ip_allow_list": {
+              "description": "Always allowed IP addresses",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_waf_share_data": {
+              "description": "Share basic data with Jetpack.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_share_debug_data": {
+              "description": "Share detailed data with Jetpack.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "tiled_galleries": {
+              "description": "Display all your gallery pictures in a cool mosaic.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "gravatar_disable_hovercards": {
+              "description": "View people&#039;s profiles when you mouse over their Gravatars",
+              "type": "string",
+              "default": "enabled",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "required": false
+            },
+            "infinite_scroll": {
+              "description": "To infinity and beyond",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "infinite_scroll_google_analytics": {
+              "description": "Use Google Analytics with Infinite Scroll",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpl_default": {
+              "description": "WordPress.com Likes are",
+              "type": "string",
+              "default": "on",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "required": false
+            },
+            "social_notifications_like": {
+              "description": "Send email notification when someone likes a post",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_publish_comments_with_markdown": {
+              "description": "Use Markdown for comments.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_publish_posts_with_markdown": {
+              "description": "Use Markdown for posts.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "monitor_receive_notifications": {
+              "description": "Receive Monitor Email Notifications.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post_by_email_address": {
+              "description": "Email Address",
+              "type": "string",
+              "default": "noop",
+              "enum": [
+                "noop",
+                "create",
+                "regenerate",
+                "delete"
+              ],
+              "required": false
+            },
+            "jetpack_protect_key": {
+              "description": "Protect API key",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_protect_global_whitelist": {
+              "description": "Protect global IP allow list",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sharing_services": {
+              "description": "Enabled Services and those hidden behind a button",
+              "type": "object",
+              "default": {
+                "visible": [
+                  "facebook",
+                  "x"
+                ],
+                "hidden": []
+              },
+              "required": false
+            },
+            "button_style": {
+              "description": "Button Style",
+              "type": "string",
+              "default": "icon",
+              "enum": [
+                "icon-text",
+                "icon",
+                "text",
+                "official"
+              ],
+              "required": false
+            },
+            "sharing_label": {
+              "description": "Sharing Label",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "show": {
+              "description": "Views where buttons are shown",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "post"
+              ],
+              "required": false
+            },
+            "jetpack-twitter-cards-site-tag": {
+              "description": "The Twitter username of the owner of this site&#039;s domain.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sharedaddy_disable_resources": {
+              "description": "Disable CSS and JS",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "custom": {
+              "description": "Custom sharing services added by user.",
+              "type": "object",
+              "default": {
+                "sharing_name": "",
+                "sharing_url": "",
+                "sharing_icon": ""
+              },
+              "required": false
+            },
+            "sharing_delete_service": {
+              "description": "Delete custom sharing service.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_sso_require_two_step": {
+              "description": "Require Two-Step Authentication",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "jetpack_sso_match_by_email": {
+              "description": "Match by Email",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "stb_enabled": {
+              "description": "Show a &lt;em&gt;&#039;follow blog&#039;&lt;\/em&gt; option in the comment form",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "stc_enabled": {
+              "description": "Show a &lt;em&gt;&#039;follow comments&#039;&lt;\/em&gt; option in the comment form",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_newsletter_categories": {
+              "description": "Array of post category ids that are marked as newsletter categories",
+              "type": "array",
+              "default": [],
+              "required": false
+            },
+            "wpcom_newsletter_categories_enabled": {
+              "description": "Whether the newsletter categories are enabled or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_featured_image_in_email": {
+              "description": "Whether to include the featured image in the email or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_gravatar_in_email": {
+              "description": "Whether to show author avatar in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "jetpack_author_in_email": {
+              "description": "Whether to show author display name in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "jetpack_post_date_in_email": {
+              "description": "Whether to show date in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_subscription_emails_use_excerpt": {
+              "description": "Whether to use the excerpt in the email or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_reply_to": {
+              "description": "Reply to email behaviour for newsletters emails",
+              "type": "string",
+              "default": "comment",
+              "required": false
+            },
+            "jetpack_subscriptions_from_name": {
+              "description": "From name for newsletters emails",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sm_enabled": {
+              "description": "Show popup Subscribe modal to readers.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscribe_overlay_enabled": {
+              "description": "Show subscribe overlay on homepage.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscribe_floating_button_enabled": {
+              "description": "Show a floating subscribe button.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_subscribe_post_end_enabled": {
+              "description": "Add Subscribe block at the end of each post.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_login_navigation_enabled": {
+              "description": "Add Subscriber Login block to the navigation.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_subscribe_navigation_enabled": {
+              "description": "Add Subscribe block to the navigation.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "social_notifications_subscribe": {
+              "description": "Send email notification when someone subscribes to my blog",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "subscription_options": {
+              "description": "Three options used in subscription email templates: &#039;invitation&#039;, &#039;welcome&#039; and &#039;comment_follow&#039;.",
+              "type": "object",
+              "default": {
+                "invitation": "",
+                "welcome": "",
+                "comment_follow": ""
+              },
+              "required": false
+            },
+            "show_headline": {
+              "description": "Highlight related content with a heading",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "show_thumbnails": {
+              "description": "Show a thumbnail image where available",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "instant_search_enabled": {
+              "description": "Enable Instant Search",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "has_jetpack_search_product": {
+              "description": "Has an active Jetpack Search product purchase",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "search_auto_config": {
+              "description": "Trigger an auto config of instant search",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google": {
+              "description": "Google Search Console",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "bing": {
+              "description": "Bing Webmaster Center",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "pinterest": {
+              "description": "Pinterest Site Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "yandex": {
+              "description": "Yandex Site Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "facebook": {
+              "description": "Facebook Domain Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "enable_header_ad": {
+              "description": "Display an ad unit at the top of each page.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_approved": {
+              "description": "Is site approved for WordAds?",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_second_belowpost": {
+              "description": "Display second ad below post?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_inline_enabled": {
+              "description": "Display inline ad within post content?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_front_page": {
+              "description": "Display ads on the front page?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_post": {
+              "description": "Display ads on posts?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_page": {
+              "description": "Display ads on pages?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_archive": {
+              "description": "Display ads on archive pages?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_custom_adstxt_enabled": {
+              "description": "Custom ads.txt",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_custom_adstxt": {
+              "description": "Custom ads.txt entries",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "wordads_ccpa_enabled": {
+              "description": "Enable support for California Consumer Privacy Act",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_ccpa_privacy_policy_url": {
+              "description": "Privacy Policy URL",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "wordads_cmp_enabled": {
+              "description": "Enable GDPR Consent Management Banner for WordAds",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google_analytics_tracking_id": {
+              "description": "Google Analytics",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_wga": {
+              "description": "Google Analytics",
+              "type": "object",
+              "required": false
+            },
+            "admin_bar": {
+              "description": "Include a small chart in your admin bar with a 48-hour traffic snapshot.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "enable_odyssey_stats": {
+              "description": "Preview the new Jetpack Stats experience (Experimental).",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "roles": {
+              "description": "Select the roles that will be able to view stats reports.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "administrator"
+              ],
+              "required": false
+            },
+            "count_roles": {
+              "description": "Count the page views of registered users who are logged in.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "administrator"
+              ],
+              "required": false
+            },
+            "blog_id": {
+              "description": "Blog ID.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "do_not_track": {
+              "description": "Do not track.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "version": {
+              "description": "Version.",
+              "type": "integer",
+              "default": 9,
+              "required": false
+            },
+            "collapse_nudges": {
+              "description": "Collapse upgrade nudges",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_reader_views_enabled": {
+              "description": "Show post views in the WordPress.com Reader.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "akismet_show_user_comments_approved": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordpress_api_key": {
+              "description": "",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "dismiss_empty_stats_card": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "dismiss_dash_backup_getting_started": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "dismiss_dash_agencies_learn_more": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "lang_id": {
+              "description": "Primary language for the site.",
+              "type": "string",
+              "default": "en_US",
+              "required": false
+            },
+            "advanced_seo_front_page_description": {
+              "description": "Front page meta description.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "advanced_seo_title_formats": {
+              "description": "SEO page title structures.",
+              "type": "object",
+              "default": {
+                "archives": [],
+                "front_page": [],
+                "groups": [],
+                "pages": [],
+                "posts": []
+              },
+              "required": false
+            },
+            "videopress_private_enabled_for_site": {
+              "description": "Video Privacy: Restrict views to members of this site",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "ai_seo_enhancer_enabled": {
+              "description": "Automatically generate SEO title, SEO description, and image alt text for new posts.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "account-protection": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "blaze": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "blocks": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "carousel": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "comment-likes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "comments": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "contact-form": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "copy-post": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "custom-content-types": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google-fonts": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "gravatar-hovercards": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "infinite-scroll": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "json-api": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "latex": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "likes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "markdown": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "monitor": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "notes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "photon-cdn": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "photon": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post-by-email": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post-list": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "protect": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "publicize": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "related-posts": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "search": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "seo-tools": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sharedaddy": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "shortcodes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "shortlinks": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sitemaps": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sso": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "stats": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "subscriptions": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "tiled-gallery": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "vaultpress": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "verification-tools": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "videopress": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "waf": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "widget-visibility": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "widgets": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "woocommerce-analytics": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/module\/(?P<slug>[a-z\\-]+)\/active": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "active": {
+              "default": true,
+              "type": "boolean",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/module\/(?P<slug>[a-z\\-]+)\/data": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "range": {
+              "default": "day",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/module\/(?P<service>[a-z\\-]+)\/key\/check": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "api_key": {
+              "default": "",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/settings": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "context": {
+              "default": "edit",
+              "required": false
+            },
+            "jetpack_blocks_disabled": {
+              "description": "Jetpack Blocks disabled.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "carousel_background_color": {
+              "description": "Color scheme.",
+              "type": "string",
+              "default": "black",
+              "enum": [
+                "black",
+                "white"
+              ],
+              "required": false
+            },
+            "carousel_display_exif": {
+              "description": "Show photo metadata (<a href=\"https:\/\/en.wikipedia.org\/wiki\/Exchangeable_image_file_format\" target=\"_blank\">Exif<\/a>) in carousel, when available.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "carousel_display_comments": {
+              "description": "Show comments area in carousel",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "highlander_comment_form_prompt": {
+              "description": "Greeting Text",
+              "type": "string",
+              "default": "Leave a Reply",
+              "required": false
+            },
+            "jetpack_comment_form_color_scheme": {
+              "description": "Color scheme",
+              "type": "string",
+              "default": "light",
+              "enum": [
+                "light",
+                "dark",
+                "transparent"
+              ],
+              "required": false
+            },
+            "jetpack_portfolio": {
+              "description": "Enable or disable Jetpack portfolio post type.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_portfolio_posts_per_page": {
+              "description": "Number of entries to show at most in Portfolio pages.",
+              "type": "integer",
+              "default": 10,
+              "required": false
+            },
+            "jetpack_testimonial": {
+              "description": "Enable or disable Jetpack testimonial post type.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_testimonial_posts_per_page": {
+              "description": "Number of entries to show at most in Testimonial pages.",
+              "type": "integer",
+              "default": 10,
+              "required": false
+            },
+            "jetpack_waf_automatic_rules": {
+              "description": "Enable automatic rules - Protect your site against untrusted traffic sources with automatic security rules.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "jetpack_waf_ip_block_list_enabled": {
+              "description": "Block list - Block a specific request IP.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_ip_block_list": {
+              "description": "Blocked IP addresses",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_waf_ip_allow_list_enabled": {
+              "description": "Allow list - Allow a specific request IP.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_ip_allow_list": {
+              "description": "Always allowed IP addresses",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_waf_share_data": {
+              "description": "Share basic data with Jetpack.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_waf_share_debug_data": {
+              "description": "Share detailed data with Jetpack.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "tiled_galleries": {
+              "description": "Display all your gallery pictures in a cool mosaic.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "gravatar_disable_hovercards": {
+              "description": "View people&#039;s profiles when you mouse over their Gravatars",
+              "type": "string",
+              "default": "enabled",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "required": false
+            },
+            "infinite_scroll": {
+              "description": "To infinity and beyond",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "infinite_scroll_google_analytics": {
+              "description": "Use Google Analytics with Infinite Scroll",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpl_default": {
+              "description": "WordPress.com Likes are",
+              "type": "string",
+              "default": "on",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "required": false
+            },
+            "social_notifications_like": {
+              "description": "Send email notification when someone likes a post",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_publish_comments_with_markdown": {
+              "description": "Use Markdown for comments.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_publish_posts_with_markdown": {
+              "description": "Use Markdown for posts.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "monitor_receive_notifications": {
+              "description": "Receive Monitor Email Notifications.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post_by_email_address": {
+              "description": "Email Address",
+              "type": "string",
+              "default": "noop",
+              "enum": [
+                "noop",
+                "create",
+                "regenerate",
+                "delete"
+              ],
+              "required": false
+            },
+            "jetpack_protect_key": {
+              "description": "Protect API key",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_protect_global_whitelist": {
+              "description": "Protect global IP allow list",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sharing_services": {
+              "description": "Enabled Services and those hidden behind a button",
+              "type": "object",
+              "default": {
+                "visible": [
+                  "facebook",
+                  "x"
+                ],
+                "hidden": []
+              },
+              "required": false
+            },
+            "button_style": {
+              "description": "Button Style",
+              "type": "string",
+              "default": "icon",
+              "enum": [
+                "icon-text",
+                "icon",
+                "text",
+                "official"
+              ],
+              "required": false
+            },
+            "sharing_label": {
+              "description": "Sharing Label",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "show": {
+              "description": "Views where buttons are shown",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "post"
+              ],
+              "required": false
+            },
+            "jetpack-twitter-cards-site-tag": {
+              "description": "The Twitter username of the owner of this site&#039;s domain.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sharedaddy_disable_resources": {
+              "description": "Disable CSS and JS",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "custom": {
+              "description": "Custom sharing services added by user.",
+              "type": "object",
+              "default": {
+                "sharing_name": "",
+                "sharing_url": "",
+                "sharing_icon": ""
+              },
+              "required": false
+            },
+            "sharing_delete_service": {
+              "description": "Delete custom sharing service.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_sso_require_two_step": {
+              "description": "Require Two-Step Authentication",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "jetpack_sso_match_by_email": {
+              "description": "Match by Email",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "stb_enabled": {
+              "description": "Show a &lt;em&gt;&#039;follow blog&#039;&lt;\/em&gt; option in the comment form",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "stc_enabled": {
+              "description": "Show a &lt;em&gt;&#039;follow comments&#039;&lt;\/em&gt; option in the comment form",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_newsletter_categories": {
+              "description": "Array of post category ids that are marked as newsletter categories",
+              "type": "array",
+              "default": [],
+              "required": false
+            },
+            "wpcom_newsletter_categories_enabled": {
+              "description": "Whether the newsletter categories are enabled or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_featured_image_in_email": {
+              "description": "Whether to include the featured image in the email or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_gravatar_in_email": {
+              "description": "Whether to show author avatar in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "jetpack_author_in_email": {
+              "description": "Whether to show author display name in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "jetpack_post_date_in_email": {
+              "description": "Whether to show date in the email byline",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wpcom_subscription_emails_use_excerpt": {
+              "description": "Whether to use the excerpt in the email or not",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_reply_to": {
+              "description": "Reply to email behaviour for newsletters emails",
+              "type": "string",
+              "default": "comment",
+              "required": false
+            },
+            "jetpack_subscriptions_from_name": {
+              "description": "From name for newsletters emails",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "sm_enabled": {
+              "description": "Show popup Subscribe modal to readers.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscribe_overlay_enabled": {
+              "description": "Show subscribe overlay on homepage.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscribe_floating_button_enabled": {
+              "description": "Show a floating subscribe button.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_subscribe_post_end_enabled": {
+              "description": "Add Subscribe block at the end of each post.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_login_navigation_enabled": {
+              "description": "Add Subscriber Login block to the navigation.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "jetpack_subscriptions_subscribe_navigation_enabled": {
+              "description": "Add Subscribe block to the navigation.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "social_notifications_subscribe": {
+              "description": "Send email notification when someone subscribes to my blog",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "subscription_options": {
+              "description": "Three options used in subscription email templates: &#039;invitation&#039;, &#039;welcome&#039; and &#039;comment_follow&#039;.",
+              "type": "object",
+              "default": {
+                "invitation": "",
+                "welcome": "",
+                "comment_follow": ""
+              },
+              "required": false
+            },
+            "show_headline": {
+              "description": "Highlight related content with a heading",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "show_thumbnails": {
+              "description": "Show a thumbnail image where available",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "instant_search_enabled": {
+              "description": "Enable Instant Search",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "has_jetpack_search_product": {
+              "description": "Has an active Jetpack Search product purchase",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "search_auto_config": {
+              "description": "Trigger an auto config of instant search",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google": {
+              "description": "Google Search Console",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "bing": {
+              "description": "Bing Webmaster Center",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "pinterest": {
+              "description": "Pinterest Site Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "yandex": {
+              "description": "Yandex Site Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "facebook": {
+              "description": "Facebook Domain Verification",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "enable_header_ad": {
+              "description": "Display an ad unit at the top of each page.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_approved": {
+              "description": "Is site approved for WordAds?",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_second_belowpost": {
+              "description": "Display second ad below post?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_inline_enabled": {
+              "description": "Display inline ad within post content?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_front_page": {
+              "description": "Display ads on the front page?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_post": {
+              "description": "Display ads on posts?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_page": {
+              "description": "Display ads on pages?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_display_archive": {
+              "description": "Display ads on archive pages?",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "wordads_custom_adstxt_enabled": {
+              "description": "Custom ads.txt",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_custom_adstxt": {
+              "description": "Custom ads.txt entries",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "wordads_ccpa_enabled": {
+              "description": "Enable support for California Consumer Privacy Act",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads_ccpa_privacy_policy_url": {
+              "description": "Privacy Policy URL",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "wordads_cmp_enabled": {
+              "description": "Enable GDPR Consent Management Banner for WordAds",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google_analytics_tracking_id": {
+              "description": "Google Analytics",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "jetpack_wga": {
+              "description": "Google Analytics",
+              "type": "object",
+              "required": false
+            },
+            "admin_bar": {
+              "description": "Include a small chart in your admin bar with a 48-hour traffic snapshot.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "enable_odyssey_stats": {
+              "description": "Preview the new Jetpack Stats experience (Experimental).",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "roles": {
+              "description": "Select the roles that will be able to view stats reports.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "administrator"
+              ],
+              "required": false
+            },
+            "count_roles": {
+              "description": "Count the page views of registered users who are logged in.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "administrator"
+              ],
+              "required": false
+            },
+            "blog_id": {
+              "description": "Blog ID.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "do_not_track": {
+              "description": "Do not track.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "version": {
+              "description": "Version.",
+              "type": "integer",
+              "default": 9,
+              "required": false
+            },
+            "collapse_nudges": {
+              "description": "Collapse upgrade nudges",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wpcom_reader_views_enabled": {
+              "description": "Show post views in the WordPress.com Reader.",
+              "type": "boolean",
+              "default": 1,
+              "required": false
+            },
+            "akismet_show_user_comments_approved": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordpress_api_key": {
+              "description": "",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "dismiss_empty_stats_card": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "dismiss_dash_backup_getting_started": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "dismiss_dash_agencies_learn_more": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "lang_id": {
+              "description": "Primary language for the site.",
+              "type": "string",
+              "default": "en_US",
+              "required": false
+            },
+            "advanced_seo_front_page_description": {
+              "description": "Front page meta description.",
+              "type": "string",
+              "default": "",
+              "required": false
+            },
+            "advanced_seo_title_formats": {
+              "description": "SEO page title structures.",
+              "type": "object",
+              "default": {
+                "archives": [],
+                "front_page": [],
+                "groups": [],
+                "pages": [],
+                "posts": []
+              },
+              "required": false
+            },
+            "videopress_private_enabled_for_site": {
+              "description": "Video Privacy: Restrict views to members of this site",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "ai_seo_enhancer_enabled": {
+              "description": "Automatically generate SEO title, SEO description, and image alt text for new posts.",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "account-protection": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "blaze": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "blocks": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "carousel": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "comment-likes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "comments": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "contact-form": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "copy-post": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "custom-content-types": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "google-fonts": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "gravatar-hovercards": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "infinite-scroll": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "json-api": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "latex": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "likes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "markdown": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "monitor": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "notes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "photon-cdn": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "photon": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post-by-email": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "post-list": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "protect": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "publicize": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "related-posts": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "search": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "seo-tools": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sharedaddy": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "shortcodes": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "shortlinks": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sitemaps": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "sso": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "stats": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "subscriptions": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "tiled-gallery": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "vaultpress": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "verification-tools": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "videopress": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "waf": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "widget-visibility": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "widgets": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "woocommerce-analytics": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            },
+            "wordads": {
+              "description": "",
+              "type": "boolean",
+              "default": 0,
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/settings\/(?P<slug>[a-z\\-]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "context": {
+              "default": "edit",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/options\/(?P<options>[a-z\\-]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/updates\/plugins": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/updates\/plugins"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/notice\/(?P<notice>[a-z\\-_]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/plugins": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "slug": {
+              "type": "string",
+              "description": "WordPress.org plugin directory slug.",
+              "pattern": "[\\w\\-]+",
+              "required": true
+            },
+            "status": {
+              "description": "The plugin activation status.",
+              "type": "string",
+              "enum": [
+                "inactive",
+                "active"
+              ],
+              "default": "inactive",
+              "required": false
+            },
+            "source": {
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/plugins"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/plugins\/(?P<plugin>[^.\\\/]+(?:\\\/[^.\\\/]+)?)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "status": {
+              "type": "string",
+              "required": true
+            },
+            "source": {
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/plugin\/(?P<plugin>[a-z\\\/\\.\\-_]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/widgets\/(?P<id>[0-9a-z\\-_]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/verify-site\/(?P<service>[a-z\\-_]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "keyring_id": {
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/verify-site\/(?P<service>[a-z\\-_]+)\/(?<keyring_id>[0-9]+)": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/recommendations\/data": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "data": {
+              "type": "object",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/recommendations\/data"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/recommendations\/step": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "step": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/recommendations\/step"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/recommendations\/product-suggestions": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/recommendations\/product-suggestions"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/recommendations\/upsell": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/recommendations\/upsell"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/recommendations\/conditional": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/recommendations\/conditional"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/site\/discount": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/site\/discount"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/jetpack_crm": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "extension": {
+              "type": "text",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/jetpack_crm"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/purchase-token": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/purchase-token"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/seen-wc-connection-modal": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/seen-wc-connection-modal"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/intro-offers": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/intro-offers"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/subscribers\/auth": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "redirect_url": {
+              "description": "The URL to redirect to.",
+              "type": "string",
+              "format": "uri",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/subscribers\/auth"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/features\/available": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/features\/available"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/features\/enabled": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/features\/enabled"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/error": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "error": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/error"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/set-license": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "license": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/set-license"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/user\/licenses": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/user\/licenses"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/user\/counts": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/user\/counts"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/user\/activation-notice-dismiss": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "last_detached_count": {
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/user\/activation-notice-dismiss"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/licensing\/attach-licenses": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "licenses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/licensing\/attach-licenses"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/heartbeat\/data": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "prefix": {
+              "description": "Prefix to add before the stats identifiers.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/heartbeat\/data"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack-boost\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/connection": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/connection"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/modules-state": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/modules-state"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/modules-state\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/modules-state\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/modules-state\/merge": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/modules-state\/merge"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-meta": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-meta"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-suggest-regenerate": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-suggest-regenerate"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-suggest-regenerate\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-suggest-regenerate\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-suggest-regenerate\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-suggest-regenerate\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/action\/request-regenerate": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/action\/request-regenerate"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-css": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-css"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-errors": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-errors"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-errors-dismissed": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/critical-css-state\/action\/set-provider-errors-dismissed"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/lcp-state": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/lcp-state"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/lcp-state\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/lcp-state\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/lcp-state\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/lcp-state\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/lcp-state\/action\/request-analyze": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/lcp-state\/action\/request-analyze"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-js-excludes": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-js-excludes"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-js-excludes\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-js-excludes\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-js-excludes-default": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-js-excludes-default"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-css-excludes": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-css-excludes"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-css-excludes\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-css-excludes\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-css-excludes-default": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-css-excludes-default"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/performance-history-toggle": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/performance-history-toggle"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/performance-history-toggle\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/performance-history-toggle\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/performance-history-toggle\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/performance-history-toggle\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/performance-history": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/performance-history"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/performance-history\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/performance-history\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/cache-debug-log": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/cache-debug-log"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/cache-engine-loading": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/cache-engine-loading"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache-error": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache-error"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache-error\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache-error\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache-error\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache-error\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache\/action\/run-setup": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache\/action\/run-setup"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache\/action\/clear-page-cache": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache\/action\/clear-page-cache"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/page-cache\/action\/deactivate-wpsc": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/page-cache\/action\/deactivate-wpsc"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/minify-legacy-notice": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/minify-legacy-notice"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/image-cdn-quality": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/image-cdn-quality"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/image-cdn-quality\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/image-cdn-quality\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/image-cdn-quality\/delete": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/image-cdn-quality\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/cloud-css\/update": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/cloud-css\/update"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/lcp\/update": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/lcp\/update"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/cornerstone-pages-list": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/cornerstone-pages-list"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/cornerstone-pages-list\/set": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/cornerstone-pages-list\/set"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost-ds\/cornerstone-pages-properties": {
+      "namespace": "jetpack-boost-ds",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost-ds\/cornerstone-pages-properties"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/list-site-urls": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/list-site-urls"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/list-source-providers": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/list-source-providers"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/list-cornerstone-pages": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/list-cornerstone-pages"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/list-lcp-analysis": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/list-lcp-analysis"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/speed-scores": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/speed-scores"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/speed-scores\/refresh": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/speed-scores\/refresh"
+          }
+        ]
+      }
+    },
+    "\/jetpack-boost\/v1\/speed-scores-history": {
+      "namespace": "jetpack-boost\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "start": {
+              "type": "number",
+              "required": true
+            },
+            "end": {
+              "type": "number",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "start": {
+              "type": "number",
+              "required": true
+            },
+            "end": {
+              "type": "number",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "start": {
+              "type": "number",
+              "required": true
+            },
+            "end": {
+              "type": "number",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack-boost\/v1\/speed-scores-history"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "my-jetpack\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "products": {
+              "description": "Comma-separated list of product slugs that should be retrieved.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products\/install": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "products": {
+              "description": "Array of Product slugs",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "anti-spam",
+                  "backup",
+                  "boost",
+                  "crm",
+                  "creator",
+                  "extras",
+                  "jetpack-ai",
+                  "ai",
+                  "scan",
+                  "search",
+                  "social",
+                  "security",
+                  "protect",
+                  "videopress",
+                  "stats",
+                  "growth",
+                  "complete",
+                  "newsletter",
+                  "site-accelerator",
+                  "related-posts"
+                ],
+                "type": "string"
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products\/install"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products\/activate": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "products": {
+              "description": "Array of Product slugs",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "anti-spam",
+                  "backup",
+                  "boost",
+                  "crm",
+                  "creator",
+                  "extras",
+                  "jetpack-ai",
+                  "ai",
+                  "scan",
+                  "search",
+                  "social",
+                  "security",
+                  "protect",
+                  "videopress",
+                  "stats",
+                  "growth",
+                  "complete",
+                  "newsletter",
+                  "site-accelerator",
+                  "related-posts"
+                ],
+                "type": "string"
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products\/activate"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products\/interstitials": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "products": {
+              "description": "Key-value pairs of product slugs and their interstitial states.",
+              "type": "object",
+              "properties": {
+                "anti-spam": {
+                  "type": "boolean"
+                },
+                "backup": {
+                  "type": "boolean"
+                },
+                "boost": {
+                  "type": "boolean"
+                },
+                "crm": {
+                  "type": "boolean"
+                },
+                "creator": {
+                  "type": "boolean"
+                },
+                "extras": {
+                  "type": "boolean"
+                },
+                "jetpack-ai": {
+                  "type": "boolean"
+                },
+                "ai": {
+                  "type": "boolean"
+                },
+                "scan": {
+                  "type": "boolean"
+                },
+                "search": {
+                  "type": "boolean"
+                },
+                "social": {
+                  "type": "boolean"
+                },
+                "security": {
+                  "type": "boolean"
+                },
+                "protect": {
+                  "type": "boolean"
+                },
+                "videopress": {
+                  "type": "boolean"
+                },
+                "stats": {
+                  "type": "boolean"
+                },
+                "growth": {
+                  "type": "boolean"
+                },
+                "complete": {
+                  "type": "boolean"
+                },
+                "newsletter": {
+                  "type": "boolean"
+                },
+                "site-accelerator": {
+                  "type": "boolean"
+                },
+                "related-posts": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "minProperties": 1,
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products\/interstitials"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products\/deactivate": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "products": {
+              "description": "Array of Product slugs",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "anti-spam",
+                  "backup",
+                  "boost",
+                  "crm",
+                  "creator",
+                  "extras",
+                  "jetpack-ai",
+                  "ai",
+                  "scan",
+                  "search",
+                  "social",
+                  "security",
+                  "protect",
+                  "videopress",
+                  "stats",
+                  "growth",
+                  "complete",
+                  "newsletter",
+                  "site-accelerator",
+                  "related-posts"
+                ],
+                "type": "string"
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products\/deactivate"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/products-ownership": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/products-ownership"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/purchases": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/purchases"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/chat\/availability": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/chat\/availability"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/chat\/authentication": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "type": {
+              "type": "string",
+              "required": false
+            },
+            "test_mode": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/chat\/authentication"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/recommendations\/evaluation": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/recommendations\/evaluation"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/recommendations\/evaluation\/result": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/recommendations\/evaluation\/result"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/backup\/undo-event": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/backup\/undo-event"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/protect\/data": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/protect\/data"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/videopress\/data": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/videopress\/data"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/update-historically-active-modules": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/update-historically-active-modules"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/jetpack-manage\/data": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/jetpack-manage\/data"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/red-bubble-notifications": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "dismissal_cookies": {
+              "type": "array",
+              "description": "Array of dismissal cookies to set for the red bubble notifications.",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/red-bubble-notifications"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site"
+          }
+        ]
+      }
+    },
+    "\/my-jetpack\/v1\/site\/dismiss-welcome-banner": {
+      "namespace": "my-jetpack\/v1",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/my-jetpack\/v1\/site\/dismiss-welcome-banner"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/explat": {
+      "namespace": "jetpack\/v4\/explat",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4\/explat",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/explat"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/explat\/assignments": {
+      "namespace": "jetpack\/v4\/explat",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "experiment_name": {
+              "type": "string",
+              "required": false
+            },
+            "anon_id": {
+              "type": "string",
+              "required": false
+            },
+            "as_connected_user": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/explat\/assignments"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/jitm": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/jitm"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/verify_xmlrpc_error": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "nonce": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/verify_xmlrpc_error"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/full-sync": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "modules": {
+              "description": "Data Modules that should be included in Full Sync",
+              "type": "array",
+              "required": false
+            },
+            "users": {
+              "description": "User IDs to include in Full Sync or \"initial\"",
+              "required": false
+            },
+            "posts": {
+              "description": "Post IDs to include in Full Sync",
+              "type": "array",
+              "required": false
+            },
+            "comments": {
+              "description": "Comment IDs to include in Full Sync",
+              "type": "array",
+              "required": false
+            },
+            "context": {
+              "description": "Context for the Full Sync",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/full-sync"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/status": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "fields": {
+              "description": "Comma seperated list of additional fields that should be included in status.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/status"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/health": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "status": {
+              "description": "New Sync health status",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/health"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/settings": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/object": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ],
+          "args": {
+            "module_name": {
+              "description": "Name of Sync module",
+              "type": "string",
+              "required": false
+            },
+            "object_type": {
+              "description": "Object Type",
+              "type": "string",
+              "required": false
+            },
+            "object_ids": {
+              "description": "Objects Identifiers",
+              "type": "array",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/object"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/now": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "queue": {
+              "description": "Name of Sync queue.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/now"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/checkout": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/checkout"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/close": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/close"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/unlock": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "queue": {
+              "description": "Name of Sync queue.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/unlock"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/object-id-range": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "sync_module": {
+              "description": "Name of Sync module.",
+              "type": "string",
+              "required": true
+            },
+            "batch_size": {
+              "description": "Size of batches",
+              "type": "int",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/object-id-range"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/data-check": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "perform_text_conversion": {
+              "description": "If text fields should be converted to latin1 in checksum calculation.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/data-check"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/data-histogram": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "columns": {
+              "description": "Column mappings",
+              "type": "array",
+              "required": false
+            },
+            "object_type": {
+              "description": "Object Type",
+              "type": "string",
+              "required": false
+            },
+            "buckets": {
+              "description": "Number of histogram buckets.",
+              "type": "int",
+              "required": false
+            },
+            "start_id": {
+              "description": "Start ID for the histogram",
+              "type": "int",
+              "required": false
+            },
+            "end_id": {
+              "description": "End ID for the histogram",
+              "type": "int",
+              "required": false
+            },
+            "strip_non_ascii": {
+              "description": "Strip non-ascii characters?",
+              "type": "boolean",
+              "required": false
+            },
+            "shared_salt": {
+              "description": "Shared Salt to use when generating checksum",
+              "type": "string",
+              "required": false
+            },
+            "only_range_edges": {
+              "description": "Should only range edges be returned",
+              "type": "boolean",
+              "required": false
+            },
+            "detailed_drilldown": {
+              "description": "Do we want the checksum or object ids.",
+              "type": "boolean",
+              "required": false
+            },
+            "perform_text_conversion": {
+              "description": "If text fields should be converted to latin1 in checksum calculation.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/data-histogram"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/spawn-sync": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/spawn-sync"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/sync\/locks": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/sync\/locks"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/confirm-safe-mode": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/confirm-safe-mode"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/migrate": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/migrate"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/start-fresh": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "redirect_uri": {
+              "description": "URI of the admin page where the user should be redirected after connection flow",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/start-fresh"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/idc-url-validation": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/idc-url-validation"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/url-secret": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/url-secret"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/identity-crisis\/compare-url-secret": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "secret": {
+              "description": "URL secret to compare to the ones stored in the database.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/identity-crisis\/compare-url-secret"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/plan": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/plan"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/settings": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/stats": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/stats"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/pricing": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/pricing"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/plan\/activate": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/plan\/activate"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/plan\/deactivate": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/plan\/deactivate"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/search\/local-stats": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/search\/local-stats"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/waf": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/waf"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/waf\/update-rules": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/waf\/update-rules"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "wpcom\/v2",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/videopress\/meta": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "The post id for the attachment.",
+              "type": "int",
+              "required": true
+            },
+            "title": {
+              "description": "The title of the video.",
+              "type": "string",
+              "required": false
+            },
+            "description": {
+              "description": "The description of the video.",
+              "type": "string",
+              "required": false
+            },
+            "caption": {
+              "description": "The caption of the video.",
+              "type": "string",
+              "required": false
+            },
+            "rating": {
+              "description": "The video content rating. One of G, PG-13 or R-17",
+              "type": "string",
+              "required": false
+            },
+            "display_embed": {
+              "description": "Display the share menu in the player.",
+              "type": "boolean",
+              "required": false
+            },
+            "allow_download": {
+              "description": "Display download option and allow viewers to download this video",
+              "type": "boolean",
+              "required": false
+            },
+            "privacy_setting": {
+              "description": "How to determine if the video should be public or private",
+              "type": "int",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/videopress\/meta"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/videopress\/(?P<video_guid>\\w+)\/poster": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "at_time": {
+              "description": "The time in the video to use as the poster frame.",
+              "type": "int",
+              "required": false
+            },
+            "is_millisec": {
+              "description": "Whether the time is in milliseconds or seconds.",
+              "type": "boolean",
+              "required": false
+            },
+            "poster_attachment_id": {
+              "description": "The attachment id of the poster image.",
+              "type": "int",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/videopress\/(?P<video_guid>\\w+)\/check-ownership\/(?P<post_id>\\d+)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wpcom\/v2\/videopress\/upload-jwt": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/videopress\/upload-jwt"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/videopress\/playback-jwt\/(?P<video_guid>\\w+)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/videopress\/v1": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "videopress\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/videopress\/v1"
+          }
+        ]
+      }
+    },
+    "\/videopress\/v1\/upload\/(?P<attachment_id>\\d+)": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "attachment_id": {
+              "description": "The ID of the attachment you want to upload to VideoPress",
+              "type": "integer",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "attachment_id": {
+              "description": "The ID of the attachment you want to upload to VideoPress",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/videopress\/v1\/stats": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/videopress\/v1\/stats"
+          }
+        ]
+      }
+    },
+    "\/videopress\/v1\/stats\/featured": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/videopress\/v1\/stats\/featured"
+          }
+        ]
+      }
+    },
+    "\/videopress\/v1\/site": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/videopress\/v1\/site"
+          }
+        ]
+      }
+    },
+    "\/videopress\/v1\/settings": {
+      "namespace": "videopress\/v1",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "videopress_videos_private_for_site": {
+              "description": "If the VideoPress videos should be private by default",
+              "type": "boolean",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/videopress\/v1\/settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats\/blog": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats\/blog"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4\/stats-app",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/(?P<resource>[\\-\\w]+)\/(?P<resource_id>[\\d]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/(?P<resource>[\\-\\w]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/posts\/(?P<resource_id>[\\d]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/posts\/(?P<resource_id>[\\d]+)\/likes": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/stats"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/site-has-never-published-post": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/site-has-never-published-post"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/posts": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/posts"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/subscribers\/counts": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/subscribers\/counts"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats\/usage": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats\/usage"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats\/user-feedback": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats\/user-feedback"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/wordads\/earnings": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/wordads\/earnings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/wordads\/stats": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/wordads\/stats"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/stats\/notices": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "type": "string",
+              "description": "ID of the notice",
+              "required": true
+            },
+            "status": {
+              "type": "string",
+              "description": "Status of the notice",
+              "required": true
+            },
+            "postponed_for": {
+              "type": "number",
+              "default": null,
+              "description": "Postponed for (in seconds)",
+              "minimum": 0,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/stats\/notices"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/notices": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "type": "string",
+              "description": "ID of the notice",
+              "required": true
+            },
+            "status": {
+              "type": "string",
+              "description": "Status of the notice",
+              "required": true
+            },
+            "postponed_for": {
+              "type": "number",
+              "default": null,
+              "description": "Postponed for (in seconds)",
+              "minimum": 0,
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/notices"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/referrers\/spam\/new": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "domain": {
+              "type": "string",
+              "description": "Domain of the referrer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/referrers\/spam\/new"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/referrers\/spam\/delete": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "domain": {
+              "type": "string",
+              "description": "Domain of the referrer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/referrers\/spam\/delete"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/modules": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/modules"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/module-settings": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/jetpack-stats-dashboard\/module-settings"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/emails\/(?P<resource>[\\-\\w\\d]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/opens\/emails\/(?P<post_id>[\\d]+)\/(?P<resource>[\\-\\w]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/clicks\/emails\/(?P<post_id>[\\d]+)\/(?P<resource>[\\-\\w]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/(?P<resource>[\\-\\w]+)\/emails\/(?P<post_id>[\\d]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/utm\/(?P<utm_params>[_,\\-\\w]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/devices\/(?P<device_property>[\\w]+)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/commercial-classification": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/commercial-classification"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/purchases": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/stats-app\/sites\/236026851\/purchases"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/stats-app\/sites\/236026851\/stats\/location-views\/(?P<geo_mode>country|region|city)": {
+      "namespace": "jetpack\/v4\/stats-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/import": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4\/import",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/blocks": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "wp_pattern_sync_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": "",
+                  "enum": [
+                    "partial",
+                    "unsynced"
+                  ]
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "wp_pattern_category": {
+              "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/blocks"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/categories": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The parent category slug.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/categories"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/comments": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "author": {
+              "description": "The ID of the user object, if author was a user.",
+              "type": "integer",
+              "required": false
+            },
+            "author_email": {
+              "description": "Email address for the comment author.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "author_ip": {
+              "description": "IP address for the comment author.",
+              "type": "string",
+              "format": "ip",
+              "required": false
+            },
+            "author_name": {
+              "description": "Display name for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "author_url": {
+              "description": "URL for the comment author.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "author_user_agent": {
+              "description": "User agent for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "The content for the comment.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the comment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the comment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "date": {
+              "description": "The date the comment was published, in the site's timezone.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the comment was published, as GMT.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "parent": {
+              "default": 0,
+              "description": "The ID for the parent of the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "post": {
+              "default": 0,
+              "description": "The ID of the associated post object.",
+              "type": "integer",
+              "required": false
+            },
+            "status": {
+              "description": "State of the comment.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/comments"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/custom-css": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/custom-css"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/end": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/end"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/global-styles": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "theme": {
+              "description": "The name of the theme.",
+              "type": "string",
+              "required": true
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/global-styles"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/media": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "upload_date": {
+              "description": "The date for the upload directory of the attachment.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^\\d{4}\\\/\\d{2}$",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "alt_text": {
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string",
+              "required": false
+            },
+            "caption": {
+              "description": "The attachment caption.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Caption for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML caption for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The attachment description.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Description for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML description for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "post": {
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/media"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/media\/(?P<id>[\\d]+)": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the attachment.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "upload_date": {
+              "description": "The date for the upload directory of the attachment.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^\\d{4}\\\/\\d{2}$",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "alt_text": {
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string",
+              "required": false
+            },
+            "caption": {
+              "description": "The attachment caption.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Caption for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML caption for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The attachment description.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Description for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML description for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "post": {
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/import\/media\/(?P<id>[\\d]+)\/post-process": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the attachment.",
+              "type": "integer",
+              "required": false
+            },
+            "action": {
+              "type": "string",
+              "enum": [
+                "create-image-subsizes"
+              ],
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/jetpack\/v4\/import\/menu-items": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "title": {
+              "description": "The title for the object.",
+              "type": [
+                "string",
+                "object"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the object, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the object, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "type": {
+              "default": "custom",
+              "description": "The family of objects originally represented, such as \"post_type\" or \"taxonomy\".",
+              "type": "string",
+              "enum": [
+                "taxonomy",
+                "post_type",
+                "post_type_archive",
+                "custom"
+              ],
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "A named status for the object.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "parent": {
+              "default": 0,
+              "description": "The ID for the parent of the object.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "attr_title": {
+              "description": "Text for the title attribute of the link element for this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "classes": {
+              "description": "Class names for the link element of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The description of this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "menu_order": {
+              "default": 1,
+              "description": "The DB ID of the nav_menu_item that is this item's menu parent, if any, otherwise 0.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "object": {
+              "description": "The type of object originally represented, such as \"category\", \"post\", or \"attachment\".",
+              "type": "string",
+              "required": false
+            },
+            "object_id": {
+              "default": 0,
+              "description": "The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "target": {
+              "description": "The target attribute of the link element for this menu item.",
+              "type": "string",
+              "enum": [
+                "_blank",
+                ""
+              ],
+              "required": false
+            },
+            "url": {
+              "description": "The URL to which this menu item points.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "xfn": {
+              "description": "The XFN relationship expressed in the link of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "menus": {
+              "description": "The parent menu slug.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/menu-items"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/menus": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            },
+            "locations": {
+              "description": "The locations assigned to the menu.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "auto_add": {
+              "description": "Whether to automatically add top level pages to this menu.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/menus"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/navigation": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/navigation"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/pages": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The ID for the parent of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "menu_order": {
+              "description": "The order of the post in relation to other posts.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "categories": {
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "tags": {
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/pages"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/posts": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "format": {
+              "description": "The format for the post.",
+              "type": "string",
+              "enum": [
+                "standard",
+                "aside",
+                "chat",
+                "gallery",
+                "link",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "_jetpack_memberships_contains_paid_content": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "sticky": {
+              "description": "Whether or not the post should be treated as sticky.",
+              "type": "boolean",
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "categories": {
+              "description": "The terms assigned to the post in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "tags": {
+              "description": "The terms assigned to the post in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/posts"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/start": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/start"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/tags": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/tags"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/template-parts": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": true
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "default": "",
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "default": "",
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "default": "",
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Where the template part is intended for use (header, footer, etc.)",
+              "type": "string",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/template-parts"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/import\/templates": {
+      "namespace": "jetpack\/v4\/import",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": true
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "default": "",
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "default": "",
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "default": "",
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            },
+            "unified_importer_id": {
+              "description": "Jetpack Import unique identifier for the term.",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/import\/templates"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/business-hours\/localized-week": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/business-hours\/localized-week"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/admin-color": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/admin-color"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/admin-menu": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/admin-menu"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/jetpack-ai\/ai-assistant-feature": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/jetpack-ai\/ai-assistant-feature"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/jetpack-search\/ai\/search": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "query": {
+              "description": "Your question to the site",
+              "required": true
+            },
+            "answer_prompt": {
+              "description": "Answer prompt override",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/jetpack-search\/ai\/search"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/jetpack-search\/ai\/rank": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "cache_key": {
+              "description": "Cache key of your response",
+              "required": true
+            },
+            "comment": {
+              "description": "Optional feedback",
+              "required": false
+            },
+            "rank": {
+              "description": "How do you rank this response",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/jetpack-search\/ai\/rank"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/app-media": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "number": {
+              "description": "Number of media items in the request",
+              "type": "number",
+              "default": 20,
+              "required": false
+            },
+            "page_handle": {
+              "type": "number",
+              "default": 1,
+              "required": false
+            },
+            "after": {
+              "description": "Timestamp since the media was uploaded",
+              "type": "number",
+              "default": 0,
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/app-media"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/editor-assets": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/editor-assets"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/blog-stats": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "post_id": {
+              "description": "Post ID to obtain stats for.",
+              "type": [
+                "string",
+                "integer"
+              ],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/blog-stats"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/email-preview": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "access": {
+              "description": "Access level.",
+              "enum": [
+                "everybody",
+                "subscribers",
+                "paid_subscribers"
+              ],
+              "default": "everybody",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/email-preview"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/external-media\/list\/(?P<service>google_photos|openverse|pexels)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "search": {
+              "description": "Media collection search term.",
+              "type": "string",
+              "required": false
+            },
+            "number": {
+              "description": "Number of media items in the request",
+              "type": "number",
+              "default": 20,
+              "required": false
+            },
+            "path": {
+              "type": "string",
+              "required": false
+            },
+            "page_handle": {
+              "type": "string",
+              "required": false
+            },
+            "session_id": {
+              "description": "Session id of a service, currently only Google Photos Picker",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/copy\/(?P<service>google_photos|openverse|pexels)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "media": {
+              "description": "Media data to copy.",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": true,
+                  "properties": {
+                    "caption": {
+                      "type": "string"
+                    },
+                    "guid": {
+                      "type": "object",
+                      "properties": {
+                        "caption": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "format": "uri",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "vertical_id": {
+                          "type": "string",
+                          "format": "text-field"
+                        },
+                        "pexels_object": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "type": "array",
+              "required": true
+            },
+            "post_id": {
+              "description": "The post ID to attach the upload to.",
+              "type": "number",
+              "minimum": 0,
+              "required": false
+            },
+            "should_proxy": {
+              "description": "Whether to proxy the media request.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/connection\/(?P<service>google_photos)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/connection\/(?P<service>google_photos)\/picker_status": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/session\/(?P<service>google_photos)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/session\/(?P<service>google_photos)\/(?P<session_id>.*)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wpcom\/v2\/external-media\/proxy\/(?P<service>google_photos)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "url": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/following\/mine": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "ignore_user_blogs": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/following\/mine"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/following\/recommendations": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "number": {
+              "type": "number",
+              "default": 5,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/following\/recommendations"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/goodreads\/user-id": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Goodreads user ID",
+              "type": "integer",
+              "minimum": 1,
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/goodreads\/user-id"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/checkGoogleDocVisibility": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/checkGoogleDocVisibility"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/instagram-gallery\/connect-url": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/instagram-gallery\/connect-url"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/instagram-gallery\/connections": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/instagram-gallery\/connections"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/instagram-gallery\/gallery": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "access_token": {
+              "description": "An Instagram Keyring access token.",
+              "type": "integer",
+              "minimum": 1,
+              "required": true
+            },
+            "count": {
+              "description": "How many Instagram posts?",
+              "type": "integer",
+              "minimum": 1,
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/instagram-gallery\/gallery"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/mailchimp": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/mailchimp"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/mailchimp\/groups": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/mailchimp\/groups"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/newsletter-categories": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/newsletter-categories"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/newsletter-categories\/count": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "term_ids": {
+              "default": "",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/newsletter-categories\/count"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/podcast-player": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "url": {
+              "description": "The Podcast RSS feed URL.",
+              "type": "string",
+              "required": true
+            },
+            "guids": {
+              "description": "A list of unique identifiers for fetching specific podcast episodes.",
+              "type": "array",
+              "required": true
+            },
+            "episode-options": {
+              "description": "Whether we should return the episodes list for use in the selection UI",
+              "type": "boolean",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/podcast-player"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/podcast-player\/track-quantity": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/podcast-player\/track-quantity"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/profile": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/profile"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/related-posts": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/related-posts"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/related-posts\/enable": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/related-posts\/enable"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/related-posts\/(?P<id>[\\d]+)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/resolve-redirect\/?(?P<url>.+)?": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "url": {
+              "description": "The URL to check for redirects.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/search": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/search"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/send-email-preview": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/send-email-preview"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/template-loader\/(?P<template_type>\\w+)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "template_type": {
+              "description": "The type of the template.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/post-types": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/post-types"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/top-posts": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "period": {
+              "description": "Timeframe for stats.",
+              "type": [
+                "string",
+                "integer"
+              ],
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/top-posts"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/transients\/(?P<name>\\w{1,172})": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "name": {
+              "description": "The name of the transient to delete.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v3": {
+      "namespace": "wpcom\/v3",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "wpcom\/v3",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v3"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v3\/blogging-prompts": {
+      "namespace": "wpcom\/v3",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "after": {
+              "description": "Show prompts following a given date.",
+              "type": "string",
+              "required": false
+            },
+            "before": {
+              "description": "Show prompts before a given date.",
+              "type": "string",
+              "required": false
+            },
+            "force_year": {
+              "description": "Force the returned prompts to be for a specific year. Returns only one prompt for each day.",
+              "type": "integer",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v3\/blogging-prompts"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v3\/blogging-prompts\/(?P<id>[\\d]+)": {
+      "namespace": "wpcom\/v3",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the prompt.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v3\/jitm": {
+      "namespace": "wpcom\/v3",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "message_path": {
+              "type": "string",
+              "description": "The message path to fetch JITMs for",
+              "required": true
+            },
+            "query": {
+              "type": "string",
+              "description": "Additional query parameters",
+              "required": false
+            },
+            "full_jp_logo_exists": {
+              "type": "boolean",
+              "description": "Whether the full Jetpack logo exists",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the JITM to dismiss",
+              "required": true
+            },
+            "feature_class": {
+              "type": "string",
+              "description": "The feature class of the JITM",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v3\/jitm"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/gutenberg\/available-extensions": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/gutenberg\/available-extensions"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/hello": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/hello"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/memberships\/status\/?": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "type": {
+              "type": "string",
+              "required": false
+            },
+            "source": {
+              "type": "string",
+              "required": false
+            },
+            "is_editable": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/memberships\/status\/?"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/memberships\/product\/?": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "title": {
+              "type": "string",
+              "required": true
+            },
+            "price": {
+              "type": "number",
+              "required": true
+            },
+            "currency": {
+              "type": "string",
+              "required": true
+            },
+            "interval": {
+              "type": "string",
+              "required": true
+            },
+            "is_editable": {
+              "type": "boolean",
+              "required": false
+            },
+            "buyer_can_change_amount": {
+              "type": "boolean",
+              "required": false
+            },
+            "tier": {
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/memberships\/product\/?"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/memberships\/products\/?": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST",
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "currency": {
+              "type": "string",
+              "required": true
+            },
+            "type": {
+              "type": "string",
+              "required": true
+            },
+            "is_editable": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/memberships\/products\/?"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/memberships\/product\/(?P<product_id>[0-9]+)\/?": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "title": {
+              "type": "string",
+              "required": true
+            },
+            "price": {
+              "type": "number",
+              "required": true
+            },
+            "currency": {
+              "type": "string",
+              "required": true
+            },
+            "interval": {
+              "type": "string",
+              "required": true
+            },
+            "is_editable": {
+              "type": "boolean",
+              "required": false
+            },
+            "buyer_can_change_amount": {
+              "type": "boolean",
+              "required": false
+            },
+            "tier": {
+              "type": "integer",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "cancel_subscriptions": {
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wpcom\/v2\/publicize\/connection-test-results": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wpcom\/v2\/publicize\/connection-test-results"
+          }
+        ]
+      }
+    },
+    "\/wpcom\/v2\/service-api-keys\/(?P<service>[a-z\\-_]+)": {
+      "namespace": "wpcom\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "service_api_key": {
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4\/blaze-app",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/blaze\/posts(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app\/sites\/236026851\/blaze\/posts(\\?.*)?"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/sites\/236026851\/blaze\/posts(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/sites\/236026851\/blaze\/posts(\\?.*)?"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/checkout": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/checkout"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/credits(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/sites\/236026851\/media(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/sites\/236026851\/media": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/sites\/236026851\/media"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/wpcom\/media(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/experiments(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/campaigns(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/campaigns(?P<sub_path>[a-zA-Z0-9-_\\\/]*)": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/sites\/236026851\/campaigns(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/stats(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/stats(?P<sub_path>[a-zA-Z0-9-_\\\/]*)": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/search(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/user(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/templates(?P<sub_path>[a-zA-Z0-9-_\\\/:]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/subscriptions(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/subscriptions(?P<sub_path>[a-zA-Z0-9-_\\\/]*)": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/payments(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/(?P<api_version>v[0-9]+\\.?[0-9]*)\/payments(?P<sub_path>[a-zA-Z0-9-_\\\/]*)": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/smart(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/smart(?P<sub_path>[a-zA-Z0-9-_\\\/]*)": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/locations(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/woo(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/image(?P<sub_path>[a-zA-Z0-9-_\\\/]*)(\\?.*)?": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/logs": {
+      "namespace": "jetpack\/v4\/blaze-app",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze-app\/sites\/236026851\/wordads\/dsp\/api\/v1\/logs"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze": {
+      "namespace": "jetpack\/v4\/blaze",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "jetpack\/v4\/blaze",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze\/eligibility": {
+      "namespace": "jetpack\/v4\/blaze",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze\/eligibility"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/blaze\/dashboard": {
+      "namespace": "jetpack\/v4\/blaze",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/blaze\/dashboard"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/feature\/custom-content-types": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/feature\/custom-content-types"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/hints": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "hint": {
+              "default": "",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/hints"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/remote_authorize": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/remote_authorize"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/remote_provision": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/remote_provision"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/remote_register": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/remote_register"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/remote_connect": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/remote_connect"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/check": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/check"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "isActive": {
+              "description": "Set to false will trigger the site to disconnect.",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/user": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/user"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/data": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/data"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/plugins": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/plugins"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/reconnect": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/reconnect"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/register": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "from": {
+              "description": "Indicates where the registration action was triggered for tracking\/segmentation purposes",
+              "type": "string",
+              "required": false
+            },
+            "redirect_uri": {
+              "description": "URI of the admin page where the user should be redirected after connection flow",
+              "type": "string",
+              "required": false
+            },
+            "plugin_slug": {
+              "description": "Indicates from what plugin the request is coming from",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/register"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/authorize_url": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "redirect_uri": {
+              "description": "URI of the admin page where the user should be redirected after connection flow",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/authorize_url"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/user-token": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "user_token": {
+              "description": "New user token",
+              "type": "string",
+              "required": true
+            },
+            "is_connection_owner": {
+              "description": "Is connection owner",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/user-token"
+          }
+        ]
+      }
+    },
+    "\/jetpack\/v4\/connection\/owner": {
+      "namespace": "jetpack\/v4",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "owner": {
+              "description": "New owner",
+              "type": "integer",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/jetpack\/v4\/connection\/owner"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "wp\/v2",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/posts": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "author": {
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "author_exclude": {
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "tax_relation": {
+              "description": "Limit result set based on relationship between multiple taxonomies.",
+              "type": "string",
+              "enum": [
+                "AND",
+                "OR"
+              ],
+              "required": false
+            },
+            "categories": {
+              "description": "Limit result set to items with specific terms assigned in the categories taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    },
+                    "include_children": {
+                      "description": "Whether to include child terms in the terms limiting the result set.",
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "operator": {
+                      "description": "Whether items must be assigned all or any of the specified terms.",
+                      "type": "string",
+                      "enum": [
+                        "AND",
+                        "OR"
+                      ],
+                      "default": "OR"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "categories_exclude": {
+              "description": "Limit result set to items except those with specific terms assigned in the categories taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    },
+                    "include_children": {
+                      "description": "Whether to include child terms in the terms limiting the result set.",
+                      "type": "boolean",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "tags": {
+              "description": "Limit result set to items with specific terms assigned in the tags taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    },
+                    "operator": {
+                      "description": "Whether items must be assigned all or any of the specified terms.",
+                      "type": "string",
+                      "enum": [
+                        "AND",
+                        "OR"
+                      ],
+                      "default": "OR"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "tags_exclude": {
+              "description": "Limit result set to items except those with specific terms assigned in the tags taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "sticky": {
+              "description": "Limit result set to items that are sticky.",
+              "type": "boolean",
+              "required": false
+            },
+            "ignore_sticky": {
+              "description": "Whether to ignore sticky posts or not.",
+              "type": "boolean",
+              "default": true,
+              "required": false
+            },
+            "format": {
+              "description": "Limit result set to items assigned one or more given formats.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "standard",
+                  "aside",
+                  "chat",
+                  "gallery",
+                  "link",
+                  "image",
+                  "quote",
+                  "status",
+                  "video",
+                  "audio"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "format": {
+              "description": "The format for the post.",
+              "type": "string",
+              "enum": [
+                "standard",
+                "aside",
+                "chat",
+                "gallery",
+                "link",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "_jetpack_memberships_contains_paid_content": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "sticky": {
+              "description": "Whether or not the post should be treated as sticky.",
+              "type": "boolean",
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "categories": {
+              "description": "The terms assigned to the post in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "tags": {
+              "description": "The terms assigned to the post in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/posts"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/posts\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "excerpt_length": {
+              "description": "Override the default excerpt length.",
+              "type": "integer",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "format": {
+              "description": "The format for the post.",
+              "type": "string",
+              "enum": [
+                "standard",
+                "aside",
+                "chat",
+                "gallery",
+                "link",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "_jetpack_memberships_contains_paid_content": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "sticky": {
+              "description": "Whether or not the post should be treated as sticky.",
+              "type": "boolean",
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "categories": {
+              "description": "The terms assigned to the post in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "tags": {
+              "description": "The terms assigned to the post in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/posts\/(?P<parent>[\\d]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/posts\/(?P<parent>[\\d]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/posts\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "format": {
+              "description": "The format for the post.",
+              "type": "string",
+              "enum": [
+                "standard",
+                "aside",
+                "chat",
+                "gallery",
+                "link",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "_jetpack_memberships_contains_paid_content": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "sticky": {
+              "description": "Whether or not the post should be treated as sticky.",
+              "type": "boolean",
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "categories": {
+              "description": "The terms assigned to the post in the category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "tags": {
+              "description": "The terms assigned to the post in the post_tag taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/posts\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/pages": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "author": {
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "author_exclude": {
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "menu_order": {
+              "description": "Limit result set to posts with a specific menu_order value.",
+              "type": "integer",
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title",
+                "menu_order"
+              ],
+              "required": false
+            },
+            "parent": {
+              "description": "Limit result set to items with particular parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "parent_exclude": {
+              "description": "Limit result set to all items except those of a particular parent ID.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "orderby_hierarchy": {
+              "description": "Sort pages by hierarchy.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The ID for the parent of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "menu_order": {
+              "description": "The order of the post in relation to other posts.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/pages"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/pages\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "excerpt_length": {
+              "description": "Override the default excerpt length.",
+              "type": "integer",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The ID for the parent of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "menu_order": {
+              "description": "The order of the post in relation to other posts.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/pages\/(?P<parent>[\\d]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/pages\/(?P<parent>[\\d]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/pages\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "menu_order": {
+              "description": "The order of the post in relation to other posts.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/pages\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/media": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "author": {
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "author_exclude": {
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "parent": {
+              "description": "Limit result set to items with particular parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "parent_exclude": {
+              "description": "Limit result set to all items except those of a particular parent ID.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "inherit",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "inherit",
+                  "private",
+                  "trash"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "media_type": {
+              "default": null,
+              "description": "Limit result set to attachments of a particular media type.",
+              "type": "string",
+              "enum": [
+                "image",
+                "video",
+                "text",
+                "application",
+                "audio"
+              ],
+              "required": false
+            },
+            "mime_type": {
+              "default": null,
+              "description": "Limit result set to attachments of a particular MIME type.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            },
+            "alt_text": {
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string",
+              "required": false
+            },
+            "caption": {
+              "description": "The attachment caption.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Caption for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML caption for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The attachment description.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Description for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML description for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "post": {
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/media"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/media\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "comment_status": {
+              "description": "Whether or not comments are open on the post.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "ping_status": {
+              "description": "Whether or not the post can be pinged.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_sharing_enabled": {
+              "description": "Are sharing buttons enabled?",
+              "type": "boolean",
+              "required": false
+            },
+            "alt_text": {
+              "description": "Alternative text to display when attachment is not displayed.",
+              "type": "string",
+              "required": false
+            },
+            "caption": {
+              "description": "The attachment caption.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Caption for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML caption for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The attachment description.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Description for the attachment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML description for the attachment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "post": {
+              "description": "The ID for the associated post of the attachment.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/media\/(?P<id>[\\d]+)\/post-process": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the attachment.",
+              "type": "integer",
+              "required": false
+            },
+            "action": {
+              "type": "string",
+              "enum": [
+                "create-image-subsizes"
+              ],
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/media\/(?P<id>[\\d]+)\/edit": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "src": {
+              "description": "URL to the edited image file.",
+              "type": "string",
+              "format": "uri",
+              "required": true
+            },
+            "modifiers": {
+              "description": "Array of image edits.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "description": "Image edit.",
+                "type": "object",
+                "required": [
+                  "type",
+                  "args"
+                ],
+                "oneOf": [
+                  {
+                    "title": "Rotation",
+                    "properties": {
+                      "type": {
+                        "description": "Rotation type.",
+                        "type": "string",
+                        "enum": [
+                          "rotate"
+                        ]
+                      },
+                      "args": {
+                        "description": "Rotation arguments.",
+                        "type": "object",
+                        "required": [
+                          "angle"
+                        ],
+                        "properties": {
+                          "angle": {
+                            "description": "Angle to rotate clockwise in degrees.",
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "Crop",
+                    "properties": {
+                      "type": {
+                        "description": "Crop type.",
+                        "type": "string",
+                        "enum": [
+                          "crop"
+                        ]
+                      },
+                      "args": {
+                        "description": "Crop arguments.",
+                        "type": "object",
+                        "required": [
+                          "left",
+                          "top",
+                          "width",
+                          "height"
+                        ],
+                        "properties": {
+                          "left": {
+                            "description": "Horizontal position from the left to begin the crop as a percentage of the image width.",
+                            "type": "number"
+                          },
+                          "top": {
+                            "description": "Vertical position from the top to begin the crop as a percentage of the image height.",
+                            "type": "number"
+                          },
+                          "width": {
+                            "description": "Width of the crop as a percentage of the image width.",
+                            "type": "number"
+                          },
+                          "height": {
+                            "description": "Height of the crop as a percentage of the image height.",
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "required": false
+            },
+            "rotation": {
+              "description": "The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.",
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 360,
+              "exclusiveMaximum": true,
+              "required": false
+            },
+            "x": {
+              "description": "As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "required": false
+            },
+            "y": {
+              "description": "As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "required": false
+            },
+            "width": {
+              "description": "As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "required": false
+            },
+            "height": {
+              "description": "As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/menu-items": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "menu_order",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title",
+                "menu_order"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "tax_relation": {
+              "description": "Limit result set based on relationship between multiple taxonomies.",
+              "type": "string",
+              "enum": [
+                "AND",
+                "OR"
+              ],
+              "required": false
+            },
+            "menus": {
+              "description": "Limit result set to items with specific terms assigned in the menus taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    },
+                    "operator": {
+                      "description": "Whether items must be assigned all or any of the specified terms.",
+                      "type": "string",
+                      "enum": [
+                        "AND",
+                        "OR"
+                      ],
+                      "default": "OR"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "menus_exclude": {
+              "description": "Limit result set to items except those with specific terms assigned in the menus taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "menu_order": {
+              "description": "Limit result set to posts with a specific menu_order value.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "title": {
+              "description": "The title for the object.",
+              "type": [
+                "string",
+                "object"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the object, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the object, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "type": {
+              "default": "custom",
+              "description": "The family of objects originally represented, such as \"post_type\" or \"taxonomy\".",
+              "type": "string",
+              "enum": [
+                "taxonomy",
+                "post_type",
+                "post_type_archive",
+                "custom"
+              ],
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "A named status for the object.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "parent": {
+              "default": 0,
+              "description": "The ID for the parent of the object.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "attr_title": {
+              "description": "Text for the title attribute of the link element for this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "classes": {
+              "description": "Class names for the link element of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The description of this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "menu_order": {
+              "default": 1,
+              "description": "The DB ID of the nav_menu_item that is this item's menu parent, if any, otherwise 0.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "object": {
+              "description": "The type of object originally represented, such as \"category\", \"post\", or \"attachment\".",
+              "type": "string",
+              "required": false
+            },
+            "object_id": {
+              "default": 0,
+              "description": "The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "target": {
+              "description": "The target attribute of the link element for this menu item.",
+              "type": "string",
+              "enum": [
+                "_blank",
+                ""
+              ],
+              "required": false
+            },
+            "url": {
+              "description": "The URL to which this menu item points.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "xfn": {
+              "description": "The XFN relationship expressed in the link of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "menus": {
+              "description": "The terms assigned to the object in the nav_menu taxonomy.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/menu-items"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/menu-items\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the object.",
+              "type": [
+                "string",
+                "object"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the object, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the object, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "type": {
+              "description": "The family of objects originally represented, such as \"post_type\" or \"taxonomy\".",
+              "type": "string",
+              "enum": [
+                "taxonomy",
+                "post_type",
+                "post_type_archive",
+                "custom"
+              ],
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the object.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "parent": {
+              "description": "The ID for the parent of the object.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "attr_title": {
+              "description": "Text for the title attribute of the link element for this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "classes": {
+              "description": "Class names for the link element of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The description of this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "menu_order": {
+              "description": "The DB ID of the nav_menu_item that is this item's menu parent, if any, otherwise 0.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "object": {
+              "description": "The type of object originally represented, such as \"category\", \"post\", or \"attachment\".",
+              "type": "string",
+              "required": false
+            },
+            "object_id": {
+              "description": "The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "target": {
+              "description": "The target attribute of the link element for this menu item.",
+              "type": "string",
+              "enum": [
+                "_blank",
+                ""
+              ],
+              "required": false
+            },
+            "url": {
+              "description": "The URL to which this menu item points.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "xfn": {
+              "description": "The XFN relationship expressed in the link of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "menus": {
+              "description": "The terms assigned to the object in the nav_menu taxonomy.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/menu-items\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the object.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "title": {
+              "description": "The title for the object.",
+              "type": [
+                "string",
+                "object"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the object, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the object, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "type": {
+              "description": "The family of objects originally represented, such as \"post_type\" or \"taxonomy\".",
+              "type": "string",
+              "enum": [
+                "taxonomy",
+                "post_type",
+                "post_type_archive",
+                "custom"
+              ],
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the object.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "attr_title": {
+              "description": "Text for the title attribute of the link element for this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "classes": {
+              "description": "Class names for the link element of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "description": {
+              "description": "The description of this menu item.",
+              "type": "string",
+              "required": false
+            },
+            "menu_order": {
+              "description": "The DB ID of the nav_menu_item that is this item's menu parent, if any, otherwise 0.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "object": {
+              "description": "The type of object originally represented, such as \"category\", \"post\", or \"attachment\".",
+              "type": "string",
+              "required": false
+            },
+            "object_id": {
+              "description": "The database ID of the original object this menu item represents, for example the ID for posts or the term_id for categories.",
+              "type": "integer",
+              "minimum": 0,
+              "required": false
+            },
+            "target": {
+              "description": "The target attribute of the link element for this menu item.",
+              "type": "string",
+              "enum": [
+                "_blank",
+                ""
+              ],
+              "required": false
+            },
+            "url": {
+              "description": "The URL to which this menu item points.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "xfn": {
+              "description": "The XFN relationship expressed in the link of this menu item.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "menus": {
+              "description": "The terms assigned to the object in the nav_menu taxonomy.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/menu-items\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/blocks": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "tax_relation": {
+              "description": "Limit result set based on relationship between multiple taxonomies.",
+              "type": "string",
+              "enum": [
+                "AND",
+                "OR"
+              ],
+              "required": false
+            },
+            "wp_pattern_category": {
+              "description": "Limit result set to items with specific terms assigned in the wp_pattern_category taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    },
+                    "operator": {
+                      "description": "Whether items must be assigned all or any of the specified terms.",
+                      "type": "string",
+                      "enum": [
+                        "AND",
+                        "OR"
+                      ],
+                      "default": "OR"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            },
+            "wp_pattern_category_exclude": {
+              "description": "Limit result set to items except those with specific terms assigned in the wp_pattern_category taxonomy.",
+              "type": [
+                "object",
+                "array"
+              ],
+              "oneOf": [
+                {
+                  "title": "Term ID List",
+                  "description": "Match terms with the listed IDs.",
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                {
+                  "title": "Term ID Taxonomy Query",
+                  "description": "Perform an advanced term query.",
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "description": "Term IDs.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "default": []
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "wp_pattern_sync_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": "",
+                  "enum": [
+                    "partial",
+                    "unsynced"
+                  ]
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "wp_pattern_category": {
+              "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/blocks"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/blocks\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "excerpt_length": {
+              "description": "Override the default excerpt length.",
+              "type": "integer",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "wp_pattern_sync_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": "",
+                  "enum": [
+                    "partial",
+                    "unsynced"
+                  ]
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "wp_pattern_category": {
+              "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/blocks\/(?P<parent>[\\d]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/blocks\/(?P<parent>[\\d]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/blocks\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "wp_pattern_sync_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": "",
+                  "enum": [
+                    "partial",
+                    "unsynced"
+                  ]
+                },
+                "footnotes": {
+                  "type": "string",
+                  "title": "",
+                  "description": "",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            },
+            "wp_pattern_category": {
+              "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/blocks\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/templates\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/templates\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/templates\/(?P<id>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": false
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/templates\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/templates": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "wp_id": {
+              "description": "Limit to the specified post id.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Limit to the specified template part area.",
+              "type": "string",
+              "required": false
+            },
+            "post_type": {
+              "description": "Post type to get the templates for.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": true
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "default": "",
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "default": "",
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "default": "",
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/templates"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/templates\/lookup": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "slug": {
+              "description": "The slug of the template to get the fallback for",
+              "type": "string",
+              "required": true
+            },
+            "is_custom": {
+              "description": "Indicates if a template is custom or part of the template hierarchy",
+              "type": "boolean",
+              "required": false
+            },
+            "template_prefix": {
+              "description": "The template prefix for the created template. This is used to extract the main template type, e.g. in `taxonomy-books` extracts the `taxonomy`",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/templates\/lookup"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/templates\/(?P<id>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": false
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/template-parts\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/template-parts\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/template-parts\/(?P<id>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": false
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Where the template part is intended for use (header, footer, etc.)",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/template-parts\/(?P<parent>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/template-parts": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "wp_id": {
+              "description": "Limit to the specified post id.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Limit to the specified template part area.",
+              "type": "string",
+              "required": false
+            },
+            "post_type": {
+              "description": "Post type to get the templates for.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": true
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "default": "",
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "default": "",
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "default": "",
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Where the template part is intended for use (header, footer, etc.)",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/template-parts"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/template-parts\/lookup": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "slug": {
+              "description": "The slug of the template to get the fallback for",
+              "type": "string",
+              "required": true
+            },
+            "is_custom": {
+              "description": "Indicates if a template is custom or part of the template hierarchy",
+              "type": "boolean",
+              "required": false
+            },
+            "template_prefix": {
+              "description": "The template prefix for the created template. This is used to extract the main template type, e.g. in `taxonomy-books` extracts the `taxonomy`",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/template-parts\/lookup"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/template-parts\/(?P<id>([^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)[\\\/\\w%-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "Unique slug identifying the template.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "[a-zA-Z0-9_\\%-]+",
+              "required": false
+            },
+            "theme": {
+              "description": "Theme identifier for the template.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "description": "Type of template.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "Content of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Content for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ]
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the template.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "title": {
+              "description": "Title of template.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the template, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the template, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "description": {
+              "description": "Description of template.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "Status of template.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the template.",
+              "type": "integer",
+              "required": false
+            },
+            "area": {
+              "description": "Where the template part is intended for use (header, footer, etc.)",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/global-styles\/(?P<parent>[\\d]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/global-styles\/(?P<parent>[\\d]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the global styles revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the global styles revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/global-styles\/themes\/(?P<stylesheet>[\\\/\\s%\\w\\.\\(\\)\\[\\]\\@_\\-]+)\/variations": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": false
+          },
+          "args": {
+            "stylesheet": {
+              "description": "The theme identifier",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/global-styles\/themes\/(?P<stylesheet>[^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": false
+          },
+          "args": {
+            "stylesheet": {
+              "description": "The theme identifier",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/global-styles\/(?P<id>[\\\/\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": false
+          },
+          "args": {
+            "id": {
+              "description": "The id of a template",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": false
+          },
+          "args": {
+            "styles": {
+              "description": "Global styles.",
+              "type": [
+                "object"
+              ],
+              "required": false
+            },
+            "settings": {
+              "description": "Global settings.",
+              "type": [
+                "object"
+              ],
+              "required": false
+            },
+            "title": {
+              "description": "Title of the global styles variation.",
+              "type": [
+                "object",
+                "string"
+              ],
+              "properties": {
+                "raw": {
+                  "description": "Title for the global styles variation, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/navigation": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/navigation"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/navigation\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/navigation\/(?P<parent>[\\d]+)\/revisions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by object attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "date",
+                "id",
+                "include",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/navigation\/(?P<parent>[\\d]+)\/revisions\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "Unique identifier for the revision.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as revisions do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/navigation\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/navigation\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/font-families": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "id",
+              "enum": [
+                "id",
+                "include"
+              ],
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "theme_json_version": {
+              "description": "Version of the theme.json schema used for the typography settings.",
+              "type": "integer",
+              "default": 3,
+              "minimum": 2,
+              "maximum": 3,
+              "required": false
+            },
+            "font_family_settings": {
+              "description": "font-family declaration in theme.json format, encoded as a string.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/font-families"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/font-families\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "theme_json_version": {
+              "description": "Version of the theme.json schema used for the typography settings.",
+              "type": "integer",
+              "default": 3,
+              "minimum": 2,
+              "maximum": 3,
+              "required": false
+            },
+            "font_family_settings": {
+              "description": "font-family declaration in theme.json format, encoded as a string.",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/font-families\/(?P<font_family_id>[\\d]+)\/font-faces": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "font_family_id": {
+              "description": "The ID for the parent font family of the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "id",
+              "enum": [
+                "id",
+                "include"
+              ],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "font_family_id": {
+              "description": "The ID for the parent font family of the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "theme_json_version": {
+              "description": "Version of the theme.json schema used for the typography settings.",
+              "type": "integer",
+              "default": 3,
+              "minimum": 2,
+              "maximum": 3,
+              "required": false
+            },
+            "font_face_settings": {
+              "description": "font-face declaration in theme.json format, encoded as a string.",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/font-families\/(?P<font_family_id>[\\d]+)\/font-faces\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "font_family_id": {
+              "description": "The ID for the parent font family of the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "id": {
+              "description": "Unique identifier for the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "font_family_id": {
+              "description": "The ID for the parent font family of the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "id": {
+              "description": "Unique identifier for the font face.",
+              "type": "integer",
+              "required": true
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jb_store_css": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/jb_store_css"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/jb_store_css\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jb_store_css\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jb_store_css\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/feedback": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "parent": {
+              "description": "Limit result set to items with particular parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "parent_exclude": {
+              "description": "Limit result set to all items except those of a particular parent ID.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/feedback"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/feedback\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/feedback\/filters": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/feedback\/filters"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/feedback\/integrations": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "version": {
+              "type": "integer",
+              "default": 1,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/feedback\/integrations"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/feedback\/integrations\/(?P<slug>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "slug": {
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "slug": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/feedback\/bulk_actions": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "mark_as_spam",
+                "mark_as_not_spam"
+              ],
+              "required": true
+            },
+            "post_ids": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/feedback\/bulk_actions"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/feedback\/trash": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "trash",
+                "spam"
+              ],
+              "default": "trash",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/feedback\/trash"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/feedback\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/feedback\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jp_pay_order": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/jp_pay_order"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/jp_pay_order\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "excerpt_length": {
+              "description": "Override the default excerpt length.",
+              "type": "integer",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "excerpt": {
+              "description": "The excerpt for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Excerpt for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML excerpt for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the excerpt is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jp_pay_product": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to posts published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_after": {
+              "description": "Limit response to posts modified after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "author": {
+              "description": "Limit result set to posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "author_exclude": {
+              "description": "Ensure result set excludes posts assigned to specific authors.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to posts published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "modified_before": {
+              "description": "Limit response to posts modified before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "search_semantics": {
+              "description": "How to interpret the search input.",
+              "type": "string",
+              "enum": [
+                "exact"
+              ],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title"
+              ],
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post_title",
+                  "post_content",
+                  "post_excerpt"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to posts with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "publish",
+              "description": "Limit result set to posts assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "publish",
+                  "future",
+                  "draft",
+                  "pending",
+                  "private",
+                  "trash",
+                  "auto-draft",
+                  "inherit",
+                  "request-pending",
+                  "request-confirmed",
+                  "request-failed",
+                  "request-completed",
+                  "spam",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "spay_price": {
+                  "type": "number",
+                  "title": "",
+                  "description": "Simple payments; price.",
+                  "default": 0
+                },
+                "spay_currency": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; currency code.",
+                  "default": ""
+                },
+                "spay_cta": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; text with &quot;Buy&quot; or other CTA",
+                  "default": ""
+                },
+                "spay_multiple": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "Simple payments; allow multiple items",
+                  "default": false
+                },
+                "spay_email": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments button; paypal email.",
+                  "default": ""
+                },
+                "spay_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; status.",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/jp_pay_product"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/jp_pay_product\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "spay_price": {
+                  "type": "number",
+                  "title": "",
+                  "description": "Simple payments; price.",
+                  "default": 0
+                },
+                "spay_currency": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; currency code.",
+                  "default": ""
+                },
+                "spay_cta": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; text with &quot;Buy&quot; or other CTA",
+                  "default": ""
+                },
+                "spay_multiple": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "Simple payments; allow multiple items",
+                  "default": false
+                },
+                "spay_email": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments button; paypal email.",
+                  "default": ""
+                },
+                "spay_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; status.",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jp_pay_product\/(?P<id>[\\d]+)\/autosaves": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "date": {
+              "description": "The date the post was published, in the site's timezone.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the post was published, as GMT.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the post unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "A named status for the post.",
+              "type": "string",
+              "enum": [
+                "publish",
+                "future",
+                "draft",
+                "pending",
+                "private",
+                "spam"
+              ],
+              "required": false
+            },
+            "password": {
+              "description": "A password to protect access to the content and excerpt.",
+              "type": "string",
+              "required": false
+            },
+            "title": {
+              "description": "The title for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Title for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML title for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "content": {
+              "description": "The content for the post.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the post, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the post, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "block_version": {
+                  "description": "Version of the content block format used by the post.",
+                  "type": "integer",
+                  "context": [
+                    "edit"
+                  ],
+                  "readonly": true
+                },
+                "protected": {
+                  "description": "Whether the content is protected with a password.",
+                  "type": "boolean",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "author": {
+              "description": "The ID for the author of the post.",
+              "type": "integer",
+              "required": false
+            },
+            "featured_media": {
+              "description": "The ID of the featured media for the post.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "spay_price": {
+                  "type": "number",
+                  "title": "",
+                  "description": "Simple payments; price.",
+                  "default": 0
+                },
+                "spay_currency": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; currency code.",
+                  "default": ""
+                },
+                "spay_cta": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; text with &quot;Buy&quot; or other CTA",
+                  "default": ""
+                },
+                "spay_multiple": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "Simple payments; allow multiple items",
+                  "default": false
+                },
+                "spay_email": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments button; paypal email.",
+                  "default": ""
+                },
+                "spay_status": {
+                  "type": "string",
+                  "title": "",
+                  "description": "Simple payments; status.",
+                  "default": ""
+                }
+              },
+              "required": false
+            },
+            "template": {
+              "description": "The theme file to use to display the post.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/jp_pay_product\/(?P<parent>[\\d]+)\/autosaves\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "parent": {
+              "description": "The ID for the parent of the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "id": {
+              "description": "The ID for the autosave.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/types": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/types"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/types\/(?P<type>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "type": {
+              "description": "An alphanumeric identifier for the post type.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/statuses": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/statuses"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/statuses\/(?P<status>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "status": {
+              "description": "An alphanumeric identifier for the status.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/taxonomies": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "type": {
+              "description": "Limit results to taxonomies associated with a specific post type.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/taxonomies"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/taxonomies\/(?P<taxonomy>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "taxonomy": {
+              "description": "An alphanumeric identifier for the taxonomy.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/categories": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by term attribute.",
+              "type": "string",
+              "default": "name",
+              "enum": [
+                "id",
+                "include",
+                "name",
+                "slug",
+                "include_slugs",
+                "term_group",
+                "description",
+                "count"
+              ],
+              "required": false
+            },
+            "hide_empty": {
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "parent": {
+              "description": "Limit result set to terms assigned to a specific parent.",
+              "type": "integer",
+              "required": false
+            },
+            "post": {
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer",
+              "default": null,
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The parent term ID.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/categories"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/categories\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "parent": {
+              "description": "The parent term ID.",
+              "type": "integer",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as terms do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/tags": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by term attribute.",
+              "type": "string",
+              "default": "name",
+              "enum": [
+                "id",
+                "include",
+                "name",
+                "slug",
+                "include_slugs",
+                "term_group",
+                "description",
+                "count"
+              ],
+              "required": false
+            },
+            "hide_empty": {
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "post": {
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer",
+              "default": null,
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/tags"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/tags\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as terms do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/menus": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by term attribute.",
+              "type": "string",
+              "default": "name",
+              "enum": [
+                "id",
+                "include",
+                "name",
+                "slug",
+                "include_slugs",
+                "term_group",
+                "description",
+                "count"
+              ],
+              "required": false
+            },
+            "hide_empty": {
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "post": {
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer",
+              "default": null,
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "locations": {
+              "description": "The locations assigned to the menu.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "auto_add": {
+              "description": "Whether to automatically add top level pages to this menu.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/menus"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/menus\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            },
+            "locations": {
+              "description": "The locations assigned to the menu.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "auto_add": {
+              "description": "Whether to automatically add top level pages to this menu.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as terms do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/wp_pattern_category": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "asc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by term attribute.",
+              "type": "string",
+              "default": "name",
+              "enum": [
+                "id",
+                "include",
+                "name",
+                "slug",
+                "include_slugs",
+                "term_group",
+                "description",
+                "count"
+              ],
+              "required": false
+            },
+            "hide_empty": {
+              "description": "Whether to hide terms not assigned to any posts.",
+              "type": "boolean",
+              "default": false,
+              "required": false
+            },
+            "post": {
+              "description": "Limit result set to terms assigned to a specific post.",
+              "type": "integer",
+              "default": null,
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to terms with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": true
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/wp_pattern_category"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/wp_pattern_category\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "description": {
+              "description": "HTML description of the term.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "HTML title for the term.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the term unique to its type.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the term.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as terms do not support trashing.",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/users": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "default": "asc",
+              "description": "Order sort attribute ascending or descending.",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string",
+              "required": false
+            },
+            "orderby": {
+              "default": "name",
+              "description": "Sort collection by user attribute.",
+              "enum": [
+                "id",
+                "include",
+                "name",
+                "registered_date",
+                "slug",
+                "include_slugs",
+                "email",
+                "url"
+              ],
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "Limit result set to users with one or more specific slugs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "roles": {
+              "description": "Limit result set to users matching at least one specific role provided. Accepts csv list or single role.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "capabilities": {
+              "description": "Limit result set to users matching at least one specific capability provided. Accepts csv list or single capability.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "who": {
+              "description": "Limit result set to users who are considered authors.",
+              "type": "string",
+              "enum": [
+                "authors"
+              ],
+              "required": false
+            },
+            "has_published_posts": {
+              "description": "Limit result set to users who have published posts.",
+              "type": [
+                "boolean",
+                "array"
+              ],
+              "items": {
+                "type": "string",
+                "enum": {
+                  "post": "post",
+                  "page": "page",
+                  "attachment": "attachment",
+                  "nav_menu_item": "nav_menu_item",
+                  "wp_block": "wp_block",
+                  "wp_template": "wp_template",
+                  "wp_template_part": "wp_template_part",
+                  "wp_global_styles": "wp_global_styles",
+                  "wp_navigation": "wp_navigation",
+                  "wp_font_family": "wp_font_family",
+                  "wp_font_face": "wp_font_face",
+                  "jb_store_css": "jb_store_css",
+                  "feedback": "feedback",
+                  "jp_pay_order": "jp_pay_order",
+                  "jp_pay_product": "jp_pay_product"
+                }
+              },
+              "required": false
+            },
+            "search_columns": {
+              "default": [],
+              "description": "Array of column names to be searched.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "email",
+                  "name",
+                  "id",
+                  "username",
+                  "slug"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "username": {
+              "description": "Login name for the user.",
+              "type": "string",
+              "required": true
+            },
+            "name": {
+              "description": "Display name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "first_name": {
+              "description": "First name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "last_name": {
+              "description": "Last name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "email": {
+              "description": "The email address for the user.",
+              "type": "string",
+              "format": "email",
+              "required": true
+            },
+            "url": {
+              "description": "URL of the user.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "description": {
+              "description": "Description of the user.",
+              "type": "string",
+              "required": false
+            },
+            "locale": {
+              "description": "Locale for the user.",
+              "type": "string",
+              "enum": [
+                "",
+                "en_US",
+                "fr_FR"
+              ],
+              "required": false
+            },
+            "nickname": {
+              "description": "The nickname for the user.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string",
+              "required": false
+            },
+            "roles": {
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "password": {
+              "description": "Password for the user (never included).",
+              "type": "string",
+              "required": true
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "persisted_preferences": {
+                  "type": "object",
+                  "title": "",
+                  "description": "",
+                  "default": [],
+                  "context": [
+                    "edit"
+                  ],
+                  "properties": {
+                    "_modified": {
+                      "description": "The date and time the preferences were updated.",
+                      "type": "string",
+                      "format": "date-time",
+                      "readonly": false
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "jetpack_donation_warning_dismissed": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                }
+              },
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/users"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/users\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the user.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the user.",
+              "type": "integer",
+              "required": false
+            },
+            "username": {
+              "description": "Login name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "Display name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "first_name": {
+              "description": "First name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "last_name": {
+              "description": "Last name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "email": {
+              "description": "The email address for the user.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "url": {
+              "description": "URL of the user.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "description": {
+              "description": "Description of the user.",
+              "type": "string",
+              "required": false
+            },
+            "locale": {
+              "description": "Locale for the user.",
+              "type": "string",
+              "enum": [
+                "",
+                "en_US",
+                "fr_FR"
+              ],
+              "required": false
+            },
+            "nickname": {
+              "description": "The nickname for the user.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string",
+              "required": false
+            },
+            "roles": {
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "password": {
+              "description": "Password for the user (never included).",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "persisted_preferences": {
+                  "type": "object",
+                  "title": "",
+                  "description": "",
+                  "default": [],
+                  "context": [
+                    "edit"
+                  ],
+                  "properties": {
+                    "_modified": {
+                      "description": "The date and time the preferences were updated.",
+                      "type": "string",
+                      "format": "date-time",
+                      "readonly": false
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "jetpack_donation_warning_dismissed": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                }
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the user.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as users do not support trashing.",
+              "required": false
+            },
+            "reassign": {
+              "type": "integer",
+              "description": "Reassign the deleted user's posts and links to this user ID.",
+              "required": true
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/users\/me": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "username": {
+              "description": "Login name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "name": {
+              "description": "Display name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "first_name": {
+              "description": "First name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "last_name": {
+              "description": "Last name for the user.",
+              "type": "string",
+              "required": false
+            },
+            "email": {
+              "description": "The email address for the user.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "url": {
+              "description": "URL of the user.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "description": {
+              "description": "Description of the user.",
+              "type": "string",
+              "required": false
+            },
+            "locale": {
+              "description": "Locale for the user.",
+              "type": "string",
+              "enum": [
+                "",
+                "en_US",
+                "fr_FR"
+              ],
+              "required": false
+            },
+            "nickname": {
+              "description": "The nickname for the user.",
+              "type": "string",
+              "required": false
+            },
+            "slug": {
+              "description": "An alphanumeric identifier for the user.",
+              "type": "string",
+              "required": false
+            },
+            "roles": {
+              "description": "Roles assigned to the user.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "required": false
+            },
+            "password": {
+              "description": "Password for the user (never included).",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": {
+                "persisted_preferences": {
+                  "type": "object",
+                  "title": "",
+                  "description": "",
+                  "default": [],
+                  "context": [
+                    "edit"
+                  ],
+                  "properties": {
+                    "_modified": {
+                      "description": "The date and time the preferences were updated.",
+                      "type": "string",
+                      "format": "date-time",
+                      "readonly": false
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "jetpack_donation_warning_dismissed": {
+                  "type": "boolean",
+                  "title": "",
+                  "description": "",
+                  "default": false
+                }
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Required to be true, as users do not support trashing.",
+              "required": false
+            },
+            "reassign": {
+              "type": "integer",
+              "description": "Reassign the deleted user's posts and links to this user ID.",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/users\/me"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/users\/(?P<user_id>(?:[\\d]+|me))\/application-passwords": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "app_id": {
+              "description": "A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.",
+              "type": "string",
+              "format": "uuid",
+              "required": false
+            },
+            "name": {
+              "description": "The name of the application password.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": ".*\\S.*",
+              "required": true
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wp\/v2\/users\/(?P<user_id>(?:[\\d]+|me))\/application-passwords\/introspect": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/users\/(?P<user_id>(?:[\\d]+|me))\/application-passwords\/(?P<uuid>[\\w\\-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "app_id": {
+              "description": "A UUID provided by the application to uniquely identify it. It is recommended to use an UUID v5 with the URL or DNS namespace.",
+              "type": "string",
+              "format": "uuid",
+              "required": false
+            },
+            "name": {
+              "description": "The name of the application password.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": ".*\\S.*",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": []
+        }
+      ]
+    },
+    "\/wp\/v2\/comments": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "after": {
+              "description": "Limit response to comments published after a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "author": {
+              "description": "Limit result set to comments assigned to specific user IDs. Requires authorization.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "author_exclude": {
+              "description": "Ensure result set excludes comments assigned to specific user IDs. Requires authorization.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "author_email": {
+              "default": null,
+              "description": "Limit result set to that from a specific author email. Requires authorization.",
+              "format": "email",
+              "type": "string",
+              "required": false
+            },
+            "before": {
+              "description": "Limit response to comments published before a given ISO8601 compliant date.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by comment attribute.",
+              "type": "string",
+              "default": "date_gmt",
+              "enum": [
+                "date",
+                "date_gmt",
+                "id",
+                "include",
+                "post",
+                "parent",
+                "type"
+              ],
+              "required": false
+            },
+            "parent": {
+              "default": [],
+              "description": "Limit result set to comments of specific parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "parent_exclude": {
+              "default": [],
+              "description": "Ensure result set excludes specific parent IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "post": {
+              "default": [],
+              "description": "Limit result set to comments assigned to specific post IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "required": false
+            },
+            "status": {
+              "default": "approve",
+              "description": "Limit result set to comments assigned a specific status. Requires authorization.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "default": "comment",
+              "description": "Limit result set to comments assigned a specific type. Requires authorization.",
+              "type": "string",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the post if it is password protected.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "author": {
+              "description": "The ID of the user object, if author was a user.",
+              "type": "integer",
+              "required": false
+            },
+            "author_email": {
+              "description": "Email address for the comment author.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "author_ip": {
+              "description": "IP address for the comment author.",
+              "type": "string",
+              "format": "ip",
+              "required": false
+            },
+            "author_name": {
+              "description": "Display name for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "author_url": {
+              "description": "URL for the comment author.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "author_user_agent": {
+              "description": "User agent for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "The content for the comment.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the comment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the comment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "date": {
+              "description": "The date the comment was published, in the site's timezone.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the comment was published, as GMT.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "parent": {
+              "default": 0,
+              "description": "The ID for the parent of the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "post": {
+              "default": 0,
+              "description": "The ID of the associated post object.",
+              "type": "integer",
+              "required": false
+            },
+            "status": {
+              "description": "State of the comment.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/comments"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/comments\/(?P<id>[\\d]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the parent post of the comment (if the post is password protected).",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "author": {
+              "description": "The ID of the user object, if author was a user.",
+              "type": "integer",
+              "required": false
+            },
+            "author_email": {
+              "description": "Email address for the comment author.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "author_ip": {
+              "description": "IP address for the comment author.",
+              "type": "string",
+              "format": "ip",
+              "required": false
+            },
+            "author_name": {
+              "description": "Display name for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "author_url": {
+              "description": "URL for the comment author.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "author_user_agent": {
+              "description": "User agent for the comment author.",
+              "type": "string",
+              "required": false
+            },
+            "content": {
+              "description": "The content for the comment.",
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "description": "Content for the comment, as it exists in the database.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "rendered": {
+                  "description": "HTML content for the comment, transformed for display.",
+                  "type": "string",
+                  "context": [
+                    "view",
+                    "edit",
+                    "embed"
+                  ],
+                  "readonly": true
+                }
+              },
+              "required": false
+            },
+            "date": {
+              "description": "The date the comment was published, in the site's timezone.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "date_gmt": {
+              "description": "The date the comment was published, as GMT.",
+              "type": "string",
+              "format": "date-time",
+              "required": false
+            },
+            "parent": {
+              "description": "The ID for the parent of the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "post": {
+              "description": "The ID of the associated post object.",
+              "type": "integer",
+              "required": false
+            },
+            "status": {
+              "description": "State of the comment.",
+              "type": "string",
+              "required": false
+            },
+            "meta": {
+              "description": "Meta fields.",
+              "type": "object",
+              "properties": [],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "id": {
+              "description": "Unique identifier for the comment.",
+              "type": "integer",
+              "required": false
+            },
+            "force": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to bypass Trash and force deletion.",
+              "required": false
+            },
+            "password": {
+              "description": "The password for the parent post of the comment (if the post is password protected).",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/search": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "type": {
+              "default": "post",
+              "description": "Limit results to items of an object type.",
+              "type": "string",
+              "enum": [
+                "post",
+                "term",
+                "post-format"
+              ],
+              "required": false
+            },
+            "subtype": {
+              "default": "any",
+              "description": "Limit results to items of one or more object subtypes.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "post",
+                  "page",
+                  "category",
+                  "post_tag",
+                  "any"
+                ],
+                "type": "string"
+              },
+              "required": false
+            },
+            "exclude": {
+              "description": "Ensure result set excludes specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            },
+            "include": {
+              "description": "Limit result set to specific IDs.",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": [],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/search"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/block-renderer\/(?P<name>[a-z0-9-]+\/[a-z0-9-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "args": {
+            "name": {
+              "description": "Unique registered name for the block.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "attributes": {
+              "description": "Attributes for the block.",
+              "type": "object",
+              "default": [],
+              "required": false
+            },
+            "post_id": {
+              "description": "ID of the post context.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/block-types": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "namespace": {
+              "description": "Block namespace.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/block-types"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/block-types\/(?P<namespace>[a-zA-Z0-9_-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "namespace": {
+              "description": "Block namespace.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/block-types\/(?P<namespace>[a-zA-Z0-9_-]+)\/(?P<name>[a-zA-Z0-9_-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "name": {
+              "description": "Block name.",
+              "type": "string",
+              "required": false
+            },
+            "namespace": {
+              "description": "Block namespace.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/settings": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "title": {
+              "title": "Title",
+              "description": "Site title.",
+              "type": "string",
+              "required": false
+            },
+            "description": {
+              "title": "Tagline",
+              "description": "Site tagline.",
+              "type": "string",
+              "required": false
+            },
+            "url": {
+              "title": "",
+              "description": "Site URL.",
+              "type": "string",
+              "format": "uri",
+              "required": false
+            },
+            "email": {
+              "title": "",
+              "description": "This address is used for admin purposes, like new user notification.",
+              "type": "string",
+              "format": "email",
+              "required": false
+            },
+            "timezone": {
+              "title": "",
+              "description": "A city in the same timezone as you.",
+              "type": "string",
+              "required": false
+            },
+            "date_format": {
+              "title": "",
+              "description": "A date format for all date strings.",
+              "type": "string",
+              "required": false
+            },
+            "time_format": {
+              "title": "",
+              "description": "A time format for all time strings.",
+              "type": "string",
+              "required": false
+            },
+            "start_of_week": {
+              "title": "",
+              "description": "A day number of the week that the week should start on.",
+              "type": "integer",
+              "required": false
+            },
+            "language": {
+              "title": "",
+              "description": "WordPress locale code.",
+              "type": "string",
+              "required": false
+            },
+            "use_smilies": {
+              "title": "",
+              "description": "Convert emoticons like :-) and :-P to graphics on display.",
+              "type": "boolean",
+              "required": false
+            },
+            "default_category": {
+              "title": "",
+              "description": "Default post category.",
+              "type": "integer",
+              "required": false
+            },
+            "default_post_format": {
+              "title": "",
+              "description": "Default post format.",
+              "type": "string",
+              "required": false
+            },
+            "posts_per_page": {
+              "title": "Maximum posts per page",
+              "description": "Blog pages show at most.",
+              "type": "integer",
+              "required": false
+            },
+            "show_on_front": {
+              "title": "Show on front",
+              "description": "What to show on the front page",
+              "type": "string",
+              "required": false
+            },
+            "page_on_front": {
+              "title": "Page on front",
+              "description": "The ID of the page that should be displayed on the front page",
+              "type": "integer",
+              "required": false
+            },
+            "page_for_posts": {
+              "title": "",
+              "description": "The ID of the page that should display the latest posts",
+              "type": "integer",
+              "required": false
+            },
+            "default_ping_status": {
+              "title": "",
+              "description": "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "default_comment_status": {
+              "title": "Allow comments on new posts",
+              "description": "Allow people to submit comments on new posts.",
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ],
+              "required": false
+            },
+            "site_logo": {
+              "title": "Logo",
+              "description": "Site logo.",
+              "type": "integer",
+              "required": false
+            },
+            "site_icon": {
+              "title": "Icon",
+              "description": "Site icon.",
+              "type": "integer",
+              "required": false
+            },
+            "jetpack_search_ai_prompt_override": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_color_theme": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_result_format": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_default_sort": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_overlay_trigger": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_excluded_post_types": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_highlight_color": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "jetpack_search_enable_sort": {
+              "title": "",
+              "description": "",
+              "type": "boolean",
+              "required": false
+            },
+            "jetpack_search_inf_scroll": {
+              "title": "",
+              "description": "",
+              "type": "boolean",
+              "required": false
+            },
+            "jetpack_search_filtering_opens_overlay": {
+              "title": "",
+              "description": "",
+              "type": "boolean",
+              "required": false
+            },
+            "jetpack_search_show_post_date": {
+              "title": "",
+              "description": "",
+              "type": "boolean",
+              "required": false
+            },
+            "jetpack_search_show_powered_by": {
+              "title": "",
+              "description": "",
+              "type": "boolean",
+              "required": false
+            },
+            "cookie_consent_template": {
+              "title": "",
+              "description": "",
+              "type": "string",
+              "required": false
+            },
+            "Blogroll Recommendations": {
+              "title": "",
+              "description": "Site Recommendations",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "text-field"
+                  },
+                  "name": {
+                    "type": "string",
+                    "format": "text-field"
+                  },
+                  "icon": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "description": {
+                    "type": "string",
+                    "format": "text-field"
+                  },
+                  "is_non_wpcom_site": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/settings"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/themes": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "status": {
+              "description": "Limit result set to themes assigned one or more statuses.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "active",
+                  "inactive"
+                ],
+                "type": "string"
+              },
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/themes"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/themes\/(?P<stylesheet>[^\\\/:<>\\*\\?\"\\|]+(?:\\\/[^\\\/:<>\\*\\?\"\\|]+)?)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "stylesheet": {
+              "description": "The theme's stylesheet. This uniquely identifies the theme.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/plugins": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "required": false
+            },
+            "status": {
+              "description": "Limits results to plugins with the given status.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "inactive",
+                  "active"
+                ]
+              },
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "slug": {
+              "type": "string",
+              "description": "WordPress.org plugin directory slug.",
+              "pattern": "[\\w\\-]+",
+              "required": true
+            },
+            "status": {
+              "description": "The plugin activation status.",
+              "type": "string",
+              "enum": [
+                "inactive",
+                "active"
+              ],
+              "default": "inactive",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/plugins"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/plugins\/(?P<plugin>[^.\\\/]+(?:\\\/[^.\\\/]+)?)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "plugin": {
+              "type": "string",
+              "pattern": "[^.\\\/]+(?:\\\/[^.\\\/]+)?",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "plugin": {
+              "type": "string",
+              "pattern": "[^.\\\/]+(?:\\\/[^.\\\/]+)?",
+              "required": false
+            },
+            "status": {
+              "description": "The plugin activation status.",
+              "type": "string",
+              "enum": [
+                "inactive",
+                "active"
+              ],
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "plugin": {
+              "type": "string",
+              "pattern": "[^.\\\/]+(?:\\\/[^.\\\/]+)?",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/sidebars": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/sidebars"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/sidebars\/(?P<id>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The id of a registered sidebar",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "args": {
+            "widgets": {
+              "description": "Nested widgets.",
+              "type": "array",
+              "items": {
+                "type": [
+                  "object",
+                  "string"
+                ]
+              },
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/widget-types": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/widget-types"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/widget-types\/(?P<id>[a-zA-Z0-9_-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "id": {
+              "description": "The widget type id.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/widget-types\/(?P<id>[a-zA-Z0-9_-]+)\/encode": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "The widget type id.",
+              "type": "string",
+              "required": true
+            },
+            "instance": {
+              "description": "Current instance settings of the widget.",
+              "type": "object",
+              "required": false
+            },
+            "form_data": {
+              "description": "Serialized widget form data to encode into instance settings.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/widget-types\/(?P<id>[a-zA-Z0-9_-]+)\/render": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "args": {
+            "id": {
+              "description": "The widget type id.",
+              "type": "string",
+              "required": true
+            },
+            "instance": {
+              "description": "Current instance settings of the widget.",
+              "type": "object",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/widgets": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "sidebar": {
+              "description": "The sidebar to return widgets for.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the widget.",
+              "type": "string",
+              "required": false
+            },
+            "id_base": {
+              "description": "The type of the widget. Corresponds to ID in widget-types endpoint.",
+              "type": "string",
+              "required": false
+            },
+            "sidebar": {
+              "default": "wp_inactive_widgets",
+              "description": "The sidebar the widget belongs to.",
+              "type": "string",
+              "required": true
+            },
+            "instance": {
+              "description": "Instance settings of the widget, if supported.",
+              "type": "object",
+              "properties": {
+                "encoded": {
+                  "description": "Base64 encoded representation of the instance settings.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "hash": {
+                  "description": "Cryptographic hash of the instance settings.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "raw": {
+                  "description": "Unencoded instance settings, if supported.",
+                  "type": "object",
+                  "context": [
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "form_data": {
+              "description": "URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.",
+              "type": "string",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/widgets"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/widgets\/(?P<id>[\\w\\-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "PUT",
+            "PATCH"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "id": {
+              "description": "Unique identifier for the widget.",
+              "type": "string",
+              "required": false
+            },
+            "id_base": {
+              "description": "The type of the widget. Corresponds to ID in widget-types endpoint.",
+              "type": "string",
+              "required": false
+            },
+            "sidebar": {
+              "description": "The sidebar the widget belongs to.",
+              "type": "string",
+              "required": false
+            },
+            "instance": {
+              "description": "Instance settings of the widget, if supported.",
+              "type": "object",
+              "properties": {
+                "encoded": {
+                  "description": "Base64 encoded representation of the instance settings.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "hash": {
+                  "description": "Cryptographic hash of the instance settings.",
+                  "type": "string",
+                  "context": [
+                    "edit"
+                  ]
+                },
+                "raw": {
+                  "description": "Unencoded instance settings, if supported.",
+                  "type": "object",
+                  "context": [
+                    "edit"
+                  ]
+                }
+              },
+              "required": false
+            },
+            "form_data": {
+              "description": "URL-encoded form data from the widget admin form. Used to update a widget that does not support instance. Write only.",
+              "type": "string",
+              "required": false
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "allow_batch": {
+            "v1": true
+          },
+          "args": {
+            "force": {
+              "description": "Whether to force removal of the widget, or move it to the inactive sidebar.",
+              "type": "boolean",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp\/v2\/block-directory\/search": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "term": {
+              "description": "Limit result set to blocks matching the search term.",
+              "type": "string",
+              "minLength": 1,
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/block-directory\/search"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/pattern-directory\/patterns": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            },
+            "search": {
+              "description": "Limit results to those matching a string.",
+              "type": "string",
+              "minLength": 1,
+              "required": false
+            },
+            "category": {
+              "description": "Limit results to those matching a category ID.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "keyword": {
+              "description": "Limit results to those matching a keyword ID.",
+              "type": "integer",
+              "minimum": 1,
+              "required": false
+            },
+            "slug": {
+              "description": "Limit results to those matching a pattern (slug).",
+              "type": "array",
+              "required": false
+            },
+            "offset": {
+              "description": "Offset the result set by a specific number of items.",
+              "type": "integer",
+              "required": false
+            },
+            "order": {
+              "description": "Order sort attribute ascending or descending.",
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "required": false
+            },
+            "orderby": {
+              "description": "Sort collection by post attribute.",
+              "type": "string",
+              "default": "date",
+              "enum": [
+                "author",
+                "date",
+                "id",
+                "include",
+                "modified",
+                "parent",
+                "relevance",
+                "slug",
+                "include_slugs",
+                "title",
+                "favorite_count"
+              ],
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/pattern-directory\/patterns"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/block-patterns\/patterns": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/block-patterns\/patterns"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/block-patterns\/categories": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/block-patterns\/categories"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "namespace": {
+              "default": "wp-site-health\/v1",
+              "required": false
+            },
+            "context": {
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/background-updates": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/background-updates"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/loopback-requests": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/loopback-requests"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/https-status": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/https-status"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/dotorg-communication": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/dotorg-communication"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/authorization-header": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/authorization-header"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/directory-sizes": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/directory-sizes"
+          }
+        ]
+      }
+    },
+    "\/wp-site-health\/v1\/tests\/page-cache": {
+      "namespace": "wp-site-health\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-site-health\/v1\/tests\/page-cache"
+          }
+        ]
+      }
+    },
+    "\/wp-block-editor\/v1\/url-details": {
+      "namespace": "wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "url": {
+              "description": "The URL to process.",
+              "type": "string",
+              "format": "uri",
+              "required": true
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-block-editor\/v1\/url-details"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/menu-locations": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/menu-locations"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/menu-locations\/(?P<location>[\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "location": {
+              "description": "An alphanumeric identifier for the menu location.",
+              "type": "string",
+              "required": false
+            },
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    },
+    "\/wp-block-editor\/v1\/navigation-fallback": {
+      "namespace": "wp-block-editor\/v1",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": []
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp-block-editor\/v1\/navigation-fallback"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/font-collections": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            },
+            "page": {
+              "description": "Current page of the collection.",
+              "type": "integer",
+              "default": 1,
+              "minimum": 1,
+              "required": false
+            },
+            "per_page": {
+              "description": "Maximum number of items to be returned in result set.",
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100,
+              "required": false
+            }
+          }
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https:\/\/jetpack.wpmt.co\/wp-json\/wp\/v2\/font-collections"
+          }
+        ]
+      }
+    },
+    "\/wp\/v2\/font-collections\/(?P<slug>[\\\/\\w-]+)": {
+      "namespace": "wp\/v2",
+      "methods": [
+        "GET"
+      ],
+      "endpoints": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "args": {
+            "context": {
+              "description": "Scope under which the request is made; determines fields present in response.",
+              "type": "string",
+              "enum": [
+                "view",
+                "embed",
+                "edit"
+              ],
+              "default": "view",
+              "required": false
+            }
+          }
+        }
+      ]
+    }
+  },
+  "site_logo": 0,
+  "site_icon": 0,
+  "site_icon_url": "",
+  "_links": {
+    "help": [
+      {
+        "href": "https:\/\/developer.wordpress.org\/rest-api\/"
+      }
+    ]
+  }
+}

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -109,7 +109,7 @@ pub enum EnumFromStrParsingError {
     UnknownVariant { value: String },
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum JsonValue {
     Null,

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -1,5 +1,6 @@
 use crate::{
-    login::url_discovery::is_local_dev_environment_url, parsed_url::ParsedUrl, uuid::WpUuid,
+    JsonValue, login::url_discovery::is_local_dev_environment_url, parsed_url::ParsedUrl,
+    uuid::WpUuid,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str, sync::Arc};
@@ -7,6 +8,7 @@ use wp_localization::{MessageBundle, WpMessages, WpSupportsLocalization};
 use wp_localization_macro::WpDeriveLocalizable;
 use wp_serde_helper::{
     deserialize_empty_array_or_hashmap, deserialize_false_or_string, deserialize_offset,
+    deserialize_string_vec_or_string_as_option,
 };
 
 const KEY_APPLICATION_PASSWORDS: &str = "application-passwords";
@@ -66,6 +68,35 @@ pub struct WpApiDetails {
     pub authentication: WpApiDetailsAuthenticationMap,
     #[serde(default, deserialize_with = "deserialize_false_or_string")]
     pub site_icon_url: Option<String>,
+    pub routes: HashMap<String, WpRoute>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct WpRoute {
+    pub namespace: String,
+    pub methods: Vec<String>,
+    pub endpoints: Vec<WpEndpoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct WpEndpoint {
+    pub methods: Vec<String>,
+    #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
+    pub args: HashMap<String, WpEndpointArg>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
+pub struct WpEndpointArg {
+    pub required: bool,
+
+    pub default: Option<JsonValue>,
+    pub description: Option<String>,
+    #[serde(deserialize_with = "deserialize_string_vec_or_string_as_option")]
+    #[serde(default)]
+    pub r#type: Option<Vec<String>>,
+    pub r#enum: Option<Vec<String>>,
+    // There are many other fields that are specific to the type of argument. These are not currently supported because
+    // they're likely to be of limited value to library users. We're open to adding them if there's a demand for them.
 }
 
 impl TryFrom<&[u8]> for WpApiDetails {
@@ -137,6 +168,16 @@ impl WpApiDetails {
     pub fn site_url_is_local_development_environment(&self) -> bool {
         ParsedUrl::parse(self.url.as_str())
             .is_ok_and(|parsed_url| is_local_dev_environment_url(&parsed_url))
+    }
+
+    /// Returns `true` if the site has routes matching the given namespace.
+    pub fn has_namespace(&self, namespace: String) -> bool {
+        self.namespaces.contains(&namespace)
+    }
+
+    /// Returns `true` if the site has the given route.
+    pub fn has_route(&self, route: String) -> bool {
+        self.routes.contains_key(&route)
     }
 }
 
@@ -421,6 +462,7 @@ mod tests {
     #[rstest]
     #[case("api-details/test-case-01.json")]
     #[case("api-details/test-case-02.json")]
+    #[case("api-details/test-case-03.json")]
     fn test_api_details_json(#[case] input: &str) {
         let json = test_json(input).expect("Failed to read test resource");
 
@@ -430,6 +472,69 @@ mod tests {
             result.is_ok(),
             "Failed to parse json as `WpApiDetails`: {result:#?}"
         );
+    }
+
+    #[test]
+    fn test_has_namespace() {
+        let json: Vec<u8> =
+            test_json("api-details/test-case-03.json").expect("Failed to read test resource");
+        let result = WpApiDetails::try_from(json.as_slice());
+        assert!(
+            result.is_ok(),
+            "Failed to parse json as `WpApiDetails`: {result:#?}"
+        );
+
+        let unwrapped_result = result.unwrap();
+
+        assert!(unwrapped_result.has_namespace("jetpack/v4".to_string()));
+        assert!(!unwrapped_result.has_namespace("jetpack/v2".to_string()));
+    }
+
+    #[rstest]
+    #[case("context", Some(JsonValue::String("edit".to_string())))]
+    #[case("jetpack_blocks_disabled", Some(JsonValue::Bool(false)))]
+    #[case("jetpack_portfolio_posts_per_page", Some(JsonValue::Int(10)))]
+    #[case("show", Some(JsonValue::Array(vec![JsonValue::String("post".to_string())])))]
+    #[case("sharing_services", Some(JsonValue::Object(HashMap::from([("visible".to_string(), JsonValue::Array(vec![JsonValue::String("facebook".to_string()), JsonValue::String("x".to_string())])), ("hidden".to_string(), JsonValue::Array(vec![]))]))))]
+    fn test_route_args(#[case] argument_name: &str, #[case] expected_result: Option<JsonValue>) {
+        let json: Vec<u8> =
+            test_json("api-details/test-case-03.json").expect("Failed to read test resource");
+        let result = WpApiDetails::try_from(json.as_slice());
+
+        assert!(
+            result.is_ok(),
+            "Failed to parse json as `WpApiDetails`: {result:#?}"
+        );
+
+        let unwrapped_result = result.unwrap();
+
+        assert!(unwrapped_result.has_route("/jetpack/v4/settings".to_string()));
+        let route = unwrapped_result.routes.get("/jetpack/v4/settings").unwrap();
+
+        let argument = route
+            .endpoints
+            .first()
+            .unwrap()
+            .args
+            .get(argument_name)
+            .unwrap();
+        assert_eq!(argument.default, expected_result);
+    }
+
+    #[test]
+    fn test_has_route() {
+        let json: Vec<u8> =
+            test_json("api-details/test-case-03.json").expect("Failed to read test resource");
+        let result = WpApiDetails::try_from(json.as_slice());
+        assert!(
+            result.is_ok(),
+            "Failed to parse json as `WpApiDetails`: {result:#?}"
+        );
+
+        let unwrapped_result = result.unwrap();
+
+        assert!(unwrapped_result.has_route("/jetpack/v4/backup-helper-script".to_string()));
+        assert!(!unwrapped_result.has_route("/jetpack/v4/fake-endpoint".to_string()));
     }
 
     fn test_json(input: &str) -> Result<Vec<u8>, std::io::Error> {

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1134,6 +1134,7 @@ mod tests {
                 gmt_offset: None,
                 timezone_string: None,
                 namespaces: vec![],
+                routes: HashMap::new(),
                 authentication: WpApiDetailsAuthenticationMap(HashMap::new()),
                 site_icon_url: None,
             }

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -298,6 +298,68 @@ where
     deserializer.deserialize_any(DeserializeEmptyArrayOrHashMapVisitor::<K, V>(PhantomData))
 }
 
+pub fn deserialize_string_vec_or_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(vec) = deserialize_string_vec_or_string_as_option(deserializer)? {
+        Ok(vec)
+    } else {
+        Err(serde::de::Error::custom(
+            "Expected a string or vector of strings",
+        ))
+    }
+}
+
+pub fn deserialize_string_vec_or_string_as_option<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(DeserializeStringVecOrStringAsOptionVisitor)
+}
+
+struct DeserializeStringVecOrStringAsOptionVisitor;
+
+impl<'de> de::Visitor<'de> for DeserializeStringVecOrStringAsOptionVisitor {
+    type Value = Option<Vec<String>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("string or a vector of strings")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Some(vec![v.to_string()]))
+    }
+
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        Ok(Some(Deserialize::deserialize(
+            de::value::SeqAccessDeserializer::new(seq),
+        )?))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -387,5 +449,46 @@ mod tests {
         let wrapper: HashMapWrapper =
             serde_json::from_str(test_case).expect("Test case should be a valid JSON");
         assert_eq!(expected_result, wrapper.map);
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct StringVecOrString {
+        #[serde(deserialize_with = "deserialize_string_vec_or_string")]
+        pub string: Vec<String>,
+    }
+
+    #[rstest]
+    #[case(r#"{"string": "string"}"#, vec!["string".to_string()])]
+    #[case(r#"{"string": ["string", "string2"]}"#, vec!["string".to_string(), "string2".to_string()])]
+    #[case(r#"{"string": []}"#, vec![])]
+    fn test_deserialize_string_vec_or_string(
+        #[case] test_case: &str,
+        #[case] expected_result: Vec<String>,
+    ) {
+        let string_vec_or_string: StringVecOrString =
+            serde_json::from_str(test_case).expect("Test case should be a valid JSON");
+        assert_eq!(expected_result, string_vec_or_string.string);
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct OptionStringVecOrString {
+        #[serde(deserialize_with = "deserialize_string_vec_or_string_as_option")]
+        #[serde(default)]
+        pub string: Option<Vec<String>>,
+    }
+
+    #[rstest]
+    #[case(r#"{"string": "string"}"#, Some(vec!["string".to_string()]))]
+    #[case(r#"{"string": ["string", "string2"]}"#, Some(vec!["string".to_string(), "string2".to_string()]))]
+    #[case(r#"{"string": []}"#, Some(vec![]))]
+    #[case(r#"{"string": null}"#, None)]
+    #[case(r#"{}"#, None)]
+    fn test_deserialize_string_vec_or_string_as_option(
+        #[case] test_case: &str,
+        #[case] expected_result: Option<Vec<String>>,
+    ) {
+        let option_string_vec_or_string: OptionStringVecOrString =
+            serde_json::from_str(test_case).expect("Test case should be a valid JSON");
+        assert_eq!(expected_result, option_string_vec_or_string.string);
     }
 }


### PR DESCRIPTION
Adds the ability to detect namespace and endpoint registration. This makes it possible for applications to answer questions like:

1. Does this site support the Gutenberg Editor Manifest?
2. Does this site support using Application Passwords for XML-RPC, or to fetch post previews?

I debated whether to implement something like `ApiDetails::supports(WpSiteFeature::ApplicationPasswords)` but this seems like an application-level concern, not a library one. That means _some_ code duplication, but I think it's preferable, because an application will have a better idea of what features it cares about.

This PR spawned https://github.com/Automattic/jetpack/pull/45186
