### PR TITLE
Add form_urlencoded serialization for requests

### DIFF
--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -145,6 +145,28 @@ impl InnerRequestBuilder {
         }
     }
 
+    pub fn post_form_urlencoded<T>(&self, url: ApiEndpointUrl, params: &T) -> WpNetworkRequest
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut header_map = self.header_map_for_post_request();
+        header_map.inner.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
+
+        WpNetworkRequest {
+            uuid: Uuid::new_v4().into(),
+            retry_count: 0,
+            method: RequestMethod::POST,
+            url: url.into(),
+            header_map: header_map.into(),
+            body: serde_urlencoded::to_string(params)
+                .ok()
+                .map(|s| Arc::new(WpNetworkRequestBody::new(s.into_bytes()))),
+        }
+    }
+
     fn header_map(&self) -> WpNetworkHeaderMap {
         let mut header_map = HeaderMap::new();
         header_map.insert(
@@ -1059,6 +1081,7 @@ pub mod user_agent {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use endpoint::ApiEndpointUrl;
     use rstest::*;
     use std::ops::Add;
     use std::time::Duration;
@@ -1354,5 +1377,253 @@ mod tests {
                 .collect::<Vec<&str>>(),
             values
         );
+    }
+
+    fn test_url() -> ApiEndpointUrl {
+        ApiEndpointUrl::new(Url::parse("https://example.com/api/endpoint").unwrap())
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_content_type() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            key: String,
+        }
+
+        let params = TestParams {
+            key: "value".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let content_type = request
+            .header_map
+            .inner
+            .get(http::header::CONTENT_TYPE)
+            .expect("Content-Type header should be set");
+        assert_eq!(
+            content_type.to_str().unwrap(),
+            "application/x-www-form-urlencoded"
+        );
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_body() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            foo: String,
+            bar: String,
+        }
+
+        let params = TestParams {
+            foo: "hello".to_string(),
+            bar: "world".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "foo=hello&bar=world");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_special_characters() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            url: String,
+            data: String,
+        }
+
+        let params = TestParams {
+            url: "https://example.com/path?query=1".to_string(),
+            data: "a&b=c".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(
+            body_str,
+            "url=https%3A%2F%2Fexample.com%2Fpath%3Fquery%3D1&data=a%26b%3Dc"
+        );
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_method() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            key: String,
+        }
+
+        let params = TestParams {
+            key: "value".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        assert_eq!(request.method, RequestMethod::POST);
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_numeric_types() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            large_number: u64,
+            negative: i32,
+        }
+
+        let params = TestParams {
+            large_number: 12345678901234,
+            negative: -42,
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "large_number=12345678901234&negative=-42");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_spaces() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            message: String,
+        }
+
+        let params = TestParams {
+            message: "hello world".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        // serde_urlencoded uses + for spaces (application/x-www-form-urlencoded standard)
+        assert_eq!(body_str, "message=hello+world");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_unicode() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            text: String,
+        }
+
+        let params = TestParams {
+            text: "日本語".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "text=%E6%97%A5%E6%9C%AC%E8%AA%9E");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_empty_string() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            empty: String,
+            filled: String,
+        }
+
+        let params = TestParams {
+            empty: "".to_string(),
+            filled: "value".to_string(),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "empty=&filled=value");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_optional_none_skipped() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            required: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            optional: Option<String>,
+        }
+
+        let params = TestParams {
+            required: "value".to_string(),
+            optional: None,
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "required=value");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_optional_some_included() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            required: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            optional: Option<String>,
+        }
+
+        let params = TestParams {
+            required: "value".to_string(),
+            optional: Some("present".to_string()),
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "required=value&optional=present");
+    }
+
+    #[test]
+    fn test_post_form_urlencoded_boolean() {
+        let builder = InnerRequestBuilder::new(WpAuthenticationProvider::none().into());
+
+        #[derive(Serialize)]
+        struct TestParams {
+            enabled: bool,
+            disabled: bool,
+        }
+
+        let params = TestParams {
+            enabled: true,
+            disabled: false,
+        };
+
+        let request = builder.post_form_urlencoded(test_url(), &params);
+
+        let body = request.body.expect("Body should be set");
+        let body_str = String::from_utf8(body.inner.clone()).expect("Body should be valid UTF-8");
+        assert_eq!(body_str, "enabled=true&disabled=false");
     }
 }

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -294,6 +294,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
                 params_type.as_ref(),
                 variant.attr.request_type,
                 variant.attr.multipart,
