### PR TITLE
Kotlin: Add interceptors support to `DefaultHttpClient` and `WpRequestExecutor`

### DIFF
--- a/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
+++ b/native/kotlin/api/android/src/androidTest/kotlin/rs/wordpress/api/android/UsersEndpointAndroidTest.kt
@@ -11,7 +11,7 @@ import java.net.URL
 class UsersEndpointAndroidTest {
     // https://developer.android.com/studio/run/emulator-networking
     private val siteUrl = "http://10.0.2.2"
-    private val client = WpApiClient(URL(siteUrl), WpAuthenticationProvider.none())
+    private val client = WpApiClient(URL(siteUrl), WpAuthenticationProvider.none(), emptyList())
 
     @Test
     fun testUserListRequest() = runTest {

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertContains
 
 @Execution(ExecutionMode.CONCURRENT)
 class ApiUrlDiscoveryTest {
-    private val loginClient: WpLoginClient = WpLoginClient()
+    private val loginClient: WpLoginClient = WpLoginClient(emptyList())
 
     @Test
     fun testLocalSite() = runTest {
@@ -186,7 +186,7 @@ class ApiUrlDiscoveryTest {
         val invalid =
             ApiDiscoveryAuthenticationMiddleware(username = "invalid", password = "invalid")
         val client = WpLoginClient(
-            WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(invalid))
+            WpRequestExecutor(emptyList()), WpApiMiddlewarePipeline(middlewares = listOf(invalid))
         )
         val reason = client.apiDiscovery("https://basic-auth.wpmt.co")
             .assertFailureFindApiRoot().getRequestExecutionErrorReason()
@@ -204,7 +204,7 @@ class ApiUrlDiscoveryTest {
         )
 
         val client = WpLoginClient(
-            WpRequestExecutor(), WpApiMiddlewarePipeline(middlewares = listOf(valid))
+            WpRequestExecutor(emptyList()), WpApiMiddlewarePipeline(middlewares = listOf(valid))
         )
 
         assertEquals(
@@ -283,7 +283,7 @@ class ApiUrlDiscoveryTest {
 
     @Test // Spec Example 17 (with exception)
     fun testInvalidHttpsWithExceptionWorks() = runTest {
-        val httpClient = WpHttpClient.DefaultHttpClient()
+        val httpClient = WpHttpClient.DefaultHttpClient(emptyList())
         val executor = WpRequestExecutor(httpClient)
         httpClient.addAllowedAlternativeNamesForHostname(
             "vanilla.wpmt.co",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/AuthProviderTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/AuthProviderTest.kt
@@ -21,7 +21,7 @@ class AuthProviderTest {
         val authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(
             username = testCredentials.adminUsername, password = testCredentials.adminPassword
         )
-        val client = WpApiClient(testCredentials.apiRootUrl, authProvider)
+        val client = WpApiClient(testCredentials.apiRootUrl, authProvider, emptyList())
 
         val currentUser = client.request { requestBuilder ->
             requestBuilder.users().retrieveMeWithEditContext()
@@ -52,7 +52,7 @@ class AuthProviderTest {
 
         val dynamicAuthProvider = DynamicAuthProvider()
         val authProvider = WpAuthenticationProvider.dynamic(dynamicAuthProvider)
-        val client = WpApiClient(testCredentials.apiRootUrl, authProvider)
+        val client = WpApiClient(testCredentials.apiRootUrl, authProvider, emptyList())
 
         // Assert that initial unauthorized request fails
         assert(client.request { requestBuilder ->
@@ -75,7 +75,7 @@ class AuthProviderTest {
         val modifiableAuthenticationProvider =
             ModifiableAuthenticationProvider(authentication = WpAuthentication.None)
         val authProvider = WpAuthenticationProvider.modifiable(modifiableAuthenticationProvider)
-        val client = WpApiClient(testCredentials.apiRootUrl, authProvider)
+        val client = WpApiClient(testCredentials.apiRootUrl, authProvider, emptyList())
 
         // Assert that request fails without authentication
         assert(client.request { requestBuilder ->

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
@@ -21,7 +21,7 @@ fun defaultApiClient(): WpApiClient {
     val authProvider = WpAuthenticationProvider.staticWithUsernameAndPassword(
         username = testCredentials.adminUsername, password = testCredentials.adminPassword
     )
-    return WpApiClient(testCredentials.apiRootUrl, authProvider)
+    return WpApiClient(testCredentials.apiRootUrl, authProvider, emptyList())
 }
 
 fun <T> WpRequestResult<T>.assertSuccess() {

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -94,6 +94,7 @@ class MediaEndpointTest {
             password = TestCredentials.INSTANCE.adminPassword
         )
         val requestExecutor = WpRequestExecutor(
+            interceptors = emptyList(),
             fileResolver = FileResolverMock(),
             uploadListener = uploadListener
         )
@@ -144,6 +145,7 @@ class MediaEndpointTest {
             username = testCredentials.adminUsername, password = testCredentials.adminPassword
         )
         val requestExecutor = WpRequestExecutor(
+            interceptors = emptyList(),
             fileResolver = FileResolverMock()
         )
         return WpApiClient(

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PluginsEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PluginsEndpointTest.kt
@@ -20,14 +20,16 @@ class PluginsEndpointTest {
         testCredentials.apiRootUrl, WpAuthenticationProvider.staticWithUsernameAndPassword(
             username = testCredentials.adminUsername,
             password = testCredentials.adminPassword
-        )
+        ),
+        emptyList()
     )
     private val clientAsSubscriber = WpApiClient(
         testCredentials.apiRootUrl,
         WpAuthenticationProvider.staticWithUsernameAndPassword(
             username = testCredentials.subscriberUsername,
             password = testCredentials.subscriberPassword
-        )
+        ),
+        emptyList()
     )
 
     @Test

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -3,6 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.Interceptor
 import uniffi.wp_api.ApiUrlResolver
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
@@ -18,20 +19,38 @@ import java.net.URL
 class JetpackApiClient(
     apiUrlResolver: ApiUrlResolver,
     authProvider: WpAuthenticationProvider,
-    private val requestExecutor: RequestExecutor = WpRequestExecutor(),
+    private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
-        requestExecutor: RequestExecutor = WpRequestExecutor(),
+        requestExecutor: RequestExecutor,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : this(
         apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
+        appNotifier,
+        dispatcher
+    )
+
+    /**
+     * Convenience constructor that accepts a list of OkHttp interceptors.
+     * Uses [WpRequestExecutor] internally with the provided interceptors.
+     */
+    constructor(
+        wpOrgSiteApiRootUrl: URL,
+        authProvider: WpAuthenticationProvider,
+        interceptors: List<Interceptor>,
+        appNotifier: WpAppNotifier = EmptyAppNotifier(),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) : this(
+        wpOrgSiteApiRootUrl,
+        authProvider,
+        requestExecutor = WpRequestExecutor(interceptors),
         appNotifier,
         dispatcher
     )

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -3,6 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.Interceptor
 import uniffi.wp_api.ApiUrlResolver
 import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.RequestExecutor
@@ -18,20 +19,38 @@ import java.net.URL
 class WpApiClient(
     apiUrlResolver: ApiUrlResolver,
     authProvider: WpAuthenticationProvider,
-    private val requestExecutor: RequestExecutor = WpRequestExecutor(),
+    private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
-        requestExecutor: RequestExecutor = WpRequestExecutor(),
+        requestExecutor: RequestExecutor,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : this(
         apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
+        appNotifier,
+        dispatcher
+    )
+
+    /**
+     * Convenience constructor that accepts a list of OkHttp interceptors.
+     * Uses [WpRequestExecutor] internally with the provided interceptors.
+     */
+    constructor(
+        wpOrgSiteApiRootUrl: URL,
+        authProvider: WpAuthenticationProvider,
+        interceptors: List<Interceptor>,
+        appNotifier: WpAppNotifier = EmptyAppNotifier(),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) : this(
+        wpOrgSiteApiRootUrl,
+        authProvider,
+        requestExecutor = WpRequestExecutor(interceptors),
         appNotifier,
         dispatcher
     )

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -3,6 +3,7 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.Interceptor
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpComApiClient
 import uniffi.wp_api.WpApiClientDelegate
@@ -13,10 +14,27 @@ import uniffi.wp_api.WpAuthenticationProvider
 
 class WpComApiClient(
     authProvider: WpAuthenticationProvider,
-    private val requestExecutor: RequestExecutor = WpRequestExecutor(),
+    private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+
+    /**
+     * Convenience constructor that accepts a list of OkHttp interceptors.
+     * Uses [WpRequestExecutor] internally with the provided interceptors.
+     */
+    constructor(
+        authProvider: WpAuthenticationProvider,
+        interceptors: List<Interceptor>,
+        appNotifier: WpAppNotifier = EmptyAppNotifier(),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) : this(
+        authProvider,
+        requestExecutor = WpRequestExecutor(interceptors),
+        appNotifier,
+        dispatcher
+    )
+
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
     private val requestBuilder by lazy {
         UniffiWpComApiClient(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -9,11 +9,11 @@ sealed class WpHttpClient {
     abstract fun getClient(): OkHttpClient
 
     class DefaultHttpClient(
-        private val interceptors: List<Interceptor> = emptyList()
+        private val interceptors: List<Interceptor>
     ) : WpHttpClient() {
-        private var client: OkHttpClient = buildClient()
-
         private var allowedHostnames: Map<String, List<String>> = emptyMap()
+
+        private var client: OkHttpClient = buildClient()
 
         fun addAllowedAlternativeNamesForHostname(hostname: String, allowedNames: List<String>) {
             // Preserve the previous records for this key

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -25,7 +25,9 @@ sealed class WpHttpClient {
         private fun buildClient(): OkHttpClient {
             return OkHttpClient.Builder().apply {
                 this@DefaultHttpClient.interceptors.forEach { addInterceptor(it) }
-                hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+                if (allowedHostnames.isNotEmpty()) {
+                    hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+                }
             }.build()
         }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -1,5 +1,6 @@
 package rs.wordpress.api.kotlin
 
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSession
@@ -7,8 +8,10 @@ import javax.net.ssl.SSLSession
 sealed class WpHttpClient {
     abstract fun getClient(): OkHttpClient
 
-    class DefaultHttpClient : WpHttpClient() {
-        private var client: OkHttpClient = OkHttpClient()
+    class DefaultHttpClient(
+        private val interceptors: List<Interceptor> = emptyList()
+    ) : WpHttpClient() {
+        private var client: OkHttpClient = buildClient()
 
         private var allowedHostnames: Map<String, List<String>> = emptyMap()
 
@@ -16,13 +19,14 @@ sealed class WpHttpClient {
             // Preserve the previous records for this key
             val previousList = allowedHostnames[hostname].orEmpty()
             allowedHostnames = allowedHostnames.plus(Pair(hostname, allowedNames.plus(previousList)))
-            updateClient()
+            client = buildClient()
         }
 
-        private fun updateClient() {
-            client = client.newBuilder()
-                .hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
-                .build()
+        private fun buildClient(): OkHttpClient {
+            return OkHttpClient.Builder().apply {
+                this@DefaultHttpClient.interceptors.forEach { addInterceptor(it) }
+                hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+            }.build()
         }
 
         override fun getClient() = client

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -3,18 +3,34 @@ package rs.wordpress.api.kotlin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.Interceptor
 import uniffi.wp_api.AutoDiscoveryAttemptFailure
 import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpLoginClient
 import uniffi.wp_api.WpApiMiddlewarePipeline
 
 class WpLoginClient(
-    requestExecutor: RequestExecutor = WpRequestExecutor(),
+    requestExecutor: RequestExecutor,
     middlewarePipeline: WpApiMiddlewarePipeline = WpApiMiddlewarePipeline(listOf()),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+
     private val internalClient: UniffiWpLoginClient =
         UniffiWpLoginClient(requestExecutor, middlewarePipeline)
+
+    /**
+     * Convenience constructor that accepts a list of OkHttp interceptors.
+     * Uses [WpRequestExecutor] internally with the provided interceptors.
+     */
+    constructor(
+        interceptors: List<Interceptor>,
+        middlewarePipeline: WpApiMiddlewarePipeline = WpApiMiddlewarePipeline(listOf()),
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) : this(
+        requestExecutor = WpRequestExecutor(interceptors),
+        middlewarePipeline = middlewarePipeline,
+        dispatcher = dispatcher
+    )
 
     suspend fun apiDiscovery(
         siteUrl: String

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -35,7 +35,7 @@ import javax.net.ssl.SSLPeerUnverifiedException
 const val USER_AGENT_HEADER_NAME = "User-Agent"
 
 class WpRequestExecutor(
-    private val httpClient: WpHttpClient = WpHttpClient.DefaultHttpClient(),
+    private val httpClient: WpHttpClient,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val fileResolver: FileResolver = DefaultFileResolver(),
     private val uploadListener: UploadListener? = null

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.HttpUrl
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttp
@@ -39,6 +40,23 @@ class WpRequestExecutor(
     private val fileResolver: FileResolver = DefaultFileResolver(),
     private val uploadListener: UploadListener? = null
 ) : RequestExecutor {
+
+    /**
+     * Convenience constructor that accepts a list of OkHttp interceptors.
+     * Uses [WpHttpClient.DefaultHttpClient] internally with the provided interceptors.
+     */
+    constructor(
+        interceptors: List<Interceptor>,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        fileResolver: FileResolver = DefaultFileResolver(),
+        uploadListener: UploadListener? = null
+    ) : this(
+        httpClient = WpHttpClient.DefaultHttpClient(interceptors),
+        dispatcher = dispatcher,
+        fileResolver = fileResolver,
+        uploadListener = uploadListener
+    )
+
     override suspend fun execute(request: WpNetworkRequest): WpNetworkResponse =
         withContext(dispatcher) {
             val requestBuilder = Request.Builder().url(request.url())

--- a/native/kotlin/example/composeApp/src/androidMain/kotlin/rs/wordpress/example/ui/welcome/WelcomeActivity.kt
+++ b/native/kotlin/example/composeApp/src/androidMain/kotlin/rs/wordpress/example/ui/welcome/WelcomeActivity.kt
@@ -30,7 +30,7 @@ class WelcomeActivity : ComponentActivity() {
 
     private fun authenticateSite(url: String) {
         val success = runBlocking {
-            when (val apiDiscoveryResult = WpLoginClient().apiDiscovery(url)) {
+            when (val apiDiscoveryResult = WpLoginClient(emptyList()).apiDiscovery(url)) {
                 is ApiDiscoveryResult.Success -> apiDiscoveryResult.success
                 else -> throw IllegalStateException("Api discovery should succeed for the example app")
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
@@ -17,7 +17,8 @@ class PluginListViewModel(private val authRepository: AuthenticationRepository) 
         authRepository.authenticationForSite(authenticatedSite)?.let {
             apiClient = WpApiClient(
                 wpOrgSiteApiRootUrl = authenticatedSite.apiRootUrl,
-                authProvider = WpAuthenticationProvider.staticWithAuth(it)
+                authProvider = WpAuthenticationProvider.staticWithAuth(it),
+                interceptors = emptyList()
             )
         }
     }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
@@ -17,7 +17,8 @@ class UserListViewModel(private val authRepository: AuthenticationRepository) {
         authRepository.authenticationForSite(authenticatedSite)?.let {
             apiClient = WpApiClient(
                 wpOrgSiteApiRootUrl = authenticatedSite.apiRootUrl,
-                authProvider = WpAuthenticationProvider.staticWithAuth(it)
+                authProvider = WpAuthenticationProvider.staticWithAuth(it),
+                interceptors = emptyList()
             )
         }
     }


### PR DESCRIPTION
Allow `OkHttp` interceptors to be passed to `DefaultHttpClient` while preserving hostname verification functionality. Add a convenience constructor to `WpRequestExecutor` that accepts interceptors directly.

This enables clients to inject interceptors (e.g., for network debugging) without needing to manage `OkHttpClient` configuration.

Changes:
- Add `interceptors` parameter to `DefaultHttpClient`
- Refactor to use `buildClient()` method for client construction
- Add convenience constructor to `WpRequestExecutor`

---

Part of CMM-998