### PR TITLE
Fix exception handling in Kotlin request executor

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -27,6 +27,15 @@ import kotlin.test.assertContains
 class ApiUrlDiscoveryTest {
     private val loginClient: WpLoginClient = WpLoginClient()
 
+    @Test
+    fun testLocalSite() = runTest {
+        assertEquals(
+            "http://localhost/wp-admin/authorize-application.php",
+            loginClient.apiDiscovery("http://localhost")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
+        )
+    }
+
     @Test // Spec Example 1
     fun testValidSiteWorksCorrectly() = runTest {
         assertEquals(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -25,6 +25,7 @@ import uniffi.wp_api.WpNetworkRequest
 import uniffi.wp_api.WpNetworkResponse
 import uniffi.wp_api.parseCertificate
 import java.io.File
+import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
@@ -162,6 +163,18 @@ class WpRequestExecutor(
             throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
         } catch (e: NoRouteToHostException) {
             throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
+        } catch (e: ConnectException) {
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.HttpError(
+                    reason = "Connection failed: ${e.localizedMessage}"
+                )
+            )
+        } catch (e: Exception) {
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.GenericError(
+                    errorMessage = e.localizedMessage ?: e.toString()
+                )
+            )
         }
     }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -131,7 +131,9 @@ class WpRequestExecutor(
         )
     }
 
-    @Suppress("ThrowsCount")
+    // We intentionally catch all exceptions to prevent UniFFI callback crashes.
+    // All exceptions are converted to proper Rust error types rather than being swallowed.
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught", "SwallowedException")
     private fun executeRequestSafely(
         urlRequest: Request,
         requestUrl: String,


### PR DESCRIPTION
## Summary

Fixes exception handling in the Kotlin request executor to prevent `UnexpectedUniFFICallbackError` crashes. The executor now properly catches and maps all network exceptions (including `ConnectException`) to appropriate Rust error types instead of letting them propagate uncaught through the UniFFI callback layer.

## Changes

- Add `ConnectException` handler mapping to `HttpError`
- Add catch-all `Exception` handler mapping to `GenericError`
- Add integration test for localhost API discovery