### PR TITLE
Use latest Gutenberg plugin in test server

### DIFF
--- a/scripts/setup-test-site.sh
+++ b/scripts/setup-test-site.sh
@@ -71,9 +71,7 @@ wp import /tmp/testdata.xml --authors=create
 wp plugin deactivate wordpress-importer
 wp plugin delete wordpress-importer
 
-curl -sSL https://downloads.wordpress.org/plugin/gutenberg.21.7.0.zip -o /tmp/gutenberg.zip
-unzip -q /tmp/gutenberg.zip -d wp-content/plugins/
-wp plugin activate gutenberg
+wp plugin install gutenberg --activate
 
 # Install custom must-use plugins for integration tests
 mkdir -p wp-content/mu-plugins


### PR DESCRIPTION
Partially reverts #955 as the issue in Gutenberg plugin should is resolved in `21.8.1`.

Even though using the latest Gutenberg plugin might occasionally break our test suite, we decided it's worth it to be able to report issues like this as soon as they happen.