### PR TITLE
Fix Android Example App

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -204,10 +204,6 @@ steps:
         agents:
           queue: android
 
-  # Android Group
-  - group: ":android: Android"
-    key: "android"
-    steps:
       - label: ":android: Build Example App"
         plugins: [$CI_TOOLKIT]
         command: |
@@ -220,7 +216,7 @@ steps:
           make setup-rust
           make setup-rust-android-targets
 
-          echo "--- :kotlin: Publishing `rs.wordpress.api:android`"
+          echo "--- :android: Building Sample App"
           ./native/kotlin/gradlew -p native/kotlin :example:composeApp:assembleDebug
         agents:
           queue: android

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -204,6 +204,27 @@ steps:
         agents:
           queue: android
 
+  # Android Group
+  - group: ":android: Android"
+    key: "android"
+    steps:
+      - label: ":android: Build Example App"
+        plugins: [$CI_TOOLKIT]
+        command: |
+          echo "--- :rust: Installing Rust"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
+
+          source "$$HOME/.cargo/env"
+
+          echo "--- :package: Installing Rust Toolchains"
+          make setup-rust
+          make setup-rust-android-targets
+
+          echo "--- :kotlin: Publishing `rs.wordpress.api:android`"
+          ./native/kotlin/gradlew -p native/kotlin :example:composeApp:assembleDebug
+        agents:
+          queue: android
+
   # Docker Group
   - group: ":wordpress: End-to-end Tests"
     key: "e2e"

--- a/native/kotlin/example/composeApp/build.gradle.kts
+++ b/native/kotlin/example/composeApp/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -8,12 +10,10 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 tasks.withType<KotlinJvmCompile>().configureEach {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_11)
+    jvmTarget.set(JvmTarget.JVM_21)
     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
   }
 }
@@ -91,8 +91,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
The Android App's build file was broken, and it wasn't using the same JDK as the rest of the project.

I've fixed these, and ensured it builds in CI.

This is mostly to test dependabot PRs, but we can also use the demo app to validate support for 16K page sizes.