### PR TITLE
`/menu-locations` endpoint

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MenuLocationsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MenuLocationsEndpointTest.kt
@@ -1,0 +1,38 @@
+package rs.wordpress.api.kotlin
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uniffi.wp_api.WpErrorCode
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MenuLocationsEndpointTest {
+    private val client = defaultApiClient()
+
+    @Test
+    fun testMenuLocationsListRequest() = runTest {
+        val menuLocations = client.request { requestBuilder ->
+            requestBuilder.menuLocations().listWithEditContext()
+        }.assertSuccessAndRetrieveData().data.locations
+
+        assertNotNull(menuLocations)
+        assertTrue(menuLocations.isNotEmpty())
+    }
+
+    @Test
+    fun testMenuLocationsRetrieveRequest() = runTest {
+        client.request { requestBuilder ->
+            requestBuilder.menuLocations()
+                .retrieveWithEditContext(TestCredentials.INSTANCE.primaryMenuLocation)
+        }.assertSuccessAndRetrieveData()
+    }
+
+    @Test
+    fun testMenuLocationsErrMenuLocationInvalid() = runTest {
+        val result = client.request { requestBuilder ->
+            requestBuilder.menuLocations()
+                .retrieveWithViewContext("invalid_location_that_does_not_exist")
+        }
+        assert(result.wpErrorCode() is WpErrorCode.MenuLocationInvalid)
+    }
+}

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/TestCredentials.kt
@@ -49,6 +49,8 @@ data class TestCredentials(
     val integrationTestCustomTemplateId: String,
     @SerialName("revisioned_post_id")
     val revisionedPostId: Long,
+    @SerialName("primary_menu_location")
+    val primaryMenuLocation: String,
 ) {
     companion object {
         private val json by lazy {

--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -161,14 +161,20 @@ struct ExampleApp: App {
             try await WordPressAPI.globalInstance.postStatuses.listWithEditContext()
                 .data
                 .postStatuses
-                .map(\.value)
-                .map(\.asListViewData)
+                .map(\.value.asListViewData)
         }, category: .posts))
 
         baseData.append(RootListData(name: "Menus", callback: {
             try await WordPressAPI.globalInstance.navMenus.listWithEditContext(params: NavMenuListParams())
                 .data
                 .map(\.asListViewData)
+        }, category: .system))
+
+        baseData.append(RootListData(name: "Menu Locations", callback: {
+            try await WordPressAPI.globalInstance.menuLocations.listWithEditContext()
+                .data
+                .locations
+                .map(\.value.asListViewData)
         }, category: .system))
 
         return baseData

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -189,6 +189,12 @@ extension NavMenuWithEditContext: ListViewDataConvertable {
     }
 }
 
