### PR TITLE
Add SiteRepository with polymorphic site support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,6 +5306,7 @@ name = "wp_mobile_cache"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "integration_test_credentials",
  "rstest",
  "rusqlite",
  "serde",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
@@ -11,7 +11,7 @@ class WordPressApiCacheTest {
 
     @Test
     fun testThatMigrationsWork() = runTest {
-        assertEquals(5, WordPressApiCache().performMigrations())
+        assertEquals(6, WordPressApiCache().performMigrations())
     }
 
     @Test

--- a/native/swift/Tests/wordpress-api-cache/WordPressApiCacheTests.swift
+++ b/native/swift/Tests/wordpress-api-cache/WordPressApiCacheTests.swift
@@ -13,7 +13,7 @@ actor Test {
 
     @Test func testMigrationsWork() async throws {
         let migrationsPerformed = try await self.cache.performMigrations()
-        #expect(migrationsPerformed == 5)
+        #expect(migrationsPerformed == 6)
     }
 
     #if !os(Linux)

--- a/wp_mobile_cache/Cargo.toml
+++ b/wp_mobile_cache/Cargo.toml
@@ -16,4 +16,5 @@ wp_api = { path = "../wp_api" }
 
 [dev-dependencies]
 chrono = { workspace = true }
+integration_test_credentials = { path = "../integration_test_credentials" }
 rstest = "0.24"

--- a/wp_mobile_cache/migrations/0001-create-sites-table.sql
+++ b/wp_mobile_cache/migrations/0001-create-sites-table.sql
@@ -9,3 +9,6 @@ CREATE TABLE `sites` (
   -- Note: Not a foreign key constraint since it can point to different tables
   `mapped_site_id` INTEGER NOT NULL
 ) STRICT;
+
+-- Unique constraint to prevent duplicate site mappings
+CREATE UNIQUE INDEX idx_sites_unique_site_type_and_mapped_site_id ON sites(site_type, mapped_site_id);

--- a/wp_mobile_cache/migrations/0001-create-sites-table.sql
+++ b/wp_mobile_cache/migrations/0001-create-sites-table.sql
@@ -1,4 +1,11 @@
 CREATE TABLE `sites` (
   -- Internal DB field (auto-incrementing)
-  `id` INTEGER PRIMARY KEY AUTOINCREMENT
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  -- Type of site (0 = SelfHosted, 1 = WordPressCom)
+  `site_type` INTEGER NOT NULL,
+
+  -- Reference to type-specific table (self_hosted_sites.id or wordpress_com_sites.id)
+  -- Note: Not a foreign key constraint since it can point to different tables
+  `mapped_site_id` INTEGER NOT NULL
 ) STRICT;

--- a/wp_mobile_cache/migrations/0001-create-sites-table.sql
+++ b/wp_mobile_cache/migrations/0001-create-sites-table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `sites` (
+CREATE TABLE `db_sites` (
   -- Internal DB field (auto-incrementing)
   `id` INTEGER PRIMARY KEY AUTOINCREMENT,
 
@@ -11,4 +11,4 @@ CREATE TABLE `sites` (
 ) STRICT;
 
 -- Unique constraint to prevent duplicate site mappings
-CREATE UNIQUE INDEX idx_sites_unique_site_type_and_mapped_site_id ON sites(site_type, mapped_site_id);
+CREATE UNIQUE INDEX idx_db_sites_unique_site_type_and_mapped_site_id ON db_sites(site_type, mapped_site_id);

--- a/wp_mobile_cache/migrations/0002-create-posts-table.sql
+++ b/wp_mobile_cache/migrations/0002-create-posts-table.sql
@@ -2,8 +2,8 @@ CREATE TABLE `posts_edit_context` (
   -- Internal DB field (auto-incrementing)
   `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
 
-  -- Site identifier (foreign key to sites table)
-  `db_site_id` INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  -- Site identifier (foreign key to db_sites table)
+  `db_site_id` INTEGER NOT NULL REFERENCES db_sites(id) ON DELETE CASCADE,
 
   -- Top-level non-nullable fields
   `id` INTEGER NOT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `posts_edit_context` (
   -- Client-side cache metadata: when this post was last fetched from the WordPress API
   `last_fetched_at` TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 
-  FOREIGN KEY (db_site_id) REFERENCES sites(id) ON DELETE CASCADE
+  FOREIGN KEY (db_site_id) REFERENCES db_sites(id) ON DELETE CASCADE
 ) STRICT;
 
 CREATE UNIQUE INDEX idx_posts_edit_context_unique_db_site_id_and_id ON posts_edit_context(db_site_id, id);

--- a/wp_mobile_cache/migrations/0003-create-term-relationships.sql
+++ b/wp_mobile_cache/migrations/0003-create-term-relationships.sql
@@ -2,7 +2,7 @@ CREATE TABLE `term_relationships` (
   -- Internal DB field (auto-incrementing)
   `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
 
-  -- Site identifier (foreign key to sites table)
+  -- Site identifier (foreign key to db_sites table)
   `db_site_id` INTEGER NOT NULL,
 
   -- Object identifier (rowid of post/page/nav_menu_item/etc)
@@ -15,7 +15,7 @@ CREATE TABLE `term_relationships` (
   -- Taxonomy type ('category', 'post_tag', or custom taxonomy)
   `taxonomy_type` TEXT NOT NULL,
 
-  FOREIGN KEY (db_site_id) REFERENCES sites(id) ON DELETE CASCADE
+  FOREIGN KEY (db_site_id) REFERENCES db_sites(id) ON DELETE CASCADE
 ) STRICT;
 
 -- Prevent duplicate associations (same object can't have same term twice in same taxonomy)

--- a/wp_mobile_cache/migrations/0004-create-posts-view-context-table.sql
+++ b/wp_mobile_cache/migrations/0004-create-posts-view-context-table.sql
@@ -2,8 +2,8 @@ CREATE TABLE `posts_view_context` (
   -- Internal DB field (auto-incrementing)
   `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
 
-  -- Site identifier (foreign key to sites table)
-  `db_site_id` INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  -- Site identifier (foreign key to db_sites table)
+  `db_site_id` INTEGER NOT NULL REFERENCES db_sites(id) ON DELETE CASCADE,
 
   -- Top-level non-nullable fields
   `id` INTEGER NOT NULL,
@@ -50,7 +50,7 @@ CREATE TABLE `posts_view_context` (
   -- Client-side cache metadata: when this post was last fetched from the WordPress API
   `last_fetched_at` TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 
-  FOREIGN KEY (db_site_id) REFERENCES sites(id) ON DELETE CASCADE
+  FOREIGN KEY (db_site_id) REFERENCES db_sites(id) ON DELETE CASCADE
 ) STRICT;
 
 CREATE UNIQUE INDEX idx_posts_view_context_unique_db_site_id_and_id ON posts_view_context(db_site_id, id);

--- a/wp_mobile_cache/migrations/0005-create-posts-embed-context-table.sql
+++ b/wp_mobile_cache/migrations/0005-create-posts-embed-context-table.sql
@@ -2,8 +2,8 @@ CREATE TABLE `posts_embed_context` (
   -- Internal DB field (auto-incrementing)
   `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
 
-  -- Site identifier (foreign key to sites table)
-  `db_site_id` INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  -- Site identifier (foreign key to db_sites table)
+  `db_site_id` INTEGER NOT NULL REFERENCES db_sites(id) ON DELETE CASCADE,
 
   -- Top-level non-nullable fields (minimal set for embed context)
   `id` INTEGER NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE `posts_embed_context` (
   -- Client-side cache metadata: when this post was last fetched from the WordPress API
   `last_fetched_at` TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 
-  FOREIGN KEY (db_site_id) REFERENCES sites(id) ON DELETE CASCADE
+  FOREIGN KEY (db_site_id) REFERENCES db_sites(id) ON DELETE CASCADE
 ) STRICT;
 
 CREATE UNIQUE INDEX idx_posts_embed_context_unique_db_site_id_and_id ON posts_embed_context(db_site_id, id);

--- a/wp_mobile_cache/migrations/0006-create-self-hosted-sites-table.sql
+++ b/wp_mobile_cache/migrations/0006-create-self-hosted-sites-table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `self_hosted_sites` (
+  -- Internal DB field (auto-incrementing)
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  -- Site URL (unique constraint for upsert logic)
+  `url` TEXT NOT NULL UNIQUE,
+
+  -- WordPress REST API root URL
+  `api_root` TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_self_hosted_sites_url ON self_hosted_sites(url);

--- a/wp_mobile_cache/migrations/0006-create-self-hosted-sites-table.sql
+++ b/wp_mobile_cache/migrations/0006-create-self-hosted-sites-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `self_hosted_sites` (
   -- Internal DB field (auto-incrementing)
-  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
 
   -- Site URL (unique constraint for upsert logic)
   `url` TEXT NOT NULL UNIQUE,

--- a/wp_mobile_cache/src/db_types.rs
+++ b/wp_mobile_cache/src/db_types.rs
@@ -1,2 +1,5 @@
 pub mod db_site;
+pub mod db_term_relationship;
+pub mod helpers;
 pub mod posts;
+pub mod row_ext;

--- a/wp_mobile_cache/src/db_types.rs
+++ b/wp_mobile_cache/src/db_types.rs
@@ -3,3 +3,4 @@ pub mod db_term_relationship;
 pub mod helpers;
 pub mod posts;
 pub mod row_ext;
+pub mod self_hosted_site;

--- a/wp_mobile_cache/src/db_types.rs
+++ b/wp_mobile_cache/src/db_types.rs
@@ -1,1 +1,2 @@
+pub mod db_site;
 pub mod posts;

--- a/wp_mobile_cache/src/db_types/db_site.rs
+++ b/wp_mobile_cache/src/db_types/db_site.rs
@@ -1,0 +1,54 @@
+use crate::RowId;
+use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput};
+
+/// Type of WordPress site stored in the database.
+///
+/// Uses integer representation in the database for performance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[repr(i64)]
+pub enum DbSiteType {
+    SelfHosted = 0,
+    WordPressCom = 1,
+}
+
+impl ToSql for DbSiteType {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(*self as i64))
+    }
+}
+
+impl FromSql for DbSiteType {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> FromSqlResult<Self> {
+        match i64::column_result(value)? {
+            0 => Ok(DbSiteType::SelfHosted),
+            1 => Ok(DbSiteType::WordPressCom),
+            other => Err(rusqlite::types::FromSqlError::OutOfRange(other)),
+        }
+    }
+}
+
+/// Represents a cached WordPress site in the database.
+///
+/// # Design Rationale
+///
+/// This is intentionally a database-specific type (hence the `Db` prefix) rather than
+/// a domain type representing a WordPress site. This design choice prevents confusion:
+///
+/// - **Not a WordPress.com site ID**: The `row_id` has no relationship to WordPress.com site IDs
+/// - **Not a self-hosted site identifier**: Self-hosted sites don't have numeric IDs
+/// - **Internal cache identifier only**: This ID exists only for our local database's multi-site support
+///
+/// # Site Type Mapping
+///
+/// The `site_type` field indicates which type-specific table contains additional data:
+/// - `DbSiteType::SelfHosted` → `mapped_site_id` references `self_hosted_sites` table
+/// - `DbSiteType::WordPressCom` → `mapped_site_id` references `wordpress_com_sites` table (future)
+///
+/// Note: `mapped_site_id` is a reference column, not a foreign key constraint, since it can
+/// point to different tables based on `site_type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DbSite {
+    pub row_id: RowId,
+    pub site_type: DbSiteType,
+    pub mapped_site_id: RowId,
+}

--- a/wp_mobile_cache/src/db_types/db_term_relationship.rs
+++ b/wp_mobile_cache/src/db_types/db_term_relationship.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DbSite, SqliteDbError,
+    SqliteDbError,
     db_types::row_ext::{ColumnIndex, RowExt},
     term_relationships::DbTermRelationship,
 };
@@ -31,12 +31,7 @@ impl DbTermRelationship {
 
         Ok(Self {
             row_id: row.get_column(Col::Rowid)?,
-            site: DbSite {
-                row_id: row.get_column(Col::DbSiteId)?,
-                // TODO: These should be fetched from sites table via JOIN or separate query
-                site_type: crate::DbSiteType::SelfHosted,
-                mapped_site_id: crate::RowId(0),
-            },
+            db_site_id: row.get_column(Col::DbSiteId)?,
             object_id: row.get_column(Col::ObjectId)?,
             term_id: TermId(row.get_column(Col::TermId)?),
             taxonomy_type: row.get_column::<String, _>(Col::TaxonomyType)?.into(),

--- a/wp_mobile_cache/src/db_types/db_term_relationship.rs
+++ b/wp_mobile_cache/src/db_types/db_term_relationship.rs
@@ -1,6 +1,6 @@
 use crate::{
     DbSite, SqliteDbError,
-    mappings::{ColumnIndex, RowExt},
+    db_types::row_ext::{ColumnIndex, RowExt},
     term_relationships::DbTermRelationship,
 };
 use rusqlite::Row;

--- a/wp_mobile_cache/src/db_types/helpers.rs
+++ b/wp_mobile_cache/src/db_types/helpers.rs
@@ -1,6 +1,6 @@
 use crate::{
     SqliteDbError,
-    mappings::{ColumnIndex, RowExt},
+    db_types::row_ext::{ColumnIndex, RowExt},
 };
 use rusqlite::Row;
 use serde::{Deserialize, Serialize};

--- a/wp_mobile_cache/src/db_types/posts/edit.rs
+++ b/wp_mobile_cache/src/db_types/posts/edit.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
+use crate::{RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithEditContext;
 
 /// Column indexes for posts_edit_context table.
@@ -7,7 +7,7 @@ use wp_api::posts::AnyPostWithEditContext;
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PostEditContextColumn {
     Rowid = 0,
-    SiteId = 1,
+    DbSiteId = 1,
     Id = 2,
     Date = 3,
     DateGmt = 4,
@@ -52,7 +52,7 @@ impl ColumnIndex for PostEditContextColumn {
 
 pub struct DbAnyPostWithEditContext {
     pub row_id: RowId,
-    pub site: DbSite,
+    pub db_site_id: RowId,
     pub post: AnyPostWithEditContext,
     pub last_fetched_at: String,
 }

--- a/wp_mobile_cache/src/db_types/posts/edit.rs
+++ b/wp_mobile_cache/src/db_types/posts/edit.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, mappings::ColumnIndex};
+use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithEditContext;
 
 /// Column indexes for posts_edit_context table.

--- a/wp_mobile_cache/src/db_types/posts/embed.rs
+++ b/wp_mobile_cache/src/db_types/posts/embed.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, mappings::ColumnIndex};
+use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithEmbedContext;
 
 /// Column indexes for posts_embed_context table.

--- a/wp_mobile_cache/src/db_types/posts/embed.rs
+++ b/wp_mobile_cache/src/db_types/posts/embed.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
+use crate::{RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithEmbedContext;
 
 /// Column indexes for posts_embed_context table.
@@ -7,7 +7,7 @@ use wp_api::posts::AnyPostWithEmbedContext;
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PostEmbedContextColumn {
     Rowid = 0,
-    SiteId = 1,
+    DbSiteId = 1,
     Id = 2,
     Date = 3,
     Link = 4,
@@ -30,7 +30,7 @@ impl ColumnIndex for PostEmbedContextColumn {
 
 pub struct DbAnyPostWithEmbedContext {
     pub row_id: RowId,
-    pub site: DbSite,
+    pub db_site_id: RowId,
     pub post: AnyPostWithEmbedContext,
     pub last_fetched_at: String,
 }

--- a/wp_mobile_cache/src/db_types/posts/view.rs
+++ b/wp_mobile_cache/src/db_types/posts/view.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
+use crate::{RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithViewContext;
 
 /// Column indexes for posts_view_context table.
@@ -7,7 +7,7 @@ use wp_api::posts::AnyPostWithViewContext;
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PostViewContextColumn {
     Rowid = 0,
-    SiteId = 1,
+    DbSiteId = 1,
     Id = 2,
     Date = 3,
     DateGmt = 4,
@@ -45,7 +45,7 @@ impl ColumnIndex for PostViewContextColumn {
 
 pub struct DbAnyPostWithViewContext {
     pub row_id: RowId,
-    pub site: DbSite,
+    pub db_site_id: RowId,
     pub post: AnyPostWithViewContext,
     pub last_fetched_at: String,
 }

--- a/wp_mobile_cache/src/db_types/posts/view.rs
+++ b/wp_mobile_cache/src/db_types/posts/view.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId, mappings::ColumnIndex};
+use crate::{DbSite, RowId, db_types::row_ext::ColumnIndex};
 use wp_api::posts::AnyPostWithViewContext;
 
 /// Column indexes for posts_view_context table.

--- a/wp_mobile_cache/src/db_types/row_ext.rs
+++ b/wp_mobile_cache/src/db_types/row_ext.rs
@@ -1,8 +1,5 @@
 use rusqlite::Row;
 
-pub mod helpers;
-pub mod term_relationships;
-
 /// Trait for types that can be used as column indexes.
 /// Implemented by column enum types to provide type-safe column access.
 pub trait ColumnIndex {

--- a/wp_mobile_cache/src/db_types/self_hosted_site.rs
+++ b/wp_mobile_cache/src/db_types/self_hosted_site.rs
@@ -1,0 +1,24 @@
+use crate::{RowId, db_types::row_ext::ColumnIndex};
+
+/// Column indexes for self_hosted_sites table.
+/// These must match the order of columns in the CREATE TABLE statement.
+#[repr(usize)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SelfHostedSiteColumn {
+    Rowid = 0,
+    Url = 1,
+    ApiRoot = 2,
+}
+
+impl ColumnIndex for SelfHostedSiteColumn {
+    fn as_index(&self) -> usize {
+        *self as usize
+    }
+}
+
+/// Represents a self-hosted WordPress site in the database.
+pub struct DbSelfHostedSite {
+    pub row_id: RowId,
+    pub url: String,
+    pub api_root: String,
+}

--- a/wp_mobile_cache/src/db_types/self_hosted_site.rs
+++ b/wp_mobile_cache/src/db_types/self_hosted_site.rs
@@ -16,9 +16,31 @@ impl ColumnIndex for SelfHostedSiteColumn {
     }
 }
 
+/// Represents a self-hosted WordPress site (domain model).
+///
+/// This type contains the site data without database metadata.
+/// Use this when creating or updating sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfHostedSite {
+    pub url: String,
+    pub api_root: String,
+}
+
 /// Represents a self-hosted WordPress site in the database.
+///
+/// This type includes the database rowid along with the site data.
 pub struct DbSelfHostedSite {
     pub row_id: RowId,
     pub url: String,
     pub api_root: String,
+}
+
+impl DbSelfHostedSite {
+    /// Convert to the domain model (without row_id).
+    pub fn to_self_hosted_site(&self) -> SelfHostedSite {
+        SelfHostedSite {
+            url: self.url.clone(),
+            api_root: self.api_root.clone(),
+        }
+    }
 }

--- a/wp_mobile_cache/src/db_types/self_hosted_site.rs
+++ b/wp_mobile_cache/src/db_types/self_hosted_site.rs
@@ -29,6 +29,7 @@ pub struct SelfHostedSite {
 /// Represents a self-hosted WordPress site in the database.
 ///
 /// This type includes the database rowid along with the site data.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbSelfHostedSite {
     pub row_id: RowId,
     pub url: String,

--- a/wp_mobile_cache/src/db_types/self_hosted_site.rs
+++ b/wp_mobile_cache/src/db_types/self_hosted_site.rs
@@ -34,13 +34,3 @@ pub struct DbSelfHostedSite {
     pub url: String,
     pub api_root: String,
 }
-
-impl DbSelfHostedSite {
-    /// Convert to the domain model (without row_id).
-    pub fn to_self_hosted_site(&self) -> SelfHostedSite {
-        SelfHostedSite {
-            url: self.url.clone(),
-            api_root: self.api_root.clone(),
-        }
-    }
-}

--- a/wp_mobile_cache/src/db_types/self_hosted_site.rs
+++ b/wp_mobile_cache/src/db_types/self_hosted_site.rs
@@ -4,13 +4,13 @@ use crate::{RowId, db_types::row_ext::ColumnIndex};
 /// These must match the order of columns in the CREATE TABLE statement.
 #[repr(usize)]
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum SelfHostedSiteColumn {
+pub(crate) enum DbSelfHostedSiteColumn {
     Rowid = 0,
     Url = 1,
     ApiRoot = 2,
 }
 
-impl ColumnIndex for SelfHostedSiteColumn {
+impl ColumnIndex for DbSelfHostedSiteColumn {
     fn as_index(&self) -> usize {
         *self as usize
     }

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -84,9 +84,6 @@ impl From<RowId> for i64 {
     }
 }
 
-// Re-export site types from db_types module
-pub use db_types::db_site::{DbSite, DbSiteType};
-
 /// Get the SQLite version string from the database.
 ///
 /// This function queries the database for its SQLite version using `SELECT sqlite_version()`.

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -193,12 +193,13 @@ impl WpApiCache {
     }
 }
 
-static MIGRATION_QUERIES: [&str; 5] = [
+static MIGRATION_QUERIES: [&str; 6] = [
     include_str!("../migrations/0001-create-sites-table.sql"),
     include_str!("../migrations/0002-create-posts-table.sql"),
     include_str!("../migrations/0003-create-term-relationships.sql"),
     include_str!("../migrations/0004-create-posts-view-context-table.sql"),
     include_str!("../migrations/0005-create-posts-embed-context-table.sql"),
+    include_str!("../migrations/0006-create-self-hosted-sites-table.sql"),
 ];
 
 pub struct MigrationManager<'a> {

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex};
 
 pub mod context;
 pub mod db_types;
-pub mod mappings;
 pub mod repository;
 pub mod term_relationships;
 

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -85,6 +85,32 @@ impl From<RowId> for i64 {
     }
 }
 
+/// Type of WordPress site stored in the database.
+///
+/// Uses integer representation in the database for performance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[repr(i64)]
+pub enum DbSiteType {
+    SelfHosted = 0,
+    WordPressCom = 1,
+}
+
+impl ToSql for DbSiteType {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(*self as i64))
+    }
+}
+
+impl FromSql for DbSiteType {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> FromSqlResult<Self> {
+        match i64::column_result(value)? {
+            0 => Ok(DbSiteType::SelfHosted),
+            1 => Ok(DbSiteType::WordPressCom),
+            other => Err(rusqlite::types::FromSqlError::OutOfRange(other)),
+        }
+    }
+}
+
 /// Represents a cached WordPress site in the database.
 ///
 /// # Design Rationale
@@ -96,21 +122,19 @@ impl From<RowId> for i64 {
 /// - **Not a self-hosted site identifier**: Self-hosted sites don't have numeric IDs
 /// - **Internal cache identifier only**: This ID exists only for our local database's multi-site support
 ///
-/// # Future Extension
+/// # Site Type Mapping
 ///
-/// When site type tables are added (e.g., `self_hosted_sites`, `wordpress_com_sites`), this
-/// struct will gain additional fields:
+/// The `site_type` field indicates which type-specific table contains additional data:
+/// - `DbSiteType::SelfHosted` → `mapped_site_id` references `self_hosted_sites` table
+/// - `DbSiteType::WordPressCom` → `mapped_site_id` references `wordpress_com_sites` table (future)
 ///
-/// ```ignore
-/// pub struct DbSite {
-///     pub row_id: RowId,
-///     pub site_type: SiteType,      // SelfHosted | WordPressCom
-///     pub mapped_site_id: RowId,    // Foreign key to specific site type table
-/// }
-/// ```
+/// Note: `mapped_site_id` is a reference column, not a foreign key constraint, since it can
+/// point to different tables based on `site_type`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DbSite {
     pub row_id: RowId,
+    pub site_type: DbSiteType,
+    pub mapped_site_id: RowId,
 }
 
 /// Get the SQLite version string from the database.

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -85,57 +85,8 @@ impl From<RowId> for i64 {
     }
 }
 
-/// Type of WordPress site stored in the database.
-///
-/// Uses integer representation in the database for performance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[repr(i64)]
-pub enum DbSiteType {
-    SelfHosted = 0,
-    WordPressCom = 1,
-}
-
-impl ToSql for DbSiteType {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::from(*self as i64))
-    }
-}
-
-impl FromSql for DbSiteType {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> FromSqlResult<Self> {
-        match i64::column_result(value)? {
-            0 => Ok(DbSiteType::SelfHosted),
-            1 => Ok(DbSiteType::WordPressCom),
-            other => Err(rusqlite::types::FromSqlError::OutOfRange(other)),
-        }
-    }
-}
-
-/// Represents a cached WordPress site in the database.
-///
-/// # Design Rationale
-///
-/// This is intentionally a database-specific type (hence the `Db` prefix) rather than
-/// a domain type representing a WordPress site. This design choice prevents confusion:
-///
-/// - **Not a WordPress.com site ID**: The `row_id` has no relationship to WordPress.com site IDs
-/// - **Not a self-hosted site identifier**: Self-hosted sites don't have numeric IDs
-/// - **Internal cache identifier only**: This ID exists only for our local database's multi-site support
-///
-/// # Site Type Mapping
-///
-/// The `site_type` field indicates which type-specific table contains additional data:
-/// - `DbSiteType::SelfHosted` → `mapped_site_id` references `self_hosted_sites` table
-/// - `DbSiteType::WordPressCom` → `mapped_site_id` references `wordpress_com_sites` table (future)
-///
-/// Note: `mapped_site_id` is a reference column, not a foreign key constraint, since it can
-/// point to different tables based on `site_type`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct DbSite {
-    pub row_id: RowId,
-    pub site_type: DbSiteType,
-    pub mapped_site_id: RowId,
-}
+// Re-export site types from db_types module
+pub use db_types::db_site::{DbSite, DbSiteType};
 
 /// Get the SQLite version string from the database.
 ///

--- a/wp_mobile_cache/src/mappings/term_relationships.rs
+++ b/wp_mobile_cache/src/mappings/term_relationships.rs
@@ -33,6 +33,9 @@ impl DbTermRelationship {
             row_id: row.get_column(Col::Rowid)?,
             site: DbSite {
                 row_id: row.get_column(Col::DbSiteId)?,
+                // TODO: These should be fetched from sites table via JOIN or separate query
+                site_type: crate::DbSiteType::SelfHosted,
+                mapped_site_id: crate::RowId(0),
             },
             object_id: row.get_column(Col::ObjectId)?,
             term_id: TermId(row.get_column(Col::TermId)?),

--- a/wp_mobile_cache/src/repository/mod.rs
+++ b/wp_mobile_cache/src/repository/mod.rs
@@ -2,6 +2,7 @@ use crate::{RowId, SqliteDbError};
 use rusqlite::Connection;
 
 pub mod posts;
+pub mod sites;
 pub mod term_relationships;
 
 #[cfg(test)]

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -271,12 +271,7 @@ impl PostContext for EditContext {
         use PostEditContextColumn::*;
 
         let row_id: RowId = row.get_column(Rowid)?;
-        let site = DbSite {
-            row_id: row.get_column(PostEditContextColumn::SiteId)?,
-            // TODO: These should be fetched from sites table via JOIN or separate query
-            site_type: crate::DbSiteType::SelfHosted,
-            mapped_site_id: RowId(0),
-        };
+        let db_site_id: RowId = row.get_column(PostEditContextColumn::DbSiteId)?;
 
         // EditContext uses term relationships (categories and tags)
         let term_relationships = fetch_terms()?;
@@ -341,7 +336,7 @@ impl PostContext for EditContext {
 
         Ok(DbAnyPostWithEditContext {
             row_id,
-            site,
+            db_site_id,
             post,
             last_fetched_at: row.get_column(LastFetchedAt)?,
         })
@@ -359,12 +354,7 @@ impl PostContext for ViewContext {
         use PostViewContextColumn::*;
 
         let row_id: RowId = row.get_column(Rowid)?;
-        let site = DbSite {
-            row_id: row.get_column(PostViewContextColumn::SiteId)?,
-            // TODO: These should be fetched from sites table via JOIN or separate query
-            site_type: crate::DbSiteType::SelfHosted,
-            mapped_site_id: RowId(0),
-        };
+        let db_site_id: RowId = row.get_column(PostViewContextColumn::DbSiteId)?;
 
         // ViewContext uses term relationships (categories and tags)
         let term_relationships = fetch_terms()?;
@@ -422,7 +412,7 @@ impl PostContext for ViewContext {
 
         Ok(DbAnyPostWithViewContext {
             row_id,
-            site,
+            db_site_id,
             post,
             last_fetched_at: row.get_column(LastFetchedAt)?,
         })
@@ -440,12 +430,7 @@ impl PostContext for EmbedContext {
         use PostEmbedContextColumn::*;
 
         let row_id: RowId = row.get_column(Rowid)?;
-        let site = DbSite {
-            row_id: row.get_column(PostEmbedContextColumn::SiteId)?,
-            // TODO: These should be fetched from sites table via JOIN or separate query
-            site_type: crate::DbSiteType::SelfHosted,
-            mapped_site_id: RowId(0),
-        };
+        let db_site_id: RowId = row.get_column(PostEmbedContextColumn::DbSiteId)?;
 
         // EmbedContext does not use term relationships (no categories/tags in embed context)
         // The fetch_terms closure is never called, avoiding unnecessary database queries
@@ -477,7 +462,7 @@ impl PostContext for EmbedContext {
 
         Ok(DbAnyPostWithEmbedContext {
             row_id,
-            site,
+            db_site_id,
             post,
             last_fetched_at: row.get_column(LastFetchedAt)?,
         })
@@ -873,7 +858,7 @@ mod tests {
 
         // Verify each enum value maps to the correct column name
         assert_eq!(columns[Rowid.as_index()], "rowid");
-        assert_eq!(columns[SiteId.as_index()], "db_site_id");
+        assert_eq!(columns[DbSiteId.as_index()], "db_site_id");
         assert_eq!(columns[Id.as_index()], "id");
         assert_eq!(columns[Date.as_index()], "date");
         assert_eq!(columns[DateGmt.as_index()], "date_gmt");
@@ -925,7 +910,7 @@ mod tests {
         let columns = get_table_column_names(&test_ctx.conn, "posts_view_context");
 
         assert_eq!(columns[Rowid.as_index()], "rowid");
-        assert_eq!(columns[SiteId.as_index()], "db_site_id");
+        assert_eq!(columns[DbSiteId.as_index()], "db_site_id");
         assert_eq!(columns[Id.as_index()], "id");
         assert_eq!(columns[Date.as_index()], "date");
         assert_eq!(columns[DateGmt.as_index()], "date_gmt");
@@ -966,7 +951,7 @@ mod tests {
         let columns = get_table_column_names(&test_ctx.conn, "posts_embed_context");
 
         assert_eq!(columns[Rowid.as_index()], "rowid");
-        assert_eq!(columns[SiteId.as_index()], "db_site_id");
+        assert_eq!(columns[DbSiteId.as_index()], "db_site_id");
         assert_eq!(columns[Id.as_index()], "id");
         assert_eq!(columns[Date.as_index()], "date");
         assert_eq!(columns[Link.as_index()], "link");
@@ -1002,7 +987,7 @@ mod tests {
 
         // Verify round-trip
         assert_eq!(retrieved.row_id, rowid);
-        assert_eq!(retrieved.site, test_ctx.site);
+        assert_eq!(retrieved.db_site_id, test_ctx.site.row_id);
         assert_recent_timestamp(&retrieved.last_fetched_at);
         assert_eq!(retrieved.post, original_post);
     }
@@ -1074,7 +1059,7 @@ mod tests {
             .expect("Post should exist");
 
         assert_eq!(retrieved.row_id, rowid);
-        assert_eq!(retrieved.site, test_ctx.site);
+        assert_eq!(retrieved.db_site_id, test_ctx.site.row_id);
         assert_eq!(retrieved.post, post);
     }
 
@@ -1096,7 +1081,7 @@ mod tests {
             .expect("Post should exist");
 
         assert_eq!(retrieved.post.id, PostId(42));
-        assert_eq!(retrieved.site, test_ctx.site);
+        assert_eq!(retrieved.db_site_id, test_ctx.site.row_id);
         assert_eq!(retrieved.post, post);
     }
 
@@ -1284,7 +1269,7 @@ mod tests {
             .expect("Failed to select post by post_id")
             .expect("Post should exist after insert");
         assert_eq!(retrieved.row_id, rowid);
-        assert_eq!(retrieved.site, test_ctx.site);
+        assert_eq!(retrieved.db_site_id, test_ctx.site.row_id);
         assert_eq!(retrieved.post.status, PostStatus::Draft);
     }
 

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1,7 +1,8 @@
 use crate::{
-    DbSite, RowId, SqliteDbError,
+    RowId, SqliteDbError,
     context::{EditContext, EmbedContext, IsContext, ViewContext},
     db_types::{
+        db_site::DbSite,
         helpers::{
             bool_to_integer, deserialize_json_value, get_id, get_optional_id, integer_to_bool,
             parse_datetime, parse_enum, parse_optional_enum, serialize_value_to_json,

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -273,6 +273,9 @@ impl PostContext for EditContext {
         let row_id: RowId = row.get_column(Rowid)?;
         let site = DbSite {
             row_id: row.get_column(PostEditContextColumn::SiteId)?,
+            // TODO: These should be fetched from sites table via JOIN or separate query
+            site_type: crate::DbSiteType::SelfHosted,
+            mapped_site_id: RowId(0),
         };
 
         // EditContext uses term relationships (categories and tags)
@@ -358,6 +361,9 @@ impl PostContext for ViewContext {
         let row_id: RowId = row.get_column(Rowid)?;
         let site = DbSite {
             row_id: row.get_column(PostViewContextColumn::SiteId)?,
+            // TODO: These should be fetched from sites table via JOIN or separate query
+            site_type: crate::DbSiteType::SelfHosted,
+            mapped_site_id: RowId(0),
         };
 
         // ViewContext uses term relationships (categories and tags)
@@ -436,6 +442,9 @@ impl PostContext for EmbedContext {
         let row_id: RowId = row.get_column(Rowid)?;
         let site = DbSite {
             row_id: row.get_column(PostEmbedContextColumn::SiteId)?,
+            // TODO: These should be fetched from sites table via JOIN or separate query
+            site_type: crate::DbSiteType::SelfHosted,
+            mapped_site_id: RowId(0),
         };
 
         // EmbedContext does not use term relationships (no categories/tags in embed context)

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1,16 +1,16 @@
 use crate::{
     DbSite, RowId, SqliteDbError,
     context::{EditContext, EmbedContext, IsContext, ViewContext},
-    db_types::posts::{
-        DbAnyPostWithEditContext, DbAnyPostWithEmbedContext, DbAnyPostWithViewContext,
-        PostEditContextColumn, PostEmbedContextColumn, PostViewContextColumn,
-    },
-    mappings::{
-        RowExt,
+    db_types::{
         helpers::{
             bool_to_integer, deserialize_json_value, get_id, get_optional_id, integer_to_bool,
             parse_datetime, parse_enum, parse_optional_enum, serialize_value_to_json,
         },
+        posts::{
+            DbAnyPostWithEditContext, DbAnyPostWithEmbedContext, DbAnyPostWithViewContext,
+            PostEditContextColumn, PostEmbedContextColumn, PostViewContextColumn,
+        },
+        row_ext::RowExt,
     },
     repository::{
         QueryExecutor, TransactionManager, term_relationships::TermRelationshipRepository,
@@ -856,7 +856,7 @@ mod tests {
     use crate::db_types::posts::{
         PostEditContextColumn, PostEmbedContextColumn, PostViewContextColumn,
     };
-    use crate::mappings::ColumnIndex;
+    use crate::db_types::row_ext::ColumnIndex;
     use crate::test_fixtures::{
         TestContext, assert_recent_timestamp, get_table_column_names, posts::PostBuilder, test_ctx,
     };

--- a/wp_mobile_cache/src/repository/posts_constraint_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_constraint_tests.rs
@@ -57,7 +57,12 @@ fn test_duplicate_post_id_in_same_site_updates_on_upsert(mut test_ctx: TestConte
 
 #[rstest]
 fn test_invalid_site_id_fails_foreign_key_constraint(mut test_ctx: TestContext) {
-    let non_existent_site = DbSite { row_id: RowId(999) }; // Site doesn't exist
+    // Site doesn't exist in database - intentionally invalid for testing error handling
+    let non_existent_site = DbSite {
+        row_id: RowId(999),
+        site_type: crate::DbSiteType::SelfHosted,
+        mapped_site_id: RowId(999),
+    };
 
     let post = PostBuilder::minimal().build();
     let result = test_ctx

--- a/wp_mobile_cache/src/repository/posts_constraint_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_constraint_tests.rs
@@ -4,7 +4,8 @@
 //! and that error cases are handled appropriately.
 
 use crate::{
-    DbSite, RowId,
+    RowId,
+    db_types::db_site::{DbSite, DbSiteType},
     test_fixtures::{TestContext, posts::PostBuilder, test_ctx},
 };
 use rstest::*;
@@ -60,7 +61,7 @@ fn test_invalid_site_id_fails_foreign_key_constraint(mut test_ctx: TestContext) 
     // Site doesn't exist in database - intentionally invalid for testing error handling
     let non_existent_site = DbSite {
         row_id: RowId(999),
-        site_type: crate::DbSiteType::SelfHosted,
+        site_type: DbSiteType::SelfHosted,
         mapped_site_id: RowId(999),
     };
 

--- a/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
@@ -1,21 +1,12 @@
 //! Multi-site isolation tests for PostRepository.
 
-use crate::{
-    db_types::self_hosted_site::SelfHostedSite,
-    test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx},
-};
+use crate::test_fixtures::{TestContext, create_random_test_site, posts::PostBuilder, test_ctx};
 use rstest::*;
 use wp_api::posts::PostId;
 
 #[rstest]
 fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     // Insert post in site 1
     let post = PostBuilder::minimal().with_id(100).build();
@@ -37,13 +28,7 @@ fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     // Create post with same ID in both sites
     let post_id = PostId(42);
@@ -84,13 +69,7 @@ fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     // Insert posts in site 1
     test_ctx
@@ -140,13 +119,7 @@ fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestConte
 
 #[rstest]
 fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     // Insert posts in both sites
     test_ctx
@@ -183,13 +156,7 @@ fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_delete_by_post_id_only_deletes_from_specified_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     let post_id = PostId(999);
 

--- a/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
@@ -1,12 +1,21 @@
 //! Multi-site isolation tests for PostRepository.
 
-use crate::test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx};
+use crate::{
+    db_types::self_hosted_site::SelfHostedSite,
+    test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx},
+};
 use rstest::*;
 use wp_api::posts::PostId;
 
 #[rstest]
 fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     // Insert post in site 1
     let post = PostBuilder::minimal().with_id(100).build();
@@ -28,7 +37,13 @@ fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     // Create post with same ID in both sites
     let post_id = PostId(42);
@@ -69,7 +84,13 @@ fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     // Insert posts in site 1
     test_ctx
@@ -119,7 +140,13 @@ fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestConte
 
 #[rstest]
 fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     // Insert posts in both sites
     test_ctx
@@ -156,7 +183,13 @@ fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_delete_by_post_id_only_deletes_from_specified_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     let post_id = PostId(999);
 

--- a/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
@@ -6,7 +6,7 @@ use wp_api::posts::PostId;
 
 #[rstest]
 fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     // Insert post in site 1
     let post = PostBuilder::minimal().with_id(100).build();
@@ -28,7 +28,7 @@ fn test_posts_in_site_1_invisible_to_site_2(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     // Create post with same ID in both sites
     let post_id = PostId(42);
@@ -69,7 +69,7 @@ fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     // Insert posts in site 1
     test_ctx
@@ -119,7 +119,7 @@ fn test_select_all_only_returns_posts_for_requested_site(mut test_ctx: TestConte
 
 #[rstest]
 fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     // Insert posts in both sites
     test_ctx
@@ -156,7 +156,7 @@ fn test_count_only_counts_posts_for_requested_site(mut test_ctx: TestContext) {
 
 #[rstest]
 fn test_delete_by_post_id_only_deletes_from_specified_site(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     let post_id = PostId(999);
 

--- a/wp_mobile_cache/src/repository/posts_transaction_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_transaction_tests.rs
@@ -4,7 +4,8 @@
 //! ensuring proper rollback on errors without leaving partial writes or corrupted data.
 
 use crate::{
-    DbSite, RowId,
+    RowId,
+    db_types::db_site::{DbSite, DbSiteType},
     test_fixtures::{TestContext, posts::PostBuilder, test_ctx},
 };
 use rstest::*;
@@ -78,7 +79,7 @@ fn test_upsert_batch_fails_on_foreign_key_violation(mut test_ctx: TestContext) {
     // Site doesn't exist in database - intentionally invalid for testing error handling
     let invalid_site = DbSite {
         row_id: RowId(999),
-        site_type: crate::DbSiteType::SelfHosted,
+        site_type: DbSiteType::SelfHosted,
         mapped_site_id: RowId(999),
     };
 

--- a/wp_mobile_cache/src/repository/posts_transaction_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_transaction_tests.rs
@@ -75,7 +75,12 @@ fn test_upsert_batch_handles_duplicate_ids_by_updating(mut test_ctx: TestContext
 
 #[rstest]
 fn test_upsert_batch_fails_on_foreign_key_violation(mut test_ctx: TestContext) {
-    let invalid_site = DbSite { row_id: RowId(999) };
+    // Site doesn't exist in database - intentionally invalid for testing error handling
+    let invalid_site = DbSite {
+        row_id: RowId(999),
+        site_type: crate::DbSiteType::SelfHosted,
+        mapped_site_id: RowId(999),
+    };
 
     let post1 = PostBuilder::minimal().build();
     let post2 = PostBuilder::minimal().build();

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -159,6 +159,68 @@ impl SiteRepository {
         let count: i64 = stmt.query_row([], |row| row.get(0))?;
         Ok(count as usize)
     }
+
+    /// Count all self-hosted sites in the database.
+    ///
+    /// This is primarily useful for testing to verify database state.
+    pub fn count_all_self_hosted_sites(
+        &self,
+        executor: &impl QueryExecutor,
+    ) -> Result<usize, SqliteDbError> {
+        let sql = format!("SELECT COUNT(*) FROM {}", Self::SELF_HOSTED_SITES_TABLE);
+        let mut stmt = executor.prepare(&sql)?;
+        let count: i64 = stmt.query_row([], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    /// Delete a site and its type-specific data.
+    ///
+    /// Deletes both the site entry and its corresponding type-specific entry
+    /// (e.g., from self_hosted_sites or wordpress_com_sites). This ensures proper
+    /// cleanup since foreign key constraints cannot be used with polymorphic references.
+    ///
+    /// Returns `true` if a site was deleted, `false` if the site didn't exist.
+    pub fn delete_site(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+    ) -> Result<bool, SqliteDbError> {
+        // Delete from type-specific table based on site_type
+        let _type_table_deleted = match site.site_type {
+            DbSiteType::SelfHosted => {
+                let sql = format!(
+                    "DELETE FROM {} WHERE rowid = ?",
+                    Self::SELF_HOSTED_SITES_TABLE
+                );
+                executor.execute(&sql, [site.mapped_site_id])?
+            }
+            DbSiteType::WordPressCom => {
+                panic!("WordPress.com site deletion is not yet implemented")
+            }
+        };
+
+        // Delete from sites table
+        let sql = format!("DELETE FROM {} WHERE rowid = ?", Self::SITES_TABLE);
+        let sites_deleted = executor.execute(&sql, [site.row_id])?;
+
+        Ok(sites_deleted > 0)
+    }
+
+    /// Delete a self-hosted site by URL (convenience wrapper).
+    ///
+    /// Returns `true` if a site was deleted, `false` if no site with that URL exists.
+    pub fn delete_self_hosted_site_by_url(
+        &self,
+        executor: &impl QueryExecutor,
+        url: &str,
+    ) -> Result<bool, SqliteDbError> {
+        let site_data = self.select_self_hosted_site_by_url(executor, url)?;
+
+        match site_data {
+            Some((db_site, _)) => self.delete_site(executor, &db_site),
+            None => Ok(false),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -424,5 +486,132 @@ mod tests {
 
         assert!(retrieved1.is_some());
         assert!(retrieved2.is_some());
+    }
+
+    #[rstest]
+    fn test_delete_site_removes_both_tables(test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        // Create site
+        let (db_site, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Verify site exists in both tables
+        let count_sites = repo.count_all_sites(&test_conn).unwrap();
+        let count_self_hosted = repo.count_all_self_hosted_sites(&test_conn).unwrap();
+        assert_eq!(count_sites, 1);
+        assert_eq!(count_self_hosted, 1);
+
+        // Delete site
+        let deleted = repo.delete_site(&test_conn, &db_site).unwrap();
+        assert!(deleted, "Should return true when site is deleted");
+
+        // Verify site is removed from both tables
+        let count_sites_after = repo.count_all_sites(&test_conn).unwrap();
+        let count_self_hosted_after = repo.count_all_self_hosted_sites(&test_conn).unwrap();
+        assert_eq!(
+            count_sites_after, 0,
+            "Site should be deleted from sites table"
+        );
+        assert_eq!(
+            count_self_hosted_after, 0,
+            "Site should be deleted from self_hosted_sites table"
+        );
+    }
+
+    #[rstest]
+    fn test_delete_site_returns_false_for_non_existent_site(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let non_existent_site = DbSite {
+            row_id: RowId(999),
+            site_type: DbSiteType::SelfHosted,
+            mapped_site_id: RowId(888),
+        };
+
+        let deleted = repo.delete_site(&test_conn, &non_existent_site).unwrap();
+        assert!(!deleted, "Should return false when site doesn't exist");
+    }
+
+    #[rstest]
+    fn test_delete_site_only_deletes_specified_site(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        // Create two sites
+        let site1 = SelfHostedSite {
+            url: "https://example1.com".to_string(),
+            api_root: "https://example1.com/wp-json".to_string(),
+        };
+        let site2 = SelfHostedSite {
+            url: "https://example2.com".to_string(),
+            api_root: "https://example2.com/wp-json".to_string(),
+        };
+
+        let (db_site1, _) = repo.upsert_self_hosted_site(&test_conn, &site1).unwrap();
+        let (db_site2, _) = repo.upsert_self_hosted_site(&test_conn, &site2).unwrap();
+
+        // Delete site1
+        let deleted = repo.delete_site(&test_conn, &db_site1).unwrap();
+        assert!(deleted);
+
+        // Verify site1 is gone
+        let retrieved1 = repo
+            .select_self_hosted_site_by_url(&test_conn, &site1.url)
+            .unwrap();
+        assert_eq!(retrieved1, None, "Site1 should be deleted");
+
+        // Verify site2 still exists
+        let retrieved2 = repo
+            .select_self_hosted_site_by_url(&test_conn, &site2.url)
+            .unwrap();
+        assert!(retrieved2.is_some(), "Site2 should still exist");
+        assert_eq!(retrieved2.unwrap().0.row_id, db_site2.row_id);
+    }
+
+    #[rstest]
+    fn test_delete_self_hosted_site_by_url_deletes_site(test_conn: Connection) {
+        let repo = SiteRepository;
+        let url = "https://example.com";
+        let site = SelfHostedSite {
+            url: url.to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        // Create site
+        repo.upsert_self_hosted_site(&test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Verify site exists
+        let before_delete = repo
+            .select_self_hosted_site_by_url(&test_conn, url)
+            .unwrap();
+        assert!(before_delete.is_some());
+
+        // Delete by URL
+        let deleted = repo
+            .delete_self_hosted_site_by_url(&test_conn, url)
+            .unwrap();
+        assert!(deleted, "Should return true when site is deleted");
+
+        // Verify site is gone
+        let after_delete = repo
+            .select_self_hosted_site_by_url(&test_conn, url)
+            .unwrap();
+        assert_eq!(after_delete, None, "Site should be deleted");
+    }
+
+    #[rstest]
+    fn test_delete_self_hosted_site_by_url_returns_false_for_non_existent(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let deleted = repo
+            .delete_self_hosted_site_by_url(&test_conn, "https://non-existent.com")
+            .unwrap();
+        assert!(!deleted, "Should return false when site doesn't exist");
     }
 }

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -2,7 +2,7 @@ use crate::{
     DbSite, DbSiteType, RowId, SqliteDbError,
     db_types::{
         row_ext::RowExt,
-        self_hosted_site::{DbSelfHostedSite, SelfHostedSiteColumn},
+        self_hosted_site::{DbSelfHostedSite, SelfHostedSite, SelfHostedSiteColumn},
     },
     repository::QueryExecutor,
 };
@@ -21,8 +21,7 @@ impl SiteRepository {
     pub fn upsert_self_hosted_site(
         &self,
         executor: &impl QueryExecutor,
-        url: &str,
-        api_root: &str,
+        site: &SelfHostedSite,
     ) -> Result<(DbSite, DbSelfHostedSite), SqliteDbError> {
         // Upsert into self_hosted_sites and get the rowid
         let sql = format!(
@@ -34,7 +33,7 @@ impl SiteRepository {
 
         let mut stmt = executor.prepare(&sql)?;
         let self_hosted_site_id: RowId = stmt
-            .query_row((url, api_root), |row| row.get(0))
+            .query_row((&site.url, &site.api_root), |row| row.get(0))
             .map_err(SqliteDbError::from)?;
 
         // Insert into sites table
@@ -59,8 +58,8 @@ impl SiteRepository {
 
         let db_self_hosted_site = DbSelfHostedSite {
             row_id: self_hosted_site_id,
-            url: url.to_string(),
-            api_root: api_root.to_string(),
+            url: site.url.clone(),
+            api_root: site.api_root.clone(),
         };
 
         Ok((db_site, db_self_hosted_site))

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -236,8 +236,9 @@ mod tests {
 
     #[fixture]
     fn test_conn() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        let mut migration_manager = MigrationManager::new(&conn).unwrap();
+        let conn = Connection::open_in_memory().expect("Failed to open in-memory database");
+        let mut migration_manager =
+            MigrationManager::new(&conn).expect("Failed to create MigrationManager");
         migration_manager
             .perform_migrations()
             .expect("All migrations should succeed");
@@ -338,7 +339,9 @@ mod tests {
         assert_eq!(db_site2.row_id, db_site3.row_id);
 
         // Verify only one entry exists in sites table (ensures bug fix works)
-        let count = repo.count_all_db_sites(&test_conn).unwrap();
+        let count = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites");
         assert_eq!(
             count, 1,
             "Multiple upserts should not create duplicate sites table entries"
@@ -453,8 +456,12 @@ mod tests {
             api_root: "https://example2.com/wp-json".to_string(),
         };
 
-        let (db_site1, _) = repo.upsert_self_hosted_site(&test_conn, &site1).unwrap();
-        let (db_site2, _) = repo.upsert_self_hosted_site(&test_conn, &site2).unwrap();
+        let (db_site1, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site1)
+            .expect("Failed to upsert site1");
+        let (db_site2, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site2)
+            .expect("Failed to upsert site2");
 
         // Verify different sites get different IDs
         assert_ne!(db_site1.row_id, db_site2.row_id);
@@ -462,10 +469,10 @@ mod tests {
         // Verify both can be retrieved by URL
         let retrieved1 = repo
             .select_self_hosted_site_by_url(&test_conn, &site1.url)
-            .unwrap();
+            .expect("Failed to select site by URL");
         let retrieved2 = repo
             .select_self_hosted_site_by_url(&test_conn, &site2.url)
-            .unwrap();
+            .expect("Failed to select site by URL");
 
         assert!(retrieved1.is_some());
         assert!(retrieved2.is_some());
@@ -485,18 +492,28 @@ mod tests {
             .expect("Failed to upsert site");
 
         // Verify site exists in both tables
-        let count_sites = repo.count_all_db_sites(&test_conn).unwrap();
-        let count_self_hosted = repo.count_all_self_hosted_sites(&test_conn).unwrap();
+        let count_sites = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites");
+        let count_self_hosted = repo
+            .count_all_self_hosted_sites(&test_conn)
+            .expect("Failed to count self_hosted_sites");
         assert_eq!(count_sites, 1);
         assert_eq!(count_self_hosted, 1);
 
         // Delete site
-        let deleted = repo.delete_site(&test_conn, &db_site).unwrap();
+        let deleted = repo
+            .delete_site(&test_conn, &db_site)
+            .expect("Failed to delete site");
         assert!(deleted, "Should return true when site is deleted");
 
         // Verify site is removed from both tables
-        let count_sites_after = repo.count_all_db_sites(&test_conn).unwrap();
-        let count_self_hosted_after = repo.count_all_self_hosted_sites(&test_conn).unwrap();
+        let count_sites_after = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites after delete");
+        let count_self_hosted_after = repo
+            .count_all_self_hosted_sites(&test_conn)
+            .expect("Failed to count self_hosted_sites after delete");
         assert_eq!(
             count_sites_after, 0,
             "Site should be deleted from sites table"
@@ -517,7 +534,9 @@ mod tests {
             mapped_site_id: RowId(888),
         };
 
-        let deleted = repo.delete_site(&test_conn, &non_existent_site).unwrap();
+        let deleted = repo
+            .delete_site(&test_conn, &non_existent_site)
+            .expect("Failed to delete site");
         assert!(!deleted, "Should return false when site doesn't exist");
     }
 
@@ -535,25 +554,34 @@ mod tests {
             api_root: "https://example2.com/wp-json".to_string(),
         };
 
-        let (db_site1, _) = repo.upsert_self_hosted_site(&test_conn, &site1).unwrap();
-        let (db_site2, _) = repo.upsert_self_hosted_site(&test_conn, &site2).unwrap();
+        let (db_site1, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site1)
+            .expect("Failed to upsert site1");
+        let (db_site2, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site2)
+            .expect("Failed to upsert site2");
 
         // Delete site1
-        let deleted = repo.delete_site(&test_conn, &db_site1).unwrap();
+        let deleted = repo
+            .delete_site(&test_conn, &db_site1)
+            .expect("Failed to delete site1");
         assert!(deleted);
 
         // Verify site1 is gone
         let retrieved1 = repo
             .select_self_hosted_site_by_url(&test_conn, &site1.url)
-            .unwrap();
+            .expect("Failed to select site by URL");
         assert_eq!(retrieved1, None, "Site1 should be deleted");
 
         // Verify site2 still exists
         let retrieved2 = repo
             .select_self_hosted_site_by_url(&test_conn, &site2.url)
-            .unwrap();
+            .expect("Failed to select site by URL");
         assert!(retrieved2.is_some(), "Site2 should still exist");
-        assert_eq!(retrieved2.unwrap().0.row_id, db_site2.row_id);
+        assert_eq!(
+            retrieved2.expect("Site2 should exist").0.row_id,
+            db_site2.row_id
+        );
     }
 
     #[rstest]
@@ -572,19 +600,19 @@ mod tests {
         // Verify site exists
         let before_delete = repo
             .select_self_hosted_site_by_url(&test_conn, url)
-            .unwrap();
+            .expect("Failed to select site by URL");
         assert!(before_delete.is_some());
 
         // Delete by URL
         let deleted = repo
             .delete_self_hosted_site_by_url(&test_conn, url)
-            .unwrap();
+            .expect("Failed to delete site by URL");
         assert!(deleted, "Should return true when site is deleted");
 
         // Verify site is gone
         let after_delete = repo
             .select_self_hosted_site_by_url(&test_conn, url)
-            .unwrap();
+            .expect("Failed to select site by URL");
         assert_eq!(after_delete, None, "Site should be deleted");
     }
 
@@ -594,7 +622,7 @@ mod tests {
 
         let deleted = repo
             .delete_self_hosted_site_by_url(&test_conn, "https://non-existent.com")
-            .unwrap();
+            .expect("Failed to delete site by URL");
         assert!(!deleted, "Should return false when site doesn't exist");
     }
 }

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -148,4 +148,280 @@ impl SiteRepository {
 
         Ok(db_site.map(|site| (site, self_hosted_site)))
     }
+
+    /// Count all sites in the database.
+    ///
+    /// This is primarily useful for testing to verify database state.
+    pub fn count_all_sites(&self, executor: &impl QueryExecutor) -> Result<usize, SqliteDbError> {
+        let sql = format!("SELECT COUNT(*) FROM {}", Self::SITES_TABLE);
+        let mut stmt = executor.prepare(&sql)?;
+        let count: i64 = stmt.query_row([], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::get_table_column_names;
+    use crate::{MigrationManager, db_types::row_ext::ColumnIndex};
+    use rstest::*;
+    use rusqlite::Connection;
+
+    #[fixture]
+    fn test_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut migration_manager = MigrationManager::new(&conn).unwrap();
+        migration_manager
+            .perform_migrations()
+            .expect("All migrations should succeed");
+        conn
+    }
+
+    /// Verify that SelfHostedSiteColumn enum values match the actual database schema.
+    /// This test protects against column reordering in migrations breaking the positional index mapping.
+    #[rstest]
+    fn test_self_hosted_site_column_enum_matches_schema(test_conn: Connection) {
+        use SelfHostedSiteColumn::*;
+
+        let columns = get_table_column_names(&test_conn, "self_hosted_sites");
+
+        // Verify each enum value maps to the correct column name
+        assert_eq!(columns[Rowid.as_index()], "rowid");
+        assert_eq!(columns[Url.as_index()], "url");
+        assert_eq!(columns[ApiRoot.as_index()], "api_root");
+
+        // Verify total column count matches
+        assert_eq!(columns.len(), ApiRoot.as_index() + 1);
+    }
+
+    #[rstest]
+    fn test_upsert_inserts_new_site(test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        let (db_site, db_self_hosted_site) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Verify self_hosted_sites entry
+        assert_eq!(db_self_hosted_site.url, site.url);
+        assert_eq!(db_self_hosted_site.api_root, site.api_root);
+
+        // Verify sites entry
+        assert_eq!(db_site.site_type, DbSiteType::SelfHosted);
+        assert_eq!(db_site.mapped_site_id, db_self_hosted_site.row_id);
+    }
+
+    #[rstest]
+    fn test_upsert_updates_existing_site_url(test_conn: Connection) {
+        let repo = SiteRepository;
+        let url = "https://example.com";
+
+        // First insert
+        let site1 = SelfHostedSite {
+            url: url.to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+        let (db_site1, db_self_hosted_site1) = repo
+            .upsert_self_hosted_site(&test_conn, &site1)
+            .expect("Failed to upsert site");
+
+        // Second upsert with same URL but different api_root
+        let site2 = SelfHostedSite {
+            url: url.to_string(),
+            api_root: "https://example.com/wordpress/wp-json".to_string(),
+        };
+        let (db_site2, db_self_hosted_site2) = repo
+            .upsert_self_hosted_site(&test_conn, &site2)
+            .expect("Failed to upsert site");
+
+        // Verify it updated the same row (same rowid) - this proves update, not insert
+        assert_eq!(db_self_hosted_site1.row_id, db_self_hosted_site2.row_id);
+        assert_eq!(db_site1.row_id, db_site2.row_id);
+
+        // Verify api_root was updated
+        assert_eq!(db_self_hosted_site2.api_root, site2.api_root);
+    }
+
+    #[rstest]
+    fn test_upsert_does_not_create_duplicate_sites_entries(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        // Insert same site multiple times
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        let (db_site1, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("First upsert failed");
+        let (db_site2, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Second upsert failed");
+        let (db_site3, _) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Third upsert failed");
+
+        // All should return the same DbSite
+        assert_eq!(db_site1.row_id, db_site2.row_id);
+        assert_eq!(db_site2.row_id, db_site3.row_id);
+
+        // Verify only one entry exists in sites table (ensures bug fix works)
+        let count = repo.count_all_sites(&test_conn).unwrap();
+        assert_eq!(
+            count, 1,
+            "Multiple upserts should not create duplicate sites table entries"
+        );
+    }
+
+    #[rstest]
+    fn test_select_self_hosted_site_by_db_site(test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        let (db_site, original_db_self_hosted_site) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Select using DbSite reference
+        let retrieved = repo
+            .select_self_hosted_site(&test_conn, &db_site)
+            .expect("Failed to select site")
+            .expect("Site should exist");
+
+        assert_eq!(retrieved.row_id, original_db_self_hosted_site.row_id);
+        assert_eq!(retrieved.url, original_db_self_hosted_site.url);
+        assert_eq!(retrieved.api_root, original_db_self_hosted_site.api_root);
+    }
+
+    #[rstest]
+    fn test_select_self_hosted_site_returns_none_for_wrong_site_type(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        // Create a DbSite with WordPressCom type (not inserted, just for testing)
+        let non_self_hosted_site = DbSite {
+            row_id: RowId(999),
+            site_type: DbSiteType::WordPressCom,
+            mapped_site_id: RowId(999),
+        };
+
+        let result = repo
+            .select_self_hosted_site(&test_conn, &non_self_hosted_site)
+            .expect("Query should succeed");
+
+        assert_eq!(
+            result, None,
+            "Should return None for non-SelfHosted site type"
+        );
+    }
+
+    #[rstest]
+    fn test_select_self_hosted_site_returns_none_for_non_existent_site(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let non_existent_site = DbSite {
+            row_id: RowId(999),
+            site_type: DbSiteType::SelfHosted,
+            mapped_site_id: RowId(999),
+        };
+
+        let result = repo
+            .select_self_hosted_site(&test_conn, &non_existent_site)
+            .expect("Query should succeed");
+
+        assert_eq!(result, None, "Should return None for non-existent site");
+    }
+
+    #[rstest]
+    fn test_select_self_hosted_site_by_url(test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        let (original_db_site, original_db_self_hosted_site) = repo
+            .upsert_self_hosted_site(&test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Select by URL
+        let (retrieved_db_site, retrieved_db_self_hosted_site) = repo
+            .select_self_hosted_site_by_url(&test_conn, &site.url)
+            .expect("Failed to select site")
+            .expect("Site should exist");
+
+        // Verify DbSite matches
+        assert_eq!(retrieved_db_site.row_id, original_db_site.row_id);
+        assert_eq!(retrieved_db_site.site_type, original_db_site.site_type);
+        assert_eq!(
+            retrieved_db_site.mapped_site_id,
+            original_db_site.mapped_site_id
+        );
+
+        // Verify DbSelfHostedSite matches
+        assert_eq!(
+            retrieved_db_self_hosted_site.row_id,
+            original_db_self_hosted_site.row_id
+        );
+        assert_eq!(
+            retrieved_db_self_hosted_site.url,
+            original_db_self_hosted_site.url
+        );
+        assert_eq!(
+            retrieved_db_self_hosted_site.api_root,
+            original_db_self_hosted_site.api_root
+        );
+    }
+
+    #[rstest]
+    fn test_select_self_hosted_site_by_url_returns_none_for_non_existent_url(
+        test_conn: Connection,
+    ) {
+        let repo = SiteRepository;
+
+        let result = repo
+            .select_self_hosted_site_by_url(&test_conn, "https://non-existent.com")
+            .expect("Query should succeed");
+
+        assert_eq!(result, None, "Should return None for non-existent URL");
+    }
+
+    #[rstest]
+    fn test_multiple_different_sites_can_coexist(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let site1 = SelfHostedSite {
+            url: "https://example1.com".to_string(),
+            api_root: "https://example1.com/wp-json".to_string(),
+        };
+        let site2 = SelfHostedSite {
+            url: "https://example2.com".to_string(),
+            api_root: "https://example2.com/wp-json".to_string(),
+        };
+
+        let (db_site1, _) = repo.upsert_self_hosted_site(&test_conn, &site1).unwrap();
+        let (db_site2, _) = repo.upsert_self_hosted_site(&test_conn, &site2).unwrap();
+
+        // Verify different sites get different IDs
+        assert_ne!(db_site1.row_id, db_site2.row_id);
+
+        // Verify both can be retrieved by URL
+        let retrieved1 = repo
+            .select_self_hosted_site_by_url(&test_conn, &site1.url)
+            .unwrap();
+        let retrieved2 = repo
+            .select_self_hosted_site_by_url(&test_conn, &site2.url)
+            .unwrap();
+
+        assert!(retrieved1.is_some());
+        assert!(retrieved2.is_some());
+    }
 }

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -36,9 +36,12 @@ impl SiteRepository {
             .query_row((&site.url, &site.api_root), |row| row.get(0))
             .map_err(SqliteDbError::from)?;
 
-        // Insert into sites table
+        // Upsert into sites table
+        // If site_type + mapped_site_id already exists, reuse that entry
         let sql = format!(
             "INSERT INTO {} (site_type, mapped_site_id) VALUES (?, ?)
+             ON CONFLICT(site_type, mapped_site_id) DO UPDATE SET
+                site_type = excluded.site_type
              RETURNING rowid",
             Self::SITES_TABLE
         );

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -13,7 +13,7 @@ pub struct SiteRepository;
 
 impl SiteRepository {
     const SELF_HOSTED_SITES_TABLE: &'static str = "self_hosted_sites";
-    const SITES_TABLE: &'static str = "sites";
+    const DB_SITES_TABLE: &'static str = "db_sites";
 
     /// Upsert a self-hosted site and return both the DbSite and DbSelfHostedSite.
     ///
@@ -44,7 +44,7 @@ impl SiteRepository {
              ON CONFLICT(site_type, mapped_site_id) DO UPDATE SET
                 site_type = excluded.site_type
              RETURNING rowid",
-            Self::SITES_TABLE
+            Self::DB_SITES_TABLE
         );
 
         let mut stmt = executor.prepare(&sql)?;
@@ -132,7 +132,7 @@ impl SiteRepository {
         let sql = format!(
             "SELECT rowid, site_type, mapped_site_id FROM {}
              WHERE site_type = ? AND mapped_site_id = ?",
-            Self::SITES_TABLE
+            Self::DB_SITES_TABLE
         );
         let mut stmt = executor.prepare(&sql)?;
 
@@ -153,8 +153,11 @@ impl SiteRepository {
     /// Count all sites in the database.
     ///
     /// This is primarily useful for testing to verify database state.
-    pub fn count_all_sites(&self, executor: &impl QueryExecutor) -> Result<usize, SqliteDbError> {
-        let sql = format!("SELECT COUNT(*) FROM {}", Self::SITES_TABLE);
+    pub fn count_all_db_sites(
+        &self,
+        executor: &impl QueryExecutor,
+    ) -> Result<usize, SqliteDbError> {
+        let sql = format!("SELECT COUNT(*) FROM {}", Self::DB_SITES_TABLE);
         let mut stmt = executor.prepare(&sql)?;
         let count: i64 = stmt.query_row([], |row| row.get(0))?;
         Ok(count as usize)
@@ -200,7 +203,7 @@ impl SiteRepository {
         };
 
         // Delete from sites table
-        let sql = format!("DELETE FROM {} WHERE rowid = ?", Self::SITES_TABLE);
+        let sql = format!("DELETE FROM {} WHERE rowid = ?", Self::DB_SITES_TABLE);
         let sites_deleted = executor.execute(&sql, [site.row_id])?;
 
         Ok(sites_deleted > 0)
@@ -335,7 +338,7 @@ mod tests {
         assert_eq!(db_site2.row_id, db_site3.row_id);
 
         // Verify only one entry exists in sites table (ensures bug fix works)
-        let count = repo.count_all_sites(&test_conn).unwrap();
+        let count = repo.count_all_db_sites(&test_conn).unwrap();
         assert_eq!(
             count, 1,
             "Multiple upserts should not create duplicate sites table entries"
@@ -502,7 +505,7 @@ mod tests {
             .expect("Failed to upsert site");
 
         // Verify site exists in both tables
-        let count_sites = repo.count_all_sites(&test_conn).unwrap();
+        let count_sites = repo.count_all_db_sites(&test_conn).unwrap();
         let count_self_hosted = repo.count_all_self_hosted_sites(&test_conn).unwrap();
         assert_eq!(count_sites, 1);
         assert_eq!(count_self_hosted, 1);
@@ -512,7 +515,7 @@ mod tests {
         assert!(deleted, "Should return true when site is deleted");
 
         // Verify site is removed from both tables
-        let count_sites_after = repo.count_all_sites(&test_conn).unwrap();
+        let count_sites_after = repo.count_all_db_sites(&test_conn).unwrap();
         let count_self_hosted_after = repo.count_all_self_hosted_sites(&test_conn).unwrap();
         assert_eq!(
             count_sites_after, 0,

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -1,0 +1,149 @@
+use crate::{
+    DbSite, DbSiteType, RowId, SqliteDbError,
+    db_types::{
+        row_ext::RowExt,
+        self_hosted_site::{DbSelfHostedSite, SelfHostedSiteColumn},
+    },
+    repository::QueryExecutor,
+};
+use rusqlite::OptionalExtension;
+
+pub struct SiteRepository;
+
+impl SiteRepository {
+    const SELF_HOSTED_SITES_TABLE: &'static str = "self_hosted_sites";
+    const SITES_TABLE: &'static str = "sites";
+
+    /// Upsert a self-hosted site and return both the DbSite and DbSelfHostedSite.
+    ///
+    /// If a site with the given URL already exists, updates it. Otherwise creates a new one.
+    /// Uses SQLite's RETURNING clause to get the inserted/updated rowid.
+    pub fn upsert_self_hosted_site(
+        &self,
+        executor: &impl QueryExecutor,
+        url: &str,
+        api_root: &str,
+    ) -> Result<(DbSite, DbSelfHostedSite), SqliteDbError> {
+        // Upsert into self_hosted_sites and get the rowid
+        let sql = format!(
+            "INSERT INTO {} (url, api_root) VALUES (?, ?)
+             ON CONFLICT(url) DO UPDATE SET api_root = excluded.api_root
+             RETURNING rowid",
+            Self::SELF_HOSTED_SITES_TABLE
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let self_hosted_site_id: RowId = stmt
+            .query_row((url, api_root), |row| row.get(0))
+            .map_err(SqliteDbError::from)?;
+
+        // Insert into sites table
+        let sql = format!(
+            "INSERT INTO {} (site_type, mapped_site_id) VALUES (?, ?)
+             RETURNING rowid",
+            Self::SITES_TABLE
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let site_id: RowId = stmt
+            .query_row((DbSiteType::SelfHosted, self_hosted_site_id), |row| {
+                row.get(0)
+            })
+            .map_err(SqliteDbError::from)?;
+
+        let db_site = DbSite {
+            row_id: site_id,
+            site_type: DbSiteType::SelfHosted,
+            mapped_site_id: self_hosted_site_id,
+        };
+
+        let db_self_hosted_site = DbSelfHostedSite {
+            row_id: self_hosted_site_id,
+            url: url.to_string(),
+            api_root: api_root.to_string(),
+        };
+
+        Ok((db_site, db_self_hosted_site))
+    }
+
+    /// Select a self-hosted site by its DbSite reference.
+    ///
+    /// Returns None if the site doesn't exist or isn't a self-hosted site.
+    pub fn select_self_hosted_site(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+    ) -> Result<Option<DbSelfHostedSite>, SqliteDbError> {
+        if site.site_type != DbSiteType::SelfHosted {
+            return Ok(None);
+        }
+
+        let sql = format!(
+            "SELECT * FROM {} WHERE rowid = ?",
+            Self::SELF_HOSTED_SITES_TABLE
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        stmt.query_row([site.mapped_site_id], |row| {
+            Ok(DbSelfHostedSite {
+                row_id: row.get_column(SelfHostedSiteColumn::Rowid)?,
+                url: row.get_column(SelfHostedSiteColumn::Url)?,
+                api_root: row.get_column(SelfHostedSiteColumn::ApiRoot)?,
+            })
+        })
+        .optional()
+        .map_err(SqliteDbError::from)
+    }
+
+    /// Select a self-hosted site by URL.
+    ///
+    /// Returns both the DbSite and DbSelfHostedSite if found.
+    pub fn select_self_hosted_site_by_url(
+        &self,
+        executor: &impl QueryExecutor,
+        url: &str,
+    ) -> Result<Option<(DbSite, DbSelfHostedSite)>, SqliteDbError> {
+        // First get the self_hosted_site
+        let sql = format!(
+            "SELECT * FROM {} WHERE url = ?",
+            Self::SELF_HOSTED_SITES_TABLE
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        let self_hosted_site: Option<DbSelfHostedSite> = stmt
+            .query_row([url], |row| {
+                Ok(DbSelfHostedSite {
+                    row_id: row.get_column(SelfHostedSiteColumn::Rowid)?,
+                    url: row.get_column(SelfHostedSiteColumn::Url)?,
+                    api_root: row.get_column(SelfHostedSiteColumn::ApiRoot)?,
+                })
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        let Some(self_hosted_site) = self_hosted_site else {
+            return Ok(None);
+        };
+
+        // Then find the corresponding site
+        let sql = format!(
+            "SELECT rowid, site_type, mapped_site_id FROM {}
+             WHERE site_type = ? AND mapped_site_id = ?",
+            Self::SITES_TABLE
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        let db_site: Option<DbSite> = stmt
+            .query_row((DbSiteType::SelfHosted, self_hosted_site.row_id), |row| {
+                Ok(DbSite {
+                    row_id: row.get(0)?,
+                    site_type: row.get(1)?,
+                    mapped_site_id: row.get(2)?,
+                })
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        Ok(db_site.map(|site| (site, self_hosted_site)))
+    }
+}

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -1,6 +1,7 @@
 use crate::{
-    DbSite, DbSiteType, RowId, SqliteDbError,
+    RowId, SqliteDbError,
     db_types::{
+        db_site::{DbSite, DbSiteType},
         row_ext::RowExt,
         self_hosted_site::{DbSelfHostedSite, DbSelfHostedSiteColumn, SelfHostedSite},
     },

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -5,7 +5,7 @@ use crate::{
         row_ext::RowExt,
         self_hosted_site::{DbSelfHostedSite, DbSelfHostedSiteColumn, SelfHostedSite},
     },
-    repository::QueryExecutor,
+    repository::{QueryExecutor, TransactionManager},
 };
 use rusqlite::OptionalExtension;
 
@@ -15,44 +15,49 @@ impl SiteRepository {
     const SELF_HOSTED_SITES_TABLE: &'static str = "self_hosted_sites";
     const DB_SITES_TABLE: &'static str = "db_sites";
 
-    /// Upsert a self-hosted site and return both the DbSite and DbSelfHostedSite.
+    /// Upsert a self-hosted site and return both the DbSite and DbSelfHostedSite (atomic transaction).
     ///
     /// If a site with the given URL already exists, updates it. Otherwise creates a new one.
     /// Uses SQLite's RETURNING clause to get the inserted/updated rowid.
     pub fn upsert_self_hosted_site(
         &self,
-        executor: &impl QueryExecutor,
+        transaction_manager: &mut impl TransactionManager,
         site: &SelfHostedSite,
     ) -> Result<(DbSite, DbSelfHostedSite), SqliteDbError> {
-        // Upsert into self_hosted_sites and get the rowid
-        let sql = format!(
-            "INSERT INTO {} (url, api_root) VALUES (?, ?)
-             ON CONFLICT(url) DO UPDATE SET api_root = excluded.api_root
-             RETURNING rowid",
-            Self::SELF_HOSTED_SITES_TABLE
-        );
+        let tx = transaction_manager.transaction()?;
 
-        let mut stmt = executor.prepare(&sql)?;
-        let self_hosted_site_id: RowId = stmt
-            .query_row((&site.url, &site.api_root), |row| row.get(0))
-            .map_err(SqliteDbError::from)?;
+        // Upsert into self_hosted_sites and get the rowid
+        let self_hosted_site_id: RowId = {
+            let sql = format!(
+                "INSERT INTO {} (url, api_root) VALUES (?, ?)
+                 ON CONFLICT(url) DO UPDATE SET api_root = excluded.api_root
+                 RETURNING rowid",
+                Self::SELF_HOSTED_SITES_TABLE
+            );
+
+            let mut stmt = tx.prepare(&sql)?;
+            stmt.query_row((&site.url, &site.api_root), |row| row.get(0))
+                .map_err(SqliteDbError::from)?
+        };
 
         // Upsert into sites table
         // If site_type + mapped_site_id already exists, reuse that entry
-        let sql = format!(
-            "INSERT INTO {} (site_type, mapped_site_id) VALUES (?, ?)
-             ON CONFLICT(site_type, mapped_site_id) DO UPDATE SET
-                site_type = excluded.site_type
-             RETURNING rowid",
-            Self::DB_SITES_TABLE
-        );
+        // Note: DO UPDATE SET is required for RETURNING to work on conflict (DO NOTHING returns no rows)
+        let site_id: RowId = {
+            let sql = format!(
+                "INSERT INTO {} (site_type, mapped_site_id) VALUES (?, ?)
+                 ON CONFLICT(site_type, mapped_site_id) DO UPDATE SET
+                    site_type = excluded.site_type
+                 RETURNING rowid",
+                Self::DB_SITES_TABLE
+            );
 
-        let mut stmt = executor.prepare(&sql)?;
-        let site_id: RowId = stmt
-            .query_row((DbSiteType::SelfHosted, self_hosted_site_id), |row| {
+            let mut stmt = tx.prepare(&sql)?;
+            stmt.query_row((DbSiteType::SelfHosted, self_hosted_site_id), |row| {
                 row.get(0)
             })
-            .map_err(SqliteDbError::from)?;
+            .map_err(SqliteDbError::from)?
+        };
 
         let db_site = DbSite {
             row_id: site_id,
@@ -66,6 +71,7 @@ impl SiteRepository {
             api_root: site.api_root.clone(),
         };
 
+        tx.commit().map_err(SqliteDbError::from)?;
         Ok((db_site, db_self_hosted_site))
     }
 
@@ -176,7 +182,7 @@ impl SiteRepository {
         Ok(count as usize)
     }
 
-    /// Delete a site and its type-specific data.
+    /// Delete a site and its type-specific data (atomic transaction).
     ///
     /// Deletes both the site entry and its corresponding type-specific entry
     /// (e.g., from self_hosted_sites or wordpress_com_sites). This ensures proper
@@ -185,17 +191,19 @@ impl SiteRepository {
     /// Returns `true` if a site was deleted, `false` if the site didn't exist.
     pub fn delete_site(
         &self,
-        executor: &impl QueryExecutor,
+        transaction_manager: &mut impl TransactionManager,
         site: &DbSite,
     ) -> Result<bool, SqliteDbError> {
+        let tx = transaction_manager.transaction()?;
+
         // Delete from type-specific table based on site_type
-        let _type_table_deleted = match site.site_type {
+        match site.site_type {
             DbSiteType::SelfHosted => {
                 let sql = format!(
                     "DELETE FROM {} WHERE rowid = ?",
                     Self::SELF_HOSTED_SITES_TABLE
                 );
-                executor.execute(&sql, [site.mapped_site_id])?
+                tx.execute(&sql, [site.mapped_site_id])?;
             }
             DbSiteType::WordPressCom => {
                 panic!("WordPress.com site deletion is not yet implemented")
@@ -203,9 +211,12 @@ impl SiteRepository {
         };
 
         // Delete from sites table
-        let sql = format!("DELETE FROM {} WHERE rowid = ?", Self::DB_SITES_TABLE);
-        let sites_deleted = executor.execute(&sql, [site.row_id])?;
+        let sites_deleted = {
+            let sql = format!("DELETE FROM {} WHERE rowid = ?", Self::DB_SITES_TABLE);
+            tx.execute(&sql, [site.row_id])?
+        };
 
+        tx.commit().map_err(SqliteDbError::from)?;
         Ok(sites_deleted > 0)
     }
 
@@ -214,13 +225,13 @@ impl SiteRepository {
     /// Returns `true` if a site was deleted, `false` if no site with that URL exists.
     pub fn delete_self_hosted_site_by_url(
         &self,
-        executor: &impl QueryExecutor,
+        transaction_manager: &mut impl TransactionManager,
         url: &str,
     ) -> Result<bool, SqliteDbError> {
-        let site_data = self.select_self_hosted_site_by_url(executor, url)?;
+        let site_data = self.select_self_hosted_site_by_url(transaction_manager, url)?;
 
         match site_data {
-            Some((db_site, _)) => self.delete_site(executor, &db_site),
+            Some((db_site, _)) => self.delete_site(transaction_manager, &db_site),
             None => Ok(false),
         }
     }
@@ -263,7 +274,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_upsert_inserts_new_site(test_conn: Connection) {
+    fn test_upsert_inserts_new_site(mut test_conn: Connection) {
         let repo = SiteRepository;
         let site = SelfHostedSite {
             url: "https://example.com".to_string(),
@@ -271,7 +282,7 @@ mod tests {
         };
 
         let (db_site, db_self_hosted_site) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
         // Verify self_hosted_sites entry
@@ -284,7 +295,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_upsert_updates_existing_site_url(test_conn: Connection) {
+    fn test_upsert_updates_existing_site_url(mut test_conn: Connection) {
         let repo = SiteRepository;
         let url = "https://example.com";
 
@@ -294,7 +305,7 @@ mod tests {
             api_root: "https://example.com/wp-json".to_string(),
         };
         let (db_site1, db_self_hosted_site1) = repo
-            .upsert_self_hosted_site(&test_conn, &site1)
+            .upsert_self_hosted_site(&mut test_conn, &site1)
             .expect("Failed to upsert site");
 
         // Second upsert with same URL but different api_root
@@ -303,7 +314,7 @@ mod tests {
             api_root: "https://example.com/wordpress/wp-json".to_string(),
         };
         let (db_site2, db_self_hosted_site2) = repo
-            .upsert_self_hosted_site(&test_conn, &site2)
+            .upsert_self_hosted_site(&mut test_conn, &site2)
             .expect("Failed to upsert site");
 
         // Verify it updated the same row (same rowid) - this proves update, not insert
@@ -315,7 +326,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_upsert_does_not_create_duplicate_sites_entries(test_conn: Connection) {
+    fn test_upsert_does_not_create_duplicate_sites_entries(mut test_conn: Connection) {
         let repo = SiteRepository;
 
         // Insert same site multiple times
@@ -325,13 +336,13 @@ mod tests {
         };
 
         let (db_site1, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("First upsert failed");
         let (db_site2, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Second upsert failed");
         let (db_site3, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Third upsert failed");
 
         // All should return the same DbSite
@@ -349,7 +360,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_select_self_hosted_site_by_db_site(test_conn: Connection) {
+    fn test_select_self_hosted_site_by_db_site(mut test_conn: Connection) {
         let repo = SiteRepository;
         let site = SelfHostedSite {
             url: "https://example.com".to_string(),
@@ -357,7 +368,7 @@ mod tests {
         };
 
         let (db_site, original_db_self_hosted_site) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
         // Select using DbSite reference
@@ -408,7 +419,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_select_self_hosted_site_by_url(test_conn: Connection) {
+    fn test_select_self_hosted_site_by_url(mut test_conn: Connection) {
         let repo = SiteRepository;
         let site = SelfHostedSite {
             url: "https://example.com".to_string(),
@@ -416,7 +427,7 @@ mod tests {
         };
 
         let (original_db_site, original_db_self_hosted_site) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
         // Select by URL
@@ -444,7 +455,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_multiple_different_sites_can_coexist(test_conn: Connection) {
+    fn test_multiple_different_sites_can_coexist(mut test_conn: Connection) {
         let repo = SiteRepository;
 
         let site1 = SelfHostedSite {
@@ -457,10 +468,10 @@ mod tests {
         };
 
         let (db_site1, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site1)
+            .upsert_self_hosted_site(&mut test_conn, &site1)
             .expect("Failed to upsert site1");
         let (db_site2, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site2)
+            .upsert_self_hosted_site(&mut test_conn, &site2)
             .expect("Failed to upsert site2");
 
         // Verify different sites get different IDs
@@ -479,7 +490,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_delete_site_removes_both_tables(test_conn: Connection) {
+    fn test_delete_site_removes_both_tables(mut test_conn: Connection) {
         let repo = SiteRepository;
         let site = SelfHostedSite {
             url: "https://example.com".to_string(),
@@ -488,7 +499,7 @@ mod tests {
 
         // Create site
         let (db_site, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site)
+            .upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
         // Verify site exists in both tables
@@ -503,7 +514,7 @@ mod tests {
 
         // Delete site
         let deleted = repo
-            .delete_site(&test_conn, &db_site)
+            .delete_site(&mut test_conn, &db_site)
             .expect("Failed to delete site");
         assert!(deleted, "Should return true when site is deleted");
 
@@ -525,7 +536,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_delete_site_returns_false_for_non_existent_site(test_conn: Connection) {
+    fn test_delete_site_returns_false_for_non_existent_site(mut test_conn: Connection) {
         let repo = SiteRepository;
 
         let non_existent_site = DbSite {
@@ -535,13 +546,13 @@ mod tests {
         };
 
         let deleted = repo
-            .delete_site(&test_conn, &non_existent_site)
+            .delete_site(&mut test_conn, &non_existent_site)
             .expect("Failed to delete site");
         assert!(!deleted, "Should return false when site doesn't exist");
     }
 
     #[rstest]
-    fn test_delete_site_only_deletes_specified_site(test_conn: Connection) {
+    fn test_delete_site_only_deletes_specified_site(mut test_conn: Connection) {
         let repo = SiteRepository;
 
         // Create two sites
@@ -555,15 +566,15 @@ mod tests {
         };
 
         let (db_site1, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site1)
+            .upsert_self_hosted_site(&mut test_conn, &site1)
             .expect("Failed to upsert site1");
         let (db_site2, _) = repo
-            .upsert_self_hosted_site(&test_conn, &site2)
+            .upsert_self_hosted_site(&mut test_conn, &site2)
             .expect("Failed to upsert site2");
 
         // Delete site1
         let deleted = repo
-            .delete_site(&test_conn, &db_site1)
+            .delete_site(&mut test_conn, &db_site1)
             .expect("Failed to delete site1");
         assert!(deleted);
 
@@ -585,7 +596,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_delete_self_hosted_site_by_url_deletes_site(test_conn: Connection) {
+    fn test_delete_self_hosted_site_by_url_deletes_site(mut test_conn: Connection) {
         let repo = SiteRepository;
         let url = "https://example.com";
         let site = SelfHostedSite {
@@ -594,7 +605,7 @@ mod tests {
         };
 
         // Create site
-        repo.upsert_self_hosted_site(&test_conn, &site)
+        repo.upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
         // Verify site exists
@@ -605,7 +616,7 @@ mod tests {
 
         // Delete by URL
         let deleted = repo
-            .delete_self_hosted_site_by_url(&test_conn, url)
+            .delete_self_hosted_site_by_url(&mut test_conn, url)
             .expect("Failed to delete site by URL");
         assert!(deleted, "Should return true when site is deleted");
 
@@ -617,11 +628,13 @@ mod tests {
     }
 
     #[rstest]
-    fn test_delete_self_hosted_site_by_url_returns_false_for_non_existent(test_conn: Connection) {
+    fn test_delete_self_hosted_site_by_url_returns_false_for_non_existent(
+        mut test_conn: Connection,
+    ) {
         let repo = SiteRepository;
 
         let deleted = repo
-            .delete_self_hosted_site_by_url(&test_conn, "https://non-existent.com")
+            .delete_self_hosted_site_by_url(&mut test_conn, "https://non-existent.com")
             .expect("Failed to delete site by URL");
         assert!(!deleted, "Should return false when site doesn't exist");
     }

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -2,7 +2,7 @@ use crate::{
     DbSite, DbSiteType, RowId, SqliteDbError,
     db_types::{
         row_ext::RowExt,
-        self_hosted_site::{DbSelfHostedSite, SelfHostedSite, SelfHostedSiteColumn},
+        self_hosted_site::{DbSelfHostedSite, DbSelfHostedSiteColumn, SelfHostedSite},
     },
     repository::QueryExecutor,
 };
@@ -88,9 +88,9 @@ impl SiteRepository {
 
         stmt.query_row([site.mapped_site_id], |row| {
             Ok(DbSelfHostedSite {
-                row_id: row.get_column(SelfHostedSiteColumn::Rowid)?,
-                url: row.get_column(SelfHostedSiteColumn::Url)?,
-                api_root: row.get_column(SelfHostedSiteColumn::ApiRoot)?,
+                row_id: row.get_column(DbSelfHostedSiteColumn::Rowid)?,
+                url: row.get_column(DbSelfHostedSiteColumn::Url)?,
+                api_root: row.get_column(DbSelfHostedSiteColumn::ApiRoot)?,
             })
         })
         .optional()
@@ -115,9 +115,9 @@ impl SiteRepository {
         let self_hosted_site: Option<DbSelfHostedSite> = stmt
             .query_row([url], |row| {
                 Ok(DbSelfHostedSite {
-                    row_id: row.get_column(SelfHostedSiteColumn::Rowid)?,
-                    url: row.get_column(SelfHostedSiteColumn::Url)?,
-                    api_root: row.get_column(SelfHostedSiteColumn::ApiRoot)?,
+                    row_id: row.get_column(DbSelfHostedSiteColumn::Rowid)?,
+                    url: row.get_column(DbSelfHostedSiteColumn::Url)?,
+                    api_root: row.get_column(DbSelfHostedSiteColumn::ApiRoot)?,
                 })
             })
             .optional()
@@ -178,11 +178,11 @@ mod tests {
         conn
     }
 
-    /// Verify that SelfHostedSiteColumn enum values match the actual database schema.
+    /// Verify that DbSelfHostedSiteColumn enum values match the actual database schema.
     /// This test protects against column reordering in migrations breaking the positional index mapping.
     #[rstest]
     fn test_self_hosted_site_column_enum_matches_schema(test_conn: Connection) {
-        use SelfHostedSiteColumn::*;
+        use DbSelfHostedSiteColumn::*;
 
         let columns = get_table_column_names(&test_conn, "self_hosted_sites");
 

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -363,9 +363,7 @@ mod tests {
             .expect("Failed to select site")
             .expect("Site should exist");
 
-        assert_eq!(retrieved.row_id, original_db_self_hosted_site.row_id);
-        assert_eq!(retrieved.url, original_db_self_hosted_site.url);
-        assert_eq!(retrieved.api_root, original_db_self_hosted_site.api_root);
+        assert_eq!(retrieved, original_db_self_hosted_site);
     }
 
     #[rstest]
@@ -424,27 +422,9 @@ mod tests {
             .expect("Failed to select site")
             .expect("Site should exist");
 
-        // Verify DbSite matches
-        assert_eq!(retrieved_db_site.row_id, original_db_site.row_id);
-        assert_eq!(retrieved_db_site.site_type, original_db_site.site_type);
-        assert_eq!(
-            retrieved_db_site.mapped_site_id,
-            original_db_site.mapped_site_id
-        );
-
-        // Verify DbSelfHostedSite matches
-        assert_eq!(
-            retrieved_db_self_hosted_site.row_id,
-            original_db_self_hosted_site.row_id
-        );
-        assert_eq!(
-            retrieved_db_self_hosted_site.url,
-            original_db_self_hosted_site.url
-        );
-        assert_eq!(
-            retrieved_db_self_hosted_site.api_root,
-            original_db_self_hosted_site.api_root
-        );
+        // Verify both structs match
+        assert_eq!(retrieved_db_site, original_db_site);
+        assert_eq!(retrieved_db_self_hosted_site, original_db_self_hosted_site);
     }
 
     #[rstest]

--- a/wp_mobile_cache/src/repository/term_relationships.rs
+++ b/wp_mobile_cache/src/repository/term_relationships.rs
@@ -1,5 +1,6 @@
 use crate::{
-    DbSite, SqliteDbError,
+    SqliteDbError,
+    db_types::db_site::DbSite,
     repository::{InTransaction, QueryExecutor},
     term_relationships::DbTermRelationship,
 };

--- a/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
@@ -8,7 +8,7 @@ use wp_api::{taxonomies::TaxonomyType, terms::TermId};
 
 #[rstest]
 fn test_term_relationships_isolated_by_site(mut test_ctx: TestContext) {
-    let site2 = create_random_test_site(&test_ctx.conn);
+    let site2 = create_random_test_site(&mut test_ctx.conn);
 
     // Insert post in site 1 with categories
     let post1 = PostBuilder::minimal()

--- a/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
@@ -2,13 +2,22 @@
 //!
 //! These tests verify that term relationships are correctly isolated between sites.
 
-use crate::test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx};
+use crate::{
+    db_types::self_hosted_site::SelfHostedSite,
+    test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx},
+};
 use rstest::*;
 use wp_api::{taxonomies::TaxonomyType, terms::TermId};
 
 #[rstest]
 fn test_term_relationships_isolated_by_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(&test_ctx.conn, 2);
+    let site2 = create_test_site(
+        &test_ctx.conn,
+        &SelfHostedSite {
+            url: "https://example-2.com".to_string(),
+            api_root: "https://example-2.com/wp-json".to_string(),
+        },
+    );
 
     // Insert post in site 1 with categories
     let post1 = PostBuilder::minimal()

--- a/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/term_relationships_multi_site_tests.rs
@@ -2,22 +2,13 @@
 //!
 //! These tests verify that term relationships are correctly isolated between sites.
 
-use crate::{
-    db_types::self_hosted_site::SelfHostedSite,
-    test_fixtures::{TestContext, create_test_site, posts::PostBuilder, test_ctx},
-};
+use crate::test_fixtures::{TestContext, create_random_test_site, posts::PostBuilder, test_ctx};
 use rstest::*;
 use wp_api::{taxonomies::TaxonomyType, terms::TermId};
 
 #[rstest]
 fn test_term_relationships_isolated_by_site(mut test_ctx: TestContext) {
-    let site2 = create_test_site(
-        &test_ctx.conn,
-        &SelfHostedSite {
-            url: "https://example-2.com".to_string(),
-            api_root: "https://example-2.com/wp-json".to_string(),
-        },
-    );
+    let site2 = create_random_test_site(&test_ctx.conn);
 
     // Insert post in site 1 with categories
     let post1 = PostBuilder::minimal()

--- a/wp_mobile_cache/src/term_relationships.rs
+++ b/wp_mobile_cache/src/term_relationships.rs
@@ -1,4 +1,4 @@
-use crate::{DbSite, RowId};
+use crate::RowId;
 use wp_api::taxonomies::TaxonomyType;
 use wp_api::terms::TermId;
 
@@ -10,8 +10,8 @@ use wp_api::terms::TermId;
 pub struct DbTermRelationship {
     /// SQLite rowid of this relationship
     pub row_id: RowId,
-    /// Site this relationship belongs to
-    pub site: DbSite,
+    /// Database site ID (rowid from sites table) this relationship belongs to
+    pub db_site_id: RowId,
     /// Row ID of the object (post, page, etc.) in its respective table
     pub object_id: RowId,
     /// WordPress term ID

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -33,7 +33,11 @@ pub struct TestContext {
 pub fn test_ctx() -> TestContext {
     TestContext {
         conn: test_db(),
-        site: DbSite { row_id: RowId(1) },
+        site: DbSite {
+            row_id: RowId(1),
+            site_type: crate::DbSiteType::SelfHosted,
+            mapped_site_id: RowId(1),
+        },
         post_repo: PostRepository::new(),
         term_repo: TermRelationshipRepository,
     }
@@ -62,6 +66,8 @@ pub fn create_test_site(conn: &Connection, id: i64) -> DbSite {
         .expect("Failed to create test site");
     DbSite {
         row_id: RowId(id as u64),
+        site_type: crate::DbSiteType::SelfHosted,
+        mapped_site_id: RowId(id as u64),
     }
 }
 

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -23,7 +23,7 @@ pub mod posts;
 ///
 /// ```rust
 /// #[rstest]
-/// fn test_something(test_ctx: TestContext) {
+/// fn test_something(mut test_ctx: TestContext) {
 ///     let post = PostBuilder::new().build();
 ///     test_ctx.post_repo.upsert(&mut test_ctx.conn, &test_ctx.site, &post).unwrap();
 /// }
@@ -47,7 +47,7 @@ pub fn test_ctx() -> TestContext {
 }
 
 fn test_db() -> (Connection, DbSite) {
-    let conn = Connection::open_in_memory().unwrap();
+    let mut conn = Connection::open_in_memory().unwrap();
     let mut migration_manager = MigrationManager::new(&conn).unwrap();
 
     migration_manager
@@ -61,7 +61,7 @@ fn test_db() -> (Connection, DbSite) {
         api_root: format!("{}/wp-json", test_creds.site_url),
     };
 
-    let db_site = create_test_site(&conn, &self_hosted_site);
+    let db_site = create_test_site(&mut conn, &self_hosted_site);
 
     (conn, db_site)
 }
@@ -69,7 +69,7 @@ fn test_db() -> (Connection, DbSite) {
 /// Helper to create a test site.
 ///
 /// Uses `SiteRepository` to insert the site into the database.
-pub fn create_test_site(conn: &Connection, site: &SelfHostedSite) -> DbSite {
+pub fn create_test_site(conn: &mut Connection, site: &SelfHostedSite) -> DbSite {
     let site_repo = SiteRepository;
     let (db_site, _) = site_repo
         .upsert_self_hosted_site(conn, site)
@@ -88,11 +88,11 @@ static RANDOM_TEST_SITE_COUNTER: AtomicU32 = AtomicU32::new(1);
 /// # Example
 ///
 /// ```rust
-/// let site1 = create_random_test_site(&conn);
-/// let site2 = create_random_test_site(&conn);
+/// let site1 = create_random_test_site(&mut conn);
+/// let site2 = create_random_test_site(&mut conn);
 /// // site1 and site2 will have different URLs
 /// ```
-pub fn create_random_test_site(conn: &Connection) -> DbSite {
+pub fn create_random_test_site(conn: &mut Connection) -> DbSite {
     let counter = RANDOM_TEST_SITE_COUNTER.fetch_add(1, Ordering::Relaxed);
     let site = SelfHostedSite {
         url: format!("https://test-site-{}.local", counter),

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use integration_test_credentials::TestCredentials;
 use rstest::*;
 use rusqlite::Connection;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 pub mod posts;
 
@@ -75,6 +76,29 @@ pub fn create_test_site(conn: &Connection, site: &SelfHostedSite) -> DbSite {
         .expect("Failed to upsert test site");
 
     db_site
+}
+
+static RANDOM_TEST_SITE_COUNTER: AtomicU32 = AtomicU32::new(1);
+
+/// Helper to create a test site with auto-generated URL.
+///
+/// Uses an internal counter to generate unique URLs for each call.
+/// Useful for tests that need multiple sites but don't care about specific URLs.
+///
+/// # Example
+///
+/// ```rust
+/// let site1 = create_random_test_site(&conn);
+/// let site2 = create_random_test_site(&conn);
+/// // site1 and site2 will have different URLs
+/// ```
+pub fn create_random_test_site(conn: &Connection) -> DbSite {
+    let counter = RANDOM_TEST_SITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let site = SelfHostedSite {
+        url: format!("https://test-site-{}.local", counter),
+        api_root: format!("https://test-site-{}.local/wp-json", counter),
+    };
+    create_test_site(conn, &site)
 }
 
 /// Validates that a timestamp is a recent, valid ISO 8601 UTC timestamp.

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -1,7 +1,7 @@
 use crate::{
-    DbSite, MigrationManager,
+    MigrationManager,
     context::EditContext,
-    db_types::self_hosted_site::SelfHostedSite,
+    db_types::{db_site::DbSite, self_hosted_site::SelfHostedSite},
     repository::{
         posts::PostRepository, sites::SiteRepository,
         term_relationships::TermRelationshipRepository,

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -1,9 +1,14 @@
 use crate::{
-    DbSite, MigrationManager, RowId,
+    DbSite, MigrationManager,
     context::EditContext,
-    repository::{posts::PostRepository, term_relationships::TermRelationshipRepository},
+    db_types::self_hosted_site::SelfHostedSite,
+    repository::{
+        posts::PostRepository, sites::SiteRepository,
+        term_relationships::TermRelationshipRepository,
+    },
 };
 use chrono::{DateTime, Utc};
+use integration_test_credentials::TestCredentials;
 use rstest::*;
 use rusqlite::Connection;
 
@@ -31,19 +36,16 @@ pub struct TestContext {
 
 #[fixture]
 pub fn test_ctx() -> TestContext {
+    let (conn, site) = test_db();
     TestContext {
-        conn: test_db(),
-        site: DbSite {
-            row_id: RowId(1),
-            site_type: crate::DbSiteType::SelfHosted,
-            mapped_site_id: RowId(1),
-        },
+        conn,
+        site,
         post_repo: PostRepository::new(),
         term_repo: TermRelationshipRepository,
     }
 }
 
-fn test_db() -> Connection {
+fn test_db() -> (Connection, DbSite) {
     let conn = Connection::open_in_memory().unwrap();
     let mut migration_manager = MigrationManager::new(&conn).unwrap();
 
@@ -51,51 +53,28 @@ fn test_db() -> Connection {
         .perform_migrations()
         .expect("All migrations should succeed");
 
-    // Insert default test site (id = 1)
-    // First insert into self_hosted_sites
-    conn.execute(
-        "INSERT INTO self_hosted_sites (id, url, api_root) VALUES (1, 'https://example.com', 'https://example.com/wp-json')",
-        []
-    )
-    .expect("Failed to insert self-hosted site");
+    // Insert default test site using real test credentials
+    let test_creds = TestCredentials::instance();
+    let self_hosted_site = SelfHostedSite {
+        url: test_creds.site_url.to_string(),
+        api_root: format!("{}/wp-json", test_creds.site_url),
+    };
 
-    // Then insert into sites referencing the self_hosted_sites entry
-    conn.execute(
-        "INSERT INTO sites (id, site_type, mapped_site_id) VALUES (1, 0, 1)",
-        [],
-    )
-    .expect("Failed to insert test site");
+    let db_site = create_test_site(&conn, &self_hosted_site);
 
-    conn
+    (conn, db_site)
 }
 
-/// Helper to create an additional test site with a specific ID.
+/// Helper to create a test site.
 ///
-/// Useful when you need more than 2 sites or specific site IDs.
-pub fn create_test_site(conn: &Connection, id: i64) -> DbSite {
-    // First insert into self_hosted_sites
-    conn.execute(
-        "INSERT INTO self_hosted_sites (id, url, api_root) VALUES (?, ?, ?)",
-        (
-            id,
-            format!("https://example-{}.com", id),
-            format!("https://example-{}.com/wp-json", id),
-        ),
-    )
-    .expect("Failed to insert self-hosted site");
+/// Uses `SiteRepository` to insert the site into the database.
+pub fn create_test_site(conn: &Connection, site: &SelfHostedSite) -> DbSite {
+    let site_repo = SiteRepository;
+    let (db_site, _) = site_repo
+        .upsert_self_hosted_site(conn, site)
+        .expect("Failed to upsert test site");
 
-    // Then insert into sites
-    conn.execute(
-        "INSERT INTO sites (id, site_type, mapped_site_id) VALUES (?, 0, ?)",
-        (id, id),
-    )
-    .expect("Failed to create test site");
-
-    DbSite {
-        row_id: RowId(id as u64),
-        site_type: crate::DbSiteType::SelfHosted,
-        mapped_site_id: RowId(id as u64),
-    }
+    db_site
 }
 
 /// Validates that a timestamp is a recent, valid ISO 8601 UTC timestamp.

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -52,8 +52,19 @@ fn test_db() -> Connection {
         .expect("All migrations should succeed");
 
     // Insert default test site (id = 1)
-    conn.execute("INSERT INTO sites (id) VALUES (1)", [])
-        .expect("Failed to insert test site");
+    // First insert into self_hosted_sites
+    conn.execute(
+        "INSERT INTO self_hosted_sites (id, url, api_root) VALUES (1, 'https://example.com', 'https://example.com/wp-json')",
+        []
+    )
+    .expect("Failed to insert self-hosted site");
+
+    // Then insert into sites referencing the self_hosted_sites entry
+    conn.execute(
+        "INSERT INTO sites (id, site_type, mapped_site_id) VALUES (1, 0, 1)",
+        [],
+    )
+    .expect("Failed to insert test site");
 
     conn
 }
@@ -62,8 +73,24 @@ fn test_db() -> Connection {
 ///
 /// Useful when you need more than 2 sites or specific site IDs.
 pub fn create_test_site(conn: &Connection, id: i64) -> DbSite {
-    conn.execute("INSERT INTO sites (id) VALUES (?)", [id])
-        .expect("Failed to create test site");
+    // First insert into self_hosted_sites
+    conn.execute(
+        "INSERT INTO self_hosted_sites (id, url, api_root) VALUES (?, ?, ?)",
+        (
+            id,
+            format!("https://example-{}.com", id),
+            format!("https://example-{}.com/wp-json", id),
+        ),
+    )
+    .expect("Failed to insert self-hosted site");
+
+    // Then insert into sites
+    conn.execute(
+        "INSERT INTO sites (id, site_type, mapped_site_id) VALUES (?, 0, ?)",
+        (id, id),
+    )
+    .expect("Failed to create test site");
+
     DbSite {
         row_id: RowId(id as u64),
         site_type: crate::DbSiteType::SelfHosted,


### PR DESCRIPTION
## Overview

Implements a repository pattern for managing WordPress sites in the mobile cache database, supporting both self-hosted and WordPress.com sites through a polymorphic table design.

## Key Additions

### Database Schema

- **Renamed table**: `sites` → `db_sites` for clarity (migrations 0001-0005)
- **New `db_sites` table structure**:
  - `site_type` - Enum discriminator (SelfHosted = 0, WordPressCom = 1)
  - `mapped_site_id` - References type-specific table rows
  - Unique constraint on `(site_type, mapped_site_id)` prevents duplicates
- **New `self_hosted_sites` table**:
  - `url` - Unique site URL
  - `api_root` - WordPress REST API endpoint

### SiteRepository Implementation

**CRUD Operations** (all atomic via transactions):
- `upsert_self_hosted_site()` - Create or update self-hosted site
- `select_self_hosted_site()` - Retrieve by `DbSite` reference
- `select_self_hosted_site_by_url()` - Retrieve by URL
- `delete_site()` - Remove from both tables atomically
- `delete_self_hosted_site_by_url()` - Convenience wrapper

**Design patterns**:
- Two-phase upsert using SQLite `RETURNING` clause for efficient ID retrieval
- Transaction wrappers ensure consistency between polymorphic and type-specific tables
- Manual cleanup in delete operations (FK constraints can't span polymorphic references)

### Type System

- `DbSite` - Database site record with polymorphic reference
- `DbSiteType` - Enum for site type discrimination
- `SelfHostedSite` - Domain model for creating/updating sites
- `DbSelfHostedSite` - Database model including rowid

### Test Infrastructure

- `create_random_test_site()` - Auto-generates unique test sites via atomic counter
- Updated `TestContext` to use real test credentials from `integration_test_credentials` crate
- Comprehensive test coverage (15 tests) including constraint validation, multi-site isolation, and transaction atomicity

## Architecture Rationale

The polymorphic design allows the `db_sites` table to reference different site type tables based on `site_type`, enabling clean separation between self-hosted and WordPress.com site data while maintaining a unified site identifier across the cache system.