+                variant.attr.form_urlencoded,
             );
             let return_type = if variant.attr.multipart {
                 static_wp_multipart_form_request_type

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -1103,7 +1103,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, RequestType::ContextualGet, false, false, "self . inner . get (url)")]
+    #[case(
+        None,
+        RequestType::ContextualGet,
+        false,
+        false,
+        "self . inner . get (url)"
+    )]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::ContextualGet,
@@ -1155,7 +1161,13 @@ mod tests {
         #[case] expected_str: &str,
     ) {
         assert_eq!(
-            fn_body_build_request_from_url(params.as_ref(), request_type, multipart, form_urlencoded).to_string(),
+            fn_body_build_request_from_url(
+                params.as_ref(),
+                request_type,
+                multipart,
+                form_urlencoded
+            )
+            .to_string(),
             expected_str
         );
     }

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -400,6 +400,7 @@ pub fn fn_body_build_request_from_url(
     params_type: Option<&ParamsType>,
     request_type: RequestType,
     multipart: bool,
+    form_urlencoded: bool,
 ) -> TokenStream {
     match request_type {
         RequestType::ContextualGet | RequestType::ContextualPaged | RequestType::Get => quote! {
@@ -417,6 +418,16 @@ pub fn fn_body_build_request_from_url(
                 } else {
                     quote! {
                         compile_error!("multipart POST requires params")
+                    }
+                }
+            } else if form_urlencoded {
+                if params_type.is_some() {
+                    quote! {
+                        self.inner.post_form_urlencoded(url, params)
+                    }
+                } else {
+                    quote! {
+                        compile_error!("form_urlencoded POST requires params")
                     }
                 }
             } else if params_type.is_some() {
@@ -1092,17 +1103,19 @@ mod tests {
     }
 
     #[rstest]
-    #[case(None, RequestType::ContextualGet, false, "self . inner . get (url)")]
+    #[case(None, RequestType::ContextualGet, false, false, "self . inner . get (url)")]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::ContextualGet,
         false,
+        false,
         "self . inner . get (url)"
     )]
-    #[case(None, RequestType::Delete, false, "self . inner . delete (url)")]
+    #[case(None, RequestType::Delete, false, false, "self . inner . delete (url)")]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::Delete,
+        false,
         false,
         "self . inner . delete (url)"
     )]
@@ -1110,11 +1123,13 @@ mod tests {
         None,
         RequestType::Post,
         false,
+        false,
         "self . inner . post (url , None :: < & () >)"
     )]
     #[case(
         referenced_params_type("UserListParams"),
         RequestType::Post,
+        false,
         false,
         "self . inner . post (url , Some (params))"
     )]
