### PR TITLE
Adds `#[WpContextualDontDerivePartialEq]`

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -141,7 +141,7 @@ pub struct AnyJson {
 }
 
 uniffi::custom_newtype!(WpResponseString, Option<String>);
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "BoolOrString")]
 pub struct WpResponseString(pub Option<String>);
 

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -341,6 +341,7 @@ impl From<MediaCreateParams> for HashMap<String, String> {
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
+#[WpContextualDontDerivePartialEq]
 pub struct SparseMedia {
     #[WpContext(edit, embed, view)]
     pub id: Option<MediaId>,

--- a/wp_api/src/plugins.rs
+++ b/wp_api/src/plugins.rs
@@ -150,7 +150,7 @@ pub enum PluginStatus {
 
 impl_as_query_value_from_to_string!(PluginStatus);
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct PluginDescription {
     pub raw: String,
     pub rendered: String,

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -467,14 +467,14 @@ pub struct SparsePostContent {
     pub block_version: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct SparsePostExcerpt {
     pub raw: Option<String>,
     pub rendered: Option<String>,
     pub protected: Option<bool>,
 }
 
-#[derive(Debug, Serialize, WpDeserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, WpDeserialize, uniffi::Record)]
 pub struct PostMeta {
     #[serde(deserialize_with = "deserialize_from_string_of_json_array")]
     #[serde(serialize_with = "serialize_as_json_string")]

--- a/wp_api/src/themes.rs
+++ b/wp_api/src/themes.rs
@@ -110,49 +110,49 @@ impl Display for ThemeStylesheet {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeAuthor {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeAuthorName {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeAuthorUri {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeAuthorDescription {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeDescription {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeName {
     pub raw: String,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeTags {
     pub raw: Vec<String>,
     pub rendered: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct ThemeUri {
     pub raw: String,
     pub rendered: String,

--- a/wp_api/src/widgets.rs
+++ b/wp_api/src/widgets.rs
@@ -32,7 +32,7 @@ pub struct SparseWidget {
     pub form_data: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct WidgetInstance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoded: Option<String>,

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -512,7 +512,8 @@ mod wp_contextual;
         WpContext,
         WpContextualField,
         WpContextualOption,
-        WpContextualExcludeFromFields
+        WpContextualExcludeFromFields,
+        WpContextualDontDerivePartialEq
     )
 )]
 pub fn derive(input: TokenStream) -> TokenStream {

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -7,6 +7,16 @@ use syn::{DeriveInput, Ident, spanned::Spanned};
 
 const IDENT_PREFIX: &str = "Sparse";
 
+/// Checks if the type has #[WpContextualDontDerivePartialEq] attribute.
+///
+/// When present, PartialEq won't be added to the generated types.
+/// This is useful for types that contain fields that don't support PartialEq.
+fn has_dont_derive_partial_eq_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("WpContextualDontDerivePartialEq"))
+}
+
 pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
     let original_ident = &ast.ident;
     let original_ident_name = original_ident.to_string();
@@ -19,17 +29,37 @@ pub fn wp_contextual(ast: DeriveInput) -> Result<TokenStream, syn::Error> {
         struct_fields(&ast.data).map_err(|err| err.into_syn_error(original_ident.span()))?;
     let parsed_fields = parse_fields(fields)?;
 
+    // Check if PartialEq should be derived
+    let should_derive_partial_eq = !has_dont_derive_partial_eq_attr(&ast.attrs);
+
     let contextual_token_streams = WpContextAttr::iter().map(|current_context| {
         let generate_type = |is_sparse, ident, generated_fields: &Vec<GeneratedContextualField>| {
             if !generated_fields.is_empty() {
-                let deserialize_derive = if is_sparse {
-                    quote! { wp_derive::WpDeserialize }
+                // Build the hardcoded derives
+                let mut derives: Vec<syn::Path> = vec![syn::parse_quote!(Debug)];
+
+                // Add PartialEq unless explicitly disabled
+                // Note: We only derive PartialEq, not Eq, because we can't guarantee
+                // that all field types will satisfy Eq's stricter requirements
+                // (e.g., floating point types where NaN != NaN)
+                if should_derive_partial_eq {
+                    derives.push(syn::parse_quote!(PartialEq));
+                }
+
+                derives.push(syn::parse_quote!(serde::Serialize));
+
+                // For sparse types use WpDeserialize, for non-sparse use Deserialize
+                if is_sparse {
+                    derives.push(syn::parse_quote!(wp_derive::WpDeserialize));
                 } else {
-                    quote! { serde::Deserialize }
-                };
+                    derives.push(syn::parse_quote!(serde::Deserialize));
+                }
+
+                derives.push(syn::parse_quote!(uniffi::Record));
+
                 let fields_to_add = generated_fields.iter().map(|f| &f.field);
                 quote! {
-                    #[derive(Debug, serde::Serialize, #deserialize_derive, uniffi::Record)]
+                    #[derive(#(#derives),*)]
                     pub struct #ident {
                         #(#fields_to_add,)*
                     }


### PR DESCRIPTION
## Summary

Enhanced `WpContextual` derive macro to automatically derive `PartialEq` on generated contextual types.

## Changes

- Generated contextual types now derive `PartialEq` by default (not `Eq` to avoid floating point issues)
- Added `#[WpContextualDontDerivePartialEq]` attribute to opt-out when needed (e.g., `SparseMedia` with `Arc<MediaDetails>`)
- Added `PartialEq` and `Eq` to helper types: `WpResponseString`, `PluginDescription`, `SparsePostExcerpt`, `PostMeta`, theme wrappers
- Added only `PartialEq` to `WidgetInstance` (contains `JsonValue` with floats)
