### PR TITLE
Use JsonValue for post type supports field

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
@@ -6,6 +6,7 @@ import uniffi.wp_api.PostType
 import uniffi.wp_api.PostTypeCapabilities
 import uniffi.wp_api.PostTypeSupports
 import uniffi.wp_api.WpErrorCode
+import uniffi.wp_api.postTypeSupports
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -26,7 +27,7 @@ class PostTypesEndpointTest {
         val postTypesPost = client.request { requestBuilder ->
             requestBuilder.postTypes().retrieveWithEditContext(PostType.Post)
         }.assertSuccessAndRetrieveData().data
-        assert(postTypesPost.supports.map[PostTypeSupports.Title]!!.asJsonBool()!!)
+        assert(postTypeSupports(postTypesPost.supports, PostTypeSupports.Title))
         assertFalse(postTypesPost.capabilities[PostTypeCapabilities.EditPosts]!!.isEmpty())
     }
 

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
@@ -26,7 +26,7 @@ class PostTypesEndpointTest {
         val postTypesPost = client.request { requestBuilder ->
             requestBuilder.postTypes().retrieveWithEditContext(PostType.Post)
         }.assertSuccessAndRetrieveData().data
-        assert(postTypesPost.supports.map[PostTypeSupports.Title]!!)
+        assert(postTypesPost.supports.map[PostTypeSupports.Title]!!.asJsonBool()!!)
         assertFalse(postTypesPost.capabilities[PostTypeCapabilities.EditPosts]!!.isEmpty())
     }
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -122,3 +122,13 @@ extension PostType: ExpressibleByStringLiteral {
         self.init(stringLiteral)
     }
 }
+
+public extension PostTypeSupportsMap {
+    func supports(_ feature: PostTypeSupports) -> Bool {
+        postTypeSupports(supportsMap: self, feature: feature)
+    }
+
+    func supports(_ feature: String) -> Bool {
+        postTypeSupports(supportsMap: self, feature: .custom(feature))
+    }
+}

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,7 +1,8 @@
-use crate::impl_as_query_value_from_to_string;
+use crate::{JsonValue, impl_as_query_value_from_to_string};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use wp_contextual::WpContextual;
 use wp_serde_helper::deserialize_empty_array_or_hashmap;
 
@@ -97,7 +98,28 @@ pub struct PostTypeSupportsMap {
     #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
     #[serde(flatten)]
     #[serde(rename = "supports")]
-    pub map: HashMap<PostTypeSupports, bool>,
+    pub map: HashMap<PostTypeSupports, Arc<PostTypeSupportsValue>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Object)]
+#[serde(transparent)]
+pub struct PostTypeSupportsValue {
+    #[serde(flatten)]
+    pub json_value: JsonValue,
+}
+
+#[uniffi::export]
+impl PostTypeSupportsValue {
+    fn as_json_value(&self) -> JsonValue {
+        self.json_value.clone()
+    }
+
+    pub fn as_json_bool(&self) -> Option<bool> {
+        match self.json_value {
+            JsonValue::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -2,7 +2,6 @@ use crate::{JsonValue, impl_as_query_value_from_to_string};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 use wp_contextual::WpContextual;
 use wp_serde_helper::deserialize_empty_array_or_hashmap;
 
@@ -98,7 +97,7 @@ pub struct PostTypeSupportsMap {
     #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
     #[serde(flatten)]
     #[serde(rename = "supports")]
-    pub map: HashMap<PostTypeSupports, Arc<PostTypeSupportsValue>>,
+    pub map: HashMap<PostTypeSupports, JsonValue>,
 }
 
 impl PostTypeSupportsMap {
@@ -121,27 +120,6 @@ impl PostTypeSupportsMap {
 #[uniffi::export]
 fn post_type_supports(supports_map: &PostTypeSupportsMap, feature: PostTypeSupports) -> bool {
     supports_map.supports(&feature)
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Object)]
-#[serde(transparent)]
-pub struct PostTypeSupportsValue {
-    #[serde(flatten)]
-    pub json_value: JsonValue,
-}
-
-#[uniffi::export]
-impl PostTypeSupportsValue {
-    fn as_json_value(&self) -> JsonValue {
-        self.json_value.clone()
-    }
-
-    pub fn as_json_bool(&self) -> Option<bool> {
-        match self.json_value {
-            JsonValue::Bool(b) => Some(b),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -101,6 +101,28 @@ pub struct PostTypeSupportsMap {
     pub map: HashMap<PostTypeSupports, Arc<PostTypeSupportsValue>>,
 }
 
+impl PostTypeSupportsMap {
+    /// Check if the post type supports a specific feature by checking if the key is present.
+    ///
+    /// Note: This only checks for key presence, not the associated value. WordPress typically
+    /// includes a feature in the map with a `true` value when supported, and omits it entirely
+    /// when not supported. The value can also be an object with additional configuration (e.g.,
+    /// `editor` may have nested settings). We assume that if a key is present, the feature is
+    /// supported, regardless of the actual value.
+    pub fn supports(&self, feature: &PostTypeSupports) -> bool {
+        self.map.contains_key(feature)
+    }
+}
+
+/// Check if a post type supports a specific feature by checking if the key is present.
+///
+/// Note: This only checks for key presence, not the associated value. See
+/// `PostTypeSupportsMap::supports` for details on this assumption.
+#[uniffi::export]
+fn post_type_supports(supports_map: &PostTypeSupportsMap, feature: PostTypeSupports) -> bool {
+    supports_map.supports(&feature)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Object)]
 #[serde(transparent)]
 pub struct PostTypeSupportsValue {

--- a/wp_api_integration_tests/tests/test_post_types_immut.rs
+++ b/wp_api_integration_tests/tests/test_post_types_immut.rs
@@ -92,14 +92,7 @@ async fn retrieve_post_types_with_edit_context(
     // It's possible that we might have more test sites in the future and some of their
     // post types might not support `Title` in which case it's perfectly fine to completely
     // remove this assertion.
-    assert_eq!(
-        post_type
-            .supports
-            .map
-            .get(&PostTypeSupports::Title)
-            .and_then(|v| v.as_json_bool()),
-        Some(true)
-    );
+    assert!(post_type.supports.supports(&PostTypeSupports::Title));
     // All post types in our current testing sites have `EditPost` capability, so we use this
     // assertion to verify that we are able to parse `capabilities` field properly.
     //

--- a/wp_api_integration_tests/tests/test_post_types_immut.rs
+++ b/wp_api_integration_tests/tests/test_post_types_immut.rs
@@ -93,8 +93,12 @@ async fn retrieve_post_types_with_edit_context(
     // post types might not support `Title` in which case it's perfectly fine to completely
     // remove this assertion.
     assert_eq!(
-        post_type.supports.map.get(&PostTypeSupports::Title),
-        Some(true).as_ref()
+        post_type
+            .supports
+            .map
+            .get(&PostTypeSupports::Title)
+            .and_then(|v| v.as_json_bool()),
+        Some(true)
     );
     // All post types in our current testing sites have `EditPost` capability, so we use this
     // assertion to verify that we are able to parse `capabilities` field properly.


### PR DESCRIPTION
Addresses a breaking change discovered in #1047: WordPress 6.9 returns post type `supports` as either `bool` or array, so we use `JsonValue`.