### PR TITLE
Fix Kotlin Upload Progress Reporting and Error Handling

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -74,6 +74,70 @@ class MediaEndpointTest {
         restoreTestServer()
     }
 
+    @Test
+    fun testCreateMediaRequestWithProgressReporting() = runTest {
+        val progressUpdates = mutableListOf<ProgressUpdate>()
+        var uploadStarted = false
+
+        val uploadListener = object : WpRequestExecutor.UploadListener {
+            override fun onProgressUpdate(uploadedBytes: Long, totalBytes: Long) {
+                progressUpdates.add(ProgressUpdate(uploadedBytes, totalBytes))
+            }
+
+            override fun onUploadStarted(cancellableUpload: WpRequestExecutor.CancellableUpload) {
+                uploadStarted = true
+            }
+        }
+
+        val authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(
+            username = TestCredentials.INSTANCE.adminUsername,
+            password = TestCredentials.INSTANCE.adminPassword
+        )
+        val requestExecutor = WpRequestExecutor(
+            fileResolver = FileResolverMock(),
+            uploadListener = uploadListener
+        )
+        val clientWithProgress = WpApiClient(
+            wpOrgSiteApiRootUrl = TestCredentials.INSTANCE.apiRootUrl,
+            authProvider = authProvider,
+            requestExecutor = requestExecutor
+        )
+
+        val title = "Testing media upload with progress from Kotlin"
+        val response = clientWithProgress.request { requestBuilder ->
+            requestBuilder.media().create(
+                params = MediaCreateParams(title = title, filePath = "test_media.jpg")
+            )
+        }.assertSuccessAndRetrieveData().data
+
+        // Verify upload was successful
+        assertEquals(title, response.title.rendered)
+
+        // Verify progress reporting worked
+        assert(uploadStarted) { "Upload should have started" }
+        assert(progressUpdates.isNotEmpty()) { "Should have received progress updates" }
+
+        // Verify final progress shows completion
+        val finalProgress = progressUpdates.last()
+        assertEquals(
+            finalProgress.uploadedBytes,
+            finalProgress.totalBytes,
+            "Final progress should show upload complete"
+        )
+
+        // Verify progress never decreases. Note: The /media endpoint only supports
+        // single files, so this validates basic progress but not multi-file scenarios.
+        var previousBytes = 0L
+        progressUpdates.forEach { update ->
+            assert(update.uploadedBytes >= previousBytes) {
+                "Progress decreased from $previousBytes to ${update.uploadedBytes}"
+            }
+            previousBytes = update.uploadedBytes
+        }
+
+        restoreTestServer()
+    }
+
     fun mediaApiClient(): WpApiClient {
         val testCredentials = TestCredentials.INSTANCE
         val authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(
@@ -88,6 +152,8 @@ class MediaEndpointTest {
             requestExecutor = requestExecutor
         )
     }
+
+    data class ProgressUpdate(val uploadedBytes: Long, val totalBytes: Long)
 
     class FileResolverMock: FileResolver {
         // in order to properly resolve the file from the test assets, we need to do it in the following way

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -135,6 +135,10 @@ class WpRequestExecutor(
                     requestBuilder.addHeader(key, value)
                 }
             }
+            requestBuilder.addHeader(
+                USER_AGENT_HEADER_NAME,
+                uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
+            )
 
             val urlRequest = requestBuilder.build()
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -10,7 +10,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttp
 import okhttp3.Request
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import uniffi.wp_api.InvalidSslErrorReason
@@ -87,75 +86,12 @@ class WpRequestExecutor(
 
     override suspend fun upload(request: WpMultipartFormRequest): WpNetworkResponse =
         withContext(dispatcher) {
-            val requestBuilder = Request.Builder().url(request.url())
-            val multipartBodyBuilder = MultipartBody.Builder()
-                .setType(MultipartBody.FORM)
-            request.fields().forEach { (k, v) ->
-                multipartBodyBuilder.addFormDataPart(k, v)
-            }
-            request.files().forEach { (name, fileInfo) ->
-                val file = fileResolver.getFile(fileInfo.filePath)
-                if (file == null || !file.canBeUploaded()) {
-                    throw RequestExecutionException.MediaFileNotFound(filePath = fileInfo.filePath)
-                }
-                val mimeType = fileInfo.mimeType ?: "application/octet-stream"
-                val filename = fileInfo.fileName ?: file.name
-                // Don't wrap individual files - we'll wrap the entire multipart body instead
-                val requestBody = file.asRequestBody(mimeType.toMediaType())
-                multipartBodyBuilder.addFormDataPart(
-                    name = name,
-                    filename = filename,
-                    body = requestBody
-                )
-            }
-
-            // Build the multipart body
-            val multipartBody = multipartBodyBuilder.build()
-
-            // Wrap the entire multipart body for progress tracking
-            // This ensures progress is cumulative across all files, not per-file
-            val bodyWithProgress = if (uploadListener != null) {
-                ProgressRequestBody(
-                    delegate = multipartBody,
-                    progressListener = object : ProgressRequestBody.ProgressListener {
-                        override fun onProgress(bytesWritten: Long, contentLength: Long) {
-                            uploadListener.onProgressUpdate(bytesWritten, contentLength)
-                        }
-                    }
-                )
-            } else {
-                multipartBody
-            }
-
-            requestBuilder.method(
-                method = request.method().toString(),
-                body = bodyWithProgress
-            )
-            request.headerMap().toMap().forEach { (key, values) ->
-                values.forEach { value ->
-                    requestBuilder.addHeader(key, value)
-                }
-            }
-            // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
-            requestBuilder.header(
-                USER_AGENT_HEADER_NAME,
-                uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
-            )
-
-            val urlRequest = requestBuilder.build()
+            val multipartBody = buildMultipartBody(request)
+            val bodyWithProgress = wrapWithProgressTracking(multipartBody)
+            val urlRequest = buildUploadRequest(request, bodyWithProgress)
 
             try {
-                val call = httpClient.getClient().newCall(urlRequest)
-                uploadListener?.onUploadStarted(CancellableCall(call))
-                call.execute().use { response ->
-                    return@withContext WpNetworkResponse(
-                        body = response.body?.bytes() ?: ByteArray(0),
-                        statusCode = response.code.toUShort(),
-                        responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
-                        requestUrl = request.url(),
-                        requestHeaderMap = request.headerMap()
-                    )
-                }
+                executeUpload(urlRequest, request)
             } catch (e: SSLPeerUnverifiedException) {
                 throw requestExecutionFailedWith(
                     RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
@@ -167,6 +103,87 @@ class WpRequestExecutor(
             }
         }
 
+    private fun buildMultipartBody(request: WpMultipartFormRequest): MultipartBody {
+        val multipartBodyBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+
+        request.fields().forEach { (k, v) ->
+            multipartBodyBuilder.addFormDataPart(k, v)
+        }
+
+        request.files().forEach { (name, fileInfo) ->
+            val file = fileResolver.getFile(fileInfo.filePath)
+            if (file == null || !file.canBeUploaded()) {
+                throw RequestExecutionException.MediaFileNotFound(filePath = fileInfo.filePath)
+            }
+            val mimeType = fileInfo.mimeType ?: "application/octet-stream"
+            val filename = fileInfo.fileName ?: file.name
+            val requestBody = file.asRequestBody(mimeType.toMediaType())
+            multipartBodyBuilder.addFormDataPart(
+                name = name,
+                filename = filename,
+                body = requestBody
+            )
+        }
+
+        return multipartBodyBuilder.build()
+    }
+
+    private fun wrapWithProgressTracking(multipartBody: MultipartBody): okhttp3.RequestBody {
+        // Wrap the entire multipart body for progress tracking
+        // This ensures progress is cumulative across all files, not per-file
+        return if (uploadListener != null) {
+            ProgressRequestBody(
+                delegate = multipartBody,
+                progressListener = object : ProgressRequestBody.ProgressListener {
+                    override fun onProgress(bytesWritten: Long, contentLength: Long) {
+                        uploadListener.onProgressUpdate(bytesWritten, contentLength)
+                    }
+                }
+            )
+        } else {
+            multipartBody
+        }
+    }
+
+    private fun buildUploadRequest(
+        request: WpMultipartFormRequest,
+        body: okhttp3.RequestBody
+    ): Request {
+        val requestBuilder = Request.Builder().url(request.url())
+
+        requestBuilder.method(request.method().toString(), body)
+
+        request.headerMap().toMap().forEach { (key, values) ->
+            values.forEach { value ->
+                requestBuilder.addHeader(key, value)
+            }
+        }
+
+        // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
+        requestBuilder.header(
+            USER_AGENT_HEADER_NAME,
+            uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
+        )
+
+        return requestBuilder.build()
+    }
+
+    private fun executeUpload(
+        urlRequest: Request,
+        request: WpMultipartFormRequest
+    ): WpNetworkResponse {
+        val call = httpClient.getClient().newCall(urlRequest)
+        uploadListener?.onUploadStarted(CancellableCall(call))
+        return call.execute().use { response ->
+            WpNetworkResponse(
+                body = response.body?.bytes() ?: ByteArray(0),
+                statusCode = response.code.toUShort(),
+                responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
+                requestUrl = request.url(),
+                requestHeaderMap = request.headerMap()
+            )
+        }
+    }
 
     override suspend fun sleep(millis: ULong) {
         delay(millis.toLong())
@@ -233,7 +250,7 @@ private fun RequestExecutionErrorReason.Companion.noRouteToHost(e: NoRouteToHost
         reason = e.localizedMessage
     )
 
-@Suppress("UNUSED_PARAMETER")
+@Suppress("UNUSED_PARAMETER", "TooGenericExceptionCaught", "SwallowedException")
 private fun RequestExecutionErrorReason.Companion.invalidSSLError(
     e: SSLPeerUnverifiedException, // To avoid `SwallowedException` from Detekt
     requestUrl: HttpUrl
@@ -262,7 +279,10 @@ private fun RequestExecutionErrorReason.Companion.invalidSSLError(
             newConnection.disconnect()
         }
     } catch (ex: Exception) {
-        // Fallback if certificate inspection fails
+        // Fallback if certificate inspection fails due to network issues, cast failures, etc.
+        // We intentionally catch Exception here as we want to return a valid error response
+        // even if certificate inspection fails. The original SSL error (e parameter) is
+        // preserved in the calling context. This is a best-effort attempt to get cert details.
         RequestExecutionErrorReason.InvalidSslError(
             reason = InvalidSslErrorReason.CertificateNotValidForName(
                 hostname = requestUrl.host,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -136,16 +136,28 @@ class WpRequestExecutor(
                 }
             }
 
-            val call = httpClient.getClient().newCall(requestBuilder.build())
-            uploadListener?.onUploadStarted(CancellableCall(call))
-            call.execute().use { response ->
-                return@withContext WpNetworkResponse(
-                    body = response.body?.bytes() ?: ByteArray(0),
-                    statusCode = response.code.toUShort(),
-                    responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
-                    requestUrl = request.url(),
-                    requestHeaderMap = request.headerMap()
+            val urlRequest = requestBuilder.build()
+
+            try {
+                val call = httpClient.getClient().newCall(urlRequest)
+                uploadListener?.onUploadStarted(CancellableCall(call))
+                call.execute().use { response ->
+                    return@withContext WpNetworkResponse(
+                        body = response.body?.bytes() ?: ByteArray(0),
+                        statusCode = response.code.toUShort(),
+                        responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
+                        requestUrl = request.url(),
+                        requestHeaderMap = request.headerMap()
+                    )
+                }
+            } catch (e: SSLPeerUnverifiedException) {
+                throw requestExecutionFailedWith(
+                    RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
                 )
+            } catch (e: UnknownHostException) {
+                throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
+            } catch (e: NoRouteToHostException) {
+                throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
             }
         }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -50,57 +50,24 @@ class WpRequestExecutor(
                     wpNetworkRequestBody
                 }
             )
-            request.headerMap().toMap().forEach { (key, values) ->
-                values.forEach { value ->
-                    requestBuilder.addHeader(key, value)
-                }
-            }
-            // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
-            requestBuilder.header(
-                USER_AGENT_HEADER_NAME,
-                uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
-            )
 
+            addRequestHeaders(requestBuilder, request.headerMap())
             val urlRequest = requestBuilder.build()
 
-            try {
-                httpClient.getClient().newCall(urlRequest).execute().use { response ->
-                    return@withContext WpNetworkResponse(
-                        body = response.body?.bytes() ?: ByteArray(0),
-                        statusCode = response.code.toUShort(),
-                        responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
-                        requestUrl = request.url(),
-                        requestHeaderMap = request.headerMap()
-                    )
-                }
-            } catch (e: SSLPeerUnverifiedException) {
-                throw requestExecutionFailedWith(
-                    RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
-                )
-            } catch (e: UnknownHostException) {
-                throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
-            } catch (e: NoRouteToHostException) {
-                throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
-            }
+            executeRequestSafely(urlRequest, request.url(), request.headerMap())
         }
 
     override suspend fun upload(request: WpMultipartFormRequest): WpNetworkResponse =
         withContext(dispatcher) {
             val multipartBody = buildMultipartBody(request)
             val bodyWithProgress = wrapWithProgressTracking(multipartBody)
-            val urlRequest = buildUploadRequest(request, bodyWithProgress)
+            val requestBuilder = Request.Builder().url(request.url())
+            requestBuilder.method(request.method().toString(), bodyWithProgress)
 
-            try {
-                executeUpload(urlRequest, request)
-            } catch (e: SSLPeerUnverifiedException) {
-                throw requestExecutionFailedWith(
-                    RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
-                )
-            } catch (e: UnknownHostException) {
-                throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
-            } catch (e: NoRouteToHostException) {
-                throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
-            }
+            addRequestHeaders(requestBuilder, request.headerMap())
+            val urlRequest = requestBuilder.build()
+
+            executeRequestSafely(urlRequest, request.url(), request.headerMap(), notifyUploadListener = true)
         }
 
     private fun buildMultipartBody(request: WpMultipartFormRequest): MultipartBody {
@@ -145,43 +112,51 @@ class WpRequestExecutor(
         }
     }
 
-    private fun buildUploadRequest(
-        request: WpMultipartFormRequest,
-        body: okhttp3.RequestBody
-    ): Request {
-        val requestBuilder = Request.Builder().url(request.url())
-
-        requestBuilder.method(request.method().toString(), body)
-
-        request.headerMap().toMap().forEach { (key, values) ->
+    private fun addRequestHeaders(requestBuilder: Request.Builder, headerMap: WpNetworkHeaderMap) {
+        headerMap.toMap().forEach { (key, values) ->
             values.forEach { value ->
                 requestBuilder.addHeader(key, value)
             }
         }
-
         // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
         requestBuilder.header(
             USER_AGENT_HEADER_NAME,
             uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
         )
-
-        return requestBuilder.build()
     }
 
-    private fun executeUpload(
+    @Suppress("ThrowsCount")
+    private fun executeRequestSafely(
         urlRequest: Request,
-        request: WpMultipartFormRequest
+        requestUrl: String,
+        requestHeaderMap: WpNetworkHeaderMap,
+        notifyUploadListener: Boolean = false
     ): WpNetworkResponse {
-        val call = httpClient.getClient().newCall(urlRequest)
-        uploadListener?.onUploadStarted(CancellableCall(call))
-        return call.execute().use { response ->
-            WpNetworkResponse(
-                body = response.body?.bytes() ?: ByteArray(0),
-                statusCode = response.code.toUShort(),
-                responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
-                requestUrl = request.url(),
-                requestHeaderMap = request.headerMap()
+        try {
+            val call = httpClient.getClient().newCall(urlRequest)
+
+            // Notify upload listener if this is an upload request
+            if (notifyUploadListener) {
+                uploadListener?.onUploadStarted(CancellableCall(call))
+            }
+
+            return call.execute().use { response ->
+                WpNetworkResponse(
+                    body = response.body?.bytes() ?: ByteArray(0),
+                    statusCode = response.code.toUShort(),
+                    responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
+                    requestUrl = requestUrl,
+                    requestHeaderMap = requestHeaderMap
+                )
+            }
+        } catch (e: SSLPeerUnverifiedException) {
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
             )
+        } catch (e: UnknownHostException) {
+            throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
+        } catch (e: NoRouteToHostException) {
+            throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
         }
     }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -242,18 +242,32 @@ private fun RequestExecutionErrorReason.Companion.invalidSSLError(
     //
     // We spin up a new connection that'll accept any certificate. The connection will then
     // contain all the details we need for the error.
-    val newConnection = requestUrl.toUrl().openConnection() as HttpsURLConnection
-    newConnection.setHostnameVerifier { _, _ -> return@setHostnameVerifier true }
-    newConnection.connect()
+    return try {
+        val newConnection = requestUrl.toUrl().openConnection() as HttpsURLConnection
+        newConnection.setHostnameVerifier { _, _ -> true }
+        newConnection.connect()
 
-    // Certificate is parsed by the Rust shared implementation.
-    val certificates = newConnection.serverCertificates.map { parseCertificate(it.encoded) }
-    return RequestExecutionErrorReason.InvalidSslError(
-        reason = InvalidSslErrorReason.CertificateNotValidForName(
-            hostname = requestUrl.host,
-            presentedHostnames = listOfNotNull(certificates.first()?.commonName())
+        try {
+            // Certificate is parsed by the Rust shared implementation.
+            val certificates = newConnection.serverCertificates.map { parseCertificate(it.encoded) }
+            RequestExecutionErrorReason.InvalidSslError(
+                reason = InvalidSslErrorReason.CertificateNotValidForName(
+                    hostname = requestUrl.host,
+                    presentedHostnames = listOfNotNull(certificates.first()?.commonName())
+                )
+            )
+        } finally {
+            newConnection.disconnect()
+        }
+    } catch (ex: Exception) {
+        // Fallback if certificate inspection fails
+        RequestExecutionErrorReason.InvalidSslError(
+            reason = InvalidSslErrorReason.CertificateNotValidForName(
+                hostname = requestUrl.host,
+                presentedHostnames = emptyList()
+            )
         )
-    )
+    }
 }
 
 private fun requestExecutionFailedWith(reason: RequestExecutionErrorReason) =

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -98,17 +98,37 @@ class WpRequestExecutor(
                     throw RequestExecutionException.MediaFileNotFound(filePath = fileInfo.filePath)
                 }
                 val mimeType = fileInfo.mimeType ?: "application/octet-stream"
-                val requestBody = getRequestBody(file, mimeType, uploadListener)
                 val filename = fileInfo.fileName ?: file.name
+                // Don't wrap individual files - we'll wrap the entire multipart body instead
+                val requestBody = file.asRequestBody(mimeType.toMediaType())
                 multipartBodyBuilder.addFormDataPart(
                     name = name,
                     filename = filename,
                     body = requestBody
                 )
             }
+
+            // Build the multipart body
+            val multipartBody = multipartBodyBuilder.build()
+
+            // Wrap the entire multipart body for progress tracking
+            // This ensures progress is cumulative across all files, not per-file
+            val bodyWithProgress = if (uploadListener != null) {
+                ProgressRequestBody(
+                    delegate = multipartBody,
+                    progressListener = object : ProgressRequestBody.ProgressListener {
+                        override fun onProgress(bytesWritten: Long, contentLength: Long) {
+                            uploadListener.onProgressUpdate(bytesWritten, contentLength)
+                        }
+                    }
+                )
+            } else {
+                multipartBody
+            }
+
             requestBuilder.method(
                 method = request.method().toString(),
-                body = multipartBodyBuilder.build()
+                body = bodyWithProgress
             )
             request.headerMap().toMap().forEach { (key, values) ->
                 values.forEach { value ->
@@ -129,25 +149,6 @@ class WpRequestExecutor(
             }
         }
 
-    private fun getRequestBody(
-        file: File,
-        mimeType: String,
-        uploadListener: UploadListener?
-    ): RequestBody {
-        val fileRequestBody = file.asRequestBody(mimeType.toMediaType())
-        return if (uploadListener != null) {
-            ProgressRequestBody(
-                delegate = fileRequestBody,
-                progressListener = object : ProgressRequestBody.ProgressListener {
-                    override fun onProgress(bytesWritten: Long, contentLength: Long) {
-                        uploadListener.onProgressUpdate(bytesWritten, contentLength)
-                    }
-                }
-            )
-        } else {
-            fileRequestBody
-        }
-    }
 
     override suspend fun sleep(millis: ULong) {
         delay(millis.toLong())

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -56,7 +56,8 @@ class WpRequestExecutor(
                     requestBuilder.addHeader(key, value)
                 }
             }
-            requestBuilder.addHeader(
+            // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
+            requestBuilder.header(
                 USER_AGENT_HEADER_NAME,
                 uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
             )
@@ -135,7 +136,8 @@ class WpRequestExecutor(
                     requestBuilder.addHeader(key, value)
                 }
             }
-            requestBuilder.addHeader(
+            // Use header() instead of addHeader() to ensure User-Agent cannot be overridden
+            requestBuilder.header(
                 USER_AGENT_HEADER_NAME,
                 uniffi.wp_api.defaultUserAgent("kotlin-okhttp/${OkHttp.VERSION}")
             )


### PR DESCRIPTION
This PR fixes several issues in the Kotlin `WpRequestExecutor` implementation:

1. **Multi-file upload progress reporting** - Progress now correctly tracks cumulative upload across all files instead of resetting per file
2. **Missing exception handling** - Upload errors are now properly caught and wrapped in `RequestExecutionException`
3. **Missing User-Agent header** - Uploads now include proper client identification
4. **Resource leak** - SSL certificate inspection now properly closes connections
5. **User-Agent override prevention** - User-Agent header can no longer be overridden by request headers
6. **Code quality improvements** - Refactored `upload()` method to reduce complexity and fix detekt warnings
7. **Eliminate code duplication** - Extracted common logic between `execute()` and `upload()` methods