### PR TITLE
`/navigation/<parent>/revisions` & `/navigation/<parent>/autosaves` endpoints

### DIFF
--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -205,6 +205,11 @@ public typealias NavigationWithEditContext = WordPressAPIInternal.NavigationWith
 public typealias NavigationWithViewContext = WordPressAPIInternal.NavigationWithViewContext
 public typealias NavigationWithEmbedContext = WordPressAPIInternal.NavigationWithEmbedContext
 
+public typealias NavigationRevisionListParams = WordPressAPIInternal.NavigationRevisionListParams
+public typealias NavigationRevisionWithEditContext = WordPressAPIInternal.NavigationRevisionWithEditContext
+public typealias NavigationRevisionWithViewContext = WordPressAPIInternal.NavigationRevisionWithViewContext
+public typealias NavigationRevisionWithEmbedContext = WordPressAPIInternal.NavigationRevisionWithEmbedContext
+
 // MARK: - Menus
 public typealias SparseNavMenu = WordPressAPIInternal.SparseNavMenu
 public typealias NavMenuListParams = WordPressAPIInternal.NavMenuListParams

--- a/native/swift/Sources/wordpress-api/Pagination.swift
+++ b/native/swift/Sources/wordpress-api/Pagination.swift
@@ -530,6 +530,36 @@ extension CommentsRequestExecutor: PaginationAwareExecutor {
 }
 
 // MARK: Menus
+extension NavigationsRequestFilterListWithEditContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationListParams
+    public typealias DataType = SparseNavigationWithEditContext
+}
+
+extension NavigationsRequestFilterListWithViewContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationListParams
+    public typealias DataType = SparseNavigationWithViewContext
+}
+
+extension NavigationsRequestFilterListWithEmbedContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationListParams
+    public typealias DataType = SparseNavigationWithEmbedContext
+}
+
+extension NavigationRevisionsRequestFilterListWithEditContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationRevisionListParams
+    public typealias DataType = SparseNavigationRevisionWithEditContext
+}
+
+extension NavigationRevisionsRequestFilterListWithViewContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationRevisionListParams
+    public typealias DataType = SparseNavigationRevisionWithViewContext
+}
+
+extension NavigationRevisionsRequestFilterListWithEmbedContextResponse: PaginatableResponse {
+    public typealias ParamsType = NavigationRevisionListParams
+    public typealias DataType = SparseNavigationRevisionWithEmbedContext
+}
+
 extension NavMenuItemsRequestListWithEditContextResponse: PaginatableResponse {
     public typealias ParamsType = NavMenuItemListParams
     public typealias DataType = NavMenuItemWithEditContext

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -138,6 +138,13 @@ create_nav_menu_item_autosave() {
   curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d "{\"title\":\"nav_menu_item_autosave_$autosave_number\", \"author\": $ADMIN_USER_ID}" "http://localhost/wp-json/wp/v2/menu-items/$nav_menu_item_id/autosaves"
 }
 
+create_navigation_revision() {
+  local revision_number="$1"
+  local navigation_id="$2"
+
+  curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d "{\"content\":\"content_revision_$revision_number\", \"author\": $ADMIN_USER_ID}" "http://localhost/wp-json/wp/v2/navigation/$navigation_id" > /dev/null
+}
+
 create_test_credentials () {
   local SITE_URL
   local ADMIN_USERNAME
@@ -243,6 +250,15 @@ create_test_credentials () {
   NAVIGATION_RESPONSE="$(curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d '{"title":"Integration Test Navigation","content":"<!-- wp:navigation --><!-- /wp:navigation -->","status":"publish"}' http://localhost/wp-json/wp/v2/navigation)"
   NAVIGATION_ID="$(echo "$NAVIGATION_RESPONSE" | jq -r '.id')"
 
+  echo "Setting up navigation with 10 revisions for integration tests.."
+  # Create revisions for the navigation
+  for i in {1..10};
+  do
+    create_navigation_revision "$i" "$NAVIGATION_ID"
+  done
+  # Generating revisions don't return an id, but since we just created the `NAVIGATION_ID`, we can use it to calculate the revision id
+  REVISION_ID_FOR_NAVIGATION_ID=$((NAVIGATION_ID + 1))
+
   rm -rf /app/test_credentials.json
   jo -p \
     site_url="$SITE_URL" \
@@ -281,6 +297,7 @@ create_test_credentials () {
     nav_menu_item_id="$NAV_MENU_ITEM_ID" \
     autosave_id_for_nav_menu_item_id="$AUTOSAVE_ID_FOR_NAV_MENU_ITEM_ID" \
     navigation_id="$NAVIGATION_ID" \
+    revision_id_for_navigation_id="$REVISION_ID_FOR_NAVIGATION_ID" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -145,6 +145,13 @@ create_navigation_revision() {
   curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d "{\"content\":\"content_revision_$revision_number\", \"author\": $ADMIN_USER_ID}" "http://localhost/wp-json/wp/v2/navigation/$navigation_id" > /dev/null
 }
 
+create_navigation_autosave() {
+  local autosave_number="$1"
+  local navigation_id="$2"
+
+  curl --silent --user "$ADMIN_USERNAME":"$ADMIN_PASSWORD" -H "Content-Type: application/json" -d "{\"content\":\"content_autosave_$autosave_number\", \"author\": $ADMIN_USER_ID}" "http://localhost/wp-json/wp/v2/navigation/$navigation_id/autosaves"
+}
+
 create_test_credentials () {
   local SITE_URL
   local ADMIN_USERNAME
@@ -259,6 +266,13 @@ create_test_credentials () {
   # Generating revisions don't return an id, but since we just created the `NAVIGATION_ID`, we can use it to calculate the revision id
   REVISION_ID_FOR_NAVIGATION_ID=$((NAVIGATION_ID + 1))
 
+  echo "Setting up navigation with autosave for integration tests.."
+  # Create navigation as author user to enable proper autosave behavior (same requirement as posts/pages)
+  AUTOSAVED_NAVIGATION_ID="$(wp post create --post_type=wp_navigation --post_title='Autosaved Navigation FOR INTEGRATION TESTS' --post_content='<!-- wp:navigation --><!-- /wp:navigation -->' --post_status=publish --post_author="$AUTHOR_USER_ID" --porcelain)"
+  # Create autosave as admin user (different from navigation author) and capture its ID
+  AUTOSAVE_NAVIGATION_RESPONSE="$(create_navigation_autosave "1" "$AUTOSAVED_NAVIGATION_ID")"
+  AUTOSAVE_ID_FOR_AUTOSAVED_NAVIGATION_ID="$(echo "$AUTOSAVE_NAVIGATION_RESPONSE" | jq -r '.id')"
+
   rm -rf /app/test_credentials.json
   jo -p \
     site_url="$SITE_URL" \
@@ -298,6 +312,8 @@ create_test_credentials () {
     autosave_id_for_nav_menu_item_id="$AUTOSAVE_ID_FOR_NAV_MENU_ITEM_ID" \
     navigation_id="$NAVIGATION_ID" \
     revision_id_for_navigation_id="$REVISION_ID_FOR_NAVIGATION_ID" \
+    autosaved_navigation_id="$AUTOSAVED_NAVIGATION_ID" \
+    autosave_id_for_autosaved_navigation_id="$AUTOSAVE_ID_FOR_AUTOSAVED_NAVIGATION_ID" \
     > /app/test_credentials.json
 }
 create_test_credentials

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -19,6 +19,12 @@ use crate::{
             },
             nav_menu_items_endpoint::{NavMenuItemsRequestBuilder, NavMenuItemsRequestExecutor},
             nav_menus_endpoint::{NavMenusRequestBuilder, NavMenusRequestExecutor},
+            navigation_autosaves_endpoint::{
+                NavigationAutosavesRequestBuilder, NavigationAutosavesRequestExecutor,
+            },
+            navigation_revisions_endpoint::{
+                NavigationRevisionsRequestBuilder, NavigationRevisionsRequestExecutor,
+            },
             navigations_endpoint::{NavigationsRequestBuilder, NavigationsRequestExecutor},
             plugins_endpoint::{PluginsRequestBuilder, PluginsRequestExecutor},
             post_autosaves_endpoint::{AutosavesRequestBuilder, AutosavesRequestExecutor},
@@ -54,6 +60,8 @@ pub struct WpApiRequestBuilder {
     nav_menu_item_autosaves: Arc<NavMenuItemAutosavesRequestBuilder>,
     nav_menu_items: Arc<NavMenuItemsRequestBuilder>,
     nav_menus: Arc<NavMenusRequestBuilder>,
+    navigation_autosaves: Arc<NavigationAutosavesRequestBuilder>,
+    navigation_revisions: Arc<NavigationRevisionsRequestBuilder>,
     navigations: Arc<NavigationsRequestBuilder>,
     plugins: Arc<PluginsRequestBuilder>,
     post_revisions: Arc<PostRevisionsRequestBuilder>,
@@ -90,6 +98,8 @@ impl WpApiRequestBuilder {
             nav_menu_item_autosaves,
             nav_menu_items,
             nav_menus,
+            navigation_autosaves,
+            navigation_revisions,
             navigations,
             plugins,
             post_revisions,
@@ -136,6 +146,8 @@ pub struct WpApiClient {
     nav_menu_item_autosaves: Arc<NavMenuItemAutosavesRequestExecutor>,
     nav_menu_items: Arc<NavMenuItemsRequestExecutor>,
     nav_menus: Arc<NavMenusRequestExecutor>,
+    navigation_autosaves: Arc<NavigationAutosavesRequestExecutor>,
+    navigation_revisions: Arc<NavigationRevisionsRequestExecutor>,
     navigations: Arc<NavigationsRequestExecutor>,
     plugins: Arc<PluginsRequestExecutor>,
     post_revisions: Arc<PostRevisionsRequestExecutor>,
@@ -169,6 +181,8 @@ impl WpApiClient {
             nav_menu_item_autosaves,
             nav_menu_items,
             nav_menus,
+            navigation_autosaves,
+            navigation_revisions,
             navigations,
             plugins,
             post_revisions,
@@ -212,6 +226,8 @@ api_client_generate_endpoint_impl!(WpApi, menu_locations);
 api_client_generate_endpoint_impl!(WpApi, nav_menu_item_autosaves);
 api_client_generate_endpoint_impl!(WpApi, nav_menu_items);
 api_client_generate_endpoint_impl!(WpApi, nav_menus);
+api_client_generate_endpoint_impl!(WpApi, navigation_autosaves);
+api_client_generate_endpoint_impl!(WpApi, navigation_revisions);
 api_client_generate_endpoint_impl!(WpApi, navigations);
 api_client_generate_endpoint_impl!(WpApi, plugins);
 api_client_generate_endpoint_impl!(WpApi, post_revisions);

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -22,6 +22,7 @@ pub mod middleware;
 pub mod nav_menu_item_revisions;
 pub mod nav_menu_items;
 pub mod nav_menus;
+pub mod navigation_revisions;
 pub mod navigations;
 pub mod parsed_url;
 pub mod plugins;

--- a/wp_api/src/navigation_revisions.rs
+++ b/wp_api/src/navigation_revisions.rs
@@ -1,0 +1,111 @@
+use crate::{
+    UserId, WpApiParamOrder,
+    date::WpGmtDateTime,
+    impl_as_query_value_from_to_string,
+    navigations::NavigationId,
+    url_query::{
+        AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
+    },
+    wp_content_i64_id,
+};
+use serde::{Deserialize, Serialize};
+use wp_contextual::WpContextual;
+use wp_derive::WpDeriveParamsField;
+
+wp_content_i64_id!(NavigationRevisionId);
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum WpApiParamNavigationRevisionsOrderBy {
+    #[default]
+    Date,
+    Id,
+    Include,
+    IncludeSlugs,
+    Relevance,
+    Slug,
+    Title,
+}
+
+impl_as_query_value_from_to_string!(WpApiParamNavigationRevisionsOrderBy);
+
+#[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
+#[supports_pagination(true)]
+pub struct NavigationRevisionListParams {
+    /// Current page of the collection.
+    /// Default: `1`
+    #[uniffi(default = None)]
+    pub page: Option<u32>,
+    /// Maximum number of items to be returned in result set.
+    #[uniffi(default = None)]
+    pub per_page: Option<u32>,
+    /// Limit results to those matching a string.
+    #[uniffi(default = None)]
+    pub search: Option<String>,
+    /// Ensure result set excludes specific IDs.
+    #[uniffi(default = [])]
+    pub exclude: Vec<NavigationRevisionId>,
+    /// Limit result set to specific IDs.
+    #[uniffi(default = [])]
+    pub include: Vec<NavigationRevisionId>,
+    /// Offset the result set by a specific number of items.
+    #[uniffi(default = None)]
+    pub offset: Option<u32>,
+    /// Order sort attribute ascending or descending.
+    /// Default: desc
+    /// One of: asc, desc
+    #[uniffi(default = None)]
+    pub order: Option<WpApiParamOrder>,
+    /// Sort collection by object attribute.
+    /// Default: date
+    /// One of: date, id, include, relevance, slug, include_slugs, title
+    #[uniffi(default = None)]
+    #[field_name("orderby")]
+    pub orderby: Option<WpApiParamNavigationRevisionsOrderBy>,
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+pub struct SparseNavigationRevision {
+    #[WpContext(edit, embed, view)]
+    pub id: Option<NavigationRevisionId>,
+    #[WpContext(edit, embed, view)]
+    pub author: Option<UserId>,
+    #[WpContext(edit, embed, view)]
+    pub date: Option<String>,
+    #[WpContext(edit, view)]
+    pub date_gmt: Option<WpGmtDateTime>,
+    #[WpContext(edit, view)]
+    pub modified: Option<String>,
+    #[WpContext(edit, view)]
+    pub modified_gmt: Option<WpGmtDateTime>,
+    #[WpContext(edit, embed, view)]
+    pub parent: Option<NavigationId>,
+    #[WpContext(edit, embed, view)]
+    pub slug: Option<String>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub guid: Option<crate::navigations::SparseNavigationGuid>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualField]
+    pub title: Option<crate::navigations::SparseNavigationTitle>,
+    #[WpContext(edit, view)]
+    #[WpContextualField]
+    pub content: Option<crate::navigations::SparseNavigationContent>,
+    // meta field omitted for now
+}
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct NavigationRevisionDeleteResponse {
+    pub deleted: bool,
+    pub previous: NavigationRevisionWithEditContext,
+}

--- a/wp_api/src/post_revisions.rs
+++ b/wp_api/src/post_revisions.rs
@@ -105,6 +105,7 @@ pub struct SparseAnyPostRevision {
     #[WpContextualOption]
     pub excerpt: Option<crate::posts::SparsePostExcerpt>,
     #[WpContext(edit, view)]
+    #[WpContextualOption]
     pub meta: Option<crate::posts::PostMeta>,
 }
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
-use wp_derive::WpDeriveParamsField;
+use wp_derive::{WpDeriveParamsField, WpDeserialize};
 use wp_serde_helper::{deserialize_from_string_of_json_array, serialize_as_json_string};
 
 #[derive(
@@ -474,11 +474,11 @@ pub struct SparsePostExcerpt {
     pub protected: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Serialize, WpDeserialize, uniffi::Record)]
 pub struct PostMeta {
     #[serde(deserialize_with = "deserialize_from_string_of_json_array")]
     #[serde(serialize_with = "serialize_as_json_string")]
-    pub footnotes: Vec<PostFootnote>,
+    pub footnotes: Option<Vec<PostFootnote>>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -11,6 +11,8 @@ pub mod menu_locations_endpoint;
 pub mod nav_menu_item_autosaves_endpoint;
 pub mod nav_menu_items_endpoint;
 pub mod nav_menus_endpoint;
+pub mod navigation_autosaves_endpoint;
+pub mod navigation_revisions_endpoint;
 pub mod navigations_endpoint;
 pub mod plugins_endpoint;
 pub mod post_autosaves_endpoint;

--- a/wp_api/src/request/endpoint/navigation_autosaves_endpoint.rs
+++ b/wp_api/src/request/endpoint/navigation_autosaves_endpoint.rs
@@ -1,0 +1,19 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{navigation_revisions::NavigationRevisionId, navigations::NavigationId};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum NavigationAutosavesRequest {
+    #[contextual_get(url = "/navigation/<navigation_id>/autosaves", output = Vec<crate::navigation_revisions::SparseNavigationRevision>, filter_by = crate::navigation_revisions::SparseNavigationRevisionField)]
+    List,
+    #[contextual_get(url = "/navigation/<navigation_id>/autosaves/<navigation_revision_id>", output = crate::navigation_revisions::SparseNavigationRevision, filter_by = crate::navigation_revisions::SparseNavigationRevisionField)]
+    Retrieve,
+    #[post(url = "/navigation/<navigation_id>/autosaves", params = &crate::navigations::NavigationCreateParams, output = crate::navigation_revisions::NavigationRevisionWithEditContext)]
+    Create,
+}
+
+impl DerivedRequest for NavigationAutosavesRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+}

--- a/wp_api/src/request/endpoint/navigation_revisions_endpoint.rs
+++ b/wp_api/src/request/endpoint/navigation_revisions_endpoint.rs
@@ -1,0 +1,29 @@
+use super::{AsNamespace, DerivedRequest, WpNamespace};
+use crate::{
+    navigation_revisions::{NavigationRevisionId, NavigationRevisionListParams},
+    navigations::NavigationId,
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum NavigationRevisionsRequest {
+    #[contextual_paged(url = "/navigation/<navigation_id>/revisions", params = &NavigationRevisionListParams, output = Vec<crate::navigation_revisions::SparseNavigationRevision>, filter_by = crate::navigation_revisions::SparseNavigationRevisionField)]
+    List,
+    #[contextual_get(url = "/navigation/<navigation_id>/revisions/<navigation_revision_id>", output = crate::navigation_revisions::SparseNavigationRevision, filter_by = crate::navigation_revisions::SparseNavigationRevisionField)]
+    Retrieve,
+    #[delete(url = "/navigation/<navigation_id>/revisions/<navigation_revision_id>", output = crate::navigation_revisions::NavigationRevisionDeleteResponse)]
+    Delete,
+}
+
+impl DerivedRequest for NavigationRevisionsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpNamespace::WpV2
+    }
+
+    fn additional_query_pairs(&self) -> Vec<(&str, String)> {
+        match self {
+            NavigationRevisionsRequest::Delete => vec![("force", "true".to_string())],
+            _ => vec![],
+        }
+    }
+}

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -48,6 +48,7 @@ pub struct TestCredentials {
     pub nav_menu_item_id: i64,
     pub autosave_id_for_nav_menu_item_id: i64,
     pub navigation_id: i64,
+    pub revision_id_for_navigation_id: i64,
 }
 
 impl TestCredentials {

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -49,6 +49,8 @@ pub struct TestCredentials {
     pub autosave_id_for_nav_menu_item_id: i64,
     pub navigation_id: i64,
     pub revision_id_for_navigation_id: i64,
+    pub autosaved_navigation_id: i64,
+    pub autosave_id_for_autosaved_navigation_id: i64,
 }
 
 impl TestCredentials {

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_err.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_err.rs
@@ -1,7 +1,6 @@
 use wp_api::{
-    post_revisions::PostRevisionId,
-    posts::{PostCreateParams, PostId},
-    request::endpoint::posts_endpoint::PostEndpointType,
+    navigation_revisions::NavigationRevisionId,
+    navigations::{NavigationCreateParams, NavigationId},
 };
 use wp_api_integration_tests::prelude::*;
 
@@ -9,8 +8,8 @@ use wp_api_integration_tests::prelude::*;
 #[parallel]
 async fn list_err_post_invalid_parent() {
     api_client()
-        .autosaves()
-        .list_with_edit_context(&PostEndpointType::Navigation, &PostId(99999999))
+        .navigation_autosaves()
+        .list_with_edit_context(&NavigationId(99999999))
         .await
         .assert_wp_error(WpErrorCode::PostInvalidParent)
 }
@@ -19,8 +18,8 @@ async fn list_err_post_invalid_parent() {
 #[parallel]
 async fn list_err_cannot_read_as_subscriber() {
     api_client_as_subscriber()
-        .autosaves()
-        .list_with_edit_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .navigation_autosaves()
+        .list_with_edit_context(&autosaved_navigation_id())
         .await
         .assert_wp_error(WpErrorCode::CannotRead)
 }
@@ -29,12 +28,8 @@ async fn list_err_cannot_read_as_subscriber() {
 #[parallel]
 async fn retrieve_err_post_invalid_parent() {
     api_client()
-        .autosaves()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &PostRevisionId(1),
-        )
+        .navigation_autosaves()
+        .retrieve_with_edit_context(&NavigationId(99999999), &NavigationRevisionId(1))
         .await
         .assert_wp_error(WpErrorCode::PostInvalidParent)
 }
@@ -43,11 +38,10 @@ async fn retrieve_err_post_invalid_parent() {
 #[parallel]
 async fn retrieve_err_post_no_autosave() {
     api_client()
-        .autosaves()
+        .navigation_autosaves()
         .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-            &PostRevisionId(1),
+            &NavigationId(TestCredentials::instance().navigation_id),
+            &NavigationRevisionId(1),
         )
         .await
         .assert_wp_error(WpErrorCode::PostNoAutosave)
@@ -57,9 +51,8 @@ async fn retrieve_err_post_no_autosave() {
 #[parallel]
 async fn retrieve_err_cannot_read_as_subscriber() {
     api_client_as_subscriber()
-        .autosaves()
+        .navigation_autosaves()
         .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
             &autosaved_navigation_id(),
             &autosave_id_for_autosaved_navigation_id(),
         )
@@ -71,12 +64,8 @@ async fn retrieve_err_cannot_read_as_subscriber() {
 #[parallel]
 async fn create_err_post_invalid_id() {
     api_client()
-        .autosaves()
-        .create(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &PostCreateParams::default(),
-        )
+        .navigation_autosaves()
+        .create(&NavigationId(99999999), &NavigationCreateParams::default())
         .await
         .assert_wp_error(WpErrorCode::PostInvalidId)
 }
@@ -85,20 +74,19 @@ async fn create_err_post_invalid_id() {
 #[parallel]
 async fn create_err_cannot_edit_as_subscriber() {
     api_client_as_subscriber()
-        .autosaves()
+        .navigation_autosaves()
         .create(
-            &PostEndpointType::Navigation,
             &autosaved_navigation_id(),
-            &PostCreateParams::default(),
+            &NavigationCreateParams::default(),
         )
         .await
         .assert_wp_error(WpErrorCode::CannotEdit)
 }
 
-fn autosaved_navigation_id() -> PostId {
-    PostId(TestCredentials::instance().autosaved_navigation_id)
+fn autosaved_navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().autosaved_navigation_id)
 }
 
-fn autosave_id_for_autosaved_navigation_id() -> PostRevisionId {
-    PostRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
+fn autosave_id_for_autosaved_navigation_id() -> NavigationRevisionId {
+    NavigationRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
 }

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_err.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_err.rs
@@ -1,0 +1,104 @@
+use wp_api::{
+    post_revisions::PostRevisionId,
+    posts::{PostCreateParams, PostId},
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn list_err_post_invalid_parent() {
+    api_client()
+        .autosaves()
+        .list_with_edit_context(&PostEndpointType::Navigation, &PostId(99999999))
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidParent)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_cannot_read_as_subscriber() {
+    api_client_as_subscriber()
+        .autosaves()
+        .list_with_edit_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .await
+        .assert_wp_error(WpErrorCode::CannotRead)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_post_invalid_parent() {
+    api_client()
+        .autosaves()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &PostId(99999999),
+            &PostRevisionId(1),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidParent)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_post_no_autosave() {
+    api_client()
+        .autosaves()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &PostId(TestCredentials::instance().navigation_id),
+            &PostRevisionId(1),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostNoAutosave)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_cannot_read_as_subscriber() {
+    api_client_as_subscriber()
+        .autosaves()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &autosave_id_for_autosaved_navigation_id(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotRead)
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_post_invalid_id() {
+    api_client()
+        .autosaves()
+        .create(
+            &PostEndpointType::Navigation,
+            &PostId(99999999),
+            &PostCreateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId)
+}
+
+#[tokio::test]
+#[parallel]
+async fn create_err_cannot_edit_as_subscriber() {
+    api_client_as_subscriber()
+        .autosaves()
+        .create(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &PostCreateParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotEdit)
+}
+
+fn autosaved_navigation_id() -> PostId {
+    PostId(TestCredentials::instance().autosaved_navigation_id)
+}
+
+fn autosave_id_for_autosaved_navigation_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
+}

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_immut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_immut.rs
@@ -1,10 +1,10 @@
 use wp_api::{
-    post_revisions::{
-        PostRevisionId, SparseAnyPostRevisionFieldWithEditContext,
-        SparseAnyPostRevisionFieldWithEmbedContext, SparseAnyPostRevisionFieldWithViewContext,
+    navigation_revisions::{
+        NavigationRevisionId, SparseNavigationRevisionFieldWithEditContext,
+        SparseNavigationRevisionFieldWithEmbedContext,
+        SparseNavigationRevisionFieldWithViewContext,
     },
-    posts::PostId,
-    request::endpoint::posts_endpoint::PostEndpointType,
+    navigations::NavigationId,
 };
 use wp_api_integration_tests::prelude::*;
 
@@ -12,8 +12,8 @@ use wp_api_integration_tests::prelude::*;
 #[parallel]
 async fn list_with_edit_context() {
     api_client()
-        .autosaves()
-        .list_with_edit_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .navigation_autosaves()
+        .list_with_edit_context(&autosaved_navigation_id())
         .await
         .assert_response();
 }
@@ -22,8 +22,8 @@ async fn list_with_edit_context() {
 #[parallel]
 async fn list_with_embed_context() {
     api_client()
-        .autosaves()
-        .list_with_embed_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .navigation_autosaves()
+        .list_with_embed_context(&autosaved_navigation_id())
         .await
         .assert_response();
 }
@@ -32,8 +32,8 @@ async fn list_with_embed_context() {
 #[parallel]
 async fn list_with_view_context() {
     api_client()
-        .autosaves()
-        .list_with_view_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .navigation_autosaves()
+        .list_with_view_context(&autosaved_navigation_id())
         .await
         .assert_response();
 }
@@ -42,9 +42,8 @@ async fn list_with_view_context() {
 #[parallel]
 async fn retrieve_with_edit_context() {
     api_client()
-        .autosaves()
+        .navigation_autosaves()
         .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
             &autosaved_navigation_id(),
             &autosave_id_for_autosaved_navigation_id(),
         )
@@ -56,9 +55,8 @@ async fn retrieve_with_edit_context() {
 #[parallel]
 async fn retrieve_with_embed_context() {
     api_client()
-        .autosaves()
+        .navigation_autosaves()
         .retrieve_with_embed_context(
-            &PostEndpointType::Navigation,
             &autosaved_navigation_id(),
             &autosave_id_for_autosaved_navigation_id(),
         )
@@ -70,9 +68,8 @@ async fn retrieve_with_embed_context() {
 #[parallel]
 async fn retrieve_with_view_context() {
     api_client()
-        .autosaves()
+        .navigation_autosaves()
         .retrieve_with_view_context(
-            &PostEndpointType::Navigation,
             &autosaved_navigation_id(),
             &autosave_id_for_autosaved_navigation_id(),
         )
@@ -80,35 +77,31 @@ async fn retrieve_with_view_context() {
         .assert_response();
 }
 
-fn autosaved_navigation_id() -> PostId {
-    PostId(TestCredentials::instance().autosaved_navigation_id)
+fn autosaved_navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().autosaved_navigation_id)
 }
 
-fn autosave_id_for_autosaved_navigation_id() -> PostRevisionId {
-    PostRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
+fn autosave_id_for_autosaved_navigation_id() -> NavigationRevisionId {
+    NavigationRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
 }
 
 mod filter {
     use super::*;
 
-    wp_api::generate_sparse_any_post_revision_field_with_edit_context_test_cases!();
-    wp_api::generate_sparse_any_post_revision_field_with_embed_context_test_cases!();
-    wp_api::generate_sparse_any_post_revision_field_with_view_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_view_context_test_cases!();
 
-    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEditContext::Id, SparseNavigationRevisionFieldWithEditContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_edit_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEditContext],
     ) {
         api_client()
-            .autosaves()
-            .filter_list_with_edit_context(
-                &PostEndpointType::Navigation,
-                &autosaved_navigation_id(),
-                fields,
-            )
+            .navigation_autosaves()
+            .filter_list_with_edit_context(&autosaved_navigation_id(), fields)
             .await
             .assert_response()
             .data
@@ -118,20 +111,16 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEmbedContext::Id, SparseNavigationRevisionFieldWithEmbedContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_embed_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEmbedContext],
     ) {
         api_client()
-            .autosaves()
-            .filter_list_with_embed_context(
-                &PostEndpointType::Navigation,
-                &autosaved_navigation_id(),
-                fields,
-            )
+            .navigation_autosaves()
+            .filter_list_with_embed_context(&autosaved_navigation_id(), fields)
             .await
             .assert_response()
             .data
@@ -141,20 +130,16 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithViewContext::Id, SparseNavigationRevisionFieldWithViewContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_view_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithViewContext],
     ) {
         api_client()
-            .autosaves()
-            .filter_list_with_view_context(
-                &PostEndpointType::Navigation,
-                &autosaved_navigation_id(),
-                fields,
-            )
+            .navigation_autosaves()
+            .filter_list_with_view_context(&autosaved_navigation_id(), fields)
             .await
             .assert_response()
             .data
@@ -164,17 +149,16 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEditContext::Id, SparseNavigationRevisionFieldWithEditContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_edit_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEditContext],
     ) {
         api_client()
-            .autosaves()
+            .navigation_autosaves()
             .filter_retrieve_with_edit_context(
-                &PostEndpointType::Navigation,
                 &autosaved_navigation_id(),
                 &autosave_id_for_autosaved_navigation_id(),
                 fields,
@@ -185,17 +169,16 @@ mod filter {
             .assert_that_instance_fields_nullability_match_provided_fields(fields);
     }
 
-    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEmbedContext::Id, SparseNavigationRevisionFieldWithEmbedContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_embed_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEmbedContext],
     ) {
         api_client()
-            .autosaves()
+            .navigation_autosaves()
             .filter_retrieve_with_embed_context(
-                &PostEndpointType::Navigation,
                 &autosaved_navigation_id(),
                 &autosave_id_for_autosaved_navigation_id(),
                 fields,
@@ -206,17 +189,16 @@ mod filter {
             .assert_that_instance_fields_nullability_match_provided_fields(fields);
     }
 
-    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithViewContext::Id, SparseNavigationRevisionFieldWithViewContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_view_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithViewContext],
     ) {
         api_client()
-            .autosaves()
+            .navigation_autosaves()
             .filter_retrieve_with_view_context(
-                &PostEndpointType::Navigation,
                 &autosaved_navigation_id(),
                 &autosave_id_for_autosaved_navigation_id(),
                 fields,

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_immut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_immut.rs
@@ -1,0 +1,229 @@
+use wp_api::{
+    post_revisions::{
+        PostRevisionId, SparseAnyPostRevisionFieldWithEditContext,
+        SparseAnyPostRevisionFieldWithEmbedContext, SparseAnyPostRevisionFieldWithViewContext,
+    },
+    posts::PostId,
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn list_with_edit_context() {
+    api_client()
+        .autosaves()
+        .list_with_edit_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_embed_context() {
+    api_client()
+        .autosaves()
+        .list_with_embed_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_view_context() {
+    api_client()
+        .autosaves()
+        .list_with_view_context(&PostEndpointType::Navigation, &autosaved_navigation_id())
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .autosaves()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &autosave_id_for_autosaved_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .autosaves()
+        .retrieve_with_embed_context(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &autosave_id_for_autosaved_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .autosaves()
+        .retrieve_with_view_context(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &autosave_id_for_autosaved_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+fn autosaved_navigation_id() -> PostId {
+    PostId(TestCredentials::instance().autosaved_navigation_id)
+}
+
+fn autosave_id_for_autosaved_navigation_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().autosave_id_for_autosaved_navigation_id)
+}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_any_post_revision_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_any_post_revision_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_any_post_revision_field_with_view_context_test_cases!();
+
+    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_edit_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_list_with_edit_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|autosave| {
+                autosave.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_list_with_embed_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|autosave| {
+                autosave.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_list_with_view_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|autosave| {
+                autosave.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_edit_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_retrieve_with_edit_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                &autosave_id_for_autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_embed_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_retrieve_with_embed_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                &autosave_id_for_autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_view_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+    ) {
+        api_client()
+            .autosaves()
+            .filter_retrieve_with_view_context(
+                &PostEndpointType::Navigation,
+                &autosaved_navigation_id(),
+                &autosave_id_for_autosaved_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+}

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_mut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_mut.rs
@@ -1,7 +1,4 @@
-use wp_api::{
-    posts::{PostCreateParams, PostId},
-    request::endpoint::posts_endpoint::PostEndpointType,
-};
+use wp_api::navigations::{NavigationCreateParams, NavigationId};
 use wp_api_integration_tests::prelude::*;
 
 #[tokio::test]
@@ -9,19 +6,15 @@ async fn create_autosave() {
     let title = "Test Autosave Navigation Title".to_string();
     let content =
         "<!-- wp:navigation -->Test autosave navigation content<!-- /wp:navigation -->".to_string();
-    let params = PostCreateParams {
+    let params = NavigationCreateParams {
         title: Some(title.clone()),
         content: Some(content.clone()),
         ..Default::default()
     };
 
     let autosave = api_client()
-        .autosaves()
-        .create(
-            &PostEndpointType::Navigation,
-            &autosaved_navigation_id(),
-            &params,
-        )
+        .navigation_autosaves()
+        .create(&autosaved_navigation_id(), &params)
         .await
         .assert_response()
         .data;
@@ -31,6 +24,6 @@ async fn create_autosave() {
     assert_eq!(autosave.content.raw, Some(content));
 }
 
-fn autosaved_navigation_id() -> PostId {
-    PostId(TestCredentials::instance().autosaved_navigation_id)
+fn autosaved_navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().autosaved_navigation_id)
 }

--- a/wp_api_integration_tests/tests/test_navigation_autosaves_mut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_autosaves_mut.rs
@@ -1,0 +1,36 @@
+use wp_api::{
+    posts::{PostCreateParams, PostId},
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+async fn create_autosave() {
+    let title = "Test Autosave Navigation Title".to_string();
+    let content =
+        "<!-- wp:navigation -->Test autosave navigation content<!-- /wp:navigation -->".to_string();
+    let params = PostCreateParams {
+        title: Some(title.clone()),
+        content: Some(content.clone()),
+        ..Default::default()
+    };
+
+    let autosave = api_client()
+        .autosaves()
+        .create(
+            &PostEndpointType::Navigation,
+            &autosaved_navigation_id(),
+            &params,
+        )
+        .await
+        .assert_response()
+        .data;
+
+    // Verify the autosave was created successfully
+    assert_eq!(autosave.title.raw, Some(title));
+    assert_eq!(autosave.content.raw, Some(content));
+}
+
+fn autosaved_navigation_id() -> PostId {
+    PostId(TestCredentials::instance().autosaved_navigation_id)
+}

--- a/wp_api_integration_tests/tests/test_navigation_revisions_err.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_err.rs
@@ -1,0 +1,196 @@
+use wp_api::{
+    post_revisions::{AnyPostRevisionListParams, PostRevisionId, WpApiParamPostRevisionsOrderBy},
+    posts::PostId,
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[parallel]
+async fn list_err_post_invalid_parent() {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &PostId(99999999),
+            &AnyPostRevisionListParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidParent)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_revision_invalid_offset_number() {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &AnyPostRevisionListParams {
+                offset: Some(99999999),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::RevisionInvalidOffsetNumber)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_revision_invalid_page_number() {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &AnyPostRevisionListParams {
+                page: Some(99999999),
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::RevisionInvalidPageNumber)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_cannot_read_as_subscriber() {
+    api_client_as_subscriber()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &AnyPostRevisionListParams::default(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotRead)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_no_search_term_defined() {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &AnyPostRevisionListParams {
+                orderby: Some(WpApiParamPostRevisionsOrderBy::Relevance),
+                search: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::NoSearchTermDefined)
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_err_orderby_include_missing_include() {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &AnyPostRevisionListParams {
+                orderby: Some(WpApiParamPostRevisionsOrderBy::Include),
+                include: vec![],
+                ..Default::default()
+            },
+        )
+        .await
+        .assert_wp_error(WpErrorCode::OrderbyIncludeMissingInclude)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_post_invalid_parent() {
+    api_client()
+        .post_revisions()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &PostId(99999999),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidParent)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_post_invalid_id() {
+    api_client()
+        .post_revisions()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &PostRevisionId(99999999),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId)
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_err_cannot_read_as_subscriber() {
+    api_client_as_subscriber()
+        .post_revisions()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotRead)
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_err_cannot_delete_as_subscriber() {
+    api_client_as_subscriber()
+        .post_revisions()
+        .delete(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::CannotDelete)
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_err_post_invalid_parent() {
+    api_client()
+        .post_revisions()
+        .delete(
+            &PostEndpointType::Navigation,
+            &PostId(99999999),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidParent)
+}
+
+#[tokio::test]
+#[parallel]
+async fn delete_err_post_invalid_id() {
+    api_client()
+        .post_revisions()
+        .delete(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &PostRevisionId(99999999),
+        )
+        .await
+        .assert_wp_error(WpErrorCode::PostInvalidId)
+}
+
+fn navigation_id() -> PostId {
+    PostId(TestCredentials::instance().navigation_id)
+}
+
+fn revision_id_for_navigation_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+}

--- a/wp_api_integration_tests/tests/test_navigation_revisions_err.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_err.rs
@@ -1,7 +1,8 @@
 use wp_api::{
-    post_revisions::{AnyPostRevisionListParams, PostRevisionId, WpApiParamPostRevisionsOrderBy},
-    posts::PostId,
-    request::endpoint::posts_endpoint::PostEndpointType,
+    navigation_revisions::{
+        NavigationRevisionId, NavigationRevisionListParams, WpApiParamNavigationRevisionsOrderBy,
+    },
+    navigations::NavigationId,
 };
 use wp_api_integration_tests::prelude::*;
 
@@ -9,11 +10,10 @@ use wp_api_integration_tests::prelude::*;
 #[parallel]
 async fn list_err_post_invalid_parent() {
     api_client()
-        .post_revisions()
+        .navigation_revisions()
         .list_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &AnyPostRevisionListParams::default(),
+            &NavigationId(99999999),
+            &NavigationRevisionListParams::default(),
         )
         .await
         .assert_wp_error(WpErrorCode::PostInvalidParent)
@@ -23,11 +23,10 @@ async fn list_err_post_invalid_parent() {
 #[parallel]
 async fn list_err_revision_invalid_offset_number() {
     api_client()
-        .post_revisions()
+        .navigation_revisions()
         .list_with_edit_context(
-            &PostEndpointType::Navigation,
             &navigation_id(),
-            &AnyPostRevisionListParams {
+            &NavigationRevisionListParams {
                 offset: Some(99999999),
                 ..Default::default()
             },
@@ -40,11 +39,10 @@ async fn list_err_revision_invalid_offset_number() {
 #[parallel]
 async fn list_err_revision_invalid_page_number() {
     api_client()
-        .post_revisions()
+        .navigation_revisions()
         .list_with_edit_context(
-            &PostEndpointType::Navigation,
             &navigation_id(),
-            &AnyPostRevisionListParams {
+            &NavigationRevisionListParams {
                 page: Some(99999999),
                 ..Default::default()
             },
@@ -57,12 +55,8 @@ async fn list_err_revision_invalid_page_number() {
 #[parallel]
 async fn list_err_cannot_read_as_subscriber() {
     api_client_as_subscriber()
-        .post_revisions()
-        .list_with_edit_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &AnyPostRevisionListParams::default(),
-        )
+        .navigation_revisions()
+        .list_with_edit_context(&navigation_id(), &NavigationRevisionListParams::default())
         .await
         .assert_wp_error(WpErrorCode::CannotRead)
 }
@@ -71,12 +65,11 @@ async fn list_err_cannot_read_as_subscriber() {
 #[parallel]
 async fn list_err_no_search_term_defined() {
     api_client()
-        .post_revisions()
+        .navigation_revisions()
         .list_with_edit_context(
-            &PostEndpointType::Navigation,
             &navigation_id(),
-            &AnyPostRevisionListParams {
-                orderby: Some(WpApiParamPostRevisionsOrderBy::Relevance),
+            &NavigationRevisionListParams {
+                orderby: Some(WpApiParamNavigationRevisionsOrderBy::Relevance),
                 search: None,
                 ..Default::default()
             },
@@ -89,12 +82,11 @@ async fn list_err_no_search_term_defined() {
 #[parallel]
 async fn list_err_orderby_include_missing_include() {
     api_client()
-        .post_revisions()
+        .navigation_revisions()
         .list_with_edit_context(
-            &PostEndpointType::Navigation,
             &navigation_id(),
-            &AnyPostRevisionListParams {
-                orderby: Some(WpApiParamPostRevisionsOrderBy::Include),
+            &NavigationRevisionListParams {
+                orderby: Some(WpApiParamNavigationRevisionsOrderBy::Include),
                 include: vec![],
                 ..Default::default()
             },
@@ -107,12 +99,8 @@ async fn list_err_orderby_include_missing_include() {
 #[parallel]
 async fn retrieve_err_post_invalid_parent() {
     api_client()
-        .post_revisions()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .retrieve_with_edit_context(&NavigationId(99999999), &revision_id_for_navigation_id())
         .await
         .assert_wp_error(WpErrorCode::PostInvalidParent)
 }
@@ -121,12 +109,8 @@ async fn retrieve_err_post_invalid_parent() {
 #[parallel]
 async fn retrieve_err_post_invalid_id() {
     api_client()
-        .post_revisions()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &PostRevisionId(99999999),
-        )
+        .navigation_revisions()
+        .retrieve_with_edit_context(&navigation_id(), &NavigationRevisionId(99999999))
         .await
         .assert_wp_error(WpErrorCode::PostInvalidId)
 }
@@ -135,12 +119,8 @@ async fn retrieve_err_post_invalid_id() {
 #[parallel]
 async fn retrieve_err_cannot_read_as_subscriber() {
     api_client_as_subscriber()
-        .post_revisions()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .retrieve_with_edit_context(&navigation_id(), &revision_id_for_navigation_id())
         .await
         .assert_wp_error(WpErrorCode::CannotRead)
 }
@@ -149,12 +129,8 @@ async fn retrieve_err_cannot_read_as_subscriber() {
 #[parallel]
 async fn delete_err_cannot_delete_as_subscriber() {
     api_client_as_subscriber()
-        .post_revisions()
-        .delete(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .delete(&navigation_id(), &revision_id_for_navigation_id())
         .await
         .assert_wp_error(WpErrorCode::CannotDelete)
 }
@@ -163,12 +139,8 @@ async fn delete_err_cannot_delete_as_subscriber() {
 #[parallel]
 async fn delete_err_post_invalid_parent() {
     api_client()
-        .post_revisions()
-        .delete(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .delete(&NavigationId(99999999), &revision_id_for_navigation_id())
         .await
         .assert_wp_error(WpErrorCode::PostInvalidParent)
 }
@@ -177,20 +149,16 @@ async fn delete_err_post_invalid_parent() {
 #[parallel]
 async fn delete_err_post_invalid_id() {
     api_client()
-        .post_revisions()
-        .delete(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &PostRevisionId(99999999),
-        )
+        .navigation_revisions()
+        .delete(&navigation_id(), &NavigationRevisionId(99999999))
         .await
         .assert_wp_error(WpErrorCode::PostInvalidId)
 }
 
-fn navigation_id() -> PostId {
-    PostId(TestCredentials::instance().navigation_id)
+fn navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().navigation_id)
 }
 
-fn revision_id_for_navigation_id() -> PostRevisionId {
-    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+fn revision_id_for_navigation_id() -> NavigationRevisionId {
+    NavigationRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
 }

--- a/wp_api_integration_tests/tests/test_navigation_revisions_immut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_immut.rs
@@ -1,20 +1,21 @@
 use wp_api::{
-    post_revisions::{
-        AnyPostRevisionListParams, PostRevisionId, SparseAnyPostRevisionFieldWithEditContext,
-        SparseAnyPostRevisionFieldWithEmbedContext, SparseAnyPostRevisionFieldWithViewContext,
-        WpApiParamPostRevisionsOrderBy,
+    navigation_revisions::{
+        NavigationRevisionId, NavigationRevisionListParams,
+        SparseNavigationRevisionFieldWithEditContext,
+        SparseNavigationRevisionFieldWithEmbedContext,
+        SparseNavigationRevisionFieldWithViewContext, WpApiParamNavigationRevisionsOrderBy,
     },
-    request::endpoint::posts_endpoint::PostEndpointType,
+    navigations::NavigationId,
 };
 use wp_api_integration_tests::prelude::*;
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_edit_context(#[case] params: AnyPostRevisionListParams) {
+async fn list_with_edit_context(#[case] params: NavigationRevisionListParams) {
     api_client()
-        .post_revisions()
-        .list_with_edit_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .navigation_revisions()
+        .list_with_edit_context(&navigation_id(), &params)
         .await
         .assert_response();
 }
@@ -22,10 +23,10 @@ async fn list_with_edit_context(#[case] params: AnyPostRevisionListParams) {
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_embed_context(#[case] params: AnyPostRevisionListParams) {
+async fn list_with_embed_context(#[case] params: NavigationRevisionListParams) {
     api_client()
-        .post_revisions()
-        .list_with_embed_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .navigation_revisions()
+        .list_with_embed_context(&navigation_id(), &params)
         .await
         .assert_response();
 }
@@ -33,10 +34,10 @@ async fn list_with_embed_context(#[case] params: AnyPostRevisionListParams) {
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_view_context(#[case] params: AnyPostRevisionListParams) {
+async fn list_with_view_context(#[case] params: NavigationRevisionListParams) {
     api_client()
-        .post_revisions()
-        .list_with_view_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .navigation_revisions()
+        .list_with_view_context(&navigation_id(), &params)
         .await
         .assert_response();
 }
@@ -45,12 +46,8 @@ async fn list_with_view_context(#[case] params: AnyPostRevisionListParams) {
 #[parallel]
 async fn retrieve_with_edit_context() {
     api_client()
-        .post_revisions()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .retrieve_with_edit_context(&navigation_id(), &revision_id_for_navigation_id())
         .await
         .assert_response();
 }
@@ -59,12 +56,8 @@ async fn retrieve_with_edit_context() {
 #[parallel]
 async fn retrieve_with_embed_context() {
     api_client()
-        .post_revisions()
-        .retrieve_with_embed_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .retrieve_with_embed_context(&navigation_id(), &revision_id_for_navigation_id())
         .await
         .assert_response();
 }
@@ -73,65 +66,56 @@ async fn retrieve_with_embed_context() {
 #[parallel]
 async fn retrieve_with_view_context() {
     api_client()
-        .post_revisions()
-        .retrieve_with_view_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id_for_navigation_id(),
-        )
+        .navigation_revisions()
+        .retrieve_with_view_context(&navigation_id(), &revision_id_for_navigation_id())
         .await
         .assert_response();
 }
 
-fn navigation_id() -> PostId {
-    PostId(TestCredentials::instance().navigation_id)
+fn navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().navigation_id)
 }
 
-fn revision_id_for_navigation_id() -> PostRevisionId {
-    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+fn revision_id_for_navigation_id() -> NavigationRevisionId {
+    NavigationRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
 }
 
 #[template]
 #[rstest]
-#[case::default(AnyPostRevisionListParams::default())]
-#[case::page(generate!(AnyPostRevisionListParams, (page, Some(1))))]
-#[case::per_page(generate!(AnyPostRevisionListParams, (per_page, Some(3))))]
-#[case::search(generate!(AnyPostRevisionListParams, (search, Some("foo".to_string()))))]
-#[case::exclude(generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(1), PostRevisionId(2)])))]
-#[case::include(generate!(AnyPostRevisionListParams, (include, vec![PostRevisionId(1)])))]
-#[case::offset(generate!(AnyPostRevisionListParams, (offset, Some(5))))]
-#[case::order(generate!(AnyPostRevisionListParams, (order, Some(WpApiParamOrder::Asc))))]
-#[case::orderby(generate!(AnyPostRevisionListParams, (orderby, Some(WpApiParamPostRevisionsOrderBy::Slug))))]
-fn list_cases(#[case] params: AnyPostRevisionListParams) {}
+#[case::default(NavigationRevisionListParams::default())]
+#[case::page(generate!(NavigationRevisionListParams, (page, Some(1))))]
+#[case::per_page(generate!(NavigationRevisionListParams, (per_page, Some(3))))]
+#[case::search(generate!(NavigationRevisionListParams, (search, Some("foo".to_string()))))]
+#[case::exclude(generate!(NavigationRevisionListParams, (exclude, vec![NavigationRevisionId(1), NavigationRevisionId(2)])))]
+#[case::include(generate!(NavigationRevisionListParams, (include, vec![NavigationRevisionId(1)])))]
+#[case::offset(generate!(NavigationRevisionListParams, (offset, Some(5))))]
+#[case::order(generate!(NavigationRevisionListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(NavigationRevisionListParams, (orderby, Some(WpApiParamNavigationRevisionsOrderBy::Slug))))]
+fn list_cases(#[case] params: NavigationRevisionListParams) {}
 
 mod filter {
     use super::*;
 
-    wp_api::generate_sparse_any_post_revision_field_with_edit_context_test_cases!();
-    wp_api::generate_sparse_any_post_revision_field_with_embed_context_test_cases!();
-    wp_api::generate_sparse_any_post_revision_field_with_view_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_navigation_revision_field_with_view_context_test_cases!();
 
-    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEditContext::Id, SparseNavigationRevisionFieldWithEditContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_edit_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEditContext],
         #[values(
-            AnyPostRevisionListParams::default(),
-            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
-            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+            NavigationRevisionListParams::default(),
+            generate!(NavigationRevisionListParams, (exclude, vec![NavigationRevisionId(2), NavigationRevisionId(3)])),
+            generate!(NavigationRevisionListParams, (search, Some("foo".to_string())))
         )]
-        params: AnyPostRevisionListParams,
+        params: NavigationRevisionListParams,
     ) {
         api_client()
-            .post_revisions()
-            .filter_list_with_edit_context(
-                &PostEndpointType::Navigation,
-                &navigation_id(),
-                &params,
-                fields,
-            )
+            .navigation_revisions()
+            .filter_list_with_edit_context(&navigation_id(), &params, fields)
             .await
             .assert_response()
             .data
@@ -141,27 +125,22 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEmbedContext::Id, SparseNavigationRevisionFieldWithEmbedContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_embed_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEmbedContext],
         #[values(
-            AnyPostRevisionListParams::default(),
-            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
-            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+            NavigationRevisionListParams::default(),
+            generate!(NavigationRevisionListParams, (exclude, vec![NavigationRevisionId(2), NavigationRevisionId(3)])),
+            generate!(NavigationRevisionListParams, (search, Some("foo".to_string())))
         )]
-        params: AnyPostRevisionListParams,
+        params: NavigationRevisionListParams,
     ) {
         api_client()
-            .post_revisions()
-            .filter_list_with_embed_context(
-                &PostEndpointType::Navigation,
-                &navigation_id(),
-                &params,
-                fields,
-            )
+            .navigation_revisions()
+            .filter_list_with_embed_context(&navigation_id(), &params, fields)
             .await
             .assert_response()
             .data
@@ -171,27 +150,22 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithViewContext::Id, SparseNavigationRevisionFieldWithViewContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_list_with_view_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithViewContext],
         #[values(
-            AnyPostRevisionListParams::default(),
-            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
-            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+            NavigationRevisionListParams::default(),
+            generate!(NavigationRevisionListParams, (exclude, vec![NavigationRevisionId(2), NavigationRevisionId(3)])),
+            generate!(NavigationRevisionListParams, (search, Some("foo".to_string())))
         )]
-        params: AnyPostRevisionListParams,
+        params: NavigationRevisionListParams,
     ) {
         api_client()
-            .post_revisions()
-            .filter_list_with_view_context(
-                &PostEndpointType::Navigation,
-                &navigation_id(),
-                &params,
-                fields,
-            )
+            .navigation_revisions()
+            .filter_list_with_view_context(&navigation_id(), &params, fields)
             .await
             .assert_response()
             .data
@@ -201,17 +175,16 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEditContext::Id, SparseNavigationRevisionFieldWithEditContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_edit_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEditContext],
     ) {
         api_client()
-            .post_revisions()
+            .navigation_revisions()
             .filter_retrieve_with_edit_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
                 &revision_id_for_navigation_id(),
                 fields,
@@ -222,17 +195,16 @@ mod filter {
             .assert_that_instance_fields_nullability_match_provided_fields(fields);
     }
 
-    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithEmbedContext::Id, SparseNavigationRevisionFieldWithEmbedContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_embed_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithEmbedContext],
     ) {
         api_client()
-            .post_revisions()
+            .navigation_revisions()
             .filter_retrieve_with_embed_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
                 &revision_id_for_navigation_id(),
                 fields,
@@ -243,17 +215,16 @@ mod filter {
             .assert_that_instance_fields_nullability_match_provided_fields(fields);
     }
 
-    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[apply(sparse_navigation_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationRevisionFieldWithViewContext::Id, SparseNavigationRevisionFieldWithViewContext::Author])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_with_view_context(
-        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+        #[case] fields: &[SparseNavigationRevisionFieldWithViewContext],
     ) {
         api_client()
-            .post_revisions()
+            .navigation_revisions()
             .filter_retrieve_with_view_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
                 &revision_id_for_navigation_id(),
                 fields,

--- a/wp_api_integration_tests/tests/test_navigation_revisions_immut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_immut.rs
@@ -1,0 +1,266 @@
+use wp_api::{
+    post_revisions::{
+        AnyPostRevisionListParams, PostRevisionId, SparseAnyPostRevisionFieldWithEditContext,
+        SparseAnyPostRevisionFieldWithEmbedContext, SparseAnyPostRevisionFieldWithViewContext,
+        WpApiParamPostRevisionsOrderBy,
+    },
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_edit_context(#[case] params: AnyPostRevisionListParams) {
+    api_client()
+        .post_revisions()
+        .list_with_edit_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_embed_context(#[case] params: AnyPostRevisionListParams) {
+    api_client()
+        .post_revisions()
+        .list_with_embed_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[apply(list_cases)]
+#[parallel]
+async fn list_with_view_context(#[case] params: AnyPostRevisionListParams) {
+    api_client()
+        .post_revisions()
+        .list_with_view_context(&PostEndpointType::Navigation, &navigation_id(), &params)
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_edit_context() {
+    api_client()
+        .post_revisions()
+        .retrieve_with_edit_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_embed_context() {
+    api_client()
+        .post_revisions()
+        .retrieve_with_embed_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+#[tokio::test]
+#[parallel]
+async fn retrieve_with_view_context() {
+    api_client()
+        .post_revisions()
+        .retrieve_with_view_context(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id_for_navigation_id(),
+        )
+        .await
+        .assert_response();
+}
+
+fn navigation_id() -> PostId {
+    PostId(TestCredentials::instance().navigation_id)
+}
+
+fn revision_id_for_navigation_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+}
+
+#[template]
+#[rstest]
+#[case::default(AnyPostRevisionListParams::default())]
+#[case::page(generate!(AnyPostRevisionListParams, (page, Some(1))))]
+#[case::per_page(generate!(AnyPostRevisionListParams, (per_page, Some(3))))]
+#[case::search(generate!(AnyPostRevisionListParams, (search, Some("foo".to_string()))))]
+#[case::exclude(generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(1), PostRevisionId(2)])))]
+#[case::include(generate!(AnyPostRevisionListParams, (include, vec![PostRevisionId(1)])))]
+#[case::offset(generate!(AnyPostRevisionListParams, (offset, Some(5))))]
+#[case::order(generate!(AnyPostRevisionListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(AnyPostRevisionListParams, (orderby, Some(WpApiParamPostRevisionsOrderBy::Slug))))]
+fn list_cases(#[case] params: AnyPostRevisionListParams) {}
+
+mod filter {
+    use super::*;
+
+    wp_api::generate_sparse_any_post_revision_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_any_post_revision_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_any_post_revision_field_with_view_context_test_cases!();
+
+    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_edit_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+        #[values(
+            AnyPostRevisionListParams::default(),
+            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
+            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+        )]
+        params: AnyPostRevisionListParams,
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_list_with_edit_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &params,
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|post| {
+                post.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_embed_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+        #[values(
+            AnyPostRevisionListParams::default(),
+            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
+            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+        )]
+        params: AnyPostRevisionListParams,
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_list_with_embed_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &params,
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|post| {
+                post.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_list_with_view_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+        #[values(
+            AnyPostRevisionListParams::default(),
+            generate!(AnyPostRevisionListParams, (exclude, vec![PostRevisionId(2), PostRevisionId(3)])),
+            generate!(AnyPostRevisionListParams, (search, Some("foo".to_string())))
+        )]
+        params: AnyPostRevisionListParams,
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_list_with_view_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &params,
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .iter()
+            .for_each(|post| {
+                post.assert_that_instance_fields_nullability_match_provided_fields(fields)
+            });
+    }
+
+    #[apply(sparse_any_post_revision_field_with_edit_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEditContext::Id, SparseAnyPostRevisionFieldWithEditContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_edit_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEditContext],
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_retrieve_with_edit_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &revision_id_for_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_any_post_revision_field_with_embed_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithEmbedContext::Id, SparseAnyPostRevisionFieldWithEmbedContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_embed_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithEmbedContext],
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_retrieve_with_embed_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &revision_id_for_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+
+    #[apply(sparse_any_post_revision_field_with_view_context_test_cases)]
+    #[case(&[SparseAnyPostRevisionFieldWithViewContext::Id, SparseAnyPostRevisionFieldWithViewContext::Author])]
+    #[tokio::test]
+    #[parallel]
+    async fn filter_retrieve_with_view_context(
+        #[case] fields: &[SparseAnyPostRevisionFieldWithViewContext],
+    ) {
+        api_client()
+            .post_revisions()
+            .filter_retrieve_with_view_context(
+                &PostEndpointType::Navigation,
+                &navigation_id(),
+                &revision_id_for_navigation_id(),
+                fields,
+            )
+            .await
+            .assert_response()
+            .data
+            .assert_that_instance_fields_nullability_match_provided_fields(fields);
+    }
+}

--- a/wp_api_integration_tests/tests/test_navigation_revisions_mut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_mut.rs
@@ -1,0 +1,38 @@
+use wp_api::{
+    post_revisions::PostRevisionId, posts::PostId,
+    request::endpoint::posts_endpoint::PostEndpointType,
+};
+use wp_api_integration_tests::prelude::*;
+
+#[tokio::test]
+#[serial]
+async fn delete_navigation_revision() {
+    let revision_id = revision_id_for_navigation_id();
+    let revision_delete_response = api_client()
+        .post_revisions()
+        .delete(
+            &PostEndpointType::Navigation,
+            &navigation_id(),
+            &revision_id,
+        )
+        .await;
+
+    assert!(
+        revision_delete_response.is_ok(),
+        "{revision_delete_response:#?}"
+    );
+
+    let delete_response = revision_delete_response.unwrap().data;
+    assert!(delete_response.deleted);
+    assert_eq!(delete_response.previous.id, revision_id);
+
+    RestoreServer::db().await;
+}
+
+fn navigation_id() -> PostId {
+    PostId(TestCredentials::instance().navigation_id)
+}
+
+fn revision_id_for_navigation_id() -> PostRevisionId {
+    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+}

--- a/wp_api_integration_tests/tests/test_navigation_revisions_mut.rs
+++ b/wp_api_integration_tests/tests/test_navigation_revisions_mut.rs
@@ -1,7 +1,4 @@
-use wp_api::{
-    post_revisions::PostRevisionId, posts::PostId,
-    request::endpoint::posts_endpoint::PostEndpointType,
-};
+use wp_api::{navigation_revisions::NavigationRevisionId, navigations::NavigationId};
 use wp_api_integration_tests::prelude::*;
 
 #[tokio::test]
@@ -9,12 +6,8 @@ use wp_api_integration_tests::prelude::*;
 async fn delete_navigation_revision() {
     let revision_id = revision_id_for_navigation_id();
     let revision_delete_response = api_client()
-        .post_revisions()
-        .delete(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &revision_id,
-        )
+        .navigation_revisions()
+        .delete(&navigation_id(), &revision_id)
         .await;
 
     assert!(
@@ -29,10 +22,10 @@ async fn delete_navigation_revision() {
     RestoreServer::db().await;
 }
 
-fn navigation_id() -> PostId {
-    PostId(TestCredentials::instance().navigation_id)
+fn navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().navigation_id)
 }
 
-fn revision_id_for_navigation_id() -> PostRevisionId {
-    PostRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
+fn revision_id_for_navigation_id() -> NavigationRevisionId {
+    NavigationRevisionId(TestCredentials::instance().revision_id_for_navigation_id)
 }

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -30,16 +30,17 @@ async fn create_page_with_title_and_meta() {
         &PostCreateParams {
             title: Some("foo".to_string()),
             meta: Some(PostMeta {
-                footnotes: vec![PostFootnote {
+                footnotes: Some(vec![PostFootnote {
                     id: "bar".to_string(),
                     content: "baz".to_string(),
-                }],
+                }]),
             }),
             ..Default::default()
         },
         |created_page, page_from_wp_cli| {
             let meta = created_page.meta.unwrap();
-            let footnote = meta.footnotes.first().unwrap();
+            let footnotes = meta.footnotes.unwrap();
+            let footnote = footnotes.first().unwrap();
             assert_eq!(created_page.title.raw, Some("foo".to_string()));
             assert_eq!(page_from_wp_cli.title, "foo");
             assert_eq!(footnote.id, "bar");
@@ -345,14 +346,15 @@ generate_update_test!(
     update_meta_to_add_footnote,
     meta,
     PostMeta {
-        footnotes: vec![PostFootnote {
+        footnotes: Some(vec![PostFootnote {
             id: "foo".to_string(),
             content: "bar".to_string()
-        }]
+        }])
     },
     |updated_page, _| {
         let meta = updated_page.meta.unwrap();
-        let footnote = meta.footnotes.first().unwrap();
+        let footnotes = meta.footnotes.unwrap();
+        let footnote = footnotes.first().unwrap();
         assert_eq!(footnote.id, "foo");
         assert_eq!(footnote.content, "bar");
     }

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -32,16 +32,17 @@ async fn create_post_with_title_and_meta() {
         &PostCreateParams {
             title: Some("foo".to_string()),
             meta: Some(PostMeta {
-                footnotes: vec![PostFootnote {
+                footnotes: Some(vec![PostFootnote {
                     id: "bar".to_string(),
                     content: "baz".to_string(),
-                }],
+                }]),
             }),
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
             let meta = created_post.meta.unwrap();
-            let footnote = meta.footnotes.first().unwrap();
+            let footnotes = meta.footnotes.unwrap();
+            let footnote = footnotes.first().unwrap();
             assert_eq!(created_post.title.raw, Some("foo".to_string()));
             assert_eq!(post_from_wp_cli.title, "foo");
             assert_eq!(footnote.id, "bar");
@@ -313,14 +314,15 @@ generate_update_test!(
     update_meta_to_add_footnote,
     meta,
     PostMeta {
-        footnotes: vec![PostFootnote {
+        footnotes: Some(vec![PostFootnote {
             id: "foo".to_string(),
             content: "bar".to_string()
-        }]
+        }])
     },
     |updated_post, _| {
         let meta = updated_post.meta.unwrap();
-        let footnote = meta.footnotes.first().unwrap();
+        let footnotes = meta.footnotes.unwrap();
+        let footnote = footnotes.first().unwrap();
         assert_eq!(footnote.id, "foo");
         assert_eq!(footnote.content, "bar");
     }

--- a/wp_serde_helper/src/lib.rs
+++ b/wp_serde_helper/src/lib.rs
@@ -24,7 +24,7 @@ where
 struct StringOfJsonArrayVisitor<T>(PhantomData<T>);
 
 impl<T: DeserializeOwned> de::Visitor<'_> for StringOfJsonArrayVisitor<T> {
-    type Value = Vec<T>;
+    type Value = Option<Vec<T>>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a string containing json array")
@@ -35,14 +35,16 @@ impl<T: DeserializeOwned> de::Visitor<'_> for StringOfJsonArrayVisitor<T> {
         E: de::Error,
     {
         if v.is_empty() {
-            Ok(vec![])
+            Ok(None)
         } else {
             serde_json::from_str(v).map_err(E::custom)
         }
     }
 }
 
-pub fn deserialize_from_string_of_json_array<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+pub fn deserialize_from_string_of_json_array<'de, T, D>(
+    deserializer: D,
+) -> Result<Option<Vec<T>>, D::Error>
 where
     T: DeserializeOwned,
     D: de::Deserializer<'de>,


### PR DESCRIPTION
Follows established patterns to implement [`/navigation/<parent>/revisions` & `/navigation/<parent>/autosaves`](https://developer.wordpress.org/rest-api/reference/wp_navigation-revisions/) endpoints.