### PR TITLE
Add a `.createForCurrentUser` API for creating application passwords

### DIFF
--- a/wp_api/src/request/endpoint/application_passwords_endpoint.rs
+++ b/wp_api/src/request/endpoint/application_passwords_endpoint.rs
@@ -18,6 +18,8 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum ApplicationPasswordsRequest {
     #[post(url = "/users/<user_id>/application-passwords", params = &ApplicationPasswordCreateParams, output = ApplicationPasswordWithEditContext)]
     Create,
+    #[post(url = "/users/me/application-passwords", params = &ApplicationPasswordCreateParams, output = ApplicationPasswordWithEditContext)]
+    CreateForCurrentUser,
     #[delete(url = "/users/<user_id>/application-passwords/<application_password_uuid>", output = ApplicationPasswordDeleteResponse)]
     Delete,
     #[delete(url = "/users/<user_id>/application-passwords", output = ApplicationPasswordDeleteAllResponse)]

--- a/wp_api_integration_tests/tests/test_application_passwords_mut.rs
+++ b/wp_api_integration_tests/tests/test_application_passwords_mut.rs
@@ -44,6 +44,49 @@ async fn create_application_password() {
 
 #[tokio::test]
 #[serial]
+async fn create_application_password_for_current_user() {
+    let client = api_client();
+    let user_id = client
+        .users()
+        .retrieve_me_with_edit_context()
+        .await
+        .assert_response()
+        .data
+        .id;
+    let password_name = "IntegrationTest";
+    // Assert that the application password name doesn't exist
+    assert!(
+        !application_password_meta_for_user(&user_id)
+            .await
+            .unwrap()
+            .meta_value
+            .contains(password_name)
+    );
+
+    // Create an application password using the API
+    let params = ApplicationPasswordCreateParams {
+        app_id: None,
+        name: password_name.to_string(),
+    };
+    let created_application_password = client
+        .application_passwords()
+        .create_for_current_user(&params)
+        .await
+        .assert_response()
+        .data;
+
+    // Assert that the application password is created
+    let user_meta_after_update = application_password_meta_for_user(&user_id).await;
+    assert!(user_meta_after_update.is_some());
+    let meta_value = user_meta_after_update.unwrap().meta_value;
+    assert!(meta_value.contains(password_name));
+    assert!(meta_value.contains(&created_application_password.uuid.uuid));
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn update_application_password() {
     let password_name = "IntegrationTest";
     // Assert that the application password name doesn't exist


### PR DESCRIPTION
What says in the title.