### PR TITLE
Add `refresh_post` function to refresh a specific cached post

### DIFF
--- a/wp_mobile/src/collection/post_metadata_collection.rs
+++ b/wp_mobile/src/collection/post_metadata_collection.rs
@@ -225,6 +225,83 @@ impl PostMetadataCollectionWithEditContext {
             .await
     }
 
+    /// Refresh a specific post if it exists in this collection.
+    ///
+    /// This method refreshes the cached data for a single post without affecting
+    /// the collection's list structure or other posts. Use this when you know a
+    /// specific post has been updated (e.g., after the user edits and saves a post).
+    ///
+    /// # Behavior
+    ///
+    /// 1. Checks if the post exists in the collection's metadata
+    /// 2. If yes, fetches the post from the API
+    /// 3. Updates all database tables (posts_edit_context, term_relationships, entity_state)
+    /// 4. Returns `true` to indicate the post was refreshed
+    ///
+    /// If the post is not in the collection's metadata, this is a no-op and returns `false`.
+    ///
+    /// # Arguments
+    /// * `post_id` - The WordPress post ID to refresh
+    ///
+    /// # Returns
+    /// - `Ok(true)` - Post was in the collection and has been refreshed
+    /// - `Ok(false)` - Post is not in this collection (no action taken)
+    /// - `Err(FetchError)` - Network or database error occurred
+    ///
+    /// # Database Updates
+    /// Triggers database update hooks which notify observers watching the relevant tables.
+    ///
+    /// # Example (Kotlin)
+    /// ```kotlin
+    /// // User edited and saved a post
+    /// val wasRefreshed = collection.refreshPost(PostId(42u))
+    /// if (wasRefreshed) {
+    ///     // Post data has been updated in cache
+    ///     // Observers will be notified via database hooks
+    /// }
+    /// ```
+    pub async fn refresh_post(&self, post_id: wp_api::posts::PostId) -> Result<bool, FetchError> {
+        let items = self.core.items();
+        let is_in_collection = items
+            .as_ref()
+            .map(|items| items.iter().any(|item| item.id() == post_id.0))
+            .unwrap_or(false);
+
+        if !is_in_collection {
+            log::debug!(
+                "PostMetadataCollection: Post {} not in collection, skipping refresh",
+                post_id.0
+            );
+            return Ok(false);
+        }
+
+        log::debug!(
+            "PostMetadataCollection: Refreshing post {} in collection",
+            post_id.0
+        );
+
+        let result = self
+            .service
+            .load_posts_by_ids(&self.endpoint_type, vec![post_id])
+            .await?;
+
+        let was_refreshed = !result.entity_ids.is_empty();
+
+        if was_refreshed {
+            log::debug!(
+                "PostMetadataCollection: Successfully refreshed post {}",
+                post_id.0
+            );
+        } else {
+            log::warn!(
+                "PostMetadataCollection: Post {} was in collection but failed to refresh (not found or error)",
+                post_id.0
+            );
+        }
+
+        Ok(was_refreshed)
+    }
+
     /// Get combined list info (pagination + sync state) in a single query.
     ///
     /// Returns `None` if the list hasn't been created yet.


### PR DESCRIPTION
The client can call this function to refresh a specific post after the user updates the post.

I explored passing the updated post data (which the app would already have after the updated post API call) to the Rust library, which can update the cache (post data, metadata, entity state, etc) without making another API call. But the result looks pretty messy, since there are now multiple places that update the cache in similar but different ways.

I think this PR produces cleaner code and a more robust solution because the syncing _always_ happens the same way: by calling the same API to update the local cache.