### PR TITLE
Fix parsing Newspack Newsletter post type

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -190,7 +190,7 @@ impl TryFrom<BoolOrString> for WpResponseString {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, uniffi::Enum)]
 #[serde(untagged)]
 pub enum BoolOrString {
     Bool(bool),

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -1,5 +1,5 @@
 use crate::request::endpoint::posts_endpoint::PostEndpointType;
-use crate::{JsonValue, impl_as_query_value_from_to_string};
+use crate::{BoolOrString, JsonValue, impl_as_query_value_from_to_string};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -89,7 +89,7 @@ pub struct SparsePostTypeDetails {
     #[WpContext(edit)]
     pub supports: Option<PostTypeSupportsMap>,
     #[WpContext(edit, view)]
-    pub has_archive: Option<bool>,
+    pub has_archive: Option<BoolOrString>,
     #[WpContext(edit, view)]
     pub taxonomies: Option<Vec<String>>,
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -223,3 +223,17 @@ pub struct PostTypeVisibility {
     pub show_in_nav_menus: bool,
     pub show_ui: bool,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_response() {
+        // Newspack Newsletters custom post type returns `"has_archive": "newsletter"`.
+        let data = include_str!("../tests/post_types/newspack-newsletter-3.27.0.json");
+        let parsed: PostTypesResponseWithEditContext =
+            serde_json::from_str(data).expect("Failed to parse post types response");
+        assert_eq!(parsed.post_types.len(), 2);
+    }
+}

--- a/wp_api/tests/post_types/newspack-newsletter-3.27.0.json
+++ b/wp_api/tests/post_types/newspack-newsletter-3.27.0.json
@@ -1,0 +1,203 @@
+{
+  "newspack_nl_cpt": {
+    "capabilities": {
+      "edit_post": "edit_post",
+      "read_post": "read_post",
+      "delete_post": "delete_post",
+      "edit_posts": "edit_posts",
+      "edit_others_posts": "edit_others_posts",
+      "delete_posts": "delete_posts",
+      "publish_posts": "publish_posts",
+      "read_private_posts": "read_private_posts",
+      "read": "read",
+      "delete_private_posts": "delete_private_posts",
+      "delete_published_posts": "delete_published_posts",
+      "delete_others_posts": "delete_others_posts",
+      "edit_private_posts": "edit_private_posts",
+      "edit_published_posts": "edit_published_posts",
+      "create_posts": "edit_posts"
+    },
+    "description": "",
+    "hierarchical": false,
+    "has_archive": "newsletter",
+    "visibility": { "show_in_nav_menus": true, "show_ui": true },
+    "viewable": true,
+    "labels": {
+      "name": "Newsletters",
+      "singular_name": "Newsletter",
+      "add_new": "Add New",
+      "add_new_item": "Add New Newsletter",
+      "edit_item": "Edit Newsletter",
+      "new_item": "New Newsletter",
+      "view_item": "View Newsletter",
+      "view_items": "View Newsletters",
+      "search_items": "Search Newsletters",
+      "not_found": "No newsletters found.",
+      "not_found_in_trash": "No newsletters found in Trash.",
+      "parent_item_colon": "Parent Newsletters:",
+      "all_items": "All Newsletters",
+      "archives": "Newsletter Archives",
+      "attributes": "Newsletter Attributes",
+      "insert_into_item": "Insert into newsletter",
+      "uploaded_to_this_item": "Uploaded to this newsletter",
+      "featured_image": "Featured image",
+      "set_featured_image": "Set featured image",
+      "remove_featured_image": "Remove featured image",
+      "use_featured_image": "Use as featured image",
+      "filter_items_list": "Filter newsletters list",
+      "filter_by_date": "Filter by date",
+      "items_list_navigation": "Newsletters list navigation",
+      "items_list": "Newsletters list",
+      "item_published": "Newsletter sent.",
+      "item_published_privately": "Newsletter published privately.",
+      "item_reverted_to_draft": "Newsletter reverted to draft.",
+      "item_trashed": "Post trashed.",
+      "item_scheduled": "Newsletter scheduled.",
+      "item_updated": "Newsletter updated.",
+      "item_link": "Newsletter Link",
+      "item_link_description": "A link to a newsletter.",
+      "menu_name": "Newsletters",
+      "name_admin_bar": "Newsletter",
+      "template_name": "Single item: Newsletter"
+    },
+    "name": "Newsletters",
+    "slug": "newspack_nl_cpt",
+    "icon": "data:image\/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSIgZmlsbD0ibm9uZSI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zIDdjMC0xLjEuOS0yIDItMmgxNGEyIDIgMCAwIDEgMiAydjEwYTIgMiAwIDAgMS0yIDJINWEyIDIgMCAwIDEtMi0yVjdabTItLjVoMTRjLjMgMCAuNS4yLjUuNXYxTDEyIDEzLjUgNC41IDcuOVY3YzAtLjMuMi0uNS41LS41Wm0tLjUgMy4zVjE3YzAgLjMuMi41LjUuNWgxNGMuMyAwIC41LS4yLjUtLjVWOS44TDEyIDE1LjQgNC41IDkuOFoiPjwvcGF0aD48L3N2Zz4=",
+    "supports": {
+      "author": true,
+      "editor": [{ "notes": true }],
+      "title": true,
+      "custom-fields": true,
+      "newspack_blocks": true,
+      "revisions": true,
+      "thumbnail": true,
+      "excerpt": true,
+      "autosave": true,
+      "jetpack-post-likes": true,
+      "jetpack-sharing-buttons": true
+    },
+    "taxonomies": ["category", "post_tag", "newspack_nl_advertiser"],
+    "rest_base": "newspack_nl_cpt",
+    "rest_namespace": "wp\/v2",
+    "template": [],
+    "template_lock": false,
+    "_links": {
+      "collection": [
+        {
+          "href": "https:\/\/paper-of-guineafowls.jurassic.ninja\/wp-json\/wp\/v2\/types"
+        }
+      ],
+      "wp:items": [
+        {
+          "href": "https:\/\/paper-of-guineafowls.jurassic.ninja\/wp-json\/wp\/v2\/newspack_nl_cpt"
+        }
+      ],
+      "curies": [
+        {
+          "name": "wp",
+          "href": "https:\/\/api.w.org\/{rel}",
+          "templated": true
+        }
+      ]
+    }
+  },
+  "newspack_nl_ads_cpt": {
+    "capabilities": {
+      "edit_post": "edit_post",
+      "read_post": "read_post",
+      "delete_post": "delete_post",
+      "edit_posts": "edit_posts",
+      "edit_others_posts": "edit_others_posts",
+      "delete_posts": "delete_posts",
+      "publish_posts": "publish_posts",
+      "read_private_posts": "read_private_posts",
+      "read": "read",
+      "delete_private_posts": "delete_private_posts",
+      "delete_published_posts": "delete_published_posts",
+      "delete_others_posts": "delete_others_posts",
+      "edit_private_posts": "edit_private_posts",
+      "edit_published_posts": "edit_published_posts",
+      "create_posts": "edit_posts"
+    },
+    "description": "",
+    "hierarchical": false,
+    "has_archive": false,
+    "visibility": { "show_in_nav_menus": false, "show_ui": true },
+    "viewable": false,
+    "labels": {
+      "name": "Newsletter Ads",
+      "singular_name": "Newsletter Ad",
+      "add_new": "Add New",
+      "add_new_item": "Add New Newsletter Ad",
+      "edit_item": "Edit Newsletter Ad",
+      "new_item": "New Newsletter Ad",
+      "view_item": "View Newsletter Ad",
+      "view_items": "View Posts",
+      "search_items": "Search Newsletter Ads",
+      "not_found": "No Newsletter Ads found.",
+      "not_found_in_trash": "No Newsletter Ads found in Trash.",
+      "parent_item_colon": "Parent Newsletter Ads:",
+      "all_items": "All Newsletter Ads",
+      "archives": "All Newsletter Ads",
+      "attributes": "Post Attributes",
+      "insert_into_item": "Insert into post",
+      "uploaded_to_this_item": "Uploaded to this post",
+      "featured_image": "Featured image",
+      "set_featured_image": "Set featured image",
+      "remove_featured_image": "Remove featured image",
+      "use_featured_image": "Use as featured image",
+      "filter_items_list": "Filter posts list",
+      "filter_by_date": "Filter by date",
+      "items_list_navigation": "Posts list navigation",
+      "items_list": "Newsletter Ads list",
+      "item_published": "Newsletter Ad published",
+      "item_published_privately": "Newsletter Ad published privately",
+      "item_reverted_to_draft": "Newsletter Ad reverted to draft",
+      "item_trashed": "Post trashed.",
+      "item_scheduled": "Newsletter Ad scheduled",
+      "item_updated": "Newsletter Ad updated",
+      "item_link": "Post Link",
+      "item_link_description": "A link to a post.",
+      "menu_name": "Newsletter Ads",
+      "name_admin_bar": "Newsletter Ad",
+      "template_name": "Single item: Newsletter Ad"
+    },
+    "name": "Newsletter Ads",
+    "slug": "newspack_nl_ads_cpt",
+    "icon": null,
+    "supports": {
+      "editor": true,
+      "title": true,
+      "custom-fields": true,
+      "autosave": true
+    },
+    "taxonomies": [
+      "category",
+      "newspack_nl_advertiser",
+      "newspack_nl_ad_placement"
+    ],
+    "rest_base": "newspack_nl_ads_cpt",
+    "rest_namespace": "wp\/v2",
+    "template": [],
+    "template_lock": false,
+    "_links": {
+      "collection": [
+        {
+          "href": "https:\/\/paper-of-guineafowls.jurassic.ninja\/wp-json\/wp\/v2\/types"
+        }
+      ],
+      "wp:items": [
+        {
+          "href": "https:\/\/paper-of-guineafowls.jurassic.ninja\/wp-json\/wp\/v2\/newspack_nl_ads_cpt"
+        }
+      ],
+      "curies": [
+        {
+          "name": "wp",
+          "href": "https:\/\/api.w.org\/{rel}",
+          "templated": true
+        }
+      ]
+    }
+  }
+}

--- a/wp_mobile_cache/src/test_fixtures/post_types.rs
+++ b/wp_mobile_cache/src/test_fixtures/post_types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use wp_api::{
-    JsonValue,
+    BoolOrString, JsonValue,
     post_types::{
         PostTypeCapabilities, PostTypeDetailsWithEditContext, PostTypeLabels, PostTypeSupports,
         PostTypeSupportsMap, PostTypeVisibility,
@@ -96,7 +96,7 @@ impl PostTypeBuilder {
                     (PostTypeSupports::Editor, JsonValue::Bool(true)),
                 ]),
             },
-            has_archive: false,
+            has_archive: BoolOrString::Bool(false),
             taxonomies: vec![],
             rest_base: slug.to_string(),
             rest_namespace: "wp/v2".to_string(),


### PR DESCRIPTION
The `has_archive` property is supposed to be a boolean, but the plugin returns a string (see the unit test file).

I think the solution here (replacing `bool` with `BoolOrString`) is not great. But since we don't use the `has_archive` property, it has no practical impact.