### PR TITLE
Add xcframework code signing

### DIFF
--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 
 echo "--- :arrow_down: Downloading xcframework"
 buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
+unzip libwordpressFFI.xcframework.zip -d .
+rm libwordpressFFI.xcframework.zip
+
 buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"
+
+# Temporarily also download to target folder because some parts still expect it there
+mkdir -p ./target
+pushd target
+buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
 unzip libwordpressFFI.xcframework.zip -d .
 rm libwordpressFFI.xcframework.zip

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 echo "--- :arrow_down: Downloading XCFramework"
+mkdir -p target
 pushd target
 buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
 unzip libwordpressFFI.xcframework.zip -d .

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- :arrow_down: Downloading xcframework"
-buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
+buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
 buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"
-unzip target/libwordpressFFI.xcframework.zip -d .
-rm target/libwordpressFFI.xcframework.zip
+unzip libwordpressFFI.xcframework.zip -d .
+rm libwordpressFFI.xcframework.zip

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -2,17 +2,12 @@
 
 set -euo pipefail
 
-echo "--- :arrow_down: Downloading xcframework"
-buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
-unzip libwordpressFFI.xcframework.zip -d .
-rm libwordpressFFI.xcframework.zip
-
-buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"
-
-# Temporarily also download to target folder because some parts still expect it there
-mkdir -p ./target
+echo "--- :arrow_down: Downloading XCFramework"
 pushd target
 buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
 unzip libwordpressFFI.xcframework.zip -d .
 rm libwordpressFFI.xcframework.zip
 popd
+
+echo "--- :arrow_down: Downloading Native WordPress API Wrapper"
+buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -3,12 +3,9 @@
 set -euo pipefail
 
 echo "--- :arrow_down: Downloading XCFramework"
-mkdir -p target
-pushd target
-buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
-unzip libwordpressFFI.xcframework.zip -d .
-rm libwordpressFFI.xcframework.zip
-popd
+buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
+unzip target/libwordpressFFI.xcframework.zip -d .
+rm target/libwordpressFFI.xcframework.zip
 
 echo "--- :arrow_down: Downloading Native WordPress API Wrapper"
 buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -15,3 +15,4 @@ pushd target
 buildkite-agent artifact download libwordpressFFI.xcframework.zip . --step "xcframework"
 unzip libwordpressFFI.xcframework.zip -d .
 rm libwordpressFFI.xcframework.zip
+popd

--- a/.buildkite/download-xcframework.sh
+++ b/.buildkite/download-xcframework.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 echo "--- :arrow_down: Downloading XCFramework"
 buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
-unzip target/libwordpressFFI.xcframework.zip -d .
+mkdir -p ./target/
+unzip target/libwordpressFFI.xcframework.zip -d ./target/
 rm target/libwordpressFFI.xcframework.zip
 
 echo "--- :arrow_down: Downloading Native WordPress API Wrapper"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,8 +80,8 @@ steps:
           make xcframework-sign
 
         artifact_paths:
