### PR TITLE
Standalone `/navigation` implementation

### DIFF
--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -185,12 +185,7 @@ extension PostStatusWithEditContext: ListViewDataConvertable {
 
 extension NavigationWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
-        let title = switch self.title {
-        case .object(let title): title.rendered
-        case .string(let string): string
-        }
-
-        return ListViewData(id: self.id.description, title: title ?? "Unknown", subtitle: self.slug, fields: [:])
+        return ListViewData(id: self.id.description, title: self.title.rendered, subtitle: self.slug, fields: [:])
     }
 }
 

--- a/wp_api/src/navigations.rs
+++ b/wp_api/src/navigations.rs
@@ -49,6 +49,7 @@ pub struct SparseNavigation {
     #[WpContext(edit, view)]
     pub date_gmt: Option<String>,
     #[WpContext(edit, view)]
+    #[WpContextualField]
     pub guid: Option<SparseNavigationGuid>,
     #[WpContext(edit, embed, view)]
     pub id: Option<NavigationId>,
@@ -69,46 +70,47 @@ pub struct SparseNavigation {
     #[WpContextualOption]
     pub password: Option<String>,
     #[WpContext(edit, embed, view)]
-    pub title: Option<SparseNavigationTitleWrapper>,
+    #[WpContextualField]
+    pub title: Option<SparseNavigationTitle>,
     #[WpContext(edit, embed, view)]
-    pub content: Option<SparseNavigationContentWrapper>,
+    #[WpContextualField]
+    pub content: Option<SparseNavigationContent>,
     #[WpContext(edit, view)]
     #[WpContextualOption]
     pub template: Option<String>,
     // _meta field omitted
 }
 
-#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, wp_derive::WpDeserialize, uniffi::Record)]
+#[derive(Debug, Serialize, Deserialize, WpContextual, uniffi::Record)]
 pub struct SparseNavigationGuid {
-    pub rendered: Option<String>,
+    #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
+    #[WpContext(edit, view)]
+    pub rendered: Option<String>,
 }
 
-#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]
-#[serde(untagged)]
-pub enum SparseNavigationTitleWrapper {
-    Object(SparseNavigationTitle),
-    String(String),
-}
-
-#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, wp_derive::WpDeserialize, uniffi::Record)]
+#[derive(Debug, Serialize, Deserialize, WpContextual, uniffi::Record)]
 pub struct SparseNavigationTitle {
+    #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
+    #[WpContext(edit, embed, view)]
     pub rendered: Option<String>,
 }
 
-#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, Deserialize, uniffi::Enum)]
-#[serde(untagged)]
-pub enum SparseNavigationContentWrapper {
-    Object(SparseNavigationContent),
-    String(String),
-}
-
-#[derive(Debug, Serialize, PartialEq, PartialOrd, Eq, wp_derive::WpDeserialize, uniffi::Record)]
+#[derive(Debug, Serialize, Deserialize, WpContextual, uniffi::Record)]
 pub struct SparseNavigationContent {
+    #[WpContext(edit)]
+    #[WpContextualOption]
     pub raw: Option<String>,
+    #[WpContext(edit, embed, view)]
     pub rendered: Option<String>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
     pub protected: Option<bool>,
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
     pub block_version: Option<u32>,
 }
 
@@ -151,7 +153,7 @@ pub struct NavigationListParams {
     /// Sort collection by post attribute.
     #[uniffi(default = None)]
     #[field_name("orderby")]
-    pub order_by: Option<NavigationOrderBy>,
+    pub order_by: Option<WpApiParamNavigationsOrderBy>,
     /// Array of column names to be searched.
     #[uniffi(default = [])]
     pub search_columns: Vec<String>,
@@ -180,7 +182,7 @@ pub struct NavigationListParams {
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-pub enum NavigationOrderBy {
+pub enum WpApiParamNavigationsOrderBy {
     Author,
     #[default]
     Date,
@@ -194,7 +196,7 @@ pub enum NavigationOrderBy {
     Title,
 }
 
-impl_as_query_value_from_to_string!(NavigationOrderBy);
+impl_as_query_value_from_to_string!(WpApiParamNavigationsOrderBy);
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record, WpDeriveParamsField)]
 #[supports_pagination(false)]

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -34,7 +34,6 @@ enum PostsRequest {
 pub enum PostEndpointType {
     Posts,
     Pages,
-    Navigation,
     #[strum(default)]
     Custom(String),
 }

--- a/wp_api_integration_tests/tests/test_navigations_err.rs
+++ b/wp_api_integration_tests/tests/test_navigations_err.rs
@@ -1,9 +1,6 @@
-use wp_api::{
-    posts::{
-        PostCreateParams, PostId, PostListParams, PostRetrieveParams, PostUpdateParams,
-        WpApiParamPostsOrderBy,
-    },
-    request::endpoint::posts_endpoint::PostEndpointType,
+use wp_api::navigations::{
+    NavigationCreateParams, NavigationId, NavigationListParams, NavigationRetrieveParams,
+    NavigationUpdateParams, WpApiParamNavigationsOrderBy,
 };
 use wp_api_integration_tests::prelude::*;
 
@@ -11,13 +8,10 @@ use wp_api_integration_tests::prelude::*;
 #[parallel]
 async fn create_navigation_err_cannot_create() {
     api_client_as_subscriber()
-        .posts()
-        .create(
-            &PostEndpointType::Navigation,
-            &PostCreateParams {
-                ..Default::default()
-            },
-        )
+        .navigations()
+        .create(&NavigationCreateParams {
+            ..Default::default()
+        })
         .await
         .assert_wp_error(WpErrorCode::CannotCreate);
 }
@@ -26,14 +20,11 @@ async fn create_navigation_err_cannot_create() {
 #[parallel]
 async fn create_navigation_err_cannot_create2() {
     api_client_as_subscriber()
-        .posts()
-        .create(
-            &PostEndpointType::Navigation,
-            &PostCreateParams {
-                title: Some("foo".to_string()),
-                ..Default::default()
-            },
-        )
+        .navigations()
+        .create(&NavigationCreateParams {
+            title: Some("foo".to_string()),
+            ..Default::default()
+        })
         .await
         .assert_wp_error(WpErrorCode::CannotCreate);
 }
@@ -42,11 +33,8 @@ async fn create_navigation_err_cannot_create2() {
 #[parallel]
 async fn delete_navigation_err_cannot_delete() {
     api_client_as_subscriber()
-        .posts()
-        .delete(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-        )
+        .navigations()
+        .delete(&NavigationId(TestCredentials::instance().navigation_id))
         .await
         .assert_wp_error(WpErrorCode::CannotDelete);
 }
@@ -55,14 +43,11 @@ async fn delete_navigation_err_cannot_delete() {
 #[parallel]
 async fn list_err_no_search_term_defined() {
     api_client()
-        .posts()
-        .list_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostListParams {
-                orderby: Some(WpApiParamPostsOrderBy::Relevance),
-                ..Default::default()
-            },
-        )
+        .navigations()
+        .list_with_edit_context(&NavigationListParams {
+            order_by: Some(WpApiParamNavigationsOrderBy::Relevance),
+            ..Default::default()
+        })
         .await
         .assert_wp_error(WpErrorCode::NoSearchTermDefined);
 }
@@ -71,14 +56,11 @@ async fn list_err_no_search_term_defined() {
 #[parallel]
 async fn list_err_order_by_include_missing_include() {
     api_client()
-        .posts()
-        .list_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostListParams {
-                orderby: Some(WpApiParamPostsOrderBy::Include),
-                ..Default::default()
-            },
-        )
+        .navigations()
+        .list_with_edit_context(&NavigationListParams {
+            order_by: Some(WpApiParamNavigationsOrderBy::Include),
+            ..Default::default()
+        })
         .await
         .assert_wp_error(WpErrorCode::OrderbyIncludeMissingInclude);
 }
@@ -87,14 +69,11 @@ async fn list_err_order_by_include_missing_include() {
 #[parallel]
 async fn list_err_post_invalid_page_number() {
     api_client()
-        .posts()
-        .list_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostListParams {
-                page: Some(99999999),
-                ..Default::default()
-            },
-        )
+        .navigations()
+        .list_with_edit_context(&NavigationListParams {
+            page: Some(99999999),
+            ..Default::default()
+        })
         .await
         .assert_wp_error(WpErrorCode::PostInvalidPageNumber);
 }
@@ -103,11 +82,10 @@ async fn list_err_post_invalid_page_number() {
 #[parallel]
 async fn retrieve_navigation_err_forbidden_context() {
     api_client_as_subscriber()
-        .posts()
+        .navigations()
         .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-            &PostRetrieveParams::default(),
+            &NavigationId(TestCredentials::instance().navigation_id),
+            &NavigationRetrieveParams::default(),
         )
         .await
         .assert_wp_error(WpErrorCode::ForbiddenContext);
@@ -117,11 +95,10 @@ async fn retrieve_navigation_err_forbidden_context() {
 #[parallel]
 async fn retrieve_navigation_err_post_invalid_id() {
     api_client()
-        .posts()
+        .navigations()
         .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &PostId(99999999),
-            &PostRetrieveParams::default(),
+            &NavigationId(99999999),
+            &NavigationRetrieveParams::default(),
         )
         .await
         .assert_wp_error(WpErrorCode::PostInvalidId);
@@ -131,11 +108,10 @@ async fn retrieve_navigation_err_post_invalid_id() {
 #[parallel]
 async fn update_navigation_err_cannot_edit() {
     api_client_as_author()
-        .posts()
+        .navigations()
         .update(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-            &PostUpdateParams::default(),
+            &NavigationId(TestCredentials::instance().navigation_id),
+            &NavigationUpdateParams::default(),
         )
         .await
         .assert_wp_error(WpErrorCode::CannotEdit);
@@ -145,11 +121,10 @@ async fn update_navigation_err_cannot_edit() {
 #[parallel]
 async fn update_navigation_err_invalid_template() {
     api_client()
-        .posts()
+        .navigations()
         .update(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-            &PostUpdateParams {
+            &NavigationId(TestCredentials::instance().navigation_id),
+            &NavigationUpdateParams {
                 template: Some("foo".to_string()),
                 ..Default::default()
             },

--- a/wp_api_integration_tests/tests/test_navigations_immut.rs
+++ b/wp_api_integration_tests/tests/test_navigations_immut.rs
@@ -1,20 +1,17 @@
-use wp_api::{
-    posts::{
-        PostListParams, PostRetrieveParams, PostStatus, SparseAnyPostFieldWithEditContext,
-        SparseAnyPostFieldWithEmbedContext, SparseAnyPostFieldWithViewContext,
-        WpApiParamPostsOrderBy, WpApiParamPostsSearchColumn,
-    },
-    request::endpoint::posts_endpoint::PostEndpointType,
+use wp_api::navigations::{
+    NavigationId, NavigationListParams, NavigationRetrieveParams, NavigationStatus,
+    SparseNavigationFieldWithEditContext, SparseNavigationFieldWithEmbedContext,
+    SparseNavigationFieldWithViewContext, WpApiParamNavigationsOrderBy,
 };
 use wp_api_integration_tests::prelude::*;
 
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_edit_context(#[case] params: PostListParams) {
+async fn list_with_edit_context(#[case] params: NavigationListParams) {
     api_client()
-        .posts()
-        .list_with_edit_context(&PostEndpointType::Navigation, &params)
+        .navigations()
+        .list_with_edit_context(&params)
         .await
         .assert_response();
 }
@@ -22,10 +19,10 @@ async fn list_with_edit_context(#[case] params: PostListParams) {
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_embed_context(#[case] params: PostListParams) {
+async fn list_with_embed_context(#[case] params: NavigationListParams) {
     api_client()
-        .posts()
-        .list_with_embed_context(&PostEndpointType::Navigation, &params)
+        .navigations()
+        .list_with_embed_context(&params)
         .await
         .assert_response();
 }
@@ -33,10 +30,10 @@ async fn list_with_embed_context(#[case] params: PostListParams) {
 #[tokio::test]
 #[apply(list_cases)]
 #[parallel]
-async fn list_with_view_context(#[case] params: PostListParams) {
+async fn list_with_view_context(#[case] params: NavigationListParams) {
     api_client()
-        .posts()
-        .list_with_view_context(&PostEndpointType::Navigation, &params)
+        .navigations()
+        .list_with_view_context(&params)
         .await
         .assert_response();
 }
@@ -45,12 +42,8 @@ async fn list_with_view_context(#[case] params: PostListParams) {
 #[parallel]
 async fn retrieve_with_edit_context() {
     api_client()
-        .posts()
-        .retrieve_with_edit_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &PostRetrieveParams::default(),
-        )
+        .navigations()
+        .retrieve_with_edit_context(&navigation_id(), &NavigationRetrieveParams::default())
         .await
         .assert_response();
 }
@@ -59,12 +52,8 @@ async fn retrieve_with_edit_context() {
 #[parallel]
 async fn retrieve_with_embed_context() {
     api_client()
-        .posts()
-        .retrieve_with_embed_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &PostRetrieveParams::default(),
-        )
+        .navigations()
+        .retrieve_with_embed_context(&navigation_id(), &NavigationRetrieveParams::default())
         .await
         .assert_response();
 }
@@ -73,12 +62,8 @@ async fn retrieve_with_embed_context() {
 #[parallel]
 async fn retrieve_with_view_context() {
     api_client()
-        .posts()
-        .retrieve_with_view_context(
-            &PostEndpointType::Navigation,
-            &navigation_id(),
-            &PostRetrieveParams::default(),
-        )
+        .navigations()
+        .retrieve_with_view_context(&navigation_id(), &NavigationRetrieveParams::default())
         .await
         .assert_response();
 }
@@ -86,79 +71,79 @@ async fn retrieve_with_view_context() {
 #[tokio::test]
 #[rstest]
 #[parallel]
-#[case(PostListParams { per_page: Some(1), ..Default::default() })]
-#[case(PostListParams { per_page: Some(1), order: Some(WpApiParamOrder::Desc), ..Default::default() })]
-#[case(PostListParams { per_page: Some(1), orderby: Some(WpApiParamPostsOrderBy::Modified), ..Default::default() })]
-async fn paginate_list_navigations_with_edit_context(#[case] params: PostListParams) {
+#[case(NavigationListParams { per_page: Some(1), ..Default::default() })]
+#[case(NavigationListParams { per_page: Some(1), order: Some(WpApiParamOrder::Desc), ..Default::default() })]
+#[case(NavigationListParams { per_page: Some(1), order_by: Some(WpApiParamNavigationsOrderBy::Modified), ..Default::default() })]
+async fn paginate_list_navigations_with_edit_context(#[case] params: NavigationListParams) {
     let first_page_response = api_client()
-        .posts()
-        .list_with_edit_context(&PostEndpointType::Navigation, &params)
+        .navigations()
+        .list_with_edit_context(&params)
         .await
         .assert_response();
     assert!(!first_page_response.data.is_empty());
     let next_page_params = first_page_response.next_page_params.unwrap();
     let next_page_response = api_client()
-        .posts()
-        .list_with_edit_context(&PostEndpointType::Navigation, &next_page_params)
+        .navigations()
+        .list_with_edit_context(&next_page_params)
         .await
         .assert_response();
     assert!(!next_page_response.data.is_empty());
     let prev_page_params = next_page_response.prev_page_params.unwrap();
     let prev_page_response = api_client()
-        .posts()
-        .list_with_edit_context(&PostEndpointType::Navigation, &prev_page_params)
+        .navigations()
+        .list_with_edit_context(&prev_page_params)
         .await
         .assert_response();
     assert!(!prev_page_response.data.is_empty());
 }
 
-fn navigation_id() -> PostId {
-    PostId(TestCredentials::instance().navigation_id)
+fn navigation_id() -> NavigationId {
+    NavigationId(TestCredentials::instance().navigation_id)
 }
 
 #[template]
 #[rstest]
-#[case::default(PostListParams::default())]
-#[case::page(generate!(PostListParams, (page, Some(1))))]
-#[case::per_page(generate!(PostListParams, (per_page, Some(3))))]
-#[case::search(generate!(PostListParams, (search, Some("foo".to_string()))))]
-#[case::after(generate!(PostListParams, (after, Some(unwrapped_wp_gmt_date_time("2020-08-14T17:00:00+0200")))))]
-#[case::modified_after(generate!(PostListParams, (modified_after, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0200")))))]
-#[case::before(generate!(PostListParams, (before, Some(unwrapped_wp_gmt_date_time("2023-08-14T17:00:00+0000")))))]
-#[case::modified_before(generate!(PostListParams, (modified_before, Some(unwrapped_wp_gmt_date_time("2024-01-14T17:00:00+0000")))))]
-#[case::exclude(generate!(PostListParams, (exclude, vec![PostId(1), PostId(2)])))]
-#[case::include(generate!(PostListParams, (include, vec![PostId(1)])))]
-#[case::offset(generate!(PostListParams, (offset, Some(2))))]
-#[case::order(generate!(PostListParams, (order, Some(WpApiParamOrder::Asc))))]
-#[case::orderby(generate!(PostListParams, (orderby, Some(WpApiParamPostsOrderBy::Id))))]
-#[case::search_columns(generate!(PostListParams, (search_columns, vec![WpApiParamPostsSearchColumn::PostContent, WpApiParamPostsSearchColumn::PostExcerpt])))]
-#[case::slug(generate!(PostListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
-#[case::status(generate!(PostListParams, (status, vec![PostStatus::Publish, PostStatus::Draft])))]
-fn list_cases(#[case] params: PostListParams) {}
+#[case::default(NavigationListParams::default())]
+#[case::page(generate!(NavigationListParams, (page, Some(1))))]
+#[case::per_page(generate!(NavigationListParams, (per_page, Some(3))))]
+#[case::search(generate!(NavigationListParams, (search, Some("foo".to_string()))))]
+#[case::after(generate!(NavigationListParams, (after, Some("2020-08-14T17:00:00".to_string()))))]
+#[case::modified_after(generate!(NavigationListParams, (modified_after, Some("2024-01-14T17:00:00".to_string()))))]
+#[case::before(generate!(NavigationListParams, (before, Some("2023-08-14T17:00:00".to_string()))))]
+#[case::modified_before(generate!(NavigationListParams, (modified_before, Some("2024-01-14T17:00:00".to_string()))))]
+#[case::exclude(generate!(NavigationListParams, (exclude, vec![NavigationId(1), NavigationId(2)])))]
+#[case::include(generate!(NavigationListParams, (include, vec![NavigationId(1)])))]
+#[case::offset(generate!(NavigationListParams, (offset, Some(2))))]
+#[case::order(generate!(NavigationListParams, (order, Some(WpApiParamOrder::Asc))))]
+#[case::orderby(generate!(NavigationListParams, (order_by, Some(WpApiParamNavigationsOrderBy::Id))))]
+#[case::search_columns(generate!(NavigationListParams, (search_columns, vec!["post_content".to_string(), "post_excerpt".to_string()])))]
+#[case::slug(generate!(NavigationListParams, (slug, vec!["foo".to_string(), "bar".to_string()])))]
+#[case::status(generate!(NavigationListParams, (status, vec![NavigationStatus::Publish, NavigationStatus::Draft])))]
+fn list_cases(#[case] params: NavigationListParams) {}
 
 mod filter {
     use super::*;
 
-    wp_api::generate_sparse_any_post_field_with_edit_context_test_cases!();
-    wp_api::generate_sparse_any_post_field_with_embed_context_test_cases!();
-    wp_api::generate_sparse_any_post_field_with_view_context_test_cases!();
+    wp_api::generate_sparse_navigation_field_with_edit_context_test_cases!();
+    wp_api::generate_sparse_navigation_field_with_embed_context_test_cases!();
+    wp_api::generate_sparse_navigation_field_with_view_context_test_cases!();
 
-    #[apply(sparse_any_post_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithEditContext::Id, SparseAnyPostFieldWithEditContext::Slug])]
+    #[apply(sparse_navigation_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithEditContext::Id, SparseNavigationFieldWithEditContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_navigations_with_edit_context(
-        #[case] fields: &[SparseAnyPostFieldWithEditContext],
+        #[case] fields: &[SparseNavigationFieldWithEditContext],
         #[values(
-            PostListParams::default(),
-            generate!(PostListParams, (status, vec![PostStatus::Draft, PostStatus::Publish])),
-            generate!(PostListParams, (search, Some("foo".to_string())))
+            NavigationListParams::default(),
+            generate!(NavigationListParams, (status, vec![NavigationStatus::Draft, NavigationStatus::Publish])),
+            generate!(NavigationListParams, (search, Some("foo".to_string())))
         )]
-        params: PostListParams,
+        params: NavigationListParams,
     ) {
         api_client()
-            .posts()
-            .filter_list_with_edit_context(&PostEndpointType::Navigation, &params, fields)
+            .navigations()
+            .filter_list_with_edit_context(&params, fields)
             .await
             .assert_response()
             .data
@@ -168,19 +153,18 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_field_with_edit_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithEditContext::Id, SparseAnyPostFieldWithEditContext::Slug])]
+    #[apply(sparse_navigation_field_with_edit_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithEditContext::Id, SparseNavigationFieldWithEditContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_navigations_with_edit_context(
-        #[case] fields: &[SparseAnyPostFieldWithEditContext],
+        #[case] fields: &[SparseNavigationFieldWithEditContext],
     ) {
         let navigation = api_client()
-            .posts()
+            .navigations()
             .filter_retrieve_with_edit_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
-                &PostRetrieveParams::default(),
+                &NavigationRetrieveParams::default(),
                 fields,
             )
             .await
@@ -189,22 +173,22 @@ mod filter {
         navigation.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
 
-    #[apply(sparse_any_post_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithEmbedContext::Id, SparseAnyPostFieldWithEmbedContext::Slug])]
+    #[apply(sparse_navigation_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithEmbedContext::Id, SparseNavigationFieldWithEmbedContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_navigations_with_embed_context(
-        #[case] fields: &[SparseAnyPostFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationFieldWithEmbedContext],
         #[values(
-            PostListParams::default(),
-            generate!(PostListParams, (status, vec![PostStatus::Draft, PostStatus::Publish])),
-            generate!(PostListParams, (search, Some("foo".to_string())))
+            NavigationListParams::default(),
+            generate!(NavigationListParams, (status, vec![NavigationStatus::Draft, NavigationStatus::Publish])),
+            generate!(NavigationListParams, (search, Some("foo".to_string())))
         )]
-        params: PostListParams,
+        params: NavigationListParams,
     ) {
         api_client()
-            .posts()
-            .filter_list_with_embed_context(&PostEndpointType::Navigation, &params, fields)
+            .navigations()
+            .filter_list_with_embed_context(&params, fields)
             .await
             .assert_response()
             .data
@@ -214,19 +198,18 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_field_with_embed_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithEmbedContext::Id, SparseAnyPostFieldWithEmbedContext::Slug])]
+    #[apply(sparse_navigation_field_with_embed_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithEmbedContext::Id, SparseNavigationFieldWithEmbedContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_navigations_with_embed_context(
-        #[case] fields: &[SparseAnyPostFieldWithEmbedContext],
+        #[case] fields: &[SparseNavigationFieldWithEmbedContext],
     ) {
         let navigation = api_client()
-            .posts()
+            .navigations()
             .filter_retrieve_with_embed_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
-                &PostRetrieveParams::default(),
+                &NavigationRetrieveParams::default(),
                 fields,
             )
             .await
@@ -235,22 +218,22 @@ mod filter {
         navigation.assert_that_instance_fields_nullability_match_provided_fields(fields)
     }
 
-    #[apply(sparse_any_post_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithViewContext::Id, SparseAnyPostFieldWithViewContext::Slug])]
+    #[apply(sparse_navigation_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithViewContext::Id, SparseNavigationFieldWithViewContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_navigations_with_view_context(
-        #[case] fields: &[SparseAnyPostFieldWithViewContext],
+        #[case] fields: &[SparseNavigationFieldWithViewContext],
         #[values(
-            PostListParams::default(),
-            generate!(PostListParams, (status, vec![PostStatus::Draft, PostStatus::Publish])),
-            generate!(PostListParams, (search, Some("foo".to_string())))
+            NavigationListParams::default(),
+            generate!(NavigationListParams, (status, vec![NavigationStatus::Draft, NavigationStatus::Publish])),
+            generate!(NavigationListParams, (search, Some("foo".to_string())))
         )]
-        params: PostListParams,
+        params: NavigationListParams,
     ) {
         api_client()
-            .posts()
-            .filter_list_with_view_context(&PostEndpointType::Navigation, &params, fields)
+            .navigations()
+            .filter_list_with_view_context(&params, fields)
             .await
             .assert_response()
             .data
@@ -260,19 +243,18 @@ mod filter {
             });
     }
 
-    #[apply(sparse_any_post_field_with_view_context_test_cases)]
-    #[case(&[SparseAnyPostFieldWithViewContext::Id, SparseAnyPostFieldWithViewContext::Slug])]
+    #[apply(sparse_navigation_field_with_view_context_test_cases)]
+    #[case(&[SparseNavigationFieldWithViewContext::Id, SparseNavigationFieldWithViewContext::Slug])]
     #[tokio::test]
     #[parallel]
     async fn filter_retrieve_navigations_with_view_context(
-        #[case] fields: &[SparseAnyPostFieldWithViewContext],
+        #[case] fields: &[SparseNavigationFieldWithViewContext],
     ) {
         let navigation = api_client()
-            .posts()
+            .navigations()
             .filter_retrieve_with_view_context(
-                &PostEndpointType::Navigation,
                 &navigation_id(),
-                &PostRetrieveParams::default(),
+                &NavigationRetrieveParams::default(),
                 fields,
             )
             .await

--- a/wp_api_integration_tests/tests/test_navigations_mut.rs
+++ b/wp_api_integration_tests/tests/test_navigations_mut.rs
@@ -1,13 +1,15 @@
 use macro_helper::{generate_update_navigation_status_test, generate_update_test};
-use wp_api::posts::{AnyPostWithEditContext, PostCreateParams, PostStatus, PostUpdateParams};
-use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
+use wp_api::navigations::{
+    NavigationCreateParams, NavigationId, NavigationStatus, NavigationUpdateParams,
+    NavigationWithEditContext,
+};
 use wp_api_integration_tests::prelude::*;
 
 #[tokio::test]
 #[serial]
 async fn create_navigation_with_just_title() {
     test_create_navigation(
-        &PostCreateParams {
+        &NavigationCreateParams {
             title: Some("foo".to_string()),
             ..Default::default()
         },
@@ -22,7 +24,7 @@ async fn create_navigation_with_just_title() {
 #[serial]
 async fn create_navigation_with_just_content() {
     test_create_navigation(
-        &PostCreateParams {
+        &NavigationCreateParams {
             content: Some("foo".to_string()),
             ..Default::default()
         },
@@ -37,7 +39,7 @@ async fn create_navigation_with_just_content() {
 #[serial]
 async fn create_navigation_with_title_and_content() {
     test_create_navigation(
-        &PostCreateParams {
+        &NavigationCreateParams {
             title: Some("foo".to_string()),
             content: Some("bar".to_string()),
             ..Default::default()
@@ -54,11 +56,8 @@ async fn create_navigation_with_title_and_content() {
 #[serial]
 async fn delete_navigation() {
     let navigation_delete_response = api_client()
-        .posts()
-        .delete(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-        )
+        .navigations()
+        .delete(&NavigationId(TestCredentials::instance().navigation_id))
         .await;
     assert!(
         navigation_delete_response.is_ok(),
@@ -73,11 +72,8 @@ async fn delete_navigation() {
 #[serial]
 async fn trash_navigation() {
     let navigation_trash_response = api_client()
-        .posts()
-        .trash(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
-        )
+        .navigations()
+        .trash(&NavigationId(TestCredentials::instance().navigation_id))
         .await;
     assert!(
         navigation_trash_response.is_ok(),
@@ -99,11 +95,11 @@ generate_update_test!(
 generate_update_test!(
     update_date_gmt,
     date_gmt,
-    unwrapped_wp_gmt_date_time("2024-09-09T12:00:00+0000"),
+    "2024-09-09T12:00:00".to_string(),
     |updated_navigation| {
         assert_eq!(
             updated_navigation.date_gmt,
-            unwrapped_wp_gmt_date_time("2024-09-09T12:00:00+0000")
+            "2024-09-09T12:00:00".to_string()
         );
     }
 );
@@ -122,7 +118,10 @@ generate_update_test!(
     password,
     "new_password".to_string(),
     |updated_navigation| {
-        assert_eq!(updated_navigation.password, "new_password");
+        assert_eq!(
+            updated_navigation.password,
+            Some("new_password".to_string())
+        );
     }
 );
 
@@ -151,13 +150,13 @@ generate_update_test!(
 #[serial]
 async fn update_status_to_future() {
     test_update_navigation(
-        &PostUpdateParams {
-            status: Some(PostStatus::Future),
+        &NavigationUpdateParams {
+            status: Some(NavigationStatus::Future),
             date: Some("2026-09-09T12:00:00".to_string()),
             ..Default::default()
         },
         |updated_navigation| {
-            assert_eq!(updated_navigation.status, PostStatus::Future);
+            assert_eq!(updated_navigation.status, NavigationStatus::Future);
         },
     )
     .await;
@@ -168,13 +167,13 @@ generate_update_navigation_status_test!(Pending);
 generate_update_navigation_status_test!(Private);
 generate_update_navigation_status_test!(Publish);
 
-async fn test_create_navigation<F>(params: &PostCreateParams, assert: F)
+async fn test_create_navigation<F>(params: &NavigationCreateParams, assert: F)
 where
-    F: Fn(AnyPostWithEditContext),
+    F: Fn(NavigationWithEditContext),
 {
     let created_navigation = api_client()
-        .posts()
-        .create(&PostEndpointType::Navigation, params)
+        .navigations()
+        .create(params)
         .await
         .assert_response()
         .data;
@@ -182,15 +181,14 @@ where
     RestoreServer::db().await;
 }
 
-async fn test_update_navigation<F>(params: &PostUpdateParams, assert: F)
+async fn test_update_navigation<F>(params: &NavigationUpdateParams, assert: F)
 where
-    F: Fn(AnyPostWithEditContext),
+    F: Fn(NavigationWithEditContext),
 {
     let updated_navigation = api_client()
-        .posts()
+        .navigations()
         .update(
-            &PostEndpointType::Navigation,
-            &PostId(TestCredentials::instance().navigation_id),
+            &NavigationId(TestCredentials::instance().navigation_id),
             params,
         )
         .await
@@ -201,6 +199,8 @@ where
 }
 
 mod macro_helper {
+    use super::*;
+
     macro_rules! generate_update_test {
         ($ident:ident, $field:ident, $new_value:expr, $assertion:expr) => {
             paste::paste! {
@@ -209,7 +209,7 @@ mod macro_helper {
                 async fn $ident() {
                     let updated_value = $new_value;
                     test_update_navigation(
-                        &PostUpdateParams {
+                        &NavigationUpdateParams {
                             $field: Some(updated_value),
                             ..Default::default()
                         }, $assertion)
@@ -226,12 +226,12 @@ mod macro_helper {
                 #[serial]
                 async fn [<update_navigation_status_to_ $status:lower>]() {
                     test_update_navigation(
-                        &PostUpdateParams {
-                            status: Some(PostStatus::$status),
+                        &NavigationUpdateParams {
+                            status: Some(NavigationStatus::$status),
                             ..Default::default()
                         },
                         |updated_navigation| {
-                            assert_eq!(updated_navigation.status, PostStatus::$status);
+                            assert_eq!(updated_navigation.status, NavigationStatus::$status);
                         }
                     ).await;
                 }


### PR DESCRIPTION
Follow up to #941. After further discussion with Jeremy, we decided to go with a navigation specific implementation instead of the `PostEndpointType::Navigation` approach. With this change, the `/navigations` will be a standalone endpoint.

Note that there were a bunch of issues in the initial `wp_api/src/navigations.rs` implementation. I hadn't fix them in the previous PR because I thought we were going to remove them and the PR ended up accidentally being auto-merged. That's why you'll find a lot of changes to the navigation types in this PR.