### PR TITLE
Fall back to OkHostnameVerifier for default SSL verification

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ApiUrlDiscoveryTest.kt
@@ -298,6 +298,31 @@ class ApiUrlDiscoveryTest {
     }
 
     @Test
+    fun testAllowedHostnamesDoesNotBreakValidSites() = runTest {
+        val httpClient = WpHttpClient.DefaultHttpClient(emptyList())
+        val executor = WpRequestExecutor(httpClient)
+        val loginClient = WpLoginClient(requestExecutor = executor)
+
+        // First, configure an allowed hostname override for a specific cert/hostname pair
+        httpClient.addAllowedAlternativeNamesForHostname(
+            "vanilla.wpmt.co",
+            listOf("wordpress-1315525-4803651.cloudwaysapps.com")
+        )
+
+        // The override should work
+        assertEquals(
+            "https://vanilla.wpmt.co/wp-admin/authorize-application.php",
+            loginClient.apiDiscovery("https://wordpress-1315525-4803651.cloudwaysapps.com")
+                .assertSuccess().applicationPasswordsAuthenticationUrl.url()
+        )
+
+        // Other valid SSL sites should still work via fallback to default hostname verification.
+        // google.com uses wildcard/SAN certificates which require proper OkHttp verification.
+        val reason = loginClient.apiDiscovery("https://google.com").assertFailureFindApiRoot()
+        assertInstanceOf(FindApiRootFailure.ProbablyNotAWordPressSite::class.java, reason)
+    }
+
+    @Test
     fun testCustomOkHttpClient() = runTest {
         val executor =
             WpRequestExecutor(httpClient = WpHttpClient.CustomOkHttpClient(client = OkHttpClient()))

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -2,6 +2,7 @@ package rs.wordpress.api.kotlin
 
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.internal.tls.OkHostnameVerifier
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSession
 
@@ -25,9 +26,7 @@ sealed class WpHttpClient {
         private fun buildClient(): OkHttpClient {
             return OkHttpClient.Builder().apply {
                 this@DefaultHttpClient.interceptors.forEach { addInterceptor(it) }
-                if (allowedHostnames.isNotEmpty()) {
-                    hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
-                }
+                hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
             }.build()
         }
 
@@ -41,9 +40,12 @@ sealed class WpHttpClient {
 
 private class WpRequestExecutorHostnameVerifier(private val allowedHostnames: Map<String, List<String>>) :
     HostnameVerifier {
-    override fun verify(hostname: String?, session: SSLSession?): Boolean =
-        session?.let {
-            val peerPrincipalName = it.peerPrincipal.name.replace("CN=", "")
-            peerPrincipalName == hostname || allowedHostnames[peerPrincipalName]?.contains(hostname) ?: false
-        } ?: false
+    override fun verify(hostname: String?, session: SSLSession?): Boolean {
+        if (hostname == null || session == null) return false
+
+        // Check our custom allowlist first, then fall back to default OkHttp verification
+        val peerPrincipalName = session.peerPrincipal.name.replace("CN=", "")
+        val customMatch = allowedHostnames[peerPrincipalName]?.contains(hostname) ?: false
+        return customMatch || OkHostnameVerifier.verify(hostname, session)
+    }
 }


### PR DESCRIPTION
## Summary
When `allowedHostnames` is configured, the custom hostname verifier now falls back to `OkHostnameVerifier` instead of rejecting all other sites. This ensures wildcard/SAN certificates work while still allowing custom overrides.

## Test plan
```bash
# Checkout first commit (test only) - should fail
git checkout 6126707c
./gradlew :api:kotlin:integrationTest --tests "ApiUrlDiscoveryTest.testAllowedHostnamesDoesNotBreakValidSites"

# Checkout fix commit - should pass
git checkout cb009f75
./gradlew :api:kotlin:integrationTest --tests "ApiUrlDiscoveryTest.testAllowedHostnamesDoesNotBreakValidSites"
```