### PR TITLE
Support uploading files in the support tickets endpoints

### DIFF
--- a/wp_api/src/wp_com/endpoint/support_tickets_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/support_tickets_endpoint.rs
@@ -12,13 +12,13 @@ use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum SupportTicketsRequest {
-    #[post(url = "/mobile-support/conversations", params = &CreateSupportTicketParams, output = SupportConversation)]
+    #[post(url = "/mobile-support/conversations", params = &CreateSupportTicketParams, output = SupportConversation, multipart = true)]
     CreateSupportTicket,
     #[get(url = "/mobile-support/conversations", output = Vec<SupportConversationSummary>)]
     GetSupportConversationList,
     #[get(url = "/mobile-support/conversations/<conversation_id>", output = SupportConversation)]
     GetSupportConversation,
-    #[post(url = "/mobile-support/conversations/<conversation_id>", params = &AddMessageToSupportConversationParams, output = SupportConversation)]
+    #[post(url = "/mobile-support/conversations/<conversation_id>", params = &AddMessageToSupportConversationParams, output = SupportConversation, multipart = true)]
     AddMessageToSupportConversation,
 }
 

--- a/wp_api/src/wp_com/support_tickets.rs
+++ b/wp_api/src/wp_com/support_tickets.rs
@@ -30,7 +30,6 @@ impl RequiresMultipartForm for CreateSupportTicketParams {
             .enumerate()
             .map(|(i, file_path)| {
                 (
-                    // TODO: The backend is not ready yet. This name may need to be changed.
                     format!("attachment_{i}"),
                     MultipartFormFile {
                         file_path: file_path.clone(),
@@ -172,8 +171,28 @@ pub struct SupportAgentIdentity {
 #[derive(Debug, PartialEq, Eq, Serialize, uniffi::Record)]
 pub struct AddMessageToSupportConversationParams {
     pub message: String,
+    #[serde(skip)]
     #[uniffi(default = [])]
     pub attachments: Vec<String>,
+}
+
+impl RequiresMultipartForm for AddMessageToSupportConversationParams {
+    fn multipart_form_files(&self) -> HashMap<String, MultipartFormFile> {
+        self.attachments
+            .iter()
+            .enumerate()
+            .map(|(i, file_path)| {
+                (
+                    format!("attachment_{i}"),
+                    MultipartFormFile {
+                        file_path: file_path.clone(),
+                        mime_type: None,
+                        file_name: None,
+                    },
+                )
+            })
+            .collect()
+    }
 }
 
 impl_as_query_value_for_new_type!(ConversationId);


### PR DESCRIPTION
The `CreateSupportTicket` and `AddMessageToSupportConversation` endpoints now support uploading files via their `attachments` parameter.