### PR TITLE
Add API to use oslog and android log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +897,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1349,6 +1389,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1362,7 +1408,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1853,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
  "serde",
  "serde_core",
 ]
@@ -2046,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2428,6 +2474,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+ "dashmap",
+ "log",
 ]
 
 [[package]]
@@ -5073,6 +5130,7 @@ dependencies = [
 name = "wp_api"
 version = "0.1.0"
 dependencies = [
+ "android_logger",
  "async-trait",
  "base64",
  "chrono",
@@ -5084,6 +5142,8 @@ dependencies = [
  "hyper-util",
  "indoc",
  "itertools 0.14.0",
+ "log",
+ "oslog",
  "parse_link_header",
  "paste",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
+android_logger = "0.14"
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.22"
@@ -46,6 +47,7 @@ indoc = "2.0"
 itertools = "0.14.0"
 linkify = "0.10.0"
 log = "0.4"
+oslog = "0.2"
 parse_link_header = "0.4"
 paste = "1.0"
 proc-macro-crate = "3.4.0"

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -24,6 +24,7 @@ hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }
 indoc = { workspace = true }
 itertools = { workspace = true }
+log = { workspace = true }
 url = { workspace = true }
 parse_link_header = { workspace = true }
 paste = { workspace = true }
@@ -57,3 +58,9 @@ tokio = { workspace = true, features = [ "full" ] }
 
 [build-dependencies]
 uniffi = { workspace = true , features = [ "build", "cli" ] }
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+oslog = { workspace = true }
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = { workspace = true }

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -240,6 +240,7 @@ macro_rules! generate {
 }
 
 #[uniffi::export]
+#[allow(unused_variables)] // The app_id is only used on Apple platforms.
 pub fn setup_logger(app_id: String) {
     #[cfg(debug_assertions)]
     let log_level = log::LevelFilter::Debug;

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -239,6 +239,33 @@ macro_rules! generate {
     }};
 }
 
+#[uniffi::export]
+pub fn setup_logger(app_id: String) {
+    #[cfg(debug_assertions)]
+    let log_level = log::LevelFilter::Debug;
+    #[cfg(not(debug_assertions))]
+    let log_level = log::LevelFilter::Warn;
+
+    #[cfg(target_vendor = "apple")]
+    {
+        match oslog::OsLogger::new(&app_id).level_filter(log_level).init() {
+            Ok(_) => println!("Logger initialized successfully."),
+            Err(e) => println!("Failed to initialize logger: {e}"),
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        android_logger::init_once(android_logger::Config::default().with_max_level(log_level));
+        println!("Logger initialized successfully.");
+    }
+
+    #[cfg(not(any(target_vendor = "apple", target_os = "android")))]
+    {
+        println!("Logger not configured for this platform.");
+    }
+}
+
 uniffi::setup_scaffolding!();
 
 #[cfg(test)]

--- a/wp_mobile_cache/src/repository/entity_state.rs
+++ b/wp_mobile_cache/src/repository/entity_state.rs
@@ -59,9 +59,10 @@ impl FromSql for EntityType {
 ///
 /// Stored in database as (state INTEGER, error_message TEXT).
 /// This type represents the database entity, not domain logic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum DbEntityState {
     /// Entity is not in cache and not being fetched.
+    #[default]
     Missing,
 
     /// Fetch is currently in progress.
@@ -134,12 +135,6 @@ impl DbEntityState {
             }),
             _ => None,
         }
-    }
-}
-
-impl Default for DbEntityState {
-    fn default() -> Self {
-        Self::Missing
     }
 }
 


### PR DESCRIPTION
The wp_mobile_cache uses `log` to log messages. If I'm not missing anything, these logs are not visible because no logger is configured. This PR adds a uniffi API, which can be used to log these messages to oslog (for Apple apps only) and Android logger (for Android apps only).