+extension MenuLocationWithEditContext: ListViewDataConvertable {
+    var asListViewData: ListViewData {
+        ListViewData(id: self.name, title: self.name, subtitle: self.description, fields: [:])
+    }
+}
+
 extension [AnyPostWithEditContext] {
     func asListViewData() -> [ListViewData] {
         self.map { $0.asListViewData }

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -203,6 +203,11 @@ public typealias NavMenuWithEditContext = WordPressAPIInternal.NavMenuWithEditCo
 public typealias NavMenuWithViewContext = WordPressAPIInternal.NavMenuWithViewContext
 public typealias NavMenuWithEmbedContext = WordPressAPIInternal.NavMenuWithEmbedContext
 
+// MARK: Menu Locations
+public typealias MenuLocationWithEditContext = WordPressAPIInternal.MenuLocationWithEditContext
+public typealias MenuLocationWithViewContext = WordPressAPIInternal.MenuLocationWithViewContext
+public typealias MenuLocationWithEmbedContext = WordPressAPIInternal.MenuLocationWithEmbedContext
+
 // MARK: – Site Settings
 public typealias SparseSiteSettings = WordPressAPIInternal.SparseSiteSettings
 public typealias SiteSettingsWithEditContext = WordPressAPIInternal.SiteSettingsWithEditContext

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -157,6 +157,10 @@ public actor WordPressAPI {
         self.requestBuilder.navMenus()
     }
 
+    public var menuLocations: MenuLocationsRequestExecutor {
+        self.requestBuilder.menuLocations()
+    }
+
 #if PROGRESS_REPORTING_ENABLED
     public func uploadMedia(
         params: MediaCreateParams,

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -87,6 +87,17 @@ wp user create test_author test_author@example.com --role=author
 # This is used in `/posts` integration tests that updates the `template` field
 wp theme activate twentytwentyfour
 
+# Create menus for integration tests
+# The mu-plugin register-menu-locations.php registers primary and footer menu locations
+PRIMARY_MENU_LOCATION="primary"
+FOOTER_MENU_LOCATION="footer"
+PRIMARY_MENU_ID="$(wp menu create "Primary Menu" --porcelain)"
+FOOTER_MENU_ID="$(wp menu create "Footer Menu" --porcelain)"
+
+# Assign menus to their locations
+wp menu location assign "$PRIMARY_MENU_ID" "$PRIMARY_MENU_LOCATION"
+wp menu location assign "$FOOTER_MENU_ID" "$FOOTER_MENU_LOCATION"
+
 wp comment trash 22
 wp comment spam 23
 
@@ -244,6 +255,8 @@ create_test_credentials () {
     revision_id_for_revisioned_page_id="$REVISION_ID_FOR_REVISIONED_PAGE_ID" \
     autosaved_page_id="$AUTOSAVED_PAGE_ID" \
     autosave_id_for_autosaved_page_id="$AUTOSAVE_ID_FOR_AUTOSAVED_PAGE_ID" \
+    primary_menu_location="$PRIMARY_MENU_LOCATION" \
+    footer_menu_location="$FOOTER_MENU_LOCATION" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/scripts/test-site-mu-plugins/register-menu-locations.php
+++ b/scripts/test-site-mu-plugins/register-menu-locations.php
@@ -1,0 +1,13 @@
+<?php
+/*
+Plugin Name: Register Menu Locations for Integration Tests
+Description: Registers primary and footer menu locations for integration testing
+Version: 1.0
+*/
+
+add_action('after_setup_theme', function() {
+    register_nav_menus(array(
+        'primary' => __('Primary Menu'),
+        'footer' => __('Footer Menu'),
+    ));
+});

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -13,6 +13,7 @@ use crate::{
             },
             comments_endpoint::{CommentsRequestBuilder, CommentsRequestExecutor},
             media_endpoint::{MediaRequestBuilder, MediaRequestExecutor},
+            menu_locations_endpoint::{MenuLocationsRequestBuilder, MenuLocationsRequestExecutor},
             nav_menus_endpoint::{NavMenusRequestBuilder, NavMenusRequestExecutor},
             plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
             post_autosaves_endpoint::{AutosavesRequestBuilder, AutosavesRequestExecutor},
@@ -49,6 +50,7 @@ pub struct WpApiRequestBuilder {
     autosaves: Arc<AutosavesRequestBuilder>,
     comments: Arc<CommentsRequestBuilder>,
     media: Arc<MediaRequestBuilder>,
+    menu_locations: Arc<MenuLocationsRequestBuilder>,
     nav_menus: Arc<NavMenusRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
     post_revisions: Arc<PostRevisionsRequestBuilder>,
@@ -81,6 +83,7 @@ impl WpApiRequestBuilder {
             autosaves,
             comments,
             media,
+            menu_locations,
             nav_menus,
             plugins,
             post_revisions,
@@ -123,6 +126,7 @@ pub struct WpApiClient {
     autosaves: Arc<AutosavesRequestExecutor>,
     comments: Arc<CommentsRequestExecutor>,
     media: Arc<MediaRequestExecutor>,
+    menu_locations: Arc<MenuLocationsRequestExecutor>,
     nav_menus: Arc<NavMenusRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
     post_revisions: Arc<PostRevisionsRequestExecutor>,
@@ -152,6 +156,7 @@ impl WpApiClient {
             autosaves,
             comments,
             media,
+            menu_locations,
             nav_menus,
             plugins,
             post_revisions,
@@ -191,6 +196,7 @@ api_client_generate_endpoint_impl!(WpApi, application_passwords);
 api_client_generate_endpoint_impl!(WpApi, autosaves);
 api_client_generate_endpoint_impl!(WpApi, comments);
 api_client_generate_endpoint_impl!(WpApi, media);
+api_client_generate_endpoint_impl!(WpApi, menu_locations);
 api_client_generate_endpoint_impl!(WpApi, nav_menus);
 api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_revisions);

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -274,6 +274,8 @@ pub enum WpErrorCode {
     InvalidWidget,
     #[serde(rename = "menu_exists")]
     MenuExists,
+    #[serde(rename = "rest_menu_location_invalid")]
+    MenuLocationInvalid,
     #[serde(rename = "rest_no_search_term_defined")]
     NoSearchTermDefined,
     #[serde(rename = "rest_orderby_include_missing_include")]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod comments;
 pub mod date;
 pub mod login;
 pub mod media;
+pub mod menu_locations;
 pub mod middleware;
 pub mod nav_menus;
 pub mod parsed_url;

--- a/wp_api/src/menu_locations.rs
+++ b/wp_api/src/menu_locations.rs
@@ -1,0 +1,25 @@
+use crate::{nav_menus::NavMenuId, wp_content_string_id};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use wp_contextual::WpContextual;
+
+wp_content_string_id!(MenuLocation);
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+#[serde(transparent)]
+pub struct SparseMenuLocationsResponse {
+    #[serde(flatten)]
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub locations: Option<HashMap<MenuLocation, SparseMenuLocation>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseMenuLocation {
+    #[WpContext(edit, embed, view)]
+    pub name: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub description: Option<String>,
+    #[WpContext(edit, embed, view)]
+    pub menu: Option<NavMenuId>,
+}

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -7,6 +7,7 @@ pub mod api_root_endpoint;
 pub mod application_passwords_endpoint;
 pub mod comments_endpoint;
 pub mod media_endpoint;
+pub mod menu_locations_endpoint;
 pub mod nav_menus_endpoint;
 pub mod plugins_endpoint;
 pub mod post_autosaves_endpoint;

--- a/wp_api/src/request/endpoint/menu_locations_endpoint.rs
+++ b/wp_api/src/request/endpoint/menu_locations_endpoint.rs
@@ -1,0 +1,68 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::menu_locations::MenuLocation;
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum MenuLocationsRequest {
+    #[contextual_get(url = "/menu-locations", output = crate::menu_locations::SparseMenuLocationsResponse)]
+    List,
+    #[contextual_get(url = "/menu-locations/<menu_location>", output = crate::menu_locations::SparseMenuLocation)]
+    Retrieve,
+}
+
+impl DerivedRequest for MenuLocationsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request::endpoint::{
+        ApiUrlResolver,
+        tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    fn list_menu_locations(endpoint: MenuLocationsRequestEndpoint) {
+        validate_wp_v2_endpoint(
+            endpoint.list_with_edit_context(),
+            "/menu-locations?context=edit",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_embed_context(),
+            "/menu-locations?context=embed",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.list_with_view_context(),
+            "/menu-locations?context=view",
+        );
+    }
+
+    #[rstest]
+    fn retrieve_menu_location(endpoint: MenuLocationsRequestEndpoint) {
+        let location = &MenuLocation("primary".to_string());
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_edit_context(location),
+            "/menu-locations/primary?context=edit",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_embed_context(location),
+            "/menu-locations/primary?context=embed",
+        );
+        validate_wp_v2_endpoint(
+            endpoint.retrieve_with_view_context(location),
+            "/menu-locations/primary?context=view",
+        );
+    }
+
+    #[fixture]
+    fn endpoint(
+        fixture_wp_org_site_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> MenuLocationsRequestEndpoint {
+        MenuLocationsRequestEndpoint::new(fixture_wp_org_site_api_url_resolver)
+    }
+}

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -1,22 +1,17 @@
-use crate::JsonValue;
-use crate::url_query::{
-    AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
-};
 use crate::widget_types::WidgetTypeId;
+use crate::{
+    JsonValue,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+    wp_content_string_id,
+};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
 use wp_contextual::WpContextual;
 use wp_derive::WpDeriveParamsField;
 
-uniffi::custom_newtype!(WidgetId, String);
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WidgetId(pub String);
-
-impl Display for WidgetId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+wp_content_string_id!(WidgetId);
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
 pub struct SparseWidget {

--- a/wp_api/src/wp_content_macros.rs
+++ b/wp_api/src/wp_content_macros.rs
@@ -60,7 +60,17 @@ macro_rules! wp_content_string_id {
     ($id_type:ident) => {
         ::uniffi::custom_newtype!($id_type, ::std::string::String);
         $crate::impl_as_query_value_from_to_string!($id_type);
-        #[derive(Debug, Clone, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(
+            Debug,
+            Clone,
+            Hash,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            ::serde::Serialize,
+            ::serde::Deserialize,
+        )]
         pub struct $id_type(pub ::std::string::String);
 
         impl ::core::str::FromStr for $id_type {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -43,6 +43,8 @@ pub struct TestCredentials {
     pub revision_id_for_revisioned_page_id: i64,
     pub autosaved_page_id: i64,
     pub autosave_id_for_autosaved_page_id: i64,
+    pub primary_menu_location: &'static str,
+    pub footer_menu_location: &'static str,
 }
 
 impl TestCredentials {

--- a/wp_api_integration_tests/tests/test_menu_locations_err.rs
+++ b/wp_api_integration_tests/tests/test_menu_locations_err.rs
@@ -1,0 +1,38 @@
+use wp_api::menu_locations::MenuLocation;
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn list_menu_locations_err_rest_cannot_view() {
+    api_client_as_subscriber()
+        .menu_locations()
+        .list_with_edit_context()
+        .await
+        .assert_wp_error(WpErrorCode::CannotView);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_menu_location_err_rest_cannot_view() {
+    api_client_as_subscriber()
+        .menu_locations()
+        .retrieve_with_edit_context(&MenuLocation(
+            TestCredentials::instance()
+                .primary_menu_location
+                .to_string(),
+        ))
+        .await
+        .assert_wp_error(WpErrorCode::CannotView);
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_menu_location_err_rest_menu_location_invalid() {
+    api_client()
+        .menu_locations()
+        .retrieve_with_edit_context(&MenuLocation(
+            "invalid_location_that_does_not_exist".to_string(),
+        ))
+        .await
+        .assert_wp_error(WpErrorCode::MenuLocationInvalid);
+}

--- a/wp_api_integration_tests/tests/test_menu_locations_immut.rs
+++ b/wp_api_integration_tests/tests/test_menu_locations_immut.rs
@@ -1,0 +1,72 @@
+use wp_api::menu_locations::MenuLocation;
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn list_with_edit_context() {
+    let response = api_client()
+        .menu_locations()
+        .list_with_edit_context()
+        .await
+        .assert_response();
+    assert!(!response.data.locations.is_empty());
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_embed_context() {
+    api_client()
+        .menu_locations()
+        .list_with_embed_context()
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_view_context() {
+    api_client()
+        .menu_locations()
+        .list_with_view_context()
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_with_edit_context(location: &str) {
+    api_client()
+        .menu_locations()
+        .retrieve_with_edit_context(&MenuLocation(location.to_string()))
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_with_embed_context(location: &str) {
+    api_client()
+        .menu_locations()
+        .retrieve_with_embed_context(&MenuLocation(location.to_string()))
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(retrieve_cases)]
+#[parallel]
+async fn retrieve_with_view_context(location: &str) {
+    api_client()
+        .menu_locations()
+        .retrieve_with_view_context(&MenuLocation(location.to_string()))
+        .await
+        .assert_response();
+}
+
+#[template]
+#[rstest]
+#[case::primary(TestCredentials::instance().primary_menu_location)]
+#[case::footer(TestCredentials::instance().footer_menu_location)]
+fn retrieve_cases(#[case] location: &str) {}


### PR DESCRIPTION
Follows established patterns to implement create [`/menu-locations`](https://developer.wordpress.org/rest-api/reference/menu-locations/) endpoint.

Note that I didn't even check if the `_fields` filtering works for this endpoint, because there are only 3 fields and filtering doesn't seem very useful. Adding filtering is super easy, but it adds a bunch of extra methods that'll not be used, so I decided to skip them.