### PR TITLE
Don’t require the `user_id` param

### DIFF
--- a/wp_api/src/wp_com/support_bots.rs
+++ b/wp_api/src/wp_com/support_bots.rs
@@ -13,7 +13,9 @@ use super::WpComSiteId;
 #[derive(Debug, PartialEq, Eq, Serialize, uniffi::Record)]
 pub struct CreateBotConversationParams {
     pub message: String,
-    pub user_id: UserId,
+    #[uniffi(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<UserId>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]


### PR DESCRIPTION
By default it’ll use the current user’s ID, which saves apps a bunch of bookkeeping