### PR TITLE
Fix Android Studio support

### DIFF
--- a/native/kotlin/api/android/build.gradle.kts
+++ b/native/kotlin/api/android/build.gradle.kts
@@ -86,6 +86,8 @@ dependencies {
 val cargoProjectRoot = rootProject.ext.get("cargoProjectRoot")!!
 val moduleName = "wp_api"
 cargo {
+    cargoCommand = rootProject.ext.get("cargoBinaryPath").toString()
+    rustcCommand = rootProject.ext.get("rustcBinaryPath").toString()
     module = "$cargoProjectRoot/$moduleName/"
     libname = moduleName
     profile = "release"

--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -93,7 +93,7 @@ val generateUniFFIBindingsTask = tasks.register<Exec>("generateUniFFIBindings") 
     dependsOn(rootProject.tasks.named("cargoBuildLibraryRelease"))
     workingDir(project.rootDir)
     commandLine(
-        "cargo",
+        rootProject.ext.get("cargoBinaryPath")!!,
         "run",
         "--release",
         "--bin",

--- a/native/kotlin/build.gradle.kts
+++ b/native/kotlin/build.gradle.kts
@@ -47,12 +47,17 @@ allprojects {
     }
 }
 
+val cargoBinaryPath = resolveBinary("cargo")
+val rustcBinaryPath = resolveBinary("rustc")
 val cargoProjectRoot = "${project.rootDir}/../.."
 val jniLibsPath = "${layout.buildDirectory.get()}/jniLibs/"
 val generatedTestResourcesPath = "${layout.buildDirectory.get()}/generatedTestResources/"
 val rustModuleName = "wp_api"
 val nativeLibraryPath =
     "$cargoProjectRoot/target/release/lib${rustModuleName}${getNativeLibraryExtension()}"
+
+rootProject.ext.set("cargoBinaryPath", cargoBinaryPath)
+rootProject.ext.set("rustcBinaryPath", rustcBinaryPath)
 rootProject.ext.set("cargoProjectRoot", cargoProjectRoot)
 rootProject.ext.set("jniLibsPath", jniLibsPath)
 rootProject.ext.set("generatedTestResourcesPath", generatedTestResourcesPath)
@@ -68,7 +73,7 @@ fun setupJniAndBindings() {
 
     val cargoBuildLibraryReleaseTask = tasks.register<Exec>("cargoBuildLibraryRelease") {
         workingDir(rootProject.ext.get("cargoProjectRoot")!!)
-        commandLine("cargo", "build", "--package", rustModuleName, "--release")
+        commandLine(cargoBinaryPath, "build", "--package", rustModuleName, "--release")
         // No inputs.dir added, because we want to always re-run this task and let Cargo handle caching
     }
 
@@ -99,6 +104,16 @@ fun setupJniAndBindings() {
         from("$cargoProjectRoot/test-data/integration-test-responses/localhost-json-root.json")
         into(generatedTestResourcesPath)
     }
+}
+
+fun resolveBinary(name: String): String {
+    val process = ProcessBuilder().apply {
+        command(listOf("which", name))
+    }.start()
+
+    process.waitFor()
+
+    return process.inputReader().readText().trim()
 }
 
 fun getNativeLibraryExtension(): String {


### PR DESCRIPTION
Works around https://github.com/gradle/gradle/issues/10483 by resolving the compiler paths at the start of the script, then passing them where they’re needed.

This is only coming up now because we’ve adopted JDK21, which seems to be related to the issue at hand (at least on a Mac).

### To Test:
Before running any tests, run `git clean -fdX` from the root of the repo, and ensure you've run `make setup-rust-android-targets` successfully.

**Android Studio**
1. Open the project in Android Studio
2. Ensure the initial Gradle Sync works
3. Run the `ApiUrlDiscoveryTest` suite from within Android Studio (in `api/kotlin/integrationTest/tests/ApiUrlDiscoveryTest.kt`) to ensure that all the JNI stuff is working.
4. Try building the `example.composeApp` configuration – it should work.

**Gradle**
1. Run `./native/kotlin/gradlew -p native/kotlin compileKotlin`
2. Note that the output is printed as the command runs
3. Run the `ApiUrlDiscoveryTest` suite using `./native/kotlin/gradlew -p native/kotlin :api:kotlin:integrationTest --tests rs.wordpress.api.kotlin.ApiUrlDiscoveryTest` to ensure that all the JNI stuff is working.
4. Build the `example.composeApp` configuration using `./native/kotlin/gradlew -p native/kotlin :example:composeApp:assembleDebug` to ensure that the Android bits are working.