### PR TITLE
Add Claude Code review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,62 @@
+name: PR Review with Progress Tracking
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review-with-tracking:
+    if: |
+      github.event.issue.pull_request && contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Related: [AINFRA-1430: Set up Claude Code Review GitHub Action for WordPress/Jetpack mobile](https://linear.app/a8c/issue/AINFRA-1430/set-up-claude-code-review-github-action-for-wordpressjetpack-mobile)
Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/22303
iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/24957

## Description
This PR adds a support for Claude Code review GitHub Action. It's based on the [newest example](https://github.com/anthropics/claude-code-action/blob/f30f5eecfce2f34fa72e40fa5f7bcdbdcad12eb8/examples/pr-review-comprehensive.yml) from Claude Code Action repo.

I've added one difference, though: instead of triggering this on every PR open, one has to add a comment with `@claude` in it, e.g. `@claude review` or `@claude review this` will be completely fine. 