@@ -1122,16 +1137,25 @@ mod tests {
         referenced_params_type("UserListParams"),
         RequestType::Post,
         true,
+        false,
         "self . inner . post_multipart (url , params)"
+    )]
+    #[case(
+        referenced_params_type("UserListParams"),
+        RequestType::Post,
+        false,
+        true,
+        "self . inner . post_form_urlencoded (url , params)"
     )]
     fn test_fn_body_build_request_from_url(
         #[case] params: Option<ParamsType>,
         #[case] request_type: RequestType,
         #[case] multipart: bool,
+        #[case] form_urlencoded: bool,
         #[case] expected_str: &str,
     ) {
         assert_eq!(
-            fn_body_build_request_from_url(params.as_ref(), request_type, multipart).to_string(),
+            fn_body_build_request_from_url(params.as_ref(), request_type, multipart, form_urlencoded).to_string(),
             expected_str
         );
     }

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -26,6 +26,7 @@ pub struct ParsedVariantAttribute {
     pub filter_by: Option<FilterByType>,
     pub available_contexts: Vec<WpContext>,
     pub multipart: bool,
+    pub form_urlencoded: bool,
 }
 
 impl ParsedVariantAttribute {
@@ -37,6 +38,7 @@ impl ParsedVariantAttribute {
         filter_by: Option<Vec<TokenTree>>,
         available_contexts: Vec<WpContext>,
         multipart: bool,
+        form_urlencoded: bool,
     ) -> Result<Self, ItemVariantAttributeParseError> {
         let non_empty_token_tree_or_none =
             |tokens: Option<Vec<TokenTree>>| -> Option<Vec<TokenTree>> {
@@ -56,6 +58,10 @@ impl ParsedVariantAttribute {
             return Err(ItemVariantAttributeParseError::ContextualPagedRequiresParamsType);
         }
 
+        if form_urlencoded && params_type.is_none() {
+            return Err(ItemVariantAttributeParseError::FormUrlencodedRequiresParams);
+        }
+
         Ok(Self {
             request_type,
             url_parts,
@@ -66,6 +72,7 @@ impl ParsedVariantAttribute {
             }),
             available_contexts,
             multipart,
+            form_urlencoded,
         })
     }
 
@@ -342,6 +349,7 @@ impl Parse for ParsedVariantAttribute {
         let mut filter_by_tokens = None;
         let mut available_contexts_tokens = None;
         let mut multipart_tokens = None;
+        let mut form_urlencoded_tokens = None;
 
         for (ident, tokens) in pair_vec.into_iter() {
             match ident.to_string().as_str() {
@@ -351,6 +359,7 @@ impl Parse for ParsedVariantAttribute {
                 "filter_by" => filter_by_tokens = Some(tokens),
                 "available_contexts" => available_contexts_tokens = Some(tokens),
                 "multipart" => multipart_tokens = Some(tokens),
+                "form_urlencoded" => form_urlencoded_tokens = Some(tokens),
                 _ => {
                     return Err(ItemVariantAttributeParseError::ExpectingKeyValuePairs
                         .into_syn_error(meta_list_span));
@@ -391,6 +400,8 @@ impl Parse for ParsedVariantAttribute {
         )?;
         let multipart =
             ParsedVariantAttribute::parse_bool_flag(multipart_tokens.as_ref(), input.span())?;
+        let form_urlencoded =
+            ParsedVariantAttribute::parse_bool_flag(form_urlencoded_tokens.as_ref(), input.span())?;
 
         ParsedVariantAttribute::new(
             request_type,
@@ -400,6 +411,7 @@ impl Parse for ParsedVariantAttribute {
             filter_by_tokens,
             available_contexts,
             multipart,
+            form_urlencoded,
         )
         .map_err(|e| e.into_syn_error(meta_list_span))
     }
@@ -409,6 +421,8 @@ impl Parse for ParsedVariantAttribute {
 enum ItemVariantAttributeParseError {
     #[error("#[contextual_paged(params = ?)] is missing `params` type")]
     ContextualPagedRequiresParamsType,
+    #[error("form_urlencoded = true requires `params` type")]
+    FormUrlencodedRequiresParams,
     #[error("Missing variant attribute")]
     MissingAttr,
     #[error("Only a single attribute is supported")]
@@ -538,5 +552,32 @@ mod tests {
             syn::parse_str(r#"#[post(url = "/test", output = TestOutput, multipart = false)]"#)
                 .unwrap();
         assert!(!parsed.multipart);
+    }
+
+    #[test]
+    fn test_form_urlencoded_flag_default() {
+        let parsed: ParsedVariantAttribute =
+            syn::parse_str(r#"#[post(url = "/test", output = TestOutput)]"#).unwrap();
+        assert!(!parsed.form_urlencoded);
+    }
+
+    #[test]
+    fn test_form_urlencoded_flag_true() {
+        let parsed: ParsedVariantAttribute =
+            syn::parse_str(
+                r#"#[post(url = "/test", params = &TestParams, output = TestOutput, form_urlencoded = true)]"#,
+            )
+            .unwrap();
+        assert!(parsed.form_urlencoded);
+    }
+
+    #[test]
+    fn test_form_urlencoded_flag_false() {
+        let parsed: ParsedVariantAttribute =
+            syn::parse_str(
+                r#"#[post(url = "/test", output = TestOutput, form_urlencoded = false)]"#,
+            )
+            .unwrap();
+        assert!(!parsed.form_urlencoded);
     }
 }

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -30,6 +30,7 @@ pub struct ParsedVariantAttribute {
 }
 
 impl ParsedVariantAttribute {
+    #[allow(clippy::too_many_arguments)] // Override Clippy here, because this is a macro not a directly-called method
     fn new(
         request_type: RequestType,
         url_parts: Vec<UrlPart>,
@@ -573,11 +574,10 @@ mod tests {
 
     #[test]
     fn test_form_urlencoded_flag_false() {
-        let parsed: ParsedVariantAttribute =
-            syn::parse_str(
-                r#"#[post(url = "/test", output = TestOutput, form_urlencoded = false)]"#,
-            )
-            .unwrap();
+        let parsed: ParsedVariantAttribute = syn::parse_str(
+            r#"#[post(url = "/test", output = TestOutput, form_urlencoded = false)]"#,
+        )
+        .unwrap();
         assert!(!parsed.form_urlencoded);
     }
 }

--- a/wp_derive_request_builder/tests/fail/form_urlencoded_missing_params.rs
+++ b/wp_derive_request_builder/tests/fail/form_urlencoded_missing_params.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum TestRequest {
+    #[post(url = "/test", output = TestOutput, form_urlencoded = true)]
+    Submit,
+}
+
+fn main() {}

--- a/wp_derive_request_builder/tests/fail/form_urlencoded_missing_params.stderr
+++ b/wp_derive_request_builder/tests/fail/form_urlencoded_missing_params.stderr
@@ -1,0 +1,5 @@
+error: form_urlencoded = true requires `params` type
+ --> tests/fail/form_urlencoded_missing_params.rs:3:7
+  |
+3 |     #[post(url = "/test", output = TestOutput, form_urlencoded = true)]
+  |       ^^^^

--- a/wp_derive_request_builder/tests/pass/form_urlencoded_post.rs
+++ b/wp_derive_request_builder/tests/pass/form_urlencoded_post.rs
@@ -1,0 +1,7 @@
+#[derive(wp_derive_request_builder::WpDerivedRequest)]
+enum TokenRequest {
+    #[post(url = "/token", params = &TokenRequestParams, output = TokenResponse, form_urlencoded = true)]
+    RequestToken,
+}
+
+fn main() {}


### PR DESCRIPTION
The oauth spec requires `form_urlencoded` for retrieving a token, so this PR adds it to the derive macro.

If the tests pass, this should be good to go – a subsequent PR will actually use it.