### PR TITLE
Skip serializing null app_id in application password params

### DIFF
--- a/wp_api/src/application_passwords.rs
+++ b/wp_api/src/application_passwords.rs
@@ -53,6 +53,7 @@ pub struct IpAddress {
 pub struct ApplicationPasswordCreateParams {
     /// A UUID provided by the application to uniquely identify it.
     /// It is recommended to use an UUID v5 with the URL or DNS namespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub app_id: Option<String>,
     /// The name of the application password.
     pub name: String,
@@ -74,6 +75,7 @@ pub struct ApplicationPasswordDeleteAllResponse {
 pub struct ApplicationPasswordUpdateParams {
     /// A UUID provided by the application to uniquely identify it.
     /// It is recommended to use an UUID v5 with the URL or DNS namespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub app_id: Option<String>,
     /// The name of the application password.
     pub name: String,


### PR DESCRIPTION
## Summary

Fixes a WordPress 6.9-RC3 compatibility issue discovered in #1047.

WordPress 6.9-RC3 rejects `app_id: null` in the `/users/<id>/application-passwords` endpoint. This adds `#[serde(skip_serializing_if = "Option::is_none")]` to omit the field when `None`.