### PR TITLE
Fix a few parsing issues when parsing custom post types

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MediaEndpointTest.kt
@@ -70,7 +70,7 @@ class MediaEndpointTest {
                 params = MediaCreateParams(title = title, filePath = "test_media.jpg")
             )
         }.assertSuccessAndRetrieveData().data
-        assertEquals(title, response.title.rendered)
+        assertEquals(title, response.title?.rendered)
         restoreTestServer()
     }
 
@@ -112,7 +112,7 @@ class MediaEndpointTest {
         }.assertSuccessAndRetrieveData().data
 
         // Verify upload was successful
-        assertEquals(title, response.title.rendered)
+        assertEquals(title, response.title?.rendered)
 
         // Verify progress reporting worked
         assert(uploadStarted) { "Upload should have started" }

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/ObservableEntityTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/ObservableEntityTest.kt
@@ -48,7 +48,7 @@ class ObservableEntityTest {
 
         // Verify data was actually updated
         val fullEntity = observableEntity.loadData()!!
-        assertEquals("Updated Title", fullEntity.data.title.rendered)
+        assertEquals("Updated Title", fullEntity.data.title?.rendered)
     }
 
     @Test

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
@@ -176,7 +176,7 @@ class PostCollectionViewModel(
                 val postDataList = allPosts.map { fullEntity ->
                     PostDisplayData(
                         entityId = fullEntity.entityId,
-                        title = fullEntity.data.title.rendered,
+                        title = fullEntity.data.title?.rendered ?: "<no-title>",
                         contentPreview = fullEntity.data.content.rendered.take(100),
                         status = fullEntity.data.status.toString(),
                         date = fullEntity.data.date,

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/stresstest/StressTestViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/stresstest/StressTestViewModel.kt
@@ -102,7 +102,7 @@ class StressTestViewModel(
                 val postDataList = allPosts.map { fullEntity ->
                     PostDisplayData(
                         entityId = fullEntity.entityId,
-                        title = fullEntity.data.title.rendered,
+                        title = fullEntity.data.title?.rendered ?: "<no-title>",
                         contentPreview = fullEntity.data.content.rendered.take(100),
                         status = fullEntity.data.status.toString(),
                         author = fullEntity.data.author?.toString(),

--- a/native/swift/Example/Example/ListViewData.swift
+++ b/native/swift/Example/Example/ListViewData.swift
@@ -146,7 +146,7 @@ extension SiteSettingsWithEditContext {
 
 extension AnyPostWithEditContext: ListViewDataConvertable {
     var asListViewData: ListViewData {
-        ListViewData(id: self.slug, title: self.title.rendered, subtitle: self.slug, fields: [:])
+        ListViewData(id: self.slug, title: self.title?.rendered ?? "<no-title>", subtitle: self.slug, fields: [:])
     }
 }
 

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -389,7 +389,7 @@ pub struct SparseAnyPost {
     #[WpContextualOption]
     pub generated_slug: Option<String>,
     #[WpContext(edit, embed, view)]
-    #[WpContextualField]
+    #[WpContextualField(option)]
     pub title: Option<SparsePostTitle>,
     #[WpContext(edit, view)]
     #[WpContextualField]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -380,6 +380,7 @@ pub struct SparseAnyPost {
     #[WpContext(edit, embed, view)]
     pub post_type: Option<String>,
     #[WpContext(edit)]
+    #[WpContextualOption]
     pub password: Option<String>,
     #[WpContext(edit)]
     #[WpContextualOption]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -477,6 +477,7 @@ pub struct SparsePostExcerpt {
 
 #[derive(Debug, PartialEq, Eq, Serialize, WpDeserialize, uniffi::Record)]
 pub struct PostMeta {
+    #[serde(default)]
     #[serde(deserialize_with = "deserialize_from_string_of_json_array")]
     #[serde(serialize_with = "serialize_as_json_string")]
     pub footnotes: Option<Vec<PostFootnote>>,
@@ -725,6 +726,26 @@ mod tests {
         #[case] expected_mapped_field_name: &str,
     ) {
         assert_eq!(field.as_mapped_field_name(), expected_mapped_field_name);
+    }
+
+    #[rstest]
+    #[case(r#"{}"#)]
+    #[case(r#"{"footnotes": ""}"#)]
+    #[case(r#"{"other": "values"}"#)]
+    fn test_meta_without_footnotes(#[case] json_data: &str) {
+        let meta: PostMeta = serde_json::from_str(json_data).unwrap();
+        assert_eq!(meta.footnotes, None);
+    }
+
+    #[test]
+    fn test_meta_footnotes() {
+        let json_data = r#"{"footnotes": "[{\"content\":\"some_content\",\"id\":\"some_id\"}]"}"#;
+        let meta: PostMeta = serde_json::from_str(json_data).unwrap();
+        let footnotes = meta.footnotes.unwrap();
+
+        assert_eq!(footnotes.len(), 1);
+        assert_eq!(footnotes[0].id, "some_id");
+        assert_eq!(footnotes[0].content, "some_content");
     }
 
     fn expected_query_pairs_for_post_list_params_with_all_fields() -> String {

--- a/wp_api_integration_tests/tests/test_pages_immut.rs
+++ b/wp_api_integration_tests/tests/test_pages_immut.rs
@@ -107,8 +107,8 @@ async fn retrieve_password_protected_with_edit_context() {
         .assert_response()
         .data;
     assert_eq!(
-        page.title.rendered,
-        test_credentials.password_protected_page_title
+        page.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_page_title.to_string()),
     );
 }
 
@@ -133,8 +133,8 @@ async fn retrieve_password_protected_with_embed_context() {
         .assert_response()
         .data;
     assert_eq!(
-        page.title.rendered,
-        test_credentials.password_protected_page_title
+        page.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_page_title.to_string())
     );
 }
 
@@ -159,8 +159,8 @@ async fn retrieve_password_protected_with_view_context() {
         .assert_response()
         .data;
     assert_eq!(
-        page.title.rendered,
-        test_credentials.password_protected_page_title
+        page.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_page_title.to_string())
     );
 }
 

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -196,7 +196,7 @@ generate_update_test!(
     password,
     "new_password".to_string(),
     |updated_page, updated_page_from_wp_cli| {
-        assert_eq!(updated_page.password, "new_password");
+        assert_eq!(updated_page.password, Some("new_password".to_string()));
         assert_eq!(updated_page_from_wp_cli.password, "new_password");
     }
 );

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -16,7 +16,10 @@ async fn create_page_with_just_title() {
             ..Default::default()
         },
         |created_page, page_from_wp_cli| {
-            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_page.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(page_from_wp_cli.title, "foo");
         },
     )
@@ -41,7 +44,10 @@ async fn create_page_with_title_and_meta() {
             let meta = created_page.meta.unwrap();
             let footnotes = meta.footnotes.unwrap();
             let footnote = footnotes.first().unwrap();
-            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_page.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(page_from_wp_cli.title, "foo");
             assert_eq!(footnote.id, "bar");
             assert_eq!(footnote.content, "baz");
@@ -93,7 +99,10 @@ async fn create_page_with_title_content_and_excerpt() {
             ..Default::default()
         },
         |created_page, page_from_wp_cli| {
-            assert_eq!(created_page.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_page.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(page_from_wp_cli.title, "foo");
             assert_eq!(created_page.content.raw, Some("bar".to_string()));
             assert_eq!(page_from_wp_cli.content, "bar");
@@ -206,7 +215,10 @@ generate_update_test!(
     title,
     "new_title".to_string(),
     |updated_page, updated_page_from_wp_cli| {
-        assert_eq!(updated_page.title.raw, Some("new_title".to_string()));
+        assert_eq!(
+            updated_page.title.and_then(|t| t.raw),
+            Some("new_title".to_string())
+        );
         assert_eq!(updated_page_from_wp_cli.title, "new_title");
     }
 );

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -117,8 +117,8 @@ async fn retrieve_password_protected_with_edit_context() {
         .assert_response()
         .data;
     assert_eq!(
-        post.title.rendered,
-        test_credentials.password_protected_post_title
+        post.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_post_title.to_string())
     );
 }
 
@@ -143,8 +143,8 @@ async fn retrieve_password_protected_with_embed_context() {
         .assert_response()
         .data;
     assert_eq!(
-        post.title.rendered,
-        test_credentials.password_protected_post_title
+        post.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_post_title.to_string())
     );
 }
 
@@ -169,8 +169,8 @@ async fn retrieve_password_protected_with_view_context() {
         .assert_response()
         .data;
     assert_eq!(
-        post.title.rendered,
-        test_credentials.password_protected_post_title
+        post.title.map(|t| t.rendered),
+        Some(test_credentials.password_protected_post_title.to_string())
     );
 }
 

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -18,7 +18,10 @@ async fn create_post_with_just_title() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_post.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(post_from_wp_cli.title, "foo");
         },
     )
@@ -43,7 +46,10 @@ async fn create_post_with_title_and_meta() {
             let meta = created_post.meta.unwrap();
             let footnotes = meta.footnotes.unwrap();
             let footnote = footnotes.first().unwrap();
-            assert_eq!(created_post.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_post.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(post_from_wp_cli.title, "foo");
             assert_eq!(footnote.id, "bar");
             assert_eq!(footnote.content, "baz");
@@ -95,7 +101,10 @@ async fn create_post_with_title_content_and_excerpt() {
             ..Default::default()
         },
         |created_post, post_from_wp_cli| {
-            assert_eq!(created_post.title.raw, Some("foo".to_string()));
+            assert_eq!(
+                created_post.title.and_then(|t| t.raw),
+                Some("foo".to_string())
+            );
             assert_eq!(post_from_wp_cli.title, "foo");
             assert_eq!(created_post.content.raw, Some("bar".to_string()));
             assert_eq!(post_from_wp_cli.content, "bar");
@@ -202,7 +211,10 @@ generate_update_test!(
     title,
     "new_title".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.title.raw, Some("new_title".to_string()));
+        assert_eq!(
+            updated_post.title.and_then(|t| t.raw),
+            Some("new_title".to_string())
+        );
         assert_eq!(updated_post_from_wp_cli.title, "new_title");
     }
 );

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -192,7 +192,7 @@ generate_update_test!(
     password,
     "new_password".to_string(),
     |updated_post, updated_post_from_wp_cli| {
-        assert_eq!(updated_post.password, "new_password");
+        assert_eq!(updated_post.password, Some("new_password".to_string()));
         assert_eq!(updated_post_from_wp_cli.password, "new_password");
     }
 );

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -249,6 +249,47 @@
 //!
 //! ---
 //!
+//! Sometimes, you may want a contextual field to remain optional even in the generated types.
+//! For this, use `#[WpContextualField(option)]`:
+//!
+//! ```
+//! # use wp_contextual::WpContextual;
+//! #[derive(WpContextual)]
+//! pub struct SparsePost {
+//!     #[WpContext(edit, embed, view)]
+//!     pub id: Option<u32>,
+//!     #[WpContext(edit)]
+//!     #[WpContextualField(option)]
+//!     pub title: Option<SparsePostTitle>,
+//! }
+//! # #[derive(Debug, serde::Serialize, serde::Deserialize, uniffi::Record, WpContextual)]
+//! # pub struct SparsePostTitle {
+//! #     #[WpContext(edit)]
+//! #     pub rendered: Option<String>,
+//! # }
+//! # // We need this line because `WpContextual` implements `crate::SparseField`
+//! # trait SparseField { fn as_mapped_field_name(&self) -> &str; }
+//! # // We need these 2 lines for UniFFI
+//! # uniffi::setup_scaffolding!();
+//! # fn main() {}
+//! ```
+//!
+//! This will generate:
+//!
+//! ```
+//! pub struct PostWithEditContext {
+//!     pub id: u32,
+//!     pub title: Option<PostTitleWithEditContext>,
+//! }
+//! # struct PostTitleWithEditContext {}
+//! ```
+//!
+//! Notice that `title` remains `Option<...>` in the generated type, unlike regular
+//! `#[WpContextualField]` which would unwrap the Option. This is useful when a nested
+//! contextual field may not always be present in the API response.
+//!
+//! ---
+//!
 //! In some instances, we might need a field to be included in contextual types, but still be an
 //! `Option`. In these cases, `WpContextualOption` attribute can be used:
 //!
@@ -392,6 +433,9 @@ mod wp_contextual;
 ///   [`WpContextual`] type. This will tell the compiler to replace the given `Option<SparseBaz>`
 ///   type with the appropriate contextual type: `BazWithEditContext`, `BazWithEmbedContext` or
 ///   `BazWithViewContext`.
+/// * `[WpContextualField(option)]` is like `[WpContextualField]` but keeps the `Option` wrapper
+///   in the generated types. This is useful when a nested contextual field may not always be
+///   present in the API response.
 /// * `[WpContextualOption]` is used to tell the compiler to keep the field's `Option` type.
 /// * `[WpContextualExcludeFromFields]` is used to exclude a field from the generated field enums
 ///   (`SparseFooFieldWithEditContext`, etc.) while still including it in the contextual types.

--- a/wp_contextual/src/wp_contextual.rs
+++ b/wp_contextual/src/wp_contextual.rs
@@ -173,7 +173,12 @@ fn parse_fields(
                         .expect("Already validated that there is only one segment");
                     let segment_ident = &path_segment.ident;
                     if is_wp_contextual_field_ident(segment_ident) {
-                        return Ok(WpParsedAttr::ParsedWpContextualField);
+                        let keep_option = if let syn::Meta::List(meta_list) = &attr.meta {
+                            parse_wp_contextual_field_option(meta_list.tokens.clone())?
+                        } else {
+                            false
+                        };
+                        return Ok(WpParsedAttr::ParsedWpContextualField { keep_option });
                     }
                     if is_wp_contextual_option_ident(segment_ident) {
                         return Ok(WpParsedAttr::ParsedWpContextualOption);
@@ -204,10 +209,10 @@ fn parse_fields(
         .collect::<Result<Vec<WpParsedField>, syn::Error>>()?;
 
     let assert_has_wp_context_attribute_if_it_has_given_attribute =
-        |attribute_to_check: WpParsedAttr, error_type: WpContextualParseError| {
+        |attribute_predicate: fn(&WpParsedAttr) -> bool, error_type: WpContextualParseError| {
             if let Some(pf) = parsed_fields
                 .iter()
-                .filter(|pf| pf.parsed_attrs.contains(&attribute_to_check))
+                .filter(|pf| pf.parsed_attrs.iter().any(attribute_predicate))
                 .find(|pf| {
                     !pf.parsed_attrs.iter().any(|pf| match pf {
                         WpParsedAttr::ParsedWpContext { contexts } => !contexts.is_empty(),
@@ -224,14 +229,14 @@ fn parse_fields(
     // Check if there are any fields that has #[WpContextualField] attribute,
     // but not the #[WpContext] attribute
     assert_has_wp_context_attribute_if_it_has_given_attribute(
-        WpParsedAttr::ParsedWpContextualField,
+        |attr| matches!(attr, WpParsedAttr::ParsedWpContextualField { .. }),
         WpContextualParseError::WpContextualFieldWithoutWpContext,
     )?;
 
-    // Check if there are any fields that has #[WpContextualField] attribute,
+    // Check if there are any fields that has #[WpContextualOption] attribute,
     // but not the #[WpContext] attribute
     assert_has_wp_context_attribute_if_it_has_given_attribute(
-        WpParsedAttr::ParsedWpContextualOption,
+        |attr| matches!(attr, WpParsedAttr::ParsedWpContextualOption),
         WpContextualParseError::WpContextualOptionWithoutWpContext,
     )?;
 
@@ -241,7 +246,8 @@ fn parse_fields(
     // it.
     if let Some(pf) = parsed_fields.iter().find(|pf| {
         pf.parsed_attrs
-            .contains(&WpParsedAttr::ParsedWpContextualField)
+            .iter()
+            .any(|attr| matches!(attr, WpParsedAttr::ParsedWpContextualField { .. }))
             && pf
                 .parsed_attrs
                 .contains(&WpParsedAttr::ParsedWpContextualOption)
@@ -402,6 +408,7 @@ fn generate_integration_test_helper(
 struct GeneratedContextualField {
     field: syn::Field,
     is_wp_contextual_option: bool,
+    is_wp_contextual_field_keep_option: bool,
     is_wp_contextual_exclude_from_fields: bool,
 }
 
@@ -437,14 +444,27 @@ impl GeneratedContextualField {
                     .parsed_attrs
                     .contains(&WpParsedAttr::ParsedWpContextualExcludeFromFields);
 
+                let is_wp_contextual_field_keep_option = pf
+                    .parsed_attrs
+                    .iter()
+                    .find_map(|attr| {
+                        if let WpParsedAttr::ParsedWpContextualField { keep_option } = attr {
+                            Some(*keep_option)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(false);
+
                 let new_type = if is_wp_contextual_option {
                     f.ty.clone()
                 } else {
-                    let mut new_type = if should_extract_option {
-                        extract_inner_type_of_option(&f.ty).unwrap_or(f.ty.clone())
-                    } else {
-                        f.ty.clone()
-                    };
+                    let mut new_type =
+                        if should_extract_option && !is_wp_contextual_field_keep_option {
+                            extract_inner_type_of_option(&f.ty).unwrap_or(f.ty.clone())
+                        } else {
+                            f.ty.clone()
+                        };
                     if f.attrs.iter().any(|attr| {
                         attr.path()
                             .segments
@@ -483,6 +503,7 @@ impl GeneratedContextualField {
                 Ok(Self {
                     field: new_field,
                     is_wp_contextual_option,
+                    is_wp_contextual_field_keep_option,
                     is_wp_contextual_exclude_from_fields,
                 })
             })
@@ -783,6 +804,38 @@ fn parse_contexts_from_tokens(
         .collect::<Result<Vec<WpContextAttr>, syn::Error>>()
 }
 
+// Parses the tokens inside #[WpContextualField(option)] to check if "option" is present.
+// Returns true if "option" is found, false for empty tokens.
+// Returns error for any other token.
+fn parse_wp_contextual_field_option(tokens: proc_macro2::TokenStream) -> Result<bool, syn::Error> {
+    let mut has_option = false;
+    for t in tokens.into_iter() {
+        match t {
+            proc_macro2::TokenTree::Ident(ident) => {
+                if ident == "option" {
+                    has_option = true;
+                } else {
+                    return Err(
+                        WpContextualParseAttrError::UnexpectedWpContextualFieldIdent {
+                            input: ident.to_string(),
+                        }
+                        .into_syn_error(ident.span()),
+                    );
+                }
+            }
+            proc_macro2::TokenTree::Punct(_) | proc_macro2::TokenTree::Group(_) => {
+                return Err(WpContextualParseAttrError::UnexpectedToken.into_syn_error(t.span()));
+            }
+            proc_macro2::TokenTree::Literal(l) => {
+                return Err(
+                    WpContextualParseAttrError::UnexpectedLiteralToken.into_syn_error(l.span())
+                );
+            }
+        }
+    }
+    Ok(has_option)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct WpParsedField {
     field: syn::Field,
@@ -791,7 +844,7 @@ struct WpParsedField {
 
 #[derive(Debug, PartialEq, Eq)]
 enum WpParsedAttr {
-    ParsedWpContextualField,
+    ParsedWpContextualField { keep_option: bool },
     ParsedWpContextualOption,
     ParsedWpContextualExcludeFromFields,
     ParsedWpContext { contexts: Vec<WpContextAttr> },
@@ -897,6 +950,8 @@ enum WpContextualParseAttrError {
     UnexpectedPunct,
     #[error("Expected 'edit', 'embed' or 'view', found '{}'", input)]
     UnexpectedWpContextIdent { input: String },
+    #[error("Expected 'option', found '{}'", input)]
+    UnexpectedWpContextualFieldIdent { input: String },
     // syn::Meta::Path or syn::Meta::NameValue
     #[error("Expected #[WpContext(edit, embed, view)]. Did you forget to add context types?")]
     MissingWpContextMeta,

--- a/wp_mobile/src/service/mock_post_service.rs
+++ b/wp_mobile/src/service/mock_post_service.rs
@@ -67,8 +67,10 @@ fn stress_test_batch_update(
         let _result = cache.execute(|conn| {
             if let Some(full_entity) = repo.select_by_entity_id(conn, entity_id)? {
                 let mut post = full_entity.data.post;
-                post.title.rendered =
-                    format!("Updated Post {} (batch #{})", post.id.0, current_count);
+                if let Some(ref mut title) = post.title {
+                    title.rendered =
+                        format!("Updated Post {} (batch #{})", post.id.0, current_count);
+                }
                 post.content.rendered =
                     format!("<p>Content updated at batch #{}</p>", current_count);
 
@@ -145,10 +147,10 @@ fn create_test_post(
         password: Some("".to_string()),
         permalink_template: None,
         generated_slug: None,
-        title: PostTitleWithEditContext {
+        title: Some(PostTitleWithEditContext {
             raw: None,
             rendered: title.to_string(),
-        },
+        }),
         content: PostContentWithEditContext {
             raw: None,
             rendered: content.to_string(),
@@ -255,7 +257,9 @@ impl MockPostService {
                     })?
                     .data
                     .post;
-                post.title.rendered = new_title;
+                if let Some(ref mut title) = post.title {
+                    title.rendered = new_title;
+                }
                 repo.upsert(conn, &self.db_site, &post)?;
                 Ok::<_, wp_mobile_cache::SqliteDbError>(())
             })
@@ -338,8 +342,12 @@ impl MockPostService {
                         // Read and update in a single atomic operation
                         if let Some(full_entity) = repo.select_by_entity_id(conn, entity_id)? {
                             let mut post = full_entity.data.post;
-                            post.title.rendered =
-                                format!("Updated Post {} (update #{})", post.id.0, current_count);
+                            if let Some(ref mut title) = post.title {
+                                title.rendered = format!(
+                                    "Updated Post {} (update #{})",
+                                    post.id.0, current_count
+                                );
+                            }
                             repo.upsert(conn, &db_site, &post)?;
                         }
                         Ok::<_, wp_mobile_cache::SqliteDbError>(())

--- a/wp_mobile/src/service/mock_post_service.rs
+++ b/wp_mobile/src/service/mock_post_service.rs
@@ -142,7 +142,7 @@ fn create_test_post(
         slug: slug.to_string(),
         status: PostStatus::Publish,
         post_type: "post".to_string(),
-        password: "".to_string(),
+        password: Some("".to_string()),
         permalink_template: None,
         generated_slug: None,
         title: PostTitleWithEditContext {

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -1026,7 +1026,10 @@ mod tests {
         /// Assert that a retrieved post matches the expected values
         fn assert_matches(&self, post: &AnyPostWithEditContext) {
             assert_eq!(post.id, self.id);
-            assert_eq!(post.title.rendered, self.title);
+            assert_eq!(
+                post.title.as_ref().map(|t| t.rendered.clone()),
+                Some(self.title.to_string())
+            );
             assert_eq!(post.slug, self.slug);
         }
     }

--- a/wp_mobile_cache/migrations/0002-create-posts-table.sql
+++ b/wp_mobile_cache/migrations/0002-create-posts-table.sql
@@ -15,7 +15,7 @@ CREATE TABLE `posts_edit_context` (
   `slug` TEXT NOT NULL,
   `status` TEXT NOT NULL,
   `post_type` TEXT NOT NULL,
-  `password` TEXT NOT NULL,
+  `password` TEXT,
   `template` TEXT NOT NULL,
 
   -- Top-level optional fields
@@ -41,7 +41,7 @@ CREATE TABLE `posts_edit_context` (
 
   -- Nested: title (title is non-optional, but title.raw is optional)
   `title_raw` TEXT,
-  `title_rendered` TEXT NOT NULL,
+  `title_rendered` TEXT,
 
   -- Nested: content (content is non-optional, but some fields are optional)
   `content_raw` TEXT,

--- a/wp_mobile_cache/migrations/0004-create-posts-view-context-table.sql
+++ b/wp_mobile_cache/migrations/0004-create-posts-view-context-table.sql
@@ -36,7 +36,7 @@ CREATE TABLE `posts_view_context` (
   `guid_rendered` TEXT NOT NULL,
 
   -- Nested: title (only rendered field in view context)
-  `title_rendered` TEXT NOT NULL,
+  `title_rendered` TEXT,
 
   -- Nested: content (only rendered and protected fields in view context)
   `content_rendered` TEXT NOT NULL,

--- a/wp_mobile_cache/migrations/0005-create-posts-embed-context-table.sql
+++ b/wp_mobile_cache/migrations/0005-create-posts-embed-context-table.sql
@@ -13,7 +13,7 @@ CREATE TABLE `posts_embed_context` (
   `post_type` TEXT NOT NULL,
 
   -- Nested: title (only rendered field in embed context)
-  `title_rendered` TEXT NOT NULL,
+  `title_rendered` TEXT,
 
   -- Top-level optional fields
   `author` INTEGER,

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -476,10 +476,10 @@ impl PostContext for EditContext {
             password: row.get_column(Password)?,
             permalink_template: row.get_column(PermalinkTemplate)?,
             generated_slug: row.get_column(GeneratedSlug)?,
-            title: PostTitleWithEditContext {
+            title: Some(PostTitleWithEditContext {
                 raw: row.get_column(TitleRaw)?,
                 rendered: row.get_column(TitleRendered)?,
-            },
+            }),
             content: PostContentWithEditContext {
                 raw: row.get_column(ContentRaw)?,
                 rendered: row.get_column(ContentRendered)?,
@@ -563,9 +563,9 @@ impl PostContext for ViewContext {
             slug: row.get_column(Slug)?,
             status: parse_enum(row, Status)?,
             post_type: row.get_column(PostType)?,
-            title: PostTitleWithViewContext {
+            title: Some(PostTitleWithViewContext {
                 rendered: row.get_column(TitleRendered)?,
-            },
+            }),
             content: PostContentWithViewContext {
                 rendered: row.get_column(ContentRendered)?,
                 protected: row.get_column(ContentProtected)?,
@@ -639,9 +639,9 @@ impl PostContext for EmbedContext {
             link: row.get_column(Link)?,
             slug: row.get_column(Slug)?,
             post_type: row.get_column(PostType)?,
-            title: PostTitleWithEmbedContext {
+            title: Some(PostTitleWithEmbedContext {
                 rendered: row.get_column(TitleRendered)?,
-            },
+            }),
             author: get_optional_id(row, Author)?,
             excerpt: {
                 let excerpt_rendered: Option<String> = row.get_column(ExcerptRendered)?;
@@ -768,8 +768,8 @@ impl PostRepository<EditContext> {
                     ":meta": serialize_value_to_json(&post.meta)?,
                     ":guid_raw": post.guid.raw,
                     ":guid_rendered": post.guid.rendered,
-                    ":title_raw": post.title.raw,
-                    ":title_rendered": post.title.rendered,
+                    ":title_raw": post.title.as_ref().and_then(|t| t.raw.clone()),
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
                     ":content_raw": post.content.raw,
                     ":content_rendered": post.content.rendered,
                     ":content_protected": post.content.protected,
@@ -904,7 +904,7 @@ impl PostRepository<ViewContext> {
                     ":format": post.format.as_ref().map(|f| f.to_string()),
                     ":meta": serialize_value_to_json(&post.meta)?,
                     ":guid_rendered": post.guid.rendered,
-                    ":title_rendered": post.title.rendered,
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
                     ":content_rendered": post.content.rendered,
                     ":content_protected": post.content.protected,
                     ":excerpt_raw": post.excerpt.as_ref().and_then(|e| e.raw.clone()),
@@ -1005,7 +1005,7 @@ impl PostRepository<EmbedContext> {
                     ":link": post.link,
                     ":slug": post.slug,
                     ":post_type": post.post_type,
-                    ":title_rendered": post.title.rendered,
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
                     ":author": post.author.map(|u| u.0),
                     ":excerpt_raw": post.excerpt.as_ref().and_then(|e| e.raw.clone()),
                     ":excerpt_rendered": post.excerpt.as_ref().and_then(|e| e.rendered.clone()),

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1192,7 +1192,25 @@ mod tests {
         assert_eq!(retrieved.data.row_id, entity_id.rowid);
         assert_eq!(retrieved.data.db_site_id, test_ctx.site.row_id);
         assert_recent_timestamp(&retrieved.data.last_fetched_at);
-        assert_eq!(retrieved.data.post, original_post);
+
+        // The 'password' and 'title_rendered' columns in the SQLite database are stored as empty
+        // strings when null. Here we adjust the retrieved post to match the original for the full
+        // post comparison at the end.
+        let mut retrieved_post = retrieved.data.post;
+        if original_post.password.is_none() {
+            assert_eq!(retrieved_post.password, Some("".to_string()));
+
+            retrieved_post.password = None;
+        }
+        if original_post.title.is_none() {
+            assert_eq!(
+                retrieved_post.title.map(|t| t.rendered),
+                Some("".to_string())
+            );
+
+            retrieved_post.title = None;
+        }
+        assert_eq!(retrieved_post, original_post);
     }
 
     #[rstest]

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1173,6 +1173,7 @@ mod tests {
     #[rstest]
     #[case(PostBuilder::minimal().build())]
     #[case(PostBuilder::full().build())]
+    #[case(PostBuilder::custom().build())]
     fn test_round_trip(mut test_ctx: TestContext, #[case] original_post: AnyPostWithEditContext) {
         // Insert into database using repository
         let entity_id = test_ctx

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1192,25 +1192,7 @@ mod tests {
         assert_eq!(retrieved.data.row_id, entity_id.rowid);
         assert_eq!(retrieved.data.db_site_id, test_ctx.site.row_id);
         assert_recent_timestamp(&retrieved.data.last_fetched_at);
-
-        // The 'password' and 'title_rendered' columns in the SQLite database are stored as empty
-        // strings when null. Here we adjust the retrieved post to match the original for the full
-        // post comparison at the end.
-        let mut retrieved_post = retrieved.data.post;
-        if original_post.password.is_none() {
-            assert_eq!(retrieved_post.password, Some("".to_string()));
-
-            retrieved_post.password = None;
-        }
-        if original_post.title.is_none() {
-            assert_eq!(
-                retrieved_post.title.map(|t| t.rendered),
-                Some("".to_string())
-            );
-
-            retrieved_post.title = None;
-        }
-        assert_eq!(retrieved_post, original_post);
+        assert_eq!(retrieved.data.post, original_post);
     }
 
     #[rstest]

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -753,7 +753,7 @@ impl PostRepository<EditContext> {
                     ":slug": post.slug,
                     ":status": post.status.to_string(),
                     ":post_type": post.post_type,
-                    ":password": post.password,
+                    ":password": post.password.clone().unwrap_or_default(),
                     ":template": post.template,
                     ":permalink_template": post.permalink_template,
                     ":generated_slug": post.generated_slug,

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -476,10 +476,13 @@ impl PostContext for EditContext {
             password: row.get_column(Password)?,
             permalink_template: row.get_column(PermalinkTemplate)?,
             generated_slug: row.get_column(GeneratedSlug)?,
-            title: Some(PostTitleWithEditContext {
-                raw: row.get_column(TitleRaw)?,
-                rendered: row.get_column(TitleRendered)?,
-            }),
+            title: {
+                let title_rendered: Option<String> = row.get_column(TitleRendered)?;
+                title_rendered.map(|rendered| PostTitleWithEditContext {
+                    raw: row.get_column(TitleRaw).ok().flatten(),
+                    rendered,
+                })
+            },
             content: PostContentWithEditContext {
                 raw: row.get_column(ContentRaw)?,
                 rendered: row.get_column(ContentRendered)?,
@@ -563,9 +566,10 @@ impl PostContext for ViewContext {
             slug: row.get_column(Slug)?,
             status: parse_enum(row, Status)?,
             post_type: row.get_column(PostType)?,
-            title: Some(PostTitleWithViewContext {
-                rendered: row.get_column(TitleRendered)?,
-            }),
+            title: {
+                let title_rendered: Option<String> = row.get_column(TitleRendered)?;
+                title_rendered.map(|rendered| PostTitleWithViewContext { rendered })
+            },
             content: PostContentWithViewContext {
                 rendered: row.get_column(ContentRendered)?,
                 protected: row.get_column(ContentProtected)?,
@@ -753,7 +757,7 @@ impl PostRepository<EditContext> {
                     ":slug": post.slug,
                     ":status": post.status.to_string(),
                     ":post_type": post.post_type,
-                    ":password": post.password.clone().unwrap_or_default(),
+                    ":password": post.password.clone(),
                     ":template": post.template,
                     ":permalink_template": post.permalink_template,
                     ":generated_slug": post.generated_slug,
@@ -769,7 +773,7 @@ impl PostRepository<EditContext> {
                     ":guid_raw": post.guid.raw,
                     ":guid_rendered": post.guid.rendered,
                     ":title_raw": post.title.as_ref().and_then(|t| t.raw.clone()),
-                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()),
                     ":content_raw": post.content.raw,
                     ":content_rendered": post.content.rendered,
                     ":content_protected": post.content.protected,
@@ -904,7 +908,7 @@ impl PostRepository<ViewContext> {
                     ":format": post.format.as_ref().map(|f| f.to_string()),
                     ":meta": serialize_value_to_json(&post.meta)?,
                     ":guid_rendered": post.guid.rendered,
-                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()),
                     ":content_rendered": post.content.rendered,
                     ":content_protected": post.content.protected,
                     ":excerpt_raw": post.excerpt.as_ref().and_then(|e| e.raw.clone()),
@@ -1005,7 +1009,7 @@ impl PostRepository<EmbedContext> {
                     ":link": post.link,
                     ":slug": post.slug,
                     ":post_type": post.post_type,
-                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()).unwrap_or_default(),
+                    ":title_rendered": post.title.as_ref().map(|t| t.rendered.clone()),
                     ":author": post.author.map(|u| u.0),
                     ":excerpt_raw": post.excerpt.as_ref().and_then(|e| e.raw.clone()),
                     ":excerpt_rendered": post.excerpt.as_ref().and_then(|e| e.rendered.clone()),

--- a/wp_mobile_cache/src/repository/posts_constraint_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_constraint_tests.rs
@@ -56,7 +56,10 @@ fn test_duplicate_post_id_in_same_site_updates_on_upsert(mut test_ctx: TestConte
         .select_by_post_id(&test_ctx.conn, &test_ctx.site, post_id)
         .expect("Failed to select post by post_id")
         .expect("Post should exist");
-    assert_eq!(retrieved.data.post.title.rendered, "Updated Title");
+    assert_eq!(
+        retrieved.data.post.title.map(|t| t.rendered),
+        Some("Updated Title".to_string())
+    );
 }
 
 #[rstest]

--- a/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_multi_site_tests.rs
@@ -63,8 +63,14 @@ fn test_same_post_id_can_exist_in_different_sites(mut test_ctx: TestContext) {
         .expect("Failed to select post by post_id")
         .expect("Post should exist in site 2");
 
-    assert_eq!(retrieved1.data.post.title.rendered, "Site 1 Post");
-    assert_eq!(retrieved2.data.post.title.rendered, "Site 2 Post");
+    assert_eq!(
+        retrieved1.data.post.title.map(|t| t.rendered),
+        Some("Site 1 Post".to_string())
+    );
+    assert_eq!(
+        retrieved2.data.post.title.map(|t| t.rendered),
+        Some("Site 2 Post".to_string())
+    );
 }
 
 #[rstest]

--- a/wp_mobile_cache/src/repository/posts_transaction_tests.rs
+++ b/wp_mobile_cache/src/repository/posts_transaction_tests.rs
@@ -62,7 +62,10 @@ fn test_upsert_batch_handles_duplicate_ids_by_updating(mut test_ctx: TestContext
         .select_by_post_id(&test_ctx.conn, &test_ctx.site, PostId(200))
         .expect("Failed to select post by post_id")
         .expect("Post should exist");
-    assert_eq!(post200.data.post.title.rendered, "Updated");
+    assert_eq!(
+        post200.data.post.title.map(|t| t.rendered),
+        Some("Updated".to_string())
+    );
 
     // Verify post 300 was inserted
     assert!(

--- a/wp_mobile_cache/src/test_fixtures/posts.rs
+++ b/wp_mobile_cache/src/test_fixtures/posts.rs
@@ -177,7 +177,7 @@ fn create_minimal_post() -> AnyPostWithEditContext {
         slug: "minimal-post".to_string(),
         status: PostStatus::Publish,
         post_type: "post".to_string(),
-        password: "".to_string(),
+        password: Some("".to_string()),
         permalink_template: None,
         generated_slug: None,
         title: PostTitleWithEditContext {
@@ -221,7 +221,7 @@ fn create_full_post() -> AnyPostWithEditContext {
         slug: "full-post".to_string(),
         status: PostStatus::Draft,
         post_type: "post".to_string(),
-        password: "secret".to_string(),
+        password: Some("secret".to_string()),
         permalink_template: Some("https://example.com/%postname%/".to_string()),
         generated_slug: Some("full-post-123".to_string()),
         title: PostTitleWithEditContext {

--- a/wp_mobile_cache/src/test_fixtures/posts.rs
+++ b/wp_mobile_cache/src/test_fixtures/posts.rs
@@ -102,8 +102,10 @@ impl PostBuilder {
 
     /// Set the post title.
     pub fn with_title(mut self, title: &str) -> Self {
-        self.post.title.rendered = title.to_string();
-        self.post.title.raw = Some(title.to_string());
+        self.post.title = Some(PostTitleWithEditContext {
+            raw: Some(title.to_string()),
+            rendered: title.to_string(),
+        });
         self
     }
 
@@ -180,10 +182,10 @@ fn create_minimal_post() -> AnyPostWithEditContext {
         password: Some("".to_string()),
         permalink_template: None,
         generated_slug: None,
-        title: PostTitleWithEditContext {
+        title: Some(PostTitleWithEditContext {
             raw: None,
             rendered: "Minimal Post".to_string(),
-        },
+        }),
         content: PostContentWithEditContext {
             raw: None,
             rendered: "<p>Content</p>".to_string(),
@@ -224,10 +226,10 @@ fn create_full_post() -> AnyPostWithEditContext {
         password: Some("secret".to_string()),
         permalink_template: Some("https://example.com/%postname%/".to_string()),
         generated_slug: Some("full-post-123".to_string()),
-        title: PostTitleWithEditContext {
+        title: Some(PostTitleWithEditContext {
             raw: Some("Full Post Title".to_string()),
             rendered: "Full Post Title".to_string(),
-        },
+        }),
         content: PostContentWithEditContext {
             raw: Some("<!-- wp:paragraph --><p>Content</p><!-- /wp:paragraph -->".to_string()),
             rendered: "<p>Content</p>".to_string(),

--- a/wp_mobile_cache/src/test_fixtures/posts.rs
+++ b/wp_mobile_cache/src/test_fixtures/posts.rs
@@ -15,6 +15,8 @@ pub enum PostBuilderInitialState {
     Minimal,
     /// Fully populated post with all optional fields set
     Full,
+    /// Custom post type with specific characteristics (e.g., jetpack-social-note)
+    Custom,
 }
 
 /// Builder for creating test posts with automatic ID management.
@@ -57,6 +59,7 @@ impl PostBuilder {
         let mut post = match initial_state {
             PostBuilderInitialState::Minimal => create_minimal_post(),
             PostBuilderInitialState::Full => create_full_post(),
+            PostBuilderInitialState::Custom => create_custom_post(),
         };
         post.id = PostId(id);
         Self { post }
@@ -74,6 +77,13 @@ impl PostBuilder {
     /// Useful for testing complete post serialization/deserialization.
     pub fn full() -> Self {
         Self::new(PostBuilderInitialState::Full)
+    }
+
+    /// Create a custom post builder with custom post type characteristics.
+    ///
+    /// Useful for testing custom post types like jetpack-social-note.
+    pub fn custom() -> Self {
+        Self::new(PostBuilderInitialState::Custom)
     }
 
     /// Set a specific post ID (overrides auto-increment).
@@ -264,5 +274,50 @@ fn create_full_post() -> AnyPostWithEditContext {
         tags: Some(vec![TermId(10), TermId(20)]),
         parent: Some(PostId(5)),
         menu_order: Some(3),
+    }
+}
+
+fn create_custom_post() -> AnyPostWithEditContext {
+    AnyPostWithEditContext {
+        id: PostId(42),
+        date: "2024-01-15T10:30:00".to_string(),
+        date_gmt: "2024-01-15T10:30:00Z".parse().unwrap(),
+        guid: PostGuidWithEditContext {
+            raw: Some("https://example.com/?p=42".to_string()),
+            rendered: "https://example.com/?p=42".to_string(),
+        },
+        link: "https://example.com/full-post".to_string(),
+        modified: "2024-01-16T14:20:00".to_string(),
+        modified_gmt: "2024-01-16T14:20:00Z".parse().unwrap(),
+        slug: "1000".to_string(),
+        status: PostStatus::Draft,
+        post_type: "jetpack-social-note".to_string(),
+        password: None,
+        permalink_template: None,
+        generated_slug: None,
+        title: None,
+        content: PostContentWithEditContext {
+            raw: Some("<!-- wp:paragraph --><p>Content</p><!-- /wp:paragraph -->".to_string()),
+            rendered: "<p>Content</p>".to_string(),
+            protected: Some(false),
+            block_version: Some(1),
+        },
+        author: None,
+        excerpt: Some(SparsePostExcerpt {
+            raw: Some("Excerpt raw".to_string()),
+            rendered: Some("<p>Excerpt</p>".to_string()),
+            protected: Some(false),
+        }),
+        featured_media: Some(MediaId(100)),
+        comment_status: Some(wp_api::posts::PostCommentStatus::Open),
+        ping_status: Some(wp_api::posts::PostPingStatus::Closed),
+        format: None,
+        meta: None,
+        sticky: None,
+        template: "".to_string(),
+        categories: None,
+        tags: None,
+        parent: None,
+        menu_order: None,
     }
 }


### PR DESCRIPTION
> [!Note]
> It should be easier to review this PR commit by commit.

The `PostMeta` can't be parsed when the meta does not contain "footnotes".

The `title` and `password` properties in `SparseAnyPost` are changed from non-optional to optional. Some custom post types (such as Jetpack Social Notes) do not include those properties.

To change the `title` declaration, the `WpContextualField` macro is updated to accept a new `option` marker attribute. When present, the `title` in the generated `AnyPostWithXxxContext` structs is declared as `Option`. Here is a snippet of the actual diff of macro-expanded code between the trunk and this PR branch:

```diff
--- wp_api_expanded_trunk.rs	2026-01-07 15:28:39
+++ wp_api_expanded_new.rs	2026-01-07 15:28:49
@@ -241994,6 +241994,16 @@
     #[automatically_derived]
     impl ::core::fmt::Debug for ParsedUrl {
         #[inline]
@@ -297777,6 +297777,7 @@
         #[WpContext(edit, embed, view)]
         pub post_type: Option<String>,
         #[WpContext(edit)]
+        #[WpContextualOption]
         pub password: Option<String>,
         #[WpContext(edit)]
         #[WpContextualOption]
@@ -297785,7 +297786,7 @@
         #[WpContextualOption]
         pub generated_slug: Option<String>,
         #[WpContext(edit, embed, view)]
-        #[WpContextualField]
+        #[WpContextualField(option)]
         pub title: Option<SparsePostTitle>,
         #[WpContext(edit, view)]
         #[WpContextualField]
@@ -299849,10 +299850,10 @@
         pub status: PostStatus,
         #[serde(rename = "type")]
         pub post_type: String,
-        pub password: String,
+        pub password: Option<String>,
         pub permalink_template: Option<String>,
         pub generated_slug: Option<String>,
-        pub title: PostTitleWithEditContext,
+        pub title: Option<PostTitleWithEditContext>,
         pub content: PostContentWithEditContext,
         pub author: Option<UserId>,
         pub excerpt: Option<SparsePostExcerpt>,
```