### PR TITLE
Swift: generate mutable records

### DIFF
--- a/wp_api/uniffi.toml
+++ b/wp_api/uniffi.toml
@@ -20,6 +20,6 @@ from_custom = "Int64({}.timeIntervalSince1970)"
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_api_uniffi"
 generate_module_map = false
-generate_immutable_records = true
+generate_immutable_records = false
 experimental_sendable_value_types = true
 omit_localized_error_conformance = true

--- a/wp_localization/uniffi.toml
+++ b/wp_localization/uniffi.toml
@@ -2,5 +2,5 @@
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_localization_uniffi"
 generate_module_map = false
-generate_immutable_records = true
+generate_immutable_records = false
 experimental_sendable_value_types = true

--- a/wp_mobile/uniffi.toml
+++ b/wp_mobile/uniffi.toml
@@ -8,6 +8,6 @@ generate_immutable_records = true
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_mobile_uniffi"
 generate_module_map = false
-generate_immutable_records = true
+generate_immutable_records = false
 experimental_sendable_value_types = true
 omit_localized_error_conformance = true

--- a/wp_mobile_cache/uniffi.toml
+++ b/wp_mobile_cache/uniffi.toml
@@ -8,6 +8,6 @@ generate_immutable_records = true
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_mobile_cache_uniffi"
 generate_module_map = false
-generate_immutable_records = true
+generate_immutable_records = false
 experimental_sendable_value_types = true
 omit_localized_error_conformance = true


### PR DESCRIPTION
Change struct properties from `let` to `var`. Sometimes it's easier, syntactically, to mutate an existing `struct` instance rather than use `.init()` to copy all the properties.