### PR TITLE
Put multipart form data into `Vec<WpMultipartFormField>`

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -18,7 +18,7 @@ import uniffi.wp_api.RequestExecutionErrorReason
 import uniffi.wp_api.RequestExecutionException
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.RequestMethod
-import uniffi.wp_api.WpMultipartFormFieldValue
+import uniffi.wp_api.WpMultipartFormField
 import uniffi.wp_api.WpMultipartFormRequest
 import uniffi.wp_api.WpNetworkHeaderMap
 import uniffi.wp_api.WpNetworkRequest
@@ -74,31 +74,27 @@ class WpRequestExecutor(
     private fun buildMultipartBody(request: WpMultipartFormRequest): MultipartBody {
         val multipartBodyBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
 
-        request.fields().forEach { (k, v) ->
-            when (v) {
-                is WpMultipartFormFieldValue.String ->
-                    multipartBodyBuilder.addFormDataPart(k, value = v.v1)
-
-                is WpMultipartFormFieldValue.Array ->
-                    for (value in v.v1) {
-                        multipartBodyBuilder.addFormDataPart("$k[]", value = value)
+        request.form().forEach { field ->
+            when (field) {
+                is WpMultipartFormField.Text -> {
+                    multipartBodyBuilder.addFormDataPart(field.name, value = field.value)
+                }
+                is WpMultipartFormField.File -> {
+                    val fileInfo = field.file
+                    val file = fileResolver.getFile(fileInfo.filePath)
+                    if (file == null || !file.canBeUploaded()) {
+                        throw RequestExecutionException.MediaFileNotFound(filePath = fileInfo.filePath)
                     }
+                    val mimeType = fileInfo.mimeType ?: "application/octet-stream"
+                    val filename = fileInfo.fileName ?: file.name
+                    val requestBody = file.asRequestBody(mimeType.toMediaType())
+                    multipartBodyBuilder.addFormDataPart(
+                        name = field.name,
+                        filename = filename,
+                        body = requestBody
+                    )
+                }
             }
-        }
-
-        request.files().forEach { (name, fileInfo) ->
-            val file = fileResolver.getFile(fileInfo.filePath)
-            if (file == null || !file.canBeUploaded()) {
-                throw RequestExecutionException.MediaFileNotFound(filePath = fileInfo.filePath)
-            }
-            val mimeType = fileInfo.mimeType ?: "application/octet-stream"
-            val filename = fileInfo.fileName ?: file.name
-            val requestBody = file.asRequestBody(mimeType.toMediaType())
-            multipartBodyBuilder.addFormDataPart(
-                name = name,
-                filename = filename,
-                body = requestBody
-            )
         }
 
         return multipartBodyBuilder.build()

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -388,37 +388,33 @@ extension WpMultipartFormRequest: NetworkRequestContent {
         var request = try buildURLRequest(additionalHeaders: headers)
 
         var form = [MultipartFormField]()
-        for (name, value) in fields() {
-            switch value {
-            case .string(let string):
-                form.append(MultipartFormField(text: string, name: name))
-            case .array(let array):
-                form.append(contentsOf: array.map { MultipartFormField(text: $0, name: "\(name)[]") })
-            }
-        }
+        for field in self.form() {
+            switch field {
+            case .text(let name, let value):
+                form.append(MultipartFormField(text: value, name: name))
+            case .file(let name, let file):
+                var mimeType = file.mimeType
 
-        for (name, file) in files() {
-            var mimeType = file.mimeType
+                #if canImport(UniformTypeIdentifiers)
+                if mimeType == nil {
+                    mimeType = UTType(
+                        filenameExtension: URL(fileURLWithPath: file.filePath).pathExtension
+                    )?.preferredMIMEType
+                }
+                #endif
 
-            #if canImport(UniformTypeIdentifiers)
-            if mimeType == nil {
-                mimeType = UTType(
-                    filenameExtension: URL(fileURLWithPath: file.filePath).pathExtension
-                )?.preferredMIMEType
-            }
-            #endif
-
-            do {
-                try form.append(
-                    .init(
-                        fileAtPath: file.filePath,
-                        name: name,
-                        filename: file.fileName,
-                        mimeType: mimeType
+                do {
+                    try form.append(
+                        .init(
+                            fileAtPath: file.filePath,
+                            name: name,
+                            filename: file.fileName,
+                            mimeType: mimeType
+                        )
                     )
-                )
-            } catch {
-                throw RequestExecutionError.MediaFileNotFound(filePath: file.filePath)
+                } catch {
+                    throw RequestExecutionError.MediaFileNotFound(filePath: file.filePath)
+                }
             }
         }
 

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -118,22 +118,16 @@ impl InnerRequestBuilder {
     where
         T: ?Sized + Serialize + RequiresMultipartForm,
     {
-        let mut fields: HashMap<String, WpMultipartFormFieldValue> = HashMap::new();
+        let mut form = Vec::new();
+
         if let Ok(serde_json::Value::Object(object)) = serde_json::to_value(params) {
             for (key, value) in object {
-                if let serde_json::Value::String(s) = value {
-                    fields.insert(key, WpMultipartFormFieldValue::String(s));
-                } else if let serde_json::Value::Array(vec) = value {
-                    fields.insert(
-                        key,
-                        WpMultipartFormFieldValue::Array(
-                            vec.into_iter().map(|v| v.to_string()).collect(),
-                        ),
-                    );
-                } else {
-                    fields.insert(key, WpMultipartFormFieldValue::String(value.to_string()));
-                }
+                form.extend(WpMultipartFormField::from_json(key, value));
             }
+        }
+
+        for (name, file) in params.multipart_form_files() {
+            form.push(WpMultipartFormField::File { name, file });
         }
 
         let mut header_map = self.header_map_for_post_request();
@@ -147,8 +141,7 @@ impl InnerRequestBuilder {
             method: RequestMethod::POST,
             url: url.into(),
             header_map: header_map.into(),
-            fields,
-            files: params.multipart_form_files(),
+            form,
         }
     }
 
@@ -340,6 +333,44 @@ impl NetworkRequestAccessor for WpNetworkRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum WpMultipartFormField {
+    Text {
+        name: String,
+        value: String,
+    },
+    File {
+        name: String,
+        file: MultipartFormFile,
+    },
+}
+
+impl WpMultipartFormField {
+    pub fn from_json(key: String, value: serde_json::Value) -> Vec<Self> {
+        match value {
+            serde_json::Value::String(s) => vec![Self::Text {
+                name: key,
+                value: s,
+            }],
+            serde_json::Value::Array(arr) => arr
+                .into_iter()
+                .enumerate()
+                .flat_map(|(idx, v)| Self::from_json(format!("{key}[{idx}]"), v))
+                .collect(),
+            serde_json::Value::Object(obj) => obj
+                .into_iter()
+                .flat_map(|(nested_key, nested_value)| {
+                    Self::from_json(format!("{key}[{nested_key}]"), nested_value)
+                })
+                .collect(),
+            _ => vec![Self::Text {
+                name: key,
+                value: value.to_string(),
+            }],
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
 pub enum WpMultipartFormFieldValue {
     String(String),
@@ -363,18 +394,13 @@ pub struct WpMultipartFormRequest {
     pub(crate) method: RequestMethod,
     pub(crate) url: WpEndpointUrl,
     pub(crate) header_map: Arc<WpNetworkHeaderMap>,
-    pub(crate) fields: HashMap<String, WpMultipartFormFieldValue>,
-    pub(crate) files: HashMap<String, MultipartFormFile>,
+    pub(crate) form: Vec<WpMultipartFormField>,
 }
 
 #[uniffi::export]
 impl WpMultipartFormRequest {
-    pub fn fields(&self) -> HashMap<String, WpMultipartFormFieldValue> {
-        self.fields.clone()
-    }
-
-    pub fn files(&self) -> HashMap<String, MultipartFormFile> {
-        self.files.clone()
+    pub fn form(&self) -> Vec<WpMultipartFormField> {
+        self.form.clone()
     }
 }
 
@@ -386,11 +412,10 @@ impl std::fmt::Debug for WpMultipartFormRequest {
                     method: '{:?}',
                     url: '{:?}',
                     header_map: '{:?}',
-                    fields: '{:?}',
-                    files: '{:?}'
+                    form: '{:?}'
                 }}
                 "},
-            self.method, self.url, self.header_map, self.fields, self.files
+            self.method, self.url, self.header_map, self.form
         );
         s.pop(); // Remove the new line at the end
         write!(f, "{s}")
@@ -1044,6 +1069,86 @@ mod tests {
         pub fn insert(&mut self, header_name: HeaderName, header_value: String) {
             let value = header_value.parse().expect("Header Value must be ascii");
             self.inner.insert(header_name, value);
+        }
+    }
+
+    #[rstest]
+    #[case(serde_json::Value::String("test".to_string()), "test")]
+    #[case(serde_json::json!(42), "42")]
+    #[case(serde_json::json!(true), "true")]
+    #[case(serde_json::Value::Null, "null")]
+    fn test_multipart_form_field_from_json_primitives(
+        #[case] value: serde_json::Value,
+        #[case] expected: &str,
+    ) {
+        let result = WpMultipartFormField::from_json("key".to_string(), value);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            WpMultipartFormField::Text {
+                name: "key".to_string(),
+                value: expected.to_string()
+            }
+        );
+    }
+
+    #[rstest]
+    #[case(
+        r#"{"key": ["a", "b", "c"]}"#,
+        vec![
+            ("key[0]", "a"),
+            ("key[1]", "b"),
+            ("key[2]", "c"),
+        ]
+    )]
+    #[case(
+        r#"{"key": [["a", "b"], ["c", "d"]]}"#,
+        vec![
+            ("key[0][0]", "a"),
+            ("key[0][1]", "b"),
+            ("key[1][0]", "c"),
+            ("key[1][1]", "d"),
+        ]
+    )]
+    #[case(
+        r#"{"key": {"foo": "bar", "baz": "qux"}}"#,
+        vec![
+            ("key[baz]", "qux"),
+            ("key[foo]", "bar"),
+        ]
+    )]
+    #[case(
+        r#"{"key": {"outer": {"inner": "value"}}}"#,
+        vec![("key[outer][inner]", "value")]
+    )]
+    #[case(
+        r#"{"key": {"tags": ["tag1", "tag2"], "metadata": {"author": "john"}}}"#,
+        vec![
+            ("key[metadata][author]", "john"),
+            ("key[tags][0]", "tag1"),
+            ("key[tags][1]", "tag2"),
+        ]
+    )]
+    fn test_multipart_form_field_from_json_complex(
+        #[case] json: serde_json::Value,
+        #[case] expected: Vec<(&str, &str)>,
+    ) {
+        let serde_json::Value::Object(obj) = json else {
+            panic!("Expected JSON object");
+        };
+        assert_eq!(obj.len(), 1, "Expected exactly one key-value pair");
+        let (key, value) = obj.into_iter().next().unwrap();
+        let result = WpMultipartFormField::from_json(key, value);
+        assert_eq!(result.len(), expected.len());
+
+        for (i, (expected_name, expected_value)) in expected.iter().enumerate() {
+            assert_eq!(
+                result[i],
+                WpMultipartFormField::Text {
+                    name: expected_name.to_string(),
+                    value: expected_value.to_string()
+                }
+            );
         }
     }
 

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -2,7 +2,7 @@ use crate::{
     api_error::{InvalidSslErrorReason, RequestExecutionError, RequestExecutionErrorReason},
     request::{
         NetworkRequestAccessor, RequestContext, RequestExecutor, RequestMethod,
-        WpMultipartFormFieldValue, WpMultipartFormRequest, WpNetworkHeaderMap, WpNetworkRequest,
+        WpMultipartFormField, WpMultipartFormRequest, WpNetworkHeaderMap, WpNetworkRequest,
         WpNetworkResponse, user_agent,
     },
 };
@@ -116,30 +116,25 @@ impl RequestExecutor for ReqwestRequestExecutor {
             .headers(upload_request.header_map().to_header_map());
         let mut form = reqwest::multipart::Form::new();
 
-        for (name, file) in upload_request.files() {
-            let file_path = file.file_path;
-            let mut file_header_map = HeaderMap::new();
-            if let Some(mime_type) = &file.mime_type {
-                file_header_map.insert(
-                    http::header::CONTENT_TYPE,
-                    HeaderValue::from_str(mime_type).unwrap(),
-                );
-            }
-            let part = Part::file(file_path)
-                .await
-                .unwrap()
-                .headers(file_header_map);
-            form = form.part(name, part);
-        }
-
-        for (k, v) in upload_request.fields() {
-            match v {
-                WpMultipartFormFieldValue::String(s) => form = form.text(k, s),
-                WpMultipartFormFieldValue::Array(vec) => {
-                    let key = format!("{k}[]", k = &k.to_string());
-                    for item in vec {
-                        form = form.text(key.clone(), item.to_string());
+        for field in upload_request.form() {
+            match field {
+                WpMultipartFormField::Text { name, value } => {
+                    form = form.text(name, value);
+                }
+                WpMultipartFormField::File { name, file } => {
+                    let file_path = file.file_path;
+                    let mut file_header_map = HeaderMap::new();
+                    if let Some(mime_type) = &file.mime_type {
+                        file_header_map.insert(
+                            http::header::CONTENT_TYPE,
+                            HeaderValue::from_str(mime_type).unwrap(),
+                        );
                     }
+                    let part = Part::file(file_path)
+                        .await
+                        .unwrap()
+                        .headers(file_header_map);
+                    form = form.part(name, part);
                 }
             }
         }

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -3,7 +3,7 @@ use wp_api::{
     media::{MediaCreateParams, MediaId, MediaListParams, MediaUpdateParams},
     posts::WpApiParamPostsOrderBy,
     prelude::*,
-    request::{RequestContext, WpMultipartFormFieldValue, WpMultipartFormRequest},
+    request::{RequestContext, WpMultipartFormField, WpMultipartFormRequest},
     users::UserId,
 };
 use wp_api_integration_tests::prelude::*;
@@ -224,15 +224,12 @@ impl RequestExecutor for MediaErrNetworking {
             }
         }
 
-        for (k, v) in upload_request.fields() {
-            match v {
-                WpMultipartFormFieldValue::String(s) => form = form.text(k, s),
-                WpMultipartFormFieldValue::Array(vec) => {
-                    let key = format!("{k}[]", k = &k.to_string());
-                    for item in vec {
-                        form = form.text(key.clone(), item.to_string());
-                    }
+        for field in upload_request.form() {
+            match field {
+                WpMultipartFormField::Text { name, value } => {
+                    form = form.text(name, value);
                 }
+                WpMultipartFormField::File { .. } => {}
             }
         }
 


### PR DESCRIPTION
This PR introduces a new `WpMultipartFormField` to include both the existing `fields` (plain text) and `files` (file binary). It also moves the key-value encoding part to the Rust library, so that the wrappers don't have to have code to encode `key=[foo, bar]` as `key[]=foo&key[]=bar`.

The encoding logic also handles nested arrays and objects. See the new unit tests to see how they are encoded. I believe the result follows the PHP convention.

It's easier to review this PR [with "Hiding whitepsaces" option one](https://github.com/Automattic/wordpress-rs/pull/997/files?w=1).