### PR TITLE
Add Post Types Collection Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,6 +5289,7 @@ name = "wp_mobile"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "log",
  "paste",
  "rand 0.9.2",

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
@@ -10,6 +10,6 @@ class WordPressApiCacheTest {
 
     @Test
     fun testThatMigrationsWork() = runTest {
-        assertEquals(7, WordPressApiCache().performMigrations())
+        assertEquals(8, WordPressApiCache().performMigrations())
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
@@ -13,7 +13,8 @@ import uniffi.wp_mobile.PostTypeService
  *
  * Unlike posts, post types don't support pagination - all types are returned in a single fetch.
  *
- * By default, only viewable post types are returned (those with `viewable = true`).
+ * By default, only viewable and UI-visible post types are returned
+ * (those with `viewable = true` and `show_ui = true`).
  * For custom filtering, use `getObservablePostTypeCollectionWithEditContextFiltered()`.
  *
  * The collection provides:
@@ -23,7 +24,7 @@ import uniffi.wp_mobile.PostTypeService
  * Example:
  * ```
  * class MyViewModel : ViewModel() {
- *     // Get viewable post types (default behavior)
+ *     // Get viewable and UI-visible post types (default behavior)
  *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContext()
  *
  *     init {
@@ -39,7 +40,8 @@ import uniffi.wp_mobile.PostTypeService
  *
  * @return Observable collection that notifies on database changes
  */
-fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
+fun PostTypeService.getObservablePostTypeCollectionWithEditContext():
+    ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
     val collection = this.createPostTypeCollectionWithEditContext()
     return createObservableCollection(
         loadData = collection::loadData,
@@ -63,8 +65,8 @@ fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): Observable
  * Example:
  * ```
  * class MyViewModel : ViewModel() {
- *     // Get all post types (no filtering)
- *     private val filter = PostTypeFilter(viewable = null)
+ *     // Get only hierarchical post types that are viewable and shown in UI
+ *     private val filter = PostTypeFilter(viewable = true, showUi = true, hierarchical = true)
  *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContextFiltered(filter)
  *
  *     init {
@@ -78,7 +80,7 @@ fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): Observable
  * }
  * ```
  *
- * @param filter Filter criteria for post types (viewable status, etc.)
+ * @param filter Filter criteria for post types (viewable, show_ui, hierarchical)
  * @return Observable collection that notifies on database changes
  */
 fun PostTypeService.getObservablePostTypeCollectionWithEditContextFiltered(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
@@ -1,10 +1,54 @@
 package rs.wordpress.cache.kotlin
 
 import uniffi.wp_mobile.FullEntityPostTypeDetailsWithEditContext
+import uniffi.wp_mobile.PostTypeFilter
 import uniffi.wp_mobile.PostTypeService
 
 /**
- * Create an observable post type collection with edit context.
+ * Create an observable post type collection with edit context using default filter.
+ *
+ * Post types define what content types are available on a WordPress site (e.g., 'post', 'page',
+ * custom post types). They're configuration data that rarely changes - typically only when
+ * plugins are activated or deactivated.
+ *
+ * Unlike posts, post types don't support pagination - all types are returned in a single fetch.
+ *
+ * By default, only viewable post types are returned (those with `viewable = true`).
+ * For custom filtering, use `getObservablePostTypeCollectionWithEditContextFiltered()`.
+ *
+ * The collection provides:
+ * - `loadData()`: Load all cached post types from the database
+ * - Observable notifications when post types change
+ *
+ * Example:
+ * ```
+ * class MyViewModel : ViewModel() {
+ *     // Get viewable post types (default behavior)
+ *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContext()
+ *
+ *     init {
+ *         postTypeCollection.addObserver {
+ *             viewModelScope.launch {
+ *                 val postTypes = postTypeCollection.loadData()
+ *                 // Update UI with post types
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @return Observable collection that notifies on database changes
+ */
+fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
+    val collection = this.createPostTypeCollectionWithEditContext()
+    return createObservableCollection(
+        loadData = collection::loadData,
+        isRelevantUpdate = collection::isRelevantUpdate
+    )
+}
+
+/**
+ * Create an observable post type collection with edit context using a custom filter.
  *
  * Post types define what content types are available on a WordPress site (e.g., 'post', 'page',
  * custom post types). They're configuration data that rarely changes - typically only when
@@ -16,12 +60,12 @@ import uniffi.wp_mobile.PostTypeService
  * - `loadData()`: Load all cached post types from the database
  * - Observable notifications when post types change
  *
- * To fetch post types from the network, use `PostTypeService.syncPostTypes()`.
- *
  * Example:
  * ```
  * class MyViewModel : ViewModel() {
- *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContext()
+ *     // Get all post types (no filtering)
+ *     private val filter = PostTypeFilter(viewable = null)
+ *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContextFiltered(filter)
  *
  *     init {
  *         postTypeCollection.addObserver {
@@ -30,24 +74,17 @@ import uniffi.wp_mobile.PostTypeService
  *                 // Update UI with post types
  *             }
  *         }
- *
- *         // Initial fetch
- *         viewModelScope.launch {
- *             postTypeService.syncPostTypes()
- *         }
- *     }
- *
- *     override fun onCleared() {
- *         super.onCleared()
- *         postTypeCollection.close()
  *     }
  * }
  * ```
  *
+ * @param filter Filter criteria for post types (viewable status, etc.)
  * @return Observable collection that notifies on database changes
  */
-fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
-    val collection = this.createPostTypeCollectionWithEditContext()
+fun PostTypeService.getObservablePostTypeCollectionWithEditContextFiltered(
+    filter: PostTypeFilter
+): ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
+    val collection = this.createPostTypeCollectionWithEditContextFiltered(filter)
     return createObservableCollection(
         loadData = collection::loadData,
         isRelevantUpdate = collection::isRelevantUpdate

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
@@ -5,21 +5,20 @@ import uniffi.wp_mobile.PostTypeFilter
 import uniffi.wp_mobile.PostTypeService
 
 /**
- * Create an observable post type collection with edit context using default filter.
+ * Create an observable post type collection with edit context.
  *
  * Post types define what content types are available on a WordPress site (e.g., 'post', 'page',
  * custom post types). They're configuration data that rarely changes - typically only when
- * plugins are activated or deactivated.
- *
- * Unlike posts, post types don't support pagination - all types are returned in a single fetch.
- *
- * By default, only viewable and UI-visible post types are returned
- * (those with `viewable = true` and `show_ui = true`).
- * For custom filtering, use `getObservablePostTypeCollectionWithEditContextFiltered()`.
+ * plugins are activated or deactivated. Unlike posts, post types don't support pagination -
+ * all types are returned in a single fetch.
  *
  * The collection provides:
  * - `loadData()`: Load all cached post types from the database
  * - Observable notifications when post types change
+ *
+ * By default, only viewable and UI-visible post types are returned
+ * (those with `viewable = true` and `show_ui = true`).
+ * For custom filtering, use [getObservablePostTypeCollectionWithEditContextFiltered].
  *
  * Example:
  * ```
@@ -52,32 +51,13 @@ fun PostTypeService.getObservablePostTypeCollectionWithEditContext():
 /**
  * Create an observable post type collection with edit context using a custom filter.
  *
- * Post types define what content types are available on a WordPress site (e.g., 'post', 'page',
- * custom post types). They're configuration data that rarely changes - typically only when
- * plugins are activated or deactivated.
- *
- * Unlike posts, post types don't support pagination - all types are returned in a single fetch.
- *
- * The collection provides:
- * - `loadData()`: Load all cached post types from the database
- * - Observable notifications when post types change
+ * See [getObservablePostTypeCollectionWithEditContext] for general information.
  *
  * Example:
  * ```
- * class MyViewModel : ViewModel() {
- *     // Get only hierarchical post types that are viewable and shown in UI
- *     private val filter = PostTypeFilter(viewable = true, showUi = true, hierarchical = true)
- *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContextFiltered(filter)
- *
- *     init {
- *         postTypeCollection.addObserver {
- *             viewModelScope.launch {
- *                 val postTypes = postTypeCollection.loadData()
- *                 // Update UI with post types
- *             }
- *         }
- *     }
- * }
+ * // Get only hierarchical post types that are viewable and shown in UI
+ * val filter = PostTypeFilter(viewable = true, showUi = true, hierarchical = true)
+ * val collection = postTypeService.getObservablePostTypeCollectionWithEditContextFiltered(filter)
  * ```
  *
  * @param filter Filter criteria for post types (viewable, show_ui, hierarchical)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/cache/kotlin/PostTypeServiceExtensions.kt
@@ -1,0 +1,55 @@
+package rs.wordpress.cache.kotlin
+
+import uniffi.wp_mobile.FullEntityPostTypeDetailsWithEditContext
+import uniffi.wp_mobile.PostTypeService
+
+/**
+ * Create an observable post type collection with edit context.
+ *
+ * Post types define what content types are available on a WordPress site (e.g., 'post', 'page',
+ * custom post types). They're configuration data that rarely changes - typically only when
+ * plugins are activated or deactivated.
+ *
+ * Unlike posts, post types don't support pagination - all types are returned in a single fetch.
+ *
+ * The collection provides:
+ * - `loadData()`: Load all cached post types from the database
+ * - Observable notifications when post types change
+ *
+ * To fetch post types from the network, use `PostTypeService.syncPostTypes()`.
+ *
+ * Example:
+ * ```
+ * class MyViewModel : ViewModel() {
+ *     private val postTypeCollection = postTypeService.getObservablePostTypeCollectionWithEditContext()
+ *
+ *     init {
+ *         postTypeCollection.addObserver {
+ *             viewModelScope.launch {
+ *                 val postTypes = postTypeCollection.loadData()
+ *                 // Update UI with post types
+ *             }
+ *         }
+ *
+ *         // Initial fetch
+ *         viewModelScope.launch {
+ *             postTypeService.syncPostTypes()
+ *         }
+ *     }
+ *
+ *     override fun onCleared() {
+ *         super.onCleared()
+ *         postTypeCollection.close()
+ *     }
+ * }
+ * ```
+ *
+ * @return Observable collection that notifies on database changes
+ */
+fun PostTypeService.getObservablePostTypeCollectionWithEditContext(): ObservableCollection<FullEntityPostTypeDetailsWithEditContext> {
+    val collection = this.createPostTypeCollectionWithEditContext()
+    return createObservableCollection(
+        loadData = collection::loadData,
+        isRelevantUpdate = collection::isRelevantUpdate
+    )
+}

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/App.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/App.kt
@@ -2,6 +2,10 @@ package rs.wordpress.example.shared
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -11,6 +15,7 @@ import rs.wordpress.example.shared.ui.plugins.PluginListScreen
 import rs.wordpress.example.shared.ui.plugins.PluginListViewModel
 import rs.wordpress.example.shared.ui.postcollection.PostCollectionScreen
 import rs.wordpress.example.shared.ui.postmetadatacollection.PostMetadataCollectionScreen
+import rs.wordpress.example.shared.ui.posttypes.PostTypesScreen
 import rs.wordpress.example.shared.ui.site.SiteScreen
 import rs.wordpress.example.shared.ui.stresstest.StressTestScreen
 import rs.wordpress.example.shared.ui.users.UserListScreen
@@ -22,6 +27,9 @@ fun App(authenticationEnabled: Boolean, authenticateSite: (String) -> Unit) {
     val userListViewModel = koinInject<UserListViewModel>()
     val pluginListViewModel = koinInject<PluginListViewModel>()
     val navController = rememberNavController()
+
+    // State to hold the current post type slug for navigation
+    var currentPostTypeSlug by remember { mutableStateOf("post") }
 
     MaterialTheme {
         NavHost(navController, startDestination = "welcome") {
@@ -59,8 +67,8 @@ fun App(authenticationEnabled: Boolean, authenticateSite: (String) -> Unit) {
                     onPostCollectionClicked = {
                         navController.navigate("postcollection")
                     },
-                    onPostMetadataCollectionClicked = {
-                        navController.navigate("postmetadatacollection")
+                    onPostTypesClicked = {
+                        navController.navigate("posttypes")
                     }
                 )
             }
@@ -78,8 +86,18 @@ fun App(authenticationEnabled: Boolean, authenticateSite: (String) -> Unit) {
                     onBackClicked = { navController.popBackStack() }
                 )
             }
+            composable("posttypes") {
+                PostTypesScreen(
+                    onBackClicked = { navController.popBackStack() },
+                    onPostTypeClicked = { postTypeSlug ->
+                        currentPostTypeSlug = postTypeSlug
+                        navController.navigate("postmetadatacollection")
+                    }
+                )
+            }
             composable("postmetadatacollection") {
                 PostMetadataCollectionScreen(
+                    postTypeSlug = currentPostTypeSlug,
                     onBackClicked = { navController.popBackStack() }
                 )
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/di/AppModule.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/di/AppModule.kt
@@ -10,6 +10,7 @@ import rs.wordpress.example.shared.repository.AuthenticationRepository
 import rs.wordpress.example.shared.ui.plugins.PluginListViewModel
 import rs.wordpress.example.shared.ui.postcollection.PostCollectionViewModel
 import rs.wordpress.example.shared.ui.postmetadatacollection.PostMetadataCollectionViewModel
+import rs.wordpress.example.shared.ui.posttypes.PostTypesViewModel
 import rs.wordpress.example.shared.ui.stresstest.StressTestViewModel
 import rs.wordpress.example.shared.ui.users.UserListViewModel
 import rs.wordpress.example.shared.ui.welcome.WelcomeViewModel
@@ -107,6 +108,7 @@ val viewModelModule = module {
     single { StressTestViewModel(get(), get(), get()) }
     single { PostCollectionViewModel(get()) }
     single { PostMetadataCollectionViewModel(get()) }
+    single { PostTypesViewModel(get()) }
 }
 
 fun commonModules() = listOf(

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionScreen.kt
@@ -36,12 +36,17 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 import uniffi.wp_mobile.PostItemState
+import uniffi.wp_mobile.WpSelfHostedService
 import uniffi.wp_mobile_cache.ListState
 
 @Composable
 @Preview
 fun PostMetadataCollectionScreen(
-    viewModel: PostMetadataCollectionViewModel = koinInject(),
+    postTypeSlug: String = "post",
+    viewModel: PostMetadataCollectionViewModel = run {
+        val service = koinInject<WpSelfHostedService>()
+        PostMetadataCollectionViewModel(service, postTypeSlug)
+    },
     onBackClicked: (() -> Unit)? = null
 ) {
     val state by viewModel.state.collectAsState()
@@ -78,7 +83,8 @@ fun PostMetadataCollectionScreen(
             InfoCard(
                 state = state,
                 itemCount = items.size,
-                onRefreshClick = { viewModel.refresh() }
+                onRefreshClick = { viewModel.refresh() },
+                postTypeSlug = postTypeSlug
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -166,7 +172,8 @@ fun RowScope.FilterButton(
 fun InfoCard(
     state: PostMetadataCollectionState,
     itemCount: Int,
-    onRefreshClick: () -> Unit
+    onRefreshClick: () -> Unit,
+    postTypeSlug: String
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -178,11 +185,18 @@ fun InfoCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = "Metadata Collection",
-                    style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold
-                )
+                Column {
+                    Text(
+                        text = "Metadata Collection",
+                        style = MaterialTheme.typography.subtitle1,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = "Post Type: ${postTypeSlug.replaceFirstChar { it.uppercase() }}",
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.primary
+                    )
+                }
                 Button(
                     onClick = onRefreshClick,
                     enabled = !state.isSyncing

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -26,6 +26,7 @@ import uniffi.wp_mobile_cache.ListState
  */
 data class PostMetadataCollectionState(
     val currentFilter: PostListFilter,
+    val postTypeSlug: String = "post",
     val listInfo: ListInfo? = null,
     val lastSyncResult: SyncResult? = null,
     val lastError: String? = null
@@ -110,11 +111,17 @@ data class PostItemDisplayData(
 }
 
 class PostMetadataCollectionViewModel(
-    private val selfHostedService: WpSelfHostedService
+    private val selfHostedService: WpSelfHostedService,
+    private val postTypeSlug: String = "post"
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    private val _state = MutableStateFlow(PostMetadataCollectionState(currentFilter = PostListFilter()))
+    private val _state = MutableStateFlow(
+        PostMetadataCollectionState(
+            currentFilter = PostListFilter(),
+            postTypeSlug = postTypeSlug
+        )
+    )
     val state: StateFlow<PostMetadataCollectionState> = _state.asStateFlow()
 
     private val _items = MutableStateFlow<List<PostItemDisplayData>>(emptyList())
@@ -142,6 +149,7 @@ class PostMetadataCollectionViewModel(
         // Read persisted state from database (single query)
         _state.value = PostMetadataCollectionState(
             currentFilter = newFilter,
+            postTypeSlug = postTypeSlug,
             listInfo = observableCollection?.listInfo(),
             lastSyncResult = null,
             lastError = null
@@ -218,8 +226,16 @@ class PostMetadataCollectionViewModel(
 
     private fun createObservableCollection(filter: PostListFilter) {
         val postService = selfHostedService.posts()
+
+        // Convert slug to PostEndpointType
+        val endpointType = when (postTypeSlug.lowercase()) {
+            "post" -> PostEndpointType.Posts
+            "page" -> PostEndpointType.Pages
+            else -> PostEndpointType.Custom(postTypeSlug)
+        }
+
         val observable = postService.getObservablePostMetadataCollectionWithEditContext(
-            PostEndpointType.Posts,
+            endpointType,
             filter
         )
 

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -226,12 +226,19 @@ class PostMetadataCollectionViewModel(
 
     private fun createObservableCollection(filter: PostListFilter) {
         val postService = selfHostedService.posts()
+        val postTypeService = selfHostedService.postTypes()
 
-        // Convert slug to PostEndpointType
-        val endpointType = when (postTypeSlug.lowercase()) {
-            "post" -> PostEndpointType.Posts
-            "page" -> PostEndpointType.Pages
-            else -> PostEndpointType.Custom(postTypeSlug)
+        // Get the post type details from cache and convert to PostEndpointType using Rust
+        val postTypeDetails = postTypeService.getBySlug(postTypeSlug)
+        val endpointType = if (postTypeDetails != null) {
+            uniffi.wp_api.postTypeDetailsToPostEndpointType(postTypeDetails)
+        } else {
+            // Fallback if post type not found in cache
+            when (postTypeSlug.lowercase()) {
+                "post" -> PostEndpointType.Posts
+                "page" -> PostEndpointType.Pages
+                else -> PostEndpointType.Custom(postTypeSlug)
+            }
         }
 
         val observable = postService.getObservablePostMetadataCollectionWithEditContext(

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -229,17 +229,10 @@ class PostMetadataCollectionViewModel(
         val postTypeService = selfHostedService.postTypes()
 
         // Get the post type details from cache and convert to PostEndpointType using Rust
+        // This should always succeed if post types were fetched first
         val postTypeDetails = postTypeService.getBySlug(postTypeSlug)
-        val endpointType = if (postTypeDetails != null) {
-            uniffi.wp_api.postTypeDetailsToPostEndpointType(postTypeDetails)
-        } else {
-            // Fallback if post type not found in cache
-            when (postTypeSlug.lowercase()) {
-                "post" -> PostEndpointType.Posts
-                "page" -> PostEndpointType.Pages
-                else -> PostEndpointType.Custom(postTypeSlug)
-            }
-        }
+            ?: error("Post type '$postTypeSlug' not found in cache. Ensure post types are fetched before creating post collections.")
+        val endpointType = uniffi.wp_api.postTypeDetailsToPostEndpointType(postTypeDetails)
 
         val observable = postService.getObservablePostMetadataCollectionWithEditContext(
             endpointType,

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesScreen.kt
@@ -1,0 +1,209 @@
+package rs.wordpress.example.shared.ui.posttypes
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.koinInject
+
+@Composable
+@Preview
+fun PostTypesScreen(
+    viewModel: PostTypesViewModel = koinInject(),
+    onBackClicked: (() -> Unit)? = null,
+    onPostTypeClicked: (String) -> Unit = {}
+) {
+    val state by viewModel.state.collectAsState()
+    val postTypes by viewModel.postTypes.collectAsState()
+
+    MaterialTheme {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+        ) {
+            // Back button (for desktop)
+            if (onBackClicked != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start
+                ) {
+                    TextButton(onClick = onBackClicked) {
+                        Text("← Back")
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // Header card with refresh button
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = 2.dp
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Post Types",
+                            style = MaterialTheme.typography.h6,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Button(
+                            onClick = { viewModel.fetch() },
+                            enabled = !state.isFetching
+                        ) {
+                            if (state.isFetching) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colors.onPrimary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            Text("Refresh")
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "${postTypes.size} post types available",
+                        style = MaterialTheme.typography.body2
+                    )
+
+                    // Show error if any
+                    state.lastError?.let { error ->
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Error: $error",
+                            style = MaterialTheme.typography.caption,
+                            color = MaterialTheme.colors.error
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Post types list
+            if (postTypes.isEmpty() && !state.isFetching) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = 2.dp
+                ) {
+                    Column(
+                        modifier = Modifier.padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = if (state.hasFetchedOnce) {
+                                "No post types found"
+                            } else {
+                                "Click Refresh to load post types"
+                            },
+                            style = MaterialTheme.typography.body1,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f).fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(postTypes) { postType ->
+                        PostTypeCard(
+                            postType = postType,
+                            onClick = { onPostTypeClicked(postType.slug) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PostTypeCard(
+    postType: PostTypeDisplayData,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        elevation = 2.dp
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = postType.name,
+                        style = MaterialTheme.typography.subtitle1,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = postType.slug,
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+                Text(
+                    text = "→",
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+            }
+
+            postType.description?.let { description ->
+                if (description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.body2,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
+                    )
+                }
+            }
+
+            postType.restBase?.let { restBase ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "REST: /$restBase",
+                    style = MaterialTheme.typography.overline,
+                    color = MaterialTheme.colors.primary.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
@@ -117,6 +117,7 @@ class PostTypesViewModel(
         val postTypeService = selfHostedService.postTypes()
 
         // Create the underlying PostTypeCollection (for fetch)
+        // Uses default filter (viewable = true)
         val underlyingCollection = postTypeService.createPostTypeCollectionWithEditContext()
         postTypeCollection = underlyingCollection
 

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
@@ -1,0 +1,163 @@
+package rs.wordpress.example.shared.ui.posttypes
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import rs.wordpress.cache.kotlin.ObservableCollection
+import rs.wordpress.cache.kotlin.getObservablePostTypeCollectionWithEditContext
+import uniffi.wp_mobile.FullEntityPostTypeDetailsWithEditContext
+import uniffi.wp_mobile.PostTypeCollectionWithEditContext
+import uniffi.wp_mobile.WpSelfHostedService
+
+/**
+ * UI state for the post types screen
+ */
+data class PostTypesState(
+    val isFetching: Boolean = false,
+    val lastError: String? = null,
+    val hasFetchedOnce: Boolean = false
+)
+
+/**
+ * Display data for a post type
+ */
+data class PostTypeDisplayData(
+    val slug: String,
+    val name: String,
+    val description: String?,
+    val hierarchical: Boolean,
+    val restBase: String?
+) {
+    companion object {
+        fun fromEntity(entity: FullEntityPostTypeDetailsWithEditContext): PostTypeDisplayData {
+            val postType = entity.data
+            return PostTypeDisplayData(
+                slug = postType.slug,
+                name = postType.name,
+                description = postType.description,
+                hierarchical = postType.hierarchical ?: false,
+                restBase = postType.restBase
+            )
+        }
+    }
+}
+
+class PostTypesViewModel(
+    private val selfHostedService: WpSelfHostedService
+) {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(PostTypesState())
+    val state: StateFlow<PostTypesState> = _state.asStateFlow()
+
+    private val _postTypes = MutableStateFlow<List<PostTypeDisplayData>>(emptyList())
+    val postTypes: StateFlow<List<PostTypeDisplayData>> = _postTypes.asStateFlow()
+
+    private var observableCollection: ObservableCollection<FullEntityPostTypeDetailsWithEditContext>? = null
+    private var postTypeCollection: PostTypeCollectionWithEditContext? = null
+
+    init {
+        createObservableCollection()
+        loadPostTypesFromCache()
+        // Auto-fetch on init to ensure we have post types
+        fetch()
+    }
+
+    /**
+     * Fetch all post types from the network
+     */
+    fun fetch() {
+        if (_state.value.isFetching) {
+            return // Already fetching, ignore
+        }
+
+        _state.value = _state.value.copy(
+            isFetching = true,
+            lastError = null
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val collection = postTypeCollection
+                if (collection == null) {
+                    _state.value = _state.value.copy(isFetching = false)
+                    return@launch
+                }
+
+                // Fetch all post types (no pagination)
+                collection.fetch()
+
+                // Update state with successful result
+                _state.value = _state.value.copy(
+                    isFetching = false,
+                    lastError = null,
+                    hasFetchedOnce = true
+                )
+
+                // Post types will auto-reload via ObservableCollection after database update
+            } catch (error: Exception) {
+                // Update state with error
+                _state.value = _state.value.copy(
+                    lastError = error.message ?: "Unknown error",
+                    isFetching = false
+                )
+            }
+        }
+    }
+
+    /**
+     * Create the observable collection
+     */
+    private fun createObservableCollection() {
+        val postTypeService = selfHostedService.postTypes()
+
+        // Create the underlying PostTypeCollection (for fetch)
+        val underlyingCollection = postTypeService.createPostTypeCollectionWithEditContext()
+        postTypeCollection = underlyingCollection
+
+        // Create observable wrapper (for auto-reload on DB changes)
+        val observable = postTypeService.getObservablePostTypeCollectionWithEditContext()
+
+        // Set up observer to reload post types when database changes
+        observable.addObserver {
+            loadPostTypesFromCache()
+        }
+
+        observableCollection = observable
+    }
+
+    /**
+     * Load post types from cache and update the state flow
+     */
+    private fun loadPostTypesFromCache() {
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                val collection = observableCollection ?: return@launch
+                val allPostTypes = collection.loadData()
+
+                val postTypeDataList = allPostTypes.map { fullEntity ->
+                    PostTypeDisplayData.fromEntity(fullEntity)
+                }
+
+                _postTypes.value = postTypeDataList
+            } catch (e: Exception) {
+                println("Error loading post types from cache: ${e.message}")
+                _postTypes.value = emptyList()
+            }
+        }
+    }
+
+    /**
+     * Clean up resources when ViewModel is destroyed
+     */
+    fun onCleared() {
+        observableCollection?.close()
+        observableCollection = null
+        viewModelScope.cancel()
+    }
+}

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteScreen.kt
@@ -18,7 +18,7 @@ fun SiteScreen(
     onPluginsClicked: () -> Unit,
     onStressTestClicked: () -> Unit,
     onPostCollectionClicked: () -> Unit,
-    onPostMetadataCollectionClicked: () -> Unit
+    onPostTypesClicked: () -> Unit
 ) {
     MaterialTheme {
         Column(
@@ -54,8 +54,8 @@ fun SiteScreen(
                         }
                     }
                     Column {
-                        Button(onClick = onPostMetadataCollectionClicked) {
-                            Text("Post Metadata Collection")
+                        Button(onClick = onPostTypesClicked) {
+                            Text("Post Types")
                         }
                     }
                 }

--- a/native/swift/Tests/wordpress-api-cache/WordPressApiCacheTests.swift
+++ b/native/swift/Tests/wordpress-api-cache/WordPressApiCacheTests.swift
@@ -16,7 +16,7 @@ actor Test {
 
     @Test func testMigrationsWork() async throws {
         let migrationsPerformed = try await self.cache.performMigrations()
-        #expect(migrationsPerformed == 7)
+        #expect(migrationsPerformed == 8)
     }
 
     #if !os(Linux)

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,3 +1,4 @@
+use crate::request::endpoint::posts_endpoint::PostEndpointType;
 use crate::{JsonValue, impl_as_query_value_from_to_string};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -47,6 +48,17 @@ fn post_type_from_string(value: String) -> PostType {
 #[uniffi::export]
 fn post_type_to_string(post_type: PostType) -> String {
     post_type.to_string()
+}
+
+#[uniffi::export]
+fn post_type_details_to_post_endpoint_type(
+    post_type_details: &PostTypeDetailsWithEditContext,
+) -> PostEndpointType {
+    match post_type_details.rest_base.as_str() {
+        "posts" => PostEndpointType::Posts,
+        "pages" => PostEndpointType::Pages,
+        other => PostEndpointType::Custom(other.to_string()),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]

--- a/wp_mobile/Cargo.toml
+++ b/wp_mobile/Cargo.toml
@@ -23,6 +23,7 @@ wp_mobile_cache = { path = "../wp_mobile_cache" }
 
 [dev-dependencies]
 async-trait = { workspace = true }
+futures = { workspace = true }
 rstest = { workspace = true }
 rusqlite = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/wp_mobile/src/collection/mod.rs
+++ b/wp_mobile/src/collection/mod.rs
@@ -4,6 +4,7 @@ mod fetch_error;
 mod fetch_result;
 pub(crate) mod post_collection;
 pub(crate) mod post_metadata_collection;
+pub(crate) mod post_type_collection;
 mod stateless_collection;
 
 pub use collection_error::CollectionError;
@@ -13,6 +14,7 @@ pub use fetch_result::FetchResult;
 pub use post_metadata_collection::{
     PostItemState, PostMetadataCollectionItem, PostMetadataCollectionWithEditContext,
 };
+pub use post_type_collection::PostTypeCollectionWithEditContext;
 pub use stateless_collection::StatelessCollection;
 
 /// Macro to create UniFFI-compatible item state enums for metadata collections.

--- a/wp_mobile/src/collection/post_type_collection.rs
+++ b/wp_mobile/src/collection/post_type_collection.rs
@@ -18,13 +18,20 @@ use wp_mobile_cache::{
 /// # Usage
 ///
 /// ```ignore
+/// use crate::filters::PostTypeFilter;
+///
+/// // Create filter to only show viewable post types
+/// let filter = PostTypeFilter {
+///     viewable: Some(true),
+/// };
+///
 /// // Create collection
-/// let collection = post_type_service.create_post_type_collection_with_edit_context();
+/// let collection = post_type_service.create_post_type_collection_with_edit_context(filter);
 ///
 /// // Fetch all post types from API
 /// collection.fetch().await?;
 ///
-/// // Load cached post types
+/// // Load cached post types (only viewable ones)
 /// let post_types = collection.load_data().await?;
 /// ```
 #[derive(uniffi::Object)]

--- a/wp_mobile/src/collection/post_type_collection.rs
+++ b/wp_mobile/src/collection/post_type_collection.rs
@@ -1,0 +1,110 @@
+use crate::{
+    FullEntityPostTypeDetailsWithEditContext,
+    collection::{CollectionError, FetchError, StatelessCollection},
+    service::post_types::PostTypeService,
+};
+use std::sync::Arc;
+use wp_mobile_cache::{
+    UpdateHook,
+    db_types::post_types::DbPostTypeDetailsWithEditContext,
+    entity::{EntityId, FullEntity},
+};
+
+/// Stateless collection for post types with edit context.
+///
+/// Provides reactive access to cached post types without tracking state or pagination.
+/// All post types are fetched in a single request (no pagination needed).
+///
+/// # Usage
+///
+/// ```ignore
+/// // Create collection
+/// let collection = post_type_service.create_post_type_collection_with_edit_context();
+///
+/// // Fetch all post types from API
+/// collection.fetch().await?;
+///
+/// // Load cached post types
+/// let post_types = collection.load_data().await?;
+/// ```
+#[derive(uniffi::Object)]
+pub struct PostTypeCollectionWithEditContext {
+    /// Underlying stateless collection for cache access
+    stateless_collection: StatelessCollection<FullEntity<DbPostTypeDetailsWithEditContext>>,
+
+    /// Reference to the service for network operations
+    post_type_service: Arc<PostTypeService>,
+}
+
+impl PostTypeCollectionWithEditContext {
+    /// Create a new post type collection
+    pub fn new(
+        stateless_collection: StatelessCollection<FullEntity<DbPostTypeDetailsWithEditContext>>,
+        service: Arc<PostTypeService>,
+    ) -> Self {
+        Self {
+            stateless_collection,
+            post_type_service: service,
+        }
+    }
+}
+
+#[uniffi::export]
+impl PostTypeCollectionWithEditContext {
+    /// Fetch all post types from the network.
+    ///
+    /// This calls the network API and upserts all post types to the database.
+    /// After successful fetch, the database change will trigger observers
+    /// who can then call load_data() to get updated results.
+    ///
+    /// Unlike posts, post types don't support pagination - all types are
+    /// returned in a single request.
+    ///
+    /// # Returns
+    /// - `Ok(Vec<EntityId>)` with entity IDs of all synced post types
+    /// - `Err(FetchError)` if network or database error occurs
+    pub async fn fetch(&self) -> Result<Vec<EntityId>, FetchError> {
+        self.post_type_service.sync_post_types().await
+    }
+
+    /// Load all cached post types from the database.
+    ///
+    /// This queries the database and returns all post types stored in the cache.
+    /// It's an expensive operation that re-queries on every call (stateless behavior).
+    ///
+    /// # Returns
+    /// - `Ok(Vec<FullEntity>>)` with all cached post types
+    /// - `Err(CollectionError)` if database error occurs
+    ///
+    /// # Note
+    /// This async function is exported to client platforms (Kotlin/Swift) where it
+    /// will be executed on a background thread. The underlying Rust implementation
+    /// is synchronous as rusqlite doesn't support async operations.
+    pub async fn load_data(&self) -> Result<Vec<FullEntityPostTypeDetailsWithEditContext>, CollectionError> {
+        self.stateless_collection
+            .load_data()
+            .map(|full_entities| {
+                full_entities
+                    .into_iter()
+                    .map(|db_full_entity| {
+                        // Convert FullEntity<DbPostTypeDetailsWithEditContext> to FullEntity<PostTypeDetailsWithEditContext>
+                        let entity_id = db_full_entity.entity_id;
+                        let post_type_details = db_full_entity.data.post_type;
+                        FullEntity::new(entity_id, post_type_details).into()
+                    })
+                    .collect()
+            })
+            .map_err(|e| CollectionError::DatabaseError {
+                err_message: e.to_string(),
+            })
+    }
+
+    /// Check if a database update is relevant to this collection.
+    ///
+    /// Returns true if the update might affect post types in this collection.
+    /// Used by platform-specific observable wrappers to determine whether to
+    /// notify observers.
+    pub fn is_relevant_update(&self, hook: &UpdateHook) -> bool {
+        self.stateless_collection.is_relevant_update(hook)
+    }
+}

--- a/wp_mobile/src/collection/post_type_collection.rs
+++ b/wp_mobile/src/collection/post_type_collection.rs
@@ -87,7 +87,9 @@ impl PostTypeCollectionWithEditContext {
     /// This async function is exported to client platforms (Kotlin/Swift) where it
     /// will be executed on a background thread. The underlying Rust implementation
     /// is synchronous as rusqlite doesn't support async operations.
-    pub async fn load_data(&self) -> Result<Vec<FullEntityPostTypeDetailsWithEditContext>, CollectionError> {
+    pub async fn load_data(
+        &self,
+    ) -> Result<Vec<FullEntityPostTypeDetailsWithEditContext>, CollectionError> {
         self.stateless_collection
             .load_data()
             .map(|full_entities| {

--- a/wp_mobile/src/filters/mod.rs
+++ b/wp_mobile/src/filters/mod.rs
@@ -1,5 +1,7 @@
 mod post_filter;
 mod post_list_filter;
+mod post_type_filter;
 
 pub use post_filter::AnyPostFilter;
 pub use post_list_filter::PostListFilter;
+pub use post_type_filter::PostTypeFilter;

--- a/wp_mobile/src/filters/post_type_filter.rs
+++ b/wp_mobile/src/filters/post_type_filter.rs
@@ -1,8 +1,9 @@
 /// Filter for querying post types in a collection
 ///
 /// Represents domain-level filtering criteria for post types.
-/// Since there are typically few post types per site, filtering happens
-/// at the collection/database level rather than at the API level.
+/// Since there are typically few post types per site (usually < 20), filtering happens
+/// in-memory after loading all types from the database. Post types don't support
+/// pagination, so all types are loaded in a single query.
 ///
 /// # Default Behavior
 /// By default, only viewable and UI-visible post types are returned

--- a/wp_mobile/src/filters/post_type_filter.rs
+++ b/wp_mobile/src/filters/post_type_filter.rs
@@ -5,24 +5,41 @@
 /// at the collection/database level rather than at the API level.
 ///
 /// # Default Behavior
-/// By default, only viewable post types are returned (`viewable = Some(true)`),
-/// as these are the types typically shown to users in a UI.
+/// By default, only viewable and UI-visible post types are returned
+/// (`viewable = Some(true)`, `show_ui = Some(true)`), as these are the types
+/// typically shown to users in a UI. The `hierarchical` filter defaults to `None`
+/// (no filtering).
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct PostTypeFilter {
     /// Filter by viewable status
     ///
     /// - `None`: No filtering - returns all post types regardless of viewable status
-    /// - `Some(true)`: Returns only post types where viewable is explicitly true
-    /// - `Some(false)`: Returns only post types where viewable is explicitly false
-    ///
-    /// Note: Post types with `viewable == None` are only included when this filter is `None`.
+    /// - `Some(true)`: Returns only post types where viewable is true
+    /// - `Some(false)`: Returns only post types where viewable is false
     pub viewable: Option<bool>,
+
+    /// Filter by show_ui status (from visibility.show_ui)
+    ///
+    /// - `None`: No filtering - returns all post types regardless of show_ui status
+    /// - `Some(true)`: Returns only post types where visibility.show_ui is true
+    /// - `Some(false)`: Returns only post types where visibility.show_ui is false
+    pub show_ui: Option<bool>,
+
+    /// Filter by hierarchical support
+    ///
+    /// - `None`: No filtering - returns all post types regardless of hierarchical status
+    /// - `Some(true)`: Returns only hierarchical post types (e.g., pages with parent/child)
+    /// - `Some(false)`: Returns only flat post types (e.g., posts without hierarchy)
+    #[uniffi(default = None)]
+    pub hierarchical: Option<bool>,
 }
 
 impl Default for PostTypeFilter {
     fn default() -> Self {
         Self {
             viewable: Some(true),
+            show_ui: Some(true),
+            hierarchical: None,
         }
     }
 }

--- a/wp_mobile/src/filters/post_type_filter.rs
+++ b/wp_mobile/src/filters/post_type_filter.rs
@@ -1,0 +1,28 @@
+/// Filter for querying post types in a collection
+///
+/// Represents domain-level filtering criteria for post types.
+/// Since there are typically few post types per site, filtering happens
+/// at the collection/database level rather than at the API level.
+///
+/// # Default Behavior
+/// By default, only viewable post types are returned (`viewable = Some(true)`),
+/// as these are the types typically shown to users in a UI.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct PostTypeFilter {
+    /// Filter by viewable status
+    ///
+    /// - `None`: No filtering - returns all post types regardless of viewable status
+    /// - `Some(true)`: Returns only post types where viewable is explicitly true
+    /// - `Some(false)`: Returns only post types where viewable is explicitly false
+    ///
+    /// Note: Post types with `viewable == None` are only included when this filter is `None`.
+    pub viewable: Option<bool>,
+}
+
+impl Default for PostTypeFilter {
+    fn default() -> Self {
+        Self {
+            viewable: Some(true),
+        }
+    }
+}

--- a/wp_mobile/src/lib.rs
+++ b/wp_mobile/src/lib.rs
@@ -20,6 +20,11 @@ wp_mobile_entity!(
     wp_api::posts::AnyPostWithEditContext
 );
 
+wp_mobile_entity!(
+    EntityPostTypeDetailsWithEditContext,
+    wp_api::post_types::PostTypeDetailsWithEditContext
+);
+
 wp_mobile_post_collection!(
     PostCollectionWithEditContext,
     AnyPostWithEditContext,

--- a/wp_mobile/src/service/mod.rs
+++ b/wp_mobile/src/service/mod.rs
@@ -1,10 +1,11 @@
-use crate::service::{posts::PostService, sites::SiteService};
+use crate::service::{post_types::PostTypeService, posts::PostService, sites::SiteService};
 use std::sync::Arc;
 use wp_api::prelude::{ApiUrlResolver, WpApiClient, WpApiClientDelegate};
 use wp_mobile_cache::WpApiCache;
 
 pub mod metadata;
 pub mod mock_post_service;
+pub mod post_types;
 pub mod posts;
 pub mod sites;
 
@@ -29,10 +30,11 @@ impl From<wp_mobile_cache::SqliteDbError> for WpServiceError {
 ///
 /// This service coordinates between the API client and cache for a specific
 /// self-hosted WordPress site. It provides access to domain-specific services
-/// like PostService, CommentService, etc.
+/// like PostService, PostTypeService, CommentService, etc.
 #[derive(uniffi::Object)]
 pub struct WpSelfHostedService {
     posts: Arc<PostService>,
+    post_types: Arc<PostTypeService>,
     sites: Arc<SiteService>,
 }
 
@@ -62,19 +64,35 @@ impl WpSelfHostedService {
         let db_site =
             SiteService::get_or_create_self_hosted_site(cache.clone(), site_url, api_root)?;
 
+        let db_site_arc = Arc::new(db_site);
+
         let posts = Arc::new(PostService::new(
+            api_client.clone(),
+            db_site_arc.clone(),
+            cache.clone(),
+        ));
+        let post_types = Arc::new(PostTypeService::new(
             api_client,
-            Arc::new(db_site),
+            db_site_arc.clone(),
             cache.clone(),
         ));
         let sites = Arc::new(SiteService::new(cache, db_site));
 
-        Ok(Self { posts, sites })
+        Ok(Self {
+            posts,
+            post_types,
+            sites,
+        })
     }
 
     /// Get the post service for this WordPress site
     pub fn posts(&self) -> Arc<PostService> {
         self.posts.clone()
+    }
+
+    /// Get the post type service for this WordPress site
+    pub fn post_types(&self) -> Arc<PostTypeService> {
+        self.post_types.clone()
     }
 
     /// Get the site service for this WordPress site

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -1,4 +1,7 @@
-use crate::collection::{FetchError, PostTypeCollectionWithEditContext, StatelessCollection};
+use crate::{
+    collection::{FetchError, PostTypeCollectionWithEditContext, StatelessCollection},
+    filters::PostTypeFilter,
+};
 use std::sync::Arc;
 use wp_api::prelude::WpApiClient;
 use wp_mobile_cache::{
@@ -72,23 +75,58 @@ impl PostTypeService {
         Ok(entity_ids)
     }
 
-    /// Create a stateless collection for post types with edit context.
+    /// Create a stateless collection for post types with edit context using default filter.
     ///
     /// The collection provides reactive access to cached post types with
     /// database change notifications.
+    ///
+    /// By default, only viewable post types are returned (those with `viewable = true`).
+    /// For custom filtering, use `create_post_type_collection_with_edit_context_filtered()`.
+    ///
+    /// # Example (Kotlin)
+    /// ```kotlin
+    /// // Get viewable post types (default behavior)
+    /// val collection = postTypeService.createPostTypeCollectionWithEditContext()
+    /// ```
     pub fn create_post_type_collection_with_edit_context(
         &self,
     ) -> Arc<PostTypeCollectionWithEditContext> {
+        self.create_post_type_collection_with_edit_context_filtered(PostTypeFilter::default())
+    }
+
+    /// Create a stateless collection for post types with edit context using a custom filter.
+    ///
+    /// The collection provides reactive access to cached post types with
+    /// database change notifications.
+    ///
+    /// # Arguments
+    /// * `filter` - Filter criteria for post types (viewable status, etc.)
+    ///
+    /// # Example (Kotlin)
+    /// ```kotlin
+    /// // Get all post types (no filtering)
+    /// val allFilter = PostTypeFilter(viewable = null)
+    /// val allCollection = postTypeService.createPostTypeCollectionWithEditContextFiltered(allFilter)
+    ///
+    /// // Get only non-viewable post types
+    /// val hiddenFilter = PostTypeFilter(viewable = false)
+    /// val hiddenCollection = postTypeService.createPostTypeCollectionWithEditContextFiltered(hiddenFilter)
+    /// ```
+    pub fn create_post_type_collection_with_edit_context_filtered(
+        &self,
+        filter: PostTypeFilter,
+    ) -> Arc<PostTypeCollectionWithEditContext> {
         let cache = self.cache.clone();
         let db_site = self.db_site.clone();
+        let filter_clone = filter.clone();
 
-        // Create the stateless collection with a closure that loads all post types
+        // Create the stateless collection with a closure that loads filtered post types
         let stateless_collection = StatelessCollection::new(
             vec![DbTable::PostTypesEditContext],
             Box::new(move || {
                 cache.execute(|conn| {
                     let repo = PostTypeRepository::<EditContext>::new();
-                    repo.select_all(conn, &db_site)
+                    repo.select_by_filter(conn, &db_site, filter_clone.viewable)
                 })
             }),
         );

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -5,10 +5,7 @@ use crate::{
 use std::sync::Arc;
 use wp_api::prelude::WpApiClient;
 use wp_mobile_cache::{
-    DbTable, WpApiCache,
-    context::EditContext,
-    db_types::db_site::DbSite,
-    entity::EntityId,
+    DbTable, WpApiCache, context::EditContext, db_types::db_site::DbSite, entity::EntityId,
     repository::post_types::PostTypeRepository,
 };
 
@@ -16,7 +13,7 @@ use wp_mobile_cache::{
 ///
 /// Provides a bridge between clients and the underlying network/cache layers.
 /// Handles fetching and caching post types for a site.
-#[derive(uniffi::Object)]
+#[derive(Clone, uniffi::Object)]
 pub struct PostTypeService {
     db_site: Arc<DbSite>,
     api_client: Arc<WpApiClient>,
@@ -191,17 +188,6 @@ impl PostTypeService {
     }
 }
 
-// Implement Clone manually since we need it for the collection
-impl Clone for PostTypeService {
-    fn clone(&self) -> Self {
-        Self {
-            db_site: self.db_site.clone(),
-            api_client: self.api_client.clone(),
-            cache: self.cache.clone(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,8 +197,8 @@ mod tests {
     use rusqlite::Connection;
     use wp_mobile_cache::{
         MigrationManager, WpApiCache,
-        test_fixtures::{create_test_site, post_types::PostTypeBuilder},
         db_types::self_hosted_site::SelfHostedSite,
+        test_fixtures::{create_test_site, post_types::PostTypeBuilder},
     };
 
     struct PostTypeServiceTestContext {
@@ -238,11 +224,7 @@ mod tests {
         let cache = Arc::new(WpApiCache::from(conn));
         let api_client = mock_api_client();
 
-        let post_type_service = PostTypeService::new(
-            api_client,
-            Arc::new(db_site),
-            cache.clone(),
-        );
+        let post_type_service = PostTypeService::new(api_client, Arc::new(db_site), cache.clone());
 
         PostTypeServiceTestContext {
             cache,
@@ -296,8 +278,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context();
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should only return the one that's both viewable AND show_ui
         assert_eq!(result.len(), 1);
@@ -335,8 +316,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should return both viewable types regardless of show_ui
         assert_eq!(result.len(), 2);
@@ -376,8 +356,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should return both show_ui=true types regardless of viewable
         assert_eq!(result.len(), 2);
@@ -420,8 +399,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should return both hierarchical types
         assert_eq!(result.len(), 2);
@@ -470,8 +448,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should only return the one matching ALL criteria
         assert_eq!(result.len(), 1);
@@ -514,8 +491,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should return all types
         assert_eq!(result.len(), 3);
@@ -549,8 +525,7 @@ mod tests {
             .post_type_service
             .create_post_type_collection_with_edit_context_filtered(filter);
 
-        let result = block_on(collection.load_data())
-            .expect("load_data should succeed");
+        let result = block_on(collection.load_data()).expect("load_data should succeed");
 
         // Should only return the non-viewable type
         assert_eq!(result.len(), 1);

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -1,0 +1,85 @@
+use crate::collection::FetchError;
+use std::sync::Arc;
+use wp_api::prelude::WpApiClient;
+use wp_mobile_cache::{
+    WpApiCache,
+    context::EditContext,
+    db_types::db_site::DbSite,
+    entity::EntityId,
+    repository::post_types::PostTypeRepository,
+};
+
+/// Service layer for post type operations.
+///
+/// Provides a bridge between clients and the underlying network/cache layers.
+/// Handles fetching and caching post types for a site.
+#[derive(uniffi::Object)]
+pub struct PostTypeService {
+    db_site: Arc<DbSite>,
+    api_client: Arc<WpApiClient>,
+    cache: Arc<WpApiCache>,
+}
+
+impl PostTypeService {
+    pub fn new(api_client: Arc<WpApiClient>, db_site: Arc<DbSite>, cache: Arc<WpApiCache>) -> Self {
+        Self {
+            api_client,
+            db_site,
+            cache,
+        }
+    }
+}
+
+#[uniffi::export]
+impl PostTypeService {
+    /// Sync all post types from the API and cache them.
+    ///
+    /// Fetches the HashMap of post types from the WordPress API and upserts
+    /// each one to the database.
+    ///
+    /// # Returns
+    /// Vector of EntityIds for all synced post types
+    pub async fn sync_post_types(&self) -> Result<Vec<EntityId>, FetchError> {
+        // Fetch post types from API
+        let response = self
+            .api_client
+            .post_types()
+            .list_with_edit_context()
+            .await?;
+
+        // Extract the HashMap from the response
+        let post_types_map = response.data.post_types;
+
+        // Upsert each post type to the database
+        let entity_ids = self
+            .cache
+            .execute(|conn| {
+                let repo = PostTypeRepository::<EditContext>::new();
+                let mut ids = Vec::new();
+
+                for (post_type_enum, post_type_details) in post_types_map.iter() {
+                    let slug = post_type_enum.to_string();
+                    let entity_id = repo.upsert(conn, &self.db_site, &slug, post_type_details)?;
+                    ids.push(entity_id);
+                }
+
+                Ok::<Vec<EntityId>, wp_mobile_cache::SqliteDbError>(ids)
+            })
+            .map_err(|e| FetchError::Database {
+                err_message: e.to_string(),
+            })?;
+
+        Ok(entity_ids)
+    }
+}
+
+// Implement Clone manually since we need it for the collection
+impl Clone for PostTypeService {
+    fn clone(&self) -> Self {
+        Self {
+            db_site: self.db_site.clone(),
+            api_client: self.api_client.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+}

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -98,6 +98,24 @@ impl PostTypeService {
             Arc::new(self.clone()),
         ))
     }
+
+    /// Get a post type by slug from the cache.
+    ///
+    /// # Returns
+    /// The post type details with edit context if found, None otherwise
+    pub fn get_by_slug(
+        &self,
+        slug: String,
+    ) -> Option<wp_api::post_types::PostTypeDetailsWithEditContext> {
+        self.cache
+            .execute(|conn| {
+                let repo = PostTypeRepository::<EditContext>::new();
+                repo.select_by_slug(conn, &self.db_site, &slug)
+            })
+            .ok()
+            .flatten()
+            .map(|db_full_entity| db_full_entity.data.post_type)
+    }
 }
 
 // Implement Clone manually since we need it for the collection

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -58,15 +58,14 @@ impl PostTypeService {
             .cache
             .execute(|conn| {
                 let repo = PostTypeRepository::<EditContext>::new();
-                let mut ids = Vec::new();
 
-                for (post_type_enum, post_type_details) in post_types_map.iter() {
-                    let slug = post_type_enum.to_string();
-                    let entity_id = repo.upsert(conn, &self.db_site, &slug, post_type_details)?;
-                    ids.push(entity_id);
-                }
-
-                Ok::<Vec<EntityId>, wp_mobile_cache::SqliteDbError>(ids)
+                post_types_map
+                    .iter()
+                    .map(|(post_type_enum, post_type_details)| {
+                        let slug = post_type_enum.to_string();
+                        repo.upsert(conn, &self.db_site, &slug, post_type_details)
+                    })
+                    .collect::<Result<Vec<EntityId>, wp_mobile_cache::SqliteDbError>>()
             })
             .map_err(|e| FetchError::Database {
                 err_message: e.to_string(),

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -138,24 +138,24 @@ impl PostTypeService {
                         .into_iter()
                         .filter(|entity| {
                             // Filter by viewable
-                            if let Some(viewable_value) = filter_clone.viewable {
-                                if entity.data.post_type.viewable != viewable_value {
-                                    return false;
-                                }
+                            if let Some(viewable_value) = filter_clone.viewable
+                                && entity.data.post_type.viewable != viewable_value
+                            {
+                                return false;
                             }
 
                             // Filter by show_ui
-                            if let Some(show_ui_value) = filter_clone.show_ui {
-                                if entity.data.post_type.visibility.show_ui != show_ui_value {
-                                    return false;
-                                }
+                            if let Some(show_ui_value) = filter_clone.show_ui
+                                && entity.data.post_type.visibility.show_ui != show_ui_value
+                            {
+                                return false;
                             }
 
                             // Filter by hierarchical
-                            if let Some(hierarchical_value) = filter_clone.hierarchical {
-                                if entity.data.post_type.hierarchical != hierarchical_value {
-                                    return false;
-                                }
+                            if let Some(hierarchical_value) = filter_clone.hierarchical
+                                && entity.data.post_type.hierarchical != hierarchical_value
+                            {
+                                return false;
                             }
 
                             true
@@ -200,5 +200,362 @@ impl Clone for PostTypeService {
             api_client: self.api_client.clone(),
             cache: self.cache.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::mock_api_client;
+    use futures::executor::block_on;
+    use rstest::*;
+    use rusqlite::Connection;
+    use wp_mobile_cache::{
+        MigrationManager, WpApiCache,
+        test_fixtures::{create_test_site, post_types::PostTypeBuilder},
+        db_types::self_hosted_site::SelfHostedSite,
+    };
+
+    struct PostTypeServiceTestContext {
+        cache: Arc<WpApiCache>,
+        db_site: Arc<DbSite>,
+        post_type_service: PostTypeService,
+    }
+
+    #[fixture]
+    fn post_type_service_ctx() -> PostTypeServiceTestContext {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let mut migration_manager = MigrationManager::new(&conn).unwrap();
+        migration_manager
+            .perform_migrations()
+            .expect("Migrations should succeed");
+
+        let self_hosted_site = SelfHostedSite {
+            url: "https://test.local".to_string(),
+            api_root: "https://test.local/wp-json".to_string(),
+        };
+        let db_site = create_test_site(&mut conn, &self_hosted_site);
+
+        let cache = Arc::new(WpApiCache::from(conn));
+        let api_client = mock_api_client();
+
+        let post_type_service = PostTypeService::new(
+            api_client,
+            Arc::new(db_site),
+            cache.clone(),
+        );
+
+        PostTypeServiceTestContext {
+            cache,
+            db_site: Arc::new(db_site),
+            post_type_service,
+        }
+    }
+
+    /// Helper to insert a post type into the test database
+    fn insert_post_type(
+        ctx: &PostTypeServiceTestContext,
+        post_type: &wp_api::post_types::PostTypeDetailsWithEditContext,
+    ) {
+        ctx.cache
+            .execute(|conn| {
+                let repo = PostTypeRepository::<EditContext>::new();
+                repo.upsert(conn, &ctx.db_site, &post_type.slug, post_type)
+            })
+            .expect("Failed to insert post type");
+    }
+
+    #[rstest]
+    fn test_filter_default_returns_only_viewable_and_shown_types(
+        post_type_service_ctx: PostTypeServiceTestContext,
+    ) {
+        // Insert 4 post types with different visibility combinations
+        let visible = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .build();
+        let hidden_ui = PostTypeBuilder::new("revision")
+            .viewable(true)
+            .show_ui(false)
+            .build();
+        let not_viewable = PostTypeBuilder::new("nav_menu_item")
+            .viewable(false)
+            .show_ui(true)
+            .build();
+        let completely_hidden = PostTypeBuilder::new("custom_css")
+            .viewable(false)
+            .show_ui(false)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &visible);
+        insert_post_type(&post_type_service_ctx, &hidden_ui);
+        insert_post_type(&post_type_service_ctx, &not_viewable);
+        insert_post_type(&post_type_service_ctx, &completely_hidden);
+
+        // Use default filter (viewable=true, show_ui=true)
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context();
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should only return the one that's both viewable AND show_ui
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].data.slug, "post");
+    }
+
+    #[rstest]
+    fn test_filter_by_viewable_only(post_type_service_ctx: PostTypeServiceTestContext) {
+        // Insert viewable and non-viewable types
+        let viewable1 = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .build();
+        let viewable2 = PostTypeBuilder::new("page")
+            .viewable(true)
+            .show_ui(false)
+            .build();
+        let not_viewable = PostTypeBuilder::new("revision")
+            .viewable(false)
+            .show_ui(true)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &viewable1);
+        insert_post_type(&post_type_service_ctx, &viewable2);
+        insert_post_type(&post_type_service_ctx, &not_viewable);
+
+        // Filter only by viewable=true, ignore show_ui
+        let filter = PostTypeFilter {
+            viewable: Some(true),
+            show_ui: None,
+            hierarchical: None,
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should return both viewable types regardless of show_ui
+        assert_eq!(result.len(), 2);
+        let slugs: Vec<_> = result.iter().map(|e| e.data.slug.as_str()).collect();
+        assert!(slugs.contains(&"post"));
+        assert!(slugs.contains(&"page"));
+    }
+
+    #[rstest]
+    fn test_filter_by_show_ui_only(post_type_service_ctx: PostTypeServiceTestContext) {
+        // Insert types with different show_ui values
+        let shown1 = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .build();
+        let shown2 = PostTypeBuilder::new("attachment")
+            .viewable(false)
+            .show_ui(true)
+            .build();
+        let hidden = PostTypeBuilder::new("revision")
+            .viewable(true)
+            .show_ui(false)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &shown1);
+        insert_post_type(&post_type_service_ctx, &shown2);
+        insert_post_type(&post_type_service_ctx, &hidden);
+
+        // Filter only by show_ui=true, ignore viewable
+        let filter = PostTypeFilter {
+            viewable: None,
+            show_ui: Some(true),
+            hierarchical: None,
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should return both show_ui=true types regardless of viewable
+        assert_eq!(result.len(), 2);
+        let slugs: Vec<_> = result.iter().map(|e| e.data.slug.as_str()).collect();
+        assert!(slugs.contains(&"post"));
+        assert!(slugs.contains(&"attachment"));
+    }
+
+    #[rstest]
+    fn test_filter_by_hierarchical_only(post_type_service_ctx: PostTypeServiceTestContext) {
+        // Insert hierarchical and flat types
+        let hierarchical1 = PostTypeBuilder::new("page")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(true)
+            .build();
+        let hierarchical2 = PostTypeBuilder::new("custom_hierarchical")
+            .viewable(false)
+            .show_ui(false)
+            .hierarchical(true)
+            .build();
+        let flat = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(false)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &hierarchical1);
+        insert_post_type(&post_type_service_ctx, &hierarchical2);
+        insert_post_type(&post_type_service_ctx, &flat);
+
+        // Filter only by hierarchical=true
+        let filter = PostTypeFilter {
+            viewable: None,
+            show_ui: None,
+            hierarchical: Some(true),
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should return both hierarchical types
+        assert_eq!(result.len(), 2);
+        let slugs: Vec<_> = result.iter().map(|e| e.data.slug.as_str()).collect();
+        assert!(slugs.contains(&"page"));
+        assert!(slugs.contains(&"custom_hierarchical"));
+    }
+
+    #[rstest]
+    fn test_filter_all_criteria_combined(post_type_service_ctx: PostTypeServiceTestContext) {
+        // Insert types with all combinations
+        let matches_all = PostTypeBuilder::new("page")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(true)
+            .build();
+        let wrong_viewable = PostTypeBuilder::new("type1")
+            .viewable(false)
+            .show_ui(true)
+            .hierarchical(true)
+            .build();
+        let wrong_show_ui = PostTypeBuilder::new("type2")
+            .viewable(true)
+            .show_ui(false)
+            .hierarchical(true)
+            .build();
+        let wrong_hierarchical = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(false)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &matches_all);
+        insert_post_type(&post_type_service_ctx, &wrong_viewable);
+        insert_post_type(&post_type_service_ctx, &wrong_show_ui);
+        insert_post_type(&post_type_service_ctx, &wrong_hierarchical);
+
+        // Filter by all three criteria
+        let filter = PostTypeFilter {
+            viewable: Some(true),
+            show_ui: Some(true),
+            hierarchical: Some(true),
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should only return the one matching ALL criteria
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].data.slug, "page");
+    }
+
+    #[rstest]
+    fn test_filter_with_all_none_returns_everything(
+        post_type_service_ctx: PostTypeServiceTestContext,
+    ) {
+        // Insert various types
+        let type1 = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(false)
+            .build();
+        let type2 = PostTypeBuilder::new("page")
+            .viewable(true)
+            .show_ui(false)
+            .hierarchical(true)
+            .build();
+        let type3 = PostTypeBuilder::new("revision")
+            .viewable(false)
+            .show_ui(false)
+            .hierarchical(false)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &type1);
+        insert_post_type(&post_type_service_ctx, &type2);
+        insert_post_type(&post_type_service_ctx, &type3);
+
+        // Filter with all None (no filtering)
+        let filter = PostTypeFilter {
+            viewable: None,
+            show_ui: None,
+            hierarchical: None,
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should return all types
+        assert_eq!(result.len(), 3);
+    }
+
+    #[rstest]
+    fn test_filter_by_false_values(post_type_service_ctx: PostTypeServiceTestContext) {
+        // Insert types to test filtering by false values
+        let hidden_type = PostTypeBuilder::new("revision")
+            .viewable(false)
+            .show_ui(false)
+            .hierarchical(false)
+            .build();
+        let visible_type = PostTypeBuilder::new("post")
+            .viewable(true)
+            .show_ui(true)
+            .hierarchical(true)
+            .build();
+
+        insert_post_type(&post_type_service_ctx, &hidden_type);
+        insert_post_type(&post_type_service_ctx, &visible_type);
+
+        // Filter for non-viewable types
+        let filter = PostTypeFilter {
+            viewable: Some(false),
+            show_ui: None,
+            hierarchical: None,
+        };
+
+        let collection = post_type_service_ctx
+            .post_type_service
+            .create_post_type_collection_with_edit_context_filtered(filter);
+
+        let result = block_on(collection.load_data())
+            .expect("load_data should succeed");
+
+        // Should only return the non-viewable type
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].data.slug, "revision");
+        assert!(!result[0].data.viewable);
     }
 }

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -120,13 +120,24 @@ impl PostTypeService {
         let db_site = self.db_site.clone();
         let filter_clone = filter.clone();
 
-        // Create the stateless collection with a closure that loads filtered post types
+        // Create the stateless collection with a closure that loads and filters post types
         let stateless_collection = StatelessCollection::new(
             vec![DbTable::PostTypesEditContext],
             Box::new(move || {
                 cache.execute(|conn| {
                     let repo = PostTypeRepository::<EditContext>::new();
-                    repo.select_by_filter(conn, &db_site, filter_clone.viewable)
+                    let all_post_types = repo.select_all(conn, &db_site)?;
+
+                    // Apply filtering in memory
+                    let filtered = match filter_clone.viewable {
+                        None => all_post_types,
+                        Some(viewable_value) => all_post_types
+                            .into_iter()
+                            .filter(|entity| entity.data.post_type.viewable == viewable_value)
+                            .collect(),
+                    };
+
+                    Ok(filtered)
                 })
             }),
         );

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -1,8 +1,8 @@
-use crate::collection::FetchError;
+use crate::collection::{FetchError, PostTypeCollectionWithEditContext, StatelessCollection};
 use std::sync::Arc;
 use wp_api::prelude::WpApiClient;
 use wp_mobile_cache::{
-    WpApiCache,
+    DbTable, WpApiCache,
     context::EditContext,
     db_types::db_site::DbSite,
     entity::EntityId,
@@ -70,6 +70,33 @@ impl PostTypeService {
             })?;
 
         Ok(entity_ids)
+    }
+
+    /// Create a stateless collection for post types with edit context.
+    ///
+    /// The collection provides reactive access to cached post types with
+    /// database change notifications.
+    pub fn create_post_type_collection_with_edit_context(
+        &self,
+    ) -> Arc<PostTypeCollectionWithEditContext> {
+        let cache = self.cache.clone();
+        let db_site = self.db_site.clone();
+
+        // Create the stateless collection with a closure that loads all post types
+        let stateless_collection = StatelessCollection::new(
+            vec![DbTable::PostTypesEditContext],
+            Box::new(move || {
+                cache.execute(|conn| {
+                    let repo = PostTypeRepository::<EditContext>::new();
+                    repo.select_all(conn, &db_site)
+                })
+            }),
+        );
+
+        Arc::new(PostTypeCollectionWithEditContext::new(
+            stateless_collection,
+            Arc::new(self.clone()),
+        ))
     }
 }
 

--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -80,12 +80,13 @@ impl PostTypeService {
     /// The collection provides reactive access to cached post types with
     /// database change notifications.
     ///
-    /// By default, only viewable post types are returned (those with `viewable = true`).
+    /// By default, only viewable and UI-visible post types are returned
+    /// (those with `viewable = true` and `show_ui = true`).
     /// For custom filtering, use `create_post_type_collection_with_edit_context_filtered()`.
     ///
     /// # Example (Kotlin)
     /// ```kotlin
-    /// // Get viewable post types (default behavior)
+    /// // Get viewable and UI-visible post types (default behavior)
     /// val collection = postTypeService.createPostTypeCollectionWithEditContext()
     /// ```
     pub fn create_post_type_collection_with_edit_context(
@@ -100,16 +101,20 @@ impl PostTypeService {
     /// database change notifications.
     ///
     /// # Arguments
-    /// * `filter` - Filter criteria for post types (viewable status, etc.)
+    /// * `filter` - Filter criteria for post types (viewable, show_ui, hierarchical)
     ///
     /// # Example (Kotlin)
     /// ```kotlin
     /// // Get all post types (no filtering)
-    /// val allFilter = PostTypeFilter(viewable = null)
+    /// val allFilter = PostTypeFilter(viewable = null, showUi = null, hierarchical = null)
     /// val allCollection = postTypeService.createPostTypeCollectionWithEditContextFiltered(allFilter)
     ///
-    /// // Get only non-viewable post types
-    /// val hiddenFilter = PostTypeFilter(viewable = false)
+    /// // Get only hierarchical post types that are viewable and shown in UI
+    /// val hierarchicalFilter = PostTypeFilter(viewable = true, showUi = true, hierarchical = true)
+    /// val hierarchicalCollection = postTypeService.createPostTypeCollectionWithEditContextFiltered(hierarchicalFilter)
+    ///
+    /// // Get hidden/internal post types
+    /// val hiddenFilter = PostTypeFilter(viewable = null, showUi = false, hierarchical = null)
     /// val hiddenCollection = postTypeService.createPostTypeCollectionWithEditContextFiltered(hiddenFilter)
     /// ```
     pub fn create_post_type_collection_with_edit_context_filtered(
@@ -129,13 +134,33 @@ impl PostTypeService {
                     let all_post_types = repo.select_all(conn, &db_site)?;
 
                     // Apply filtering in memory
-                    let filtered = match filter_clone.viewable {
-                        None => all_post_types,
-                        Some(viewable_value) => all_post_types
-                            .into_iter()
-                            .filter(|entity| entity.data.post_type.viewable == viewable_value)
-                            .collect(),
-                    };
+                    let filtered = all_post_types
+                        .into_iter()
+                        .filter(|entity| {
+                            // Filter by viewable
+                            if let Some(viewable_value) = filter_clone.viewable {
+                                if entity.data.post_type.viewable != viewable_value {
+                                    return false;
+                                }
+                            }
+
+                            // Filter by show_ui
+                            if let Some(show_ui_value) = filter_clone.show_ui {
+                                if entity.data.post_type.visibility.show_ui != show_ui_value {
+                                    return false;
+                                }
+                            }
+
+                            // Filter by hierarchical
+                            if let Some(hierarchical_value) = filter_clone.hierarchical {
+                                if entity.data.post_type.hierarchical != hierarchical_value {
+                                    return false;
+                                }
+                            }
+
+                            true
+                        })
+                        .collect();
 
                     Ok(filtered)
                 })

--- a/wp_mobile_cache/migrations/0008-create-post-types-table.sql
+++ b/wp_mobile_cache/migrations/0008-create-post-types-table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `post_types_edit_context` (
+  -- Internal DB field (auto-incrementing)
+  `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  -- Site identifier (foreign key to db_sites table)
+  `db_site_id` INTEGER NOT NULL REFERENCES db_sites(id) ON DELETE CASCADE,
+
+  -- Post type slug (e.g., 'post', 'page', 'wp_block')
+  `slug` TEXT NOT NULL,
+
+  -- Full post type data as JSON (PostTypeDetailsWithEditContext)
+  `data` TEXT NOT NULL,
+
+  -- Client-side cache metadata: when this post type was last fetched from the WordPress API
+  `last_fetched_at` TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+
+  FOREIGN KEY (db_site_id) REFERENCES db_sites(id) ON DELETE CASCADE
+) STRICT;
+
+CREATE UNIQUE INDEX idx_post_types_edit_context_unique_db_site_id_and_slug ON post_types_edit_context(db_site_id, slug);
+CREATE INDEX idx_post_types_edit_context_db_site_id ON post_types_edit_context(db_site_id);

--- a/wp_mobile_cache/src/db_types.rs
+++ b/wp_mobile_cache/src/db_types.rs
@@ -2,6 +2,7 @@ pub mod db_list_metadata;
 pub mod db_site;
 pub mod db_term_relationship;
 pub mod helpers;
+pub mod post_types;
 pub mod posts;
 pub mod row_ext;
 pub mod self_hosted_site;

--- a/wp_mobile_cache/src/db_types/post_types/edit.rs
+++ b/wp_mobile_cache/src/db_types/post_types/edit.rs
@@ -1,0 +1,13 @@
+use crate::RowId;
+use wp_api::post_types::PostTypeDetailsWithEditContext;
+
+/// Database representation of a post type with edit context.
+///
+/// This wraps the API type along with database metadata (rowid, site_id, last_fetched_at).
+pub struct DbPostTypeDetailsWithEditContext {
+    pub row_id: RowId,
+    pub db_site_id: RowId,
+    pub slug: String,
+    pub post_type: PostTypeDetailsWithEditContext,
+    pub last_fetched_at: String,
+}

--- a/wp_mobile_cache/src/db_types/post_types/edit.rs
+++ b/wp_mobile_cache/src/db_types/post_types/edit.rs
@@ -1,5 +1,23 @@
-use crate::RowId;
+use crate::{RowId, db_types::row_ext::ColumnIndex};
 use wp_api::post_types::PostTypeDetailsWithEditContext;
+
+/// Column indexes for post_types_edit_context table.
+/// These must match the order of columns in the CREATE TABLE statement.
+#[repr(usize)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PostTypeEditContextColumn {
+    Rowid = 0,
+    DbSiteId = 1,
+    Slug = 2,
+    Data = 3,
+    LastFetchedAt = 4,
+}
+
+impl ColumnIndex for PostTypeEditContextColumn {
+    fn as_index(&self) -> usize {
+        *self as usize
+    }
+}
 
 /// Database representation of a post type with edit context.
 ///

--- a/wp_mobile_cache/src/db_types/post_types/mod.rs
+++ b/wp_mobile_cache/src/db_types/post_types/mod.rs
@@ -1,3 +1,4 @@
 pub mod edit;
 
 pub use edit::DbPostTypeDetailsWithEditContext;
+pub(crate) use edit::PostTypeEditContextColumn;

--- a/wp_mobile_cache/src/db_types/post_types/mod.rs
+++ b/wp_mobile_cache/src/db_types/post_types/mod.rs
@@ -1,0 +1,3 @@
+pub mod edit;
+
+pub use edit::DbPostTypeDetailsWithEditContext;

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -78,6 +78,8 @@ pub enum DbTable {
     PostsViewContext,
     /// Posts with embed context (minimal data for embeds)
     PostsEmbedContext,
+    /// Post types with edit context (post type configuration data)
+    PostTypesEditContext,
     /// Self-hosted WordPress sites
     SelfHostedSites,
     /// Database sites mapping table
@@ -102,6 +104,7 @@ impl DbTable {
             DbTable::PostsEditContext => "posts_edit_context",
             DbTable::PostsViewContext => "posts_view_context",
             DbTable::PostsEmbedContext => "posts_embed_context",
+            DbTable::PostTypesEditContext => "post_types_edit_context",
             DbTable::SelfHostedSites => "self_hosted_sites",
             DbTable::DbSites => "db_sites",
             DbTable::TermRelationships => "term_relationships",
@@ -133,6 +136,7 @@ impl TryFrom<&str> for DbTable {
             "posts_edit_context" => Ok(DbTable::PostsEditContext),
             "posts_view_context" => Ok(DbTable::PostsViewContext),
             "posts_embed_context" => Ok(DbTable::PostsEmbedContext),
+            "post_types_edit_context" => Ok(DbTable::PostTypesEditContext),
             "self_hosted_sites" => Ok(DbTable::SelfHostedSites),
             "db_sites" => Ok(DbTable::DbSites),
             "term_relationships" => Ok(DbTable::TermRelationships),

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -396,7 +396,7 @@ impl From<Connection> for WpApiCache {
     }
 }
 
-static MIGRATION_QUERIES: [&str; 7] = [
+static MIGRATION_QUERIES: [&str; 8] = [
     include_str!("../migrations/0001-create-sites-table.sql"),
     include_str!("../migrations/0002-create-posts-table.sql"),
     include_str!("../migrations/0003-create-term-relationships.sql"),
@@ -404,6 +404,7 @@ static MIGRATION_QUERIES: [&str; 7] = [
     include_str!("../migrations/0005-create-posts-embed-context-table.sql"),
     include_str!("../migrations/0006-create-self-hosted-sites-table.sql"),
     include_str!("../migrations/0007-create-list-metadata-tables.sql"),
+    include_str!("../migrations/0008-create-post-types-table.sql"),
 ];
 
 pub struct MigrationManager<'a> {

--- a/wp_mobile_cache/src/repository/mod.rs
+++ b/wp_mobile_cache/src/repository/mod.rs
@@ -2,6 +2,7 @@ use crate::{RowId, SqliteDbError};
 use rusqlite::Connection;
 
 pub mod list_metadata;
+pub mod post_types;
 pub mod posts;
 pub mod sites;
 pub mod term_relationships;

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -1,7 +1,11 @@
 use crate::{
     DbTable, RowId, SqliteDbError,
     context::{EditContext, IsContext},
-    db_types::{db_site::DbSite, post_types::DbPostTypeDetailsWithEditContext},
+    db_types::{
+        db_site::DbSite,
+        post_types::{DbPostTypeDetailsWithEditContext, PostTypeEditContextColumn},
+        row_ext::RowExt,
+    },
     entity::{EntityId, FullEntity},
     repository::QueryExecutor,
 };
@@ -38,11 +42,13 @@ impl PostTypeContext for EditContext {
     }
 
     fn from_row(row: &Row) -> Result<Self::DbPostTypeDetails, SqliteDbError> {
-        let row_id: RowId = row.get(0)?;
-        let db_site_id: RowId = row.get(1)?;
-        let slug: String = row.get(2)?;
-        let data_json: String = row.get(3)?;
-        let last_fetched_at: String = row.get(4)?;
+        use PostTypeEditContextColumn::*;
+
+        let row_id: RowId = row.get_column(Rowid)?;
+        let db_site_id: RowId = row.get_column(DbSiteId)?;
+        let slug: String = row.get_column(Slug)?;
+        let data_json: String = row.get_column(Data)?;
+        let last_fetched_at: String = row.get_column(LastFetchedAt)?;
 
         // Deserialize the JSON data into PostTypeDetailsWithEditContext
         let post_type: PostTypeDetailsWithEditContext = serde_json::from_str(&data_json)
@@ -183,5 +189,37 @@ impl<C: PostTypeContext> PostTypeRepository<C> {
         }
 
         Ok(post_types)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{db_types::row_ext::ColumnIndex, test_fixtures::test_ctx};
+    use rstest::*;
+
+    /// Verify that PostTypeEditContextColumn enum values match the actual database schema.
+    ///
+    /// This test ensures the column enum stays synchronized with the SQL schema.
+    /// If columns are added, removed, or reordered, this test will fail.
+    #[rstest]
+    fn test_post_type_edit_context_column_enum_matches_schema(test_ctx: crate::test_fixtures::TestContext) {
+        use PostTypeEditContextColumn::*;
+
+        let columns = crate::test_fixtures::get_table_column_names(&test_ctx.conn, "post_types_edit_context");
+
+        // Verify each enum value maps to the correct column name
+        assert_eq!(columns[Rowid.as_index()], "rowid");
+        assert_eq!(columns[DbSiteId.as_index()], "db_site_id");
+        assert_eq!(columns[Slug.as_index()], "slug");
+        assert_eq!(columns[Data.as_index()], "data");
+        assert_eq!(columns[LastFetchedAt.as_index()], "last_fetched_at");
+
+        // Verify we have exactly the expected number of columns
+        assert_eq!(
+            columns.len(),
+            5,
+            "Expected 5 columns in post_types_edit_context table"
+        );
     }
 }

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -164,13 +164,54 @@ impl<C: PostTypeContext> PostTypeRepository<C> {
         executor: &impl QueryExecutor,
         site: &DbSite,
     ) -> Result<Vec<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
+        self.select_by_filter(executor, site, None)
+    }
+
+    /// Select post types filtered by criteria.
+    ///
+    /// Similar to `select_all` but applies filtering based on provided parameters.
+    /// Currently supports filtering by viewable status.
+    ///
+    /// # Arguments
+    /// * `executor` - Database connection or transaction
+    /// * `site` - The site to query post types from
+    /// * `viewable` - Optional viewable filter:
+    ///   - `None`: Returns all post types (viewable=true, viewable=false, viewable=null)
+    ///   - `Some(true)`: Returns only post types where viewable is explicitly true
+    ///   - `Some(false)`: Returns only post types where viewable is explicitly false
+    ///   - Post types with viewable=null are excluded when any filter is applied
+    ///
+    /// # Returns
+    /// Vector of post types matching the filter criteria, empty if no matches found.
+    pub fn select_by_filter(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+        viewable: Option<bool>,
+    ) -> Result<Vec<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
+        // Build WHERE clause
+        let mut where_clauses = vec!["db_site_id = ?"];
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(site.row_id)];
+
+        if let Some(viewable_value) = viewable {
+            // Filter by viewable field in the JSON data
+            // json_extract returns the JSON value, so we compare against JSON boolean
+            where_clauses.push("json_extract(data, '$.viewable') = ?");
+            params.push(Box::new(viewable_value));
+        }
+
+        let where_clause = where_clauses.join(" AND ");
+
         let sql = format!(
-            "SELECT * FROM {} WHERE db_site_id = ? ORDER BY slug",
-            Self::table_name()
+            "SELECT * FROM {} WHERE {} ORDER BY slug",
+            Self::table_name(),
+            where_clause
         );
 
         let mut stmt = executor.prepare(&sql)?;
-        let rows = stmt.query_map([site.row_id.0], |row| {
+        let param_refs: Vec<&dyn rusqlite::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
             C::from_row(row).map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
         })?;
 

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -1,0 +1,187 @@
+use crate::{
+    DbTable, RowId, SqliteDbError,
+    context::{EditContext, IsContext},
+    db_types::{db_site::DbSite, post_types::DbPostTypeDetailsWithEditContext},
+    entity::{EntityId, FullEntity},
+    repository::QueryExecutor,
+};
+use rusqlite::{OptionalExtension, Row};
+use std::{marker::PhantomData, sync::Arc};
+use wp_api::post_types::PostTypeDetailsWithEditContext;
+
+/// Entity-specific context trait for PostTypes.
+///
+/// Associates a context with post-type-specific types and provides database row mapping.
+pub trait PostTypeContext: IsContext {
+    /// The context-specific post type entity type (e.g., PostTypeDetailsWithEditContext)
+    type PostTypeDetails: serde::Serialize;
+
+    /// The context-specific database wrapper type (e.g., DbPostTypeDetailsWithEditContext)
+    type DbPostTypeDetails;
+
+    /// Get the database table for this context
+    fn table() -> DbTable;
+
+    /// Construct DbPostTypeDetails from a database row
+    fn from_row(row: &Row) -> Result<Self::DbPostTypeDetails, SqliteDbError>;
+
+    /// Extract the rowid from DbPostTypeDetails (for EntityId creation)
+    fn rowid(db_post_type: &Self::DbPostTypeDetails) -> RowId;
+}
+
+impl PostTypeContext for EditContext {
+    type PostTypeDetails = PostTypeDetailsWithEditContext;
+    type DbPostTypeDetails = DbPostTypeDetailsWithEditContext;
+
+    fn table() -> DbTable {
+        DbTable::PostTypesEditContext
+    }
+
+    fn from_row(row: &Row) -> Result<Self::DbPostTypeDetails, SqliteDbError> {
+        let row_id: RowId = row.get(0)?;
+        let db_site_id: RowId = row.get(1)?;
+        let slug: String = row.get(2)?;
+        let data_json: String = row.get(3)?;
+        let last_fetched_at: String = row.get(4)?;
+
+        // Deserialize the JSON data into PostTypeDetailsWithEditContext
+        let post_type: PostTypeDetailsWithEditContext = serde_json::from_str(&data_json)
+            .map_err(|e| SqliteDbError::SqliteError(format!("Failed to parse JSON: {}", e)))?;
+
+        Ok(DbPostTypeDetailsWithEditContext {
+            row_id,
+            db_site_id,
+            slug,
+            post_type,
+            last_fetched_at,
+        })
+    }
+
+    fn rowid(db_post_type: &Self::DbPostTypeDetails) -> RowId {
+        db_post_type.row_id
+    }
+}
+
+/// Repository for managing post types in the database.
+///
+/// Generic over PostTypeContext trait to support different contexts (currently just edit).
+///
+/// # Type Parameters
+/// * `C` - The context type (EditContext)
+pub struct PostTypeRepository<C: PostTypeContext> {
+    _phantom: PhantomData<C>,
+}
+
+impl<C: PostTypeContext> Default for PostTypeRepository<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<C: PostTypeContext> PostTypeRepository<C> {
+    /// Create a new repository instance.
+    pub fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get the full table name for this context.
+    pub fn table_name() -> &'static str {
+        C::table().table_name()
+    }
+
+    /// Upsert a post type to the database.
+    ///
+    /// Inserts or updates the post type based on (db_site_id, slug) uniqueness constraint.
+    ///
+    /// # Returns
+    /// EntityId of the upserted post type
+    pub fn upsert(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+        slug: &str,
+        post_type: &C::PostTypeDetails,
+    ) -> Result<EntityId, SqliteDbError> {
+        // Serialize the post type to JSON
+        let data_json = serde_json::to_string(post_type).map_err(|e| {
+            SqliteDbError::SqliteError(format!("Failed to serialize to JSON: {}", e))
+        })?;
+
+        let sql = format!(
+            "INSERT INTO {} (db_site_id, slug, data) VALUES (?, ?, ?)
+             ON CONFLICT(db_site_id, slug) DO UPDATE SET
+             data = excluded.data,
+             last_fetched_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+             RETURNING rowid",
+            Self::table_name()
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let row_id: RowId = stmt
+            .query_row(rusqlite::params![site.row_id.0, slug, data_json], |row| {
+                row.get(0)
+            })?;
+
+        Ok(EntityId::new(*site, C::table(), row_id))
+    }
+
+    /// Select a post type by its slug.
+    ///
+    /// Returns `Ok(None)` if no post type with the given slug exists.
+    pub fn select_by_slug(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+        slug: &str,
+    ) -> Result<Option<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
+        let sql = format!(
+            "SELECT * FROM {} WHERE db_site_id = ? AND slug = ?",
+            Self::table_name()
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let db_post_type = stmt
+            .query_row(rusqlite::params![site.row_id.0, slug], |row| {
+                C::from_row(row).map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        Ok(db_post_type.map(|db_post_type| {
+            let row_id = C::rowid(&db_post_type);
+            let entity_id = Arc::new(EntityId::new(*site, C::table(), row_id));
+            FullEntity::new(entity_id, db_post_type)
+        }))
+    }
+
+    /// Select all post types for a given site.
+    ///
+    /// Returns an empty vector if no post types exist for the site.
+    pub fn select_all(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+    ) -> Result<Vec<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
+        let sql = format!(
+            "SELECT * FROM {} WHERE db_site_id = ? ORDER BY slug",
+            Self::table_name()
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let rows = stmt.query_map([site.row_id.0], |row| {
+            C::from_row(row).map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+        })?;
+
+        let mut post_types = Vec::new();
+        for row_result in rows {
+            let db_post_type = row_result?;
+            let row_id = C::rowid(&db_post_type);
+            let entity_id = Arc::new(EntityId::new(*site, C::table(), row_id));
+            post_types.push(FullEntity::new(entity_id, db_post_type));
+        }
+
+        Ok(post_types)
+    }
+}

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -180,15 +180,13 @@ impl<C: PostTypeContext> PostTypeRepository<C> {
             C::from_row(row).map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
         })?;
 
-        let mut post_types = Vec::new();
-        for row_result in rows {
+        rows.map(|row_result| {
             let db_post_type = row_result?;
             let row_id = C::rowid(&db_post_type);
             let entity_id = Arc::new(EntityId::new(*site, C::table(), row_id));
-            post_types.push(FullEntity::new(entity_id, db_post_type));
-        }
-
-        Ok(post_types)
+            Ok(FullEntity::new(entity_id, db_post_type))
+        })
+        .collect()
     }
 }
 

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -201,10 +201,13 @@ mod tests {
     /// This test ensures the column enum stays synchronized with the SQL schema.
     /// If columns are added, removed, or reordered, this test will fail.
     #[rstest]
-    fn test_post_type_edit_context_column_enum_matches_schema(test_ctx: crate::test_fixtures::TestContext) {
+    fn test_post_type_edit_context_column_enum_matches_schema(
+        test_ctx: crate::test_fixtures::TestContext,
+    ) {
         use PostTypeEditContextColumn::*;
 
-        let columns = crate::test_fixtures::get_table_column_names(&test_ctx.conn, "post_types_edit_context");
+        let columns =
+            crate::test_fixtures::get_table_column_names(&test_ctx.conn, "post_types_edit_context");
 
         // Verify each enum value maps to the correct column name
         assert_eq!(columns[Rowid.as_index()], "rowid");

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -164,54 +164,13 @@ impl<C: PostTypeContext> PostTypeRepository<C> {
         executor: &impl QueryExecutor,
         site: &DbSite,
     ) -> Result<Vec<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
-        self.select_by_filter(executor, site, None)
-    }
-
-    /// Select post types filtered by criteria.
-    ///
-    /// Similar to `select_all` but applies filtering based on provided parameters.
-    /// Currently supports filtering by viewable status.
-    ///
-    /// # Arguments
-    /// * `executor` - Database connection or transaction
-    /// * `site` - The site to query post types from
-    /// * `viewable` - Optional viewable filter:
-    ///   - `None`: Returns all post types (viewable=true, viewable=false, viewable=null)
-    ///   - `Some(true)`: Returns only post types where viewable is explicitly true
-    ///   - `Some(false)`: Returns only post types where viewable is explicitly false
-    ///   - Post types with viewable=null are excluded when any filter is applied
-    ///
-    /// # Returns
-    /// Vector of post types matching the filter criteria, empty if no matches found.
-    pub fn select_by_filter(
-        &self,
-        executor: &impl QueryExecutor,
-        site: &DbSite,
-        viewable: Option<bool>,
-    ) -> Result<Vec<FullEntity<C::DbPostTypeDetails>>, SqliteDbError> {
-        // Build WHERE clause
-        let mut where_clauses = vec!["db_site_id = ?"];
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(site.row_id)];
-
-        if let Some(viewable_value) = viewable {
-            // Filter by viewable field in the JSON data
-            // json_extract returns the JSON value, so we compare against JSON boolean
-            where_clauses.push("json_extract(data, '$.viewable') = ?");
-            params.push(Box::new(viewable_value));
-        }
-
-        let where_clause = where_clauses.join(" AND ");
-
         let sql = format!(
-            "SELECT * FROM {} WHERE {} ORDER BY slug",
-            Self::table_name(),
-            where_clause
+            "SELECT * FROM {} WHERE db_site_id = ? ORDER BY slug",
+            Self::table_name()
         );
 
         let mut stmt = executor.prepare(&sql)?;
-        let param_refs: Vec<&dyn rusqlite::ToSql> =
-            params.iter().map(|p| p.as_ref()).collect();
-        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        let rows = stmt.query_map([site.row_id.0], |row| {
             C::from_row(row).map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
         })?;
 

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -14,6 +14,7 @@ use rusqlite::Connection;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 pub mod posts;
+pub mod post_types;
 
 /// Test context bundling common test dependencies.
 ///

--- a/wp_mobile_cache/src/test_fixtures.rs
+++ b/wp_mobile_cache/src/test_fixtures.rs
@@ -13,8 +13,8 @@ use rstest::*;
 use rusqlite::Connection;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-pub mod posts;
 pub mod post_types;
+pub mod posts;
 
 /// Test context bundling common test dependencies.
 ///

--- a/wp_mobile_cache/src/test_fixtures/post_types.rs
+++ b/wp_mobile_cache/src/test_fixtures/post_types.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use wp_api::{
     JsonValue,
     post_types::{
-        PostTypeCapabilities, PostTypeDetailsWithEditContext, PostTypeLabels,
-        PostTypeSupports, PostTypeSupportsMap, PostTypeVisibility,
+        PostTypeCapabilities, PostTypeDetailsWithEditContext, PostTypeLabels, PostTypeSupports,
+        PostTypeSupportsMap, PostTypeVisibility,
     },
 };
 

--- a/wp_mobile_cache/src/test_fixtures/post_types.rs
+++ b/wp_mobile_cache/src/test_fixtures/post_types.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+use wp_api::{
+    JsonValue,
+    post_types::{
+        PostTypeCapabilities, PostTypeDetailsWithEditContext, PostTypeLabels,
+        PostTypeSupports, PostTypeSupportsMap, PostTypeVisibility,
+    },
+};
+
+/// Builder for creating test post types with configurable attributes.
+///
+/// Simplifies creation of post type test data with different viewable, show_ui,
+/// and hierarchical values for testing filtering logic.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // Create a viewable, UI-visible, hierarchical post type (like 'page')
+/// let page = PostTypeBuilder::new("page")
+///     .viewable(true)
+///     .show_ui(true)
+///     .hierarchical(true)
+///     .build();
+///
+/// // Create a non-viewable, hidden post type (like 'revision')
+/// let revision = PostTypeBuilder::new("revision")
+///     .viewable(false)
+///     .show_ui(false)
+///     .hierarchical(false)
+///     .build();
+/// ```
+pub struct PostTypeBuilder {
+    post_type: PostTypeDetailsWithEditContext,
+}
+
+impl PostTypeBuilder {
+    /// Create a new builder with defaults matching a typical viewable post type.
+    ///
+    /// Default values:
+    /// - viewable: true
+    /// - show_ui: true
+    /// - hierarchical: false
+    /// - rest_base: same as slug
+    pub fn new(slug: &str) -> Self {
+        let post_type = PostTypeDetailsWithEditContext {
+            capabilities: HashMap::from([
+                (PostTypeCapabilities::EditPost, "edit_posts".to_string()),
+                (PostTypeCapabilities::ReadPost, "read".to_string()),
+                (PostTypeCapabilities::DeletePost, "delete_posts".to_string()),
+            ]),
+            description: format!("Test {} post type", slug),
+            hierarchical: false,
+            viewable: true,
+            labels: PostTypeLabels {
+                name: slug.to_string(),
+                singular_name: slug.to_string(),
+                add_new: "Add New".to_string(),
+                add_new_item: format!("Add New {}", slug),
+                edit_item: format!("Edit {}", slug),
+                new_item: format!("New {}", slug),
+                view_item: format!("View {}", slug),
+                view_items: format!("View {}", slug),
+                search_items: format!("Search {}", slug),
+                not_found: format!("No {} found", slug),
+                not_found_in_trash: format!("No {} found in Trash", slug),
+                parent_item_colon: None,
+                all_items: format!("All {}", slug),
+                archives: format!("{} Archives", slug),
+                attributes: format!("{} Attributes", slug),
+                insert_into_item: format!("Insert into {}", slug),
+                uploaded_to_this_item: format!("Uploaded to this {}", slug),
+                featured_image: "Featured Image".to_string(),
+                set_featured_image: "Set featured image".to_string(),
+                remove_featured_image: "Remove featured image".to_string(),
+                use_featured_image: "Use as featured image".to_string(),
+                filter_items_list: format!("Filter {} list", slug),
+                filter_by_date: "Filter by date".to_string(),
+                items_list_navigation: format!("{} list navigation", slug),
+                items_list: format!("{} list", slug),
+                item_published: format!("{} published", slug),
+                item_published_privately: format!("{} published privately", slug),
+                item_reverted_to_draft: format!("{} reverted to draft", slug),
+                item_trashed: format!("{} trashed", slug),
+                item_scheduled: format!("{} scheduled", slug),
+                item_updated: format!("{} updated", slug),
+                item_link: format!("{} Link", slug),
+                item_link_description: format!("A link to a {}", slug),
+                menu_name: slug.to_string(),
+                name_admin_bar: slug.to_string(),
+            },
+            name: slug.to_string(),
+            slug: slug.to_string(),
+            supports: PostTypeSupportsMap {
+                map: HashMap::from([
+                    (PostTypeSupports::Title, JsonValue::Bool(true)),
+                    (PostTypeSupports::Editor, JsonValue::Bool(true)),
+                ]),
+            },
+            has_archive: false,
+            taxonomies: vec![],
+            rest_base: slug.to_string(),
+            rest_namespace: "wp/v2".to_string(),
+            visibility: PostTypeVisibility {
+                show_in_nav_menus: true,
+                show_ui: true,
+            },
+            icon: None,
+        };
+
+        Self { post_type }
+    }
+
+    /// Set the viewable attribute.
+    pub fn viewable(mut self, viewable: bool) -> Self {
+        self.post_type.viewable = viewable;
+        self
+    }
+
+    /// Set the show_ui attribute (via visibility.show_ui).
+    pub fn show_ui(mut self, show_ui: bool) -> Self {
+        self.post_type.visibility.show_ui = show_ui;
+        self
+    }
+
+    /// Set the hierarchical attribute.
+    pub fn hierarchical(mut self, hierarchical: bool) -> Self {
+        self.post_type.hierarchical = hierarchical;
+        self
+    }
+
+    /// Set the rest_base (defaults to slug if not set).
+    pub fn rest_base(mut self, rest_base: &str) -> Self {
+        self.post_type.rest_base = rest_base.to_string();
+        self
+    }
+
+    /// Build the final PostTypeDetailsWithEditContext.
+    pub fn build(self) -> PostTypeDetailsWithEditContext {
+        self.post_type
+    }
+}


### PR DESCRIPTION
Adds complete post types collection functionality to enable clients to discover and manage available WordPress content types (posts, pages, custom post types, etc.).

### Summary

This PR implements the full stack for post types:
- **Database layer**: SQLite storage with edit context support
- **Service layer**: Fetch and sync operations with in-memory filtering
- **Collection layer**: Reactive collections with database change notifications
- **Platform bindings**: Kotlin/Swift wrappers with observable pattern
- **Example app**: UI for viewing and filtering post types

### Key Features

**Smart Filtering**
- Filter by `viewable` (user-facing vs internal types)
- Filter by `show_ui` (types shown in admin UI)
- Filter by `hierarchical` (supports parent/child relationships)
- Default behavior: Returns only viewable + UI-visible types (post, page, attachment, etc.)
- Filtering happens in-memory since post types are a small dataset (<20 per site)

**Endpoint Resolution**
- Uses `rest_base` from post type details for accurate API endpoint construction
- Handles custom post types with non-standard REST bases (e.g., 'attachment' → 'media')

**Type Safety**
- Column enum with schema validation ensures database consistency
- Functional programming patterns throughout (no mutable state or imperative loops)