-          - libwordpressFFI.xcframework.zip
-          - libwordpressFFI.xcframework.zip.checksum.txt
+          - target/libwordpressFFI.xcframework.zip
+          - target/libwordpressFFI.xcframework.zip.checksum.txt
           - native/swift/Sources/wordpress-api-wrapper/*.swift
         plugins: [$CI_TOOLKIT]
         agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,10 +69,12 @@ steps:
           echo "--- :package: Installing Rust Toolchains"
           make setup-rust
 
-          echo "--- :swift: Building xcframework"
+          echo "--- :ruby: Installing Ruby tools"
           install_gems
+          echo "--- :xcode: Setting up code signing"
           bundle exec fastlane set_up_signing_release
 
+          echo "--- :swift: Building XCFramework"
           make xcframework-package
           make xcframework-package-checksum
           make xcframework-sign

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,11 +70,18 @@ steps:
           make setup-rust
 
           echo "--- :swift: Building xcframework"
-          make xcframework
-          zip -r target/libwordpressFFI.xcframework.zip target/libwordpressFFI.xcframework
+          install_gems
+          bundle exec fastlane set_up_signing
+
+          make xcframework-package
+          make xcframework-package-checksum
+          make xcframework-sign
+
         artifact_paths:
-          - target/libwordpressFFI.xcframework.zip
+          - libwordpressFFI.xcframework.zip
+          - libwordpressFFI.xcframework.zip.checksum.txt
           - native/swift/Sources/wordpress-api-wrapper/*.swift
+        plugins: [$CI_TOOLKIT]
         agents:
           queue: mac
       - label: ":swift: Build Docs"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,7 +71,7 @@ steps:
 
           echo "--- :swift: Building xcframework"
           install_gems
-          bundle exec fastlane set_up_signing
+          bundle exec fastlane set_up_signing_release
 
           make xcframework-package
           make xcframework-package-checksum

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -21,9 +21,13 @@ make setup-rust
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+echo "--- :closed_lock_with_key: Setting up Code Signing"
+bundle exec fastlane set_up_signing
+
 echo "--- :rust: Building XCFramework"
 make xcframework-package
 make xcframework-package-checksum
+make xcframework-sign
 
 release_version="$1"
 echo "--- :rocket: Publish release $release_version"

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -22,7 +22,7 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :closed_lock_with_key: Setting up Code Signing"
-bundle exec fastlane set_up_signing
+bundle exec fastlane set_up_signing_release
 
 echo "--- :rust: Building XCFramework"
 make xcframework-package

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ swift_package_platform_ios = $(call swift_package_platform_version,ios)
 swift_package_platform_watchos = $(call swift_package_platform_version,watchos)
 swift_package_platform_tvos = $(call swift_package_platform_version,tvos)
 
+certificate_name_release = Apple Distribution: Automattic, Inc. (PZYM8XX95Q)
+
 # Required for supporting tvOS and watchOS. We can update the nightly toolchain version if needed.
 rust_nightly_toolchain := nightly-2025-07-29
 
@@ -138,7 +140,7 @@ xcframework-package-checksum:
 	swift package compute-checksum libwordpressFFI.xcframework.zip | tee libwordpressFFI.xcframework.zip.checksum.txt
 
 xcframework-sign:
-	codesign --timestamp -v --sign "Apple Development: Created via API (886NX39KP6)" target/libwordpressFFI.xcframework
+	codesign --timestamp -v --sign "${certificate_name_release}" target/libwordpressFFI.xcframework
 
 docker-image-web:
 	docker build -t wordpress-rs-web -f wp_rs_web/Dockerfile . --progress=plain

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ xcframework-package: xcframework-all
 xcframework-package-checksum:
 	swift package compute-checksum libwordpressFFI.xcframework.zip | tee libwordpressFFI.xcframework.zip.checksum.txt
 
+xcframework-sign:
+	codesign --timestamp -v --sign "Apple Development: Created via API (886NX39KP6)" target/libwordpressFFI.xcframework
+
 docker-image-web:
 	docker build -t wordpress-rs-web -f wp_rs_web/Dockerfile . --progress=plain
 

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,11 @@ xcframework: xcframework-all
 endif
 
 xcframework-package: xcframework-all
-	rm -rf libwordpressFFI.xcframework.zip
-	ditto -c -k --sequesterRsrc --keepParent target/libwordpressFFI.xcframework/ libwordpressFFI.xcframework.zip
+	rm -rf target/libwordpressFFI.xcframework.zip
+	ditto -c -k --sequesterRsrc --keepParent target/libwordpressFFI.xcframework/ target/libwordpressFFI.xcframework.zip
 
 xcframework-package-checksum:
-	swift package compute-checksum libwordpressFFI.xcframework.zip | tee libwordpressFFI.xcframework.zip.checksum.txt
+	swift package compute-checksum target/libwordpressFFI.xcframework.zip | tee libwordpressFFI.xcframework.zip.checksum.txt
 
 xcframework-sign:
 	codesign --timestamp -v --sign "${certificate_name_release}" target/libwordpressFFI.xcframework

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -431,7 +431,6 @@ lane :set_up_signing do |readonly: true|
   )
 end
 
-
 # Utils
 
 def xcframework_checksum

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,6 +95,11 @@ SUPPORTED_LOCALES = [
   { glotpress: 'zh-tw', project: 'zh-TW'  }
 ].freeze
 
+before_all do
+  # Fixes issues with keychain in CI
+  setup_ci
+end
+
 lane :release do |options|
   version = options[:version] || UI.user_error!('version is required')
   lane_context[LANE_VALUE_VERSION] = version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -246,7 +246,7 @@ lane :download_translations do |commit_changes: false|
     updated_fluent_files = []
 
     if downloaded_files.empty?
-      UI.message("No .po files were downloaded from GlotPress")
+      UI.message('No .po files were downloaded from GlotPress')
       next
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,6 +24,21 @@ PROJECT_NAME = 'wordpress-rs'
 # GlotPress configuration
 GLOTPRESS_PROJECT_BASE_URL = 'https://translate.wordpress.com/projects/mobile/wordpress-rs'
 
+# Code Signing
+APPLE_TEAM_ID = 'PZYM8XX95Q'
+APPLE_BUNDLE_IDENTIFIER = 'com.automattic.hostmgr'
+
+ASC_API_KEY_ENV_VARS = %w[
+  APP_STORE_CONNECT_API_KEY_KEY_ID
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY
+].freeze
+
+CODE_SIGNING_STORAGE_ENV_VARS = %w[
+  MATCH_S3_ACCESS_KEY
+  MATCH_S3_SECRET_ACCESS_KEY
+].freeze
+
 # Supported locales mapping between GlotPress and project locale codes
 # This list combines locales supported in the iOS and Android apps
 SUPPORTED_LOCALES = [
@@ -90,7 +105,7 @@ lane :release do |options|
 
   validate
   update_swift_package
-  publish_github_release
+  publish_release_to_github
   publish_to_s3
 end
 
@@ -124,7 +139,7 @@ lane :update_swift_package do
   File.open(file_path, 'w') { |file| file.puts lines }
 end
 
-lane :publish_github_release do
+lane :publish_release_to_github do
   version = lane_context[LANE_VALUE_VERSION] || UI.user_error!('Missing version lane context')
   github_token = lane_context[LANE_VALUE_GITHUB_TOKEN] || UI.user_error!('Missing github token lane context')
 
@@ -396,6 +411,27 @@ lane :generate_fluent_file_from_po do |file_path:|
   fluent_file_path
 end
 
+desc 'Download the development signing certificates to this machine'
+lane :set_up_signing do |readonly: true|
+  require_env_vars!(*ASC_API_KEY_ENV_VARS, *CODE_SIGNING_STORAGE_ENV_VARS)
+
+  sync_code_signing(
+    platform: 'macos',
+    app_identifier: APPLE_BUNDLE_IDENTIFIER,
+    team_id: APPLE_TEAM_ID,
+    api_key: app_store_connect_api_key,
+    type: 'development',
+    certificate_id: 'Apple Development: Created via API (886NX39KP6)',
+
+    storage_mode: 's3',
+    s3_region: 'us-east-2',
+    s3_bucket: 'a8c-fastlane-match',
+
+    readonly: readonly
+  )
+end
+
+
 # Utils
 
 def xcframework_checksum
@@ -462,4 +498,18 @@ def only_date_headers_changed?(file_path)
   end
 
   changed_lines.all? { |l| l.include?('"POT-Creation-Date:') || l.include?('"PO-Revision-Date:') }
+end
+
+# Use this to ensure all env vars a lane requires are set.
+#
+# The best place to call this is at the start of a lane, to fail early.
+def require_env_vars!(*keys)
+  keys.each { |key| get_required_env!(key) }
+end
+
+# Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing.
+def get_required_env!(key)
+  return ENV.fetch(key) if ENV.key?(key)
+
+  UI.user_error!("Environment variable `#{key}` is not set.")
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,6 @@ GLOTPRESS_PROJECT_BASE_URL = 'https://translate.wordpress.com/projects/mobile/wo
 
 # Code Signing
 APPLE_TEAM_ID = 'PZYM8XX95Q'
-APPLE_BUNDLE_IDENTIFIER = 'com.automattic.hostmgr'
 
 ASC_API_KEY_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY_ID
@@ -411,24 +410,20 @@ lane :generate_fluent_file_from_po do |file_path:|
   fluent_file_path
 end
 
-desc 'Download the development signing certificates to this machine'
+desc 'Downloads all code signing certificates'
 lane :set_up_signing do |readonly: true|
-  require_env_vars!(*ASC_API_KEY_ENV_VARS, *CODE_SIGNING_STORAGE_ENV_VARS)
+  set_up_signing_development(readonly: readonly)
+  set_up_signing_release(readonly: readonly)
+end
 
-  sync_code_signing(
-    platform: 'macos',
-    app_identifier: APPLE_BUNDLE_IDENTIFIER,
-    team_id: APPLE_TEAM_ID,
-    api_key: app_store_connect_api_key,
-    type: 'development',
-    certificate_id: 'Apple Development: Created via API (886NX39KP6)',
+desc 'Download the development signing certificates to this machine'
+lane :set_up_signing_development do |readonly: true|
+  set_up_certificate_in_keychain(type: 'development', readonly: readonly)
+end
 
-    storage_mode: 's3',
-    s3_region: 'us-east-2',
-    s3_bucket: 'a8c-fastlane-match',
-
-    readonly: readonly
-  )
+desc 'Download the release (distribution) signing certificates to this machine'
+lane :set_up_signing_release do |readonly: true|
+  set_up_certificate_in_keychain(type: 'appstore', readonly: readonly)
 end
 
 # Utils
@@ -511,4 +506,31 @@ def get_required_env!(key)
   return ENV.fetch(key) if ENV.key?(key)
 
   UI.user_error!("Environment variable `#{key}` is not set.")
+end
+
+def set_up_certificate_in_keychain(type:, readonly:)
+  require_env_vars!(*ASC_API_KEY_ENV_VARS, *CODE_SIGNING_STORAGE_ENV_VARS)
+
+  # This will fetch the certificate and provisioning profile for the given type from remote storage.
+  # It will then set them up in the local keychain, where 'codesign' looks for identities.
+  #
+  # Notice we do not need the provisioning profile because we sign with 'codesign' elsewhere.
+  # However, there is no other way to set up the certificate in the keychain.
+  # Fastlane offers a tool called cert, but it only downloads certificates.
+  sync_code_signing(
+    team_id: APPLE_TEAM_ID,
+    api_key: app_store_connect_api_key,
+    type: type,
+    storage_mode: 's3',
+    s3_region: 'us-east-2',
+    s3_bucket: 'a8c-fastlane-match',
+    readonly: readonly,
+    # We need to provide an app identifier, but remember we only care about the certificate that gets downloaded.
+    # The identifier is used to find a provisioning profile, but we don't care about it.
+    #
+    # Similar rationale for the platform argument,
+    # with the addition that it's required to identify the existing provisioning profile for the given app id.
+    app_identifier: 'com.automattic.hostmgr',
+    platform: 'macos'
+  )
 end


### PR DESCRIPTION
Adds code signing to the release and debug XCFrameworks. This allows consumer projects to ensure the binary dependency hasn't been tampered with.