### PR TITLE
Don't generate uniffi bindings for Request Builders

### DIFF
--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -44,11 +44,6 @@ use crate::{
 };
 use std::sync::Arc;
 
-#[derive(uniffi::Object)]
-struct UniffiWpApiRequestBuilder {
-    inner: WpApiRequestBuilder,
-}
-
 pub struct WpApiRequestBuilder {
     api_root: Arc<ApiRootRequestBuilder>,
     application_passwords: Arc<ApplicationPasswordsRequestBuilder>,
@@ -239,14 +234,6 @@ api_client_generate_endpoint_impl!(WpApi, wp_site_health_tests);
 macro_rules! api_client_generate_endpoint_impl {
     ($client_name_prefix: ident, $feature:ident) => {
         paste::paste! {
-            #[uniffi::export]
-
-            impl [<Uniffi $client_name_prefix RequestBuilder>] {
-                fn $feature(&self) -> Arc<[<$feature:camel RequestBuilder>]> {
-                    self.inner.$feature.clone()
-                }
-            }
-
             impl [<$client_name_prefix RequestBuilder>] {
                 pub fn $feature(&self) -> &[<$feature:camel RequestBuilder>] {
                     self.$feature.as_ref()

--- a/wp_api/src/jetpack/client.rs
+++ b/wp_api/src/jetpack/client.rs
@@ -8,32 +8,6 @@ use crate::{
 };
 use std::sync::Arc;
 
-#[derive(uniffi::Object)]
-struct UniffiJetpackApiRequestBuilder {
-    inner: JetpackApiRequestBuilder,
-}
-
-#[uniffi::export]
-impl UniffiJetpackApiRequestBuilder {
-    #[uniffi::constructor]
-    pub fn new(
-        api_url_resolver: Arc<dyn ApiUrlResolver>,
-        auth_provider: Arc<WpAuthenticationProvider>,
-    ) -> Self {
-        Self {
-            inner: JetpackApiRequestBuilder::new(api_url_resolver, auth_provider),
-        }
-    }
-
-    #[uniffi::constructor]
-    pub fn with_api_root_url(
-        api_root_url: Arc<ParsedUrl>,
-        auth_provider: Arc<WpAuthenticationProvider>,
-    ) -> Self {
-        Self::new(jetpack_api_url_resolver(api_root_url), auth_provider)
-    }
-}
-
 pub struct JetpackApiRequestBuilder {
     connection: Arc<ConnectionRequestBuilder>,
 }

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -154,7 +154,6 @@ impl NetworkRequestAccessor for MediaUploadRequest {
     }
 }
 
-#[uniffi::export]
 impl MediaRequestBuilder {
     pub fn create(
         &self,

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -20,21 +20,6 @@ use crate::{
 };
 use std::sync::Arc;
 
-#[derive(uniffi::Object)]
-struct UniffiWpComApiRequestBuilder {
-    inner: WpComApiRequestBuilder,
-}
-
-#[uniffi::export]
-impl UniffiWpComApiRequestBuilder {
-    #[uniffi::constructor]
-    pub fn new(auth_provider: Arc<WpAuthenticationProvider>) -> Self {
-        Self {
-            inner: WpComApiRequestBuilder::new(auth_provider),
-        }
-    }
-}
-
 pub struct WpComApiRequestBuilder {
     followers: Arc<FollowersRequestBuilder>,
     jetpack_connection: Arc<JetpackConnectionRequestBuilder>,

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -296,7 +296,6 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
     });
 
     quote! {
-        #[derive(uniffi::Object)]
         pub struct #generated_request_builder_ident {
             endpoint: #generated_endpoint_ident,
             inner: #static_inner_request_builder_type,
@@ -309,7 +308,6 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
                 }
             }
         }
-        #[uniffi::export]
         impl #generated_request_builder_ident {
             #(#functions)*
         }


### PR DESCRIPTION
We are hitting `MethodTooLargeException` issues in Kotlin bindings due to the number of methods we are generating, so we are going to stop exporting some of the ones we are not actively using at the moment.