### PR TITLE
Add @JvmOverloads to Kotlin API client constructors

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -16,13 +16,14 @@ import uniffi.wp_api.WpAuthenticationProvider
 import uniffi.wp_api.WpOrgSiteApiUrlResolver
 import java.net.URL
 
-class WpApiClient(
+class WpApiClient @JvmOverloads constructor(
     apiUrlResolver: ApiUrlResolver,
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+    @JvmOverloads
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
@@ -41,6 +42,7 @@ class WpApiClient(
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpRequestExecutor] internally with the provided interceptors.
      */
+    @JvmOverloads
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -9,7 +9,7 @@ import uniffi.wp_api.RequestExecutor
 import uniffi.wp_api.UniffiWpLoginClient
 import uniffi.wp_api.WpApiMiddlewarePipeline
 
-class WpLoginClient(
+class WpLoginClient @JvmOverloads constructor(
     requestExecutor: RequestExecutor,
     middlewarePipeline: WpApiMiddlewarePipeline = WpApiMiddlewarePipeline(listOf()),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
@@ -22,6 +22,7 @@ class WpLoginClient(
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpRequestExecutor] internally with the provided interceptors.
      */
+    @JvmOverloads
     constructor(
         interceptors: List<Interceptor>,
         middlewarePipeline: WpApiMiddlewarePipeline = WpApiMiddlewarePipeline(listOf()),

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -34,7 +34,7 @@ import javax.net.ssl.SSLPeerUnverifiedException
 
 const val USER_AGENT_HEADER_NAME = "User-Agent"
 
-class WpRequestExecutor(
+class WpRequestExecutor @JvmOverloads constructor(
     private val httpClient: WpHttpClient,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val fileResolver: FileResolver = DefaultFileResolver(),
@@ -45,6 +45,7 @@ class WpRequestExecutor(
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpHttpClient.DefaultHttpClient] internally with the provided interceptors.
      */
+    @JvmOverloads
     constructor(
         interceptors: List<Interceptor>,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,


### PR DESCRIPTION
Enable Java callers to use constructors with default parameter values for `WpApiClient`, `WpLoginClient`, and `WpRequestExecutor`.

---

Part of CMM-998