### PR TITLE
Pin Gutenberg plugin version and address test issues

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
@@ -26,7 +26,7 @@ class PostTypesEndpointTest {
         val postTypesPost = client.request { requestBuilder ->
             requestBuilder.postTypes().retrieveWithEditContext(PostType.Post)
         }.assertSuccessAndRetrieveData().data
-        assert(postTypesPost.supports[PostTypeSupports.Title]!!)
+        assert(postTypesPost.supports.map[PostTypeSupports.Title]!!)
         assertFalse(postTypesPost.capabilities[PostTypeCapabilities.EditPosts]!!.isEmpty())
     }
 
@@ -35,7 +35,7 @@ class PostTypesEndpointTest {
         val postTypesPost = client.request { requestBuilder ->
             requestBuilder.postTypes().retrieveWithEditContext(PostType.WpFontFace)
         }.assertSuccessAndRetrieveData().data
-        assertNull(postTypesPost.supports[PostTypeSupports.Author])
+        assertNull(postTypesPost.supports.map[PostTypeSupports.Author])
     }
 
     @Test

--- a/native/swift/Example/Example/ExampleApp.swift
+++ b/native/swift/Example/Example/ExampleApp.swift
@@ -128,7 +128,7 @@ struct ExampleApp: App {
             .postTypes
             .map(\.value)
             .filter { $0.visibility.showInNavMenus }
-            .filter { $0.supports.keys.contains(allOf: [.title, .author, .customFields]) }
+            .filter { $0.supports.map.keys.contains(allOf: [.title, .author, .customFields]) }
 
         for type in postTypes {
             baseData.append(RootListData(name: type.name, sequence: {

--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -71,7 +71,9 @@ wp import /tmp/testdata.xml --authors=create
 wp plugin deactivate wordpress-importer
 wp plugin delete wordpress-importer
 
-wp plugin install gutenberg --activate
+curl -sSL https://downloads.wordpress.org/plugin/gutenberg.21.7.0.zip -o /tmp/gutenberg.zip
+unzip -q /tmp/gutenberg.zip -d wp-content/plugins/
+wp plugin activate gutenberg
 
 # Install custom must-use plugins for integration tests
 mkdir -p wp-content/mu-plugins

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 use wp_contextual::WpContextual;
+use wp_serde_helper::deserialize_empty_array_or_hashmap;
 
 #[derive(
     Debug,
@@ -74,7 +75,7 @@ pub struct SparsePostTypeDetails {
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit)]
-    pub supports: Option<HashMap<PostTypeSupports, bool>>,
+    pub supports: Option<PostTypeSupportsMap>,
     #[WpContext(edit, view)]
     pub has_archive: Option<bool>,
     #[WpContext(edit, view)]
@@ -88,6 +89,15 @@ pub struct SparsePostTypeDetails {
     #[WpContext(edit, embed, view)]
     #[WpContextualOption]
     pub icon: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
+#[serde(transparent)]
+pub struct PostTypeSupportsMap {
+    #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
+    #[serde(flatten)]
+    #[serde(rename = "supports")]
+    pub map: HashMap<PostTypeSupports, bool>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/templates.rs
+++ b/wp_api/src/templates.rs
@@ -94,6 +94,7 @@ pub struct SparseTemplate {
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
     pub theme: Option<String>,
     #[serde(rename = "type")]
     #[WpContext(edit, embed, view)]

--- a/wp_api_integration_tests/tests/test_post_types_immut.rs
+++ b/wp_api_integration_tests/tests/test_post_types_immut.rs
@@ -93,7 +93,7 @@ async fn retrieve_post_types_with_edit_context(
     // post types might not support `Title` in which case it's perfectly fine to completely
     // remove this assertion.
     assert_eq!(
-        post_type.supports.get(&PostTypeSupports::Title),
+        post_type.supports.map.get(&PostTypeSupports::Title),
         Some(true).as_ref()
     );
     // All post types in our current testing sites have `EditPost` capability, so we use this

--- a/wp_api_integration_tests/tests/test_templates_mut.rs
+++ b/wp_api_integration_tests/tests/test_templates_mut.rs
@@ -52,7 +52,7 @@ async fn create_template_with_slug_title_and_theme() {
     test_create_template(&params, |created_template| {
         assert_slug(&created_template);
         assert_title(&created_template);
-        assert_eq!(created_template.theme, theme);
+        assert_eq!(created_template.theme, Some(theme.to_string()));
     })
     .await;
 }


### PR DESCRIPTION
## Summary

- Pin Gutenberg plugin version to 21.7.0 for test server
- Fix `PostTypeSupports` deserialization to handle empty arrays
- Fix `Template.theme` field to be properly optional

## Changes

- Modified test server setup to download and install Gutenberg 21.7.0 directly from WordPress.org
- Wrapped `PostTypeSupports` in `PostTypeSupportsMap` with custom deserialization to handle cases where WordPress returns `[]` instead of `{}`
- Made `Template.theme` field properly optional with `#[WpContextualOption]` attribute
- Updated Kotlin and Swift integration tests to access `supports.map` instead of `supports` directly
