### PR TITLE
Temporarily disable `test_fetching_wpcom_api_root`

### DIFF
--- a/wp_api_integration_tests/tests/test_api_root_immut.rs
+++ b/wp_api_integration_tests/tests/test_api_root_immut.rs
@@ -11,6 +11,7 @@ async fn test_fetching_api_root() {
 
 #[tokio::test]
 #[parallel]
+#[ignore]
 async fn test_fetching_wpcom_api_root() {
     let response = WpApiClient::new(
         Arc::new(WpComDotOrgApiUrlResolver::new(


### PR DESCRIPTION
The test fails because the new `authentication` field added to WP.com site's `wp-json` response does not contain `endpoints.authorization`.

@jkmassel I presume the issue will be fixed properly, because you are working on this area. I'm happy to have a look at the parsing code and fix it properly, if that does not overlaps with what you are working on right now.

Here is an example build: https://buildkite.com/automattic/wordpress-rs/builds/4458#019bb3e3-4388-4788-8f6e-20ed8accbe56/L3963
```
[2026-01-12T20:41:32Z] thread 'test_fetching_wpcom_api_root' (20083) panicked at /app/wp_api_integration_tests/src/lib.rs:221:9:
[2026-01-12T20:41:32Z] Request failed with: Response couldn't be parsed: ⁨missing field `authorization` at line 1 column 923⁩.
[2026-01-12T20:41:32Z] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```