### PR TITLE
`WpEndpointArgs` now accepts all JSON types

### DIFF
--- a/test-data/api-details/test-case-05.json
+++ b/test-data/api-details/test-case-05.json
@@ -1,0 +1,78 @@
+{
+  "name": "Example WordPress Site",
+  "description": "",
+  "url": "https://example-site.wordpress.test",
+  "home": "https://example-site.wordpress.test",
+  "gmt_offset": 13,
+  "timezone_string": "Pacific/Auckland",
+  "page_for_posts": 0,
+  "page_on_front": 0,
+  "show_on_front": "posts",
+  "namespaces": [
+    "oembed/1.0",
+    "akismet/v1",
+    "jetpack/v4",
+    "tec/tickets/onboarding",
+    "tribe/tickets/v1",
+    "tribe/event-aggregator/v1",
+    "tribe/events/v1",
+    "tribe/views/v2",
+    "tec/v2/onboarding",
+    "tec/v1",
+    "wpcom/v2",
+    "jetpack/v4/stats-app",
+    "wpcom/v3",
+    "jetpack-boost/v1",
+    "my-jetpack/v1",
+    "jetpack/v4/explat",
+    "wp/v2",
+    "wp-site-health/v1",
+    "wp-block-editor/v1",
+    "wp-abilities/v1"
+  ],
+  "authentication": {
+    "application-passwords": {
+      "endpoints": {
+        "authorization": "https://example-site.wordpress.test/wp-admin/authorize-application.php"
+      }
+    }
+  },
+  "routes": {
+    "/tribe/tickets/v1/tickets": {
+      "namespace": "tribe/tickets/v1",
+      "methods": ["GET", "POST"],
+      "endpoints": [
+        {
+          "methods": ["POST"],
+          "ISSUE": "This plugin has a irregular `args` structure. https://github.com/the-events-calendar/event-tickets",
+          "args": [
+            { "required": false },
+            {
+              "description": {
+                "type": "string",
+                "in": "body",
+                "validate_callback": [{}, "is_string_or_empty"],
+                "sanitize_callback": "sanitize_text_field",
+                "default": ""
+              },
+              "required": false
+            }
+          ]
+        }
+      ],
+      "_links": {
+        "self": [
+          {
+            "href": "https://example-site.wordpress.test/wp-json/tribe/tickets/v1/tickets"
+          }
+        ]
+      }
+    }
+  },
+  "site_logo": 0,
+  "site_icon": 0,
+  "site_icon_url": "",
+  "_links": {
+    "help": [{ "href": "https://developer.wordpress.org/rest-api/" }]
+  }
+}

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -465,6 +465,7 @@ mod tests {
     #[case("api-details/test-case-02.json")]
     #[case("api-details/test-case-03.json")]
     #[case("api-details/test-case-04.json")]
+    #[case("api-details/test-case-05.json")]
     fn test_api_details_json(#[case] input: &str) {
         let json = test_json(input).expect("Failed to read test resource");
 

--- a/wp_api/src/login.rs
+++ b/wp_api/src/login.rs
@@ -82,8 +82,19 @@ pub struct WpRoute {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
 pub struct WpEndpoint {
     pub methods: Vec<String>,
-    #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
-    pub args: HashMap<String, WpEndpointArg>,
+    pub args: Arc<WpEndpointArgs>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Object)]
+#[serde(transparent)]
+pub struct WpEndpointArgs(serde_json::Value);
+
+impl WpEndpointArgs {
+    pub fn get(&self, arg: &str) -> Option<WpEndpointArg> {
+        let obj = self.0.as_object()?;
+        let value = obj.get(arg)?;
+        serde_json::from_value(value.clone()).ok()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]


### PR DESCRIPTION
I found a plugin ([The Event Tickets plugin](https://wordpress.org/plugins/event-tickets/)) has an unexpected `args` in its `wp-json` response, which causes the `WpApiDetails` parsing failure. That means any site with that plugin won't be able to sign in with application passwords from the app.