### PR TITLE
Fix issues with release

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -25,9 +25,8 @@ echo "--- :closed_lock_with_key: Setting up Code Signing"
 bundle exec fastlane set_up_signing_release
 
 echo "--- :rust: Building XCFramework"
-make xcframework-package
+make xcframework-package-sign
 make xcframework-package-checksum
-make xcframework-sign
 
 release_version="$1"
 echo "--- :rocket: Publish release $release_version"

--- a/Makefile
+++ b/Makefile
@@ -136,11 +136,15 @@ xcframework-package: xcframework-all
 	rm -rf target/libwordpressFFI.xcframework.zip
 	ditto -c -k --sequesterRsrc --keepParent target/libwordpressFFI.xcframework/ target/libwordpressFFI.xcframework.zip
 
+xcframework-package-sign: xcframework-all xcframework-sign xcframework-package
+
 xcframework-package-checksum:
-	swift package compute-checksum target/libwordpressFFI.xcframework.zip | tee libwordpressFFI.xcframework.zip.checksum.txt
+	swift package compute-checksum target/libwordpressFFI.xcframework.zip | tee target/libwordpressFFI.xcframework.zip.checksum.txt
 
 xcframework-sign:
 	codesign --timestamp -v --sign "${certificate_name_release}" target/libwordpressFFI.xcframework
+	codesign -dvv target/libwordpressFFI.xcframework
+
 
 docker-image-web:
 	docker build -t wordpress-rs-web -f wp_rs_web/Dockerfile . --progress=plain

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -438,11 +438,11 @@ def xcframework_checksum
 end
 
 def xcframework_checksum_file_path
-  File.join(PROJECT_ROOT, 'libwordpressFFI.xcframework.zip.checksum.txt')
+  File.join(PROJECT_ROOT, 'target', 'libwordpressFFI.xcframework.zip.checksum.txt')
 end
 
 def xcframework_file_path
-  File.join(PROJECT_ROOT, 'libwordpressFFI.xcframework.zip')
+  File.join(PROJECT_ROOT, 'target', 'libwordpressFFI.xcframework.zip')
 end
 
 def xcframework_bindings_file_path


### PR DESCRIPTION
The release at https://buildkite.com/automattic/wordpress-rs/builds/4165/steps/canvas?sid=019aa024-d085-4fb1-8f81-53af3ac9b4de is failing because it can't find the `XCFramework` bundle. This PR should fix it.