### PR TITLE
Export a function to return the API root URL

### DIFF
--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -132,6 +132,10 @@ impl WpOrgSiteApiUrlResolver {
     pub fn new(api_root_url: Arc<ParsedUrl>) -> Self {
         Self { api_root_url }
     }
+
+    fn api_root_url(&self) -> Arc<ParsedUrl> {
+        self.api_root_url.clone()
+    }
 }
 
 #[uniffi::export]


### PR DESCRIPTION
The iOS apps can benefit from this change.