### PR TITLE
Fix a bug where fetching post types returns non-existing ones

### DIFF
--- a/wp_mobile/src/service/post_types.rs
+++ b/wp_mobile/src/service/post_types.rs
@@ -50,11 +50,13 @@ impl PostTypeService {
         // Extract the HashMap from the response
         let post_types_map = response.data.post_types;
 
-        // Upsert each post type to the database
+        // Delete all existing post types and insert new ones
         let entity_ids = self
             .cache
             .execute(|conn| {
                 let repo = PostTypeRepository::<EditContext>::new();
+
+                repo.delete_all(conn, &self.db_site)?;
 
                 post_types_map
                     .iter()

--- a/wp_mobile_cache/src/repository/post_types.rs
+++ b/wp_mobile_cache/src/repository/post_types.rs
@@ -188,6 +188,22 @@ impl<C: PostTypeContext> PostTypeRepository<C> {
         })
         .collect()
     }
+
+    /// Delete all post types for a given site.
+    ///
+    /// Returns the number of rows deleted.
+    pub fn delete_all(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+    ) -> Result<usize, SqliteDbError> {
+        let sql = format!("DELETE FROM {} WHERE db_site_id = ?", Self::table_name());
+
+        let mut stmt = executor.prepare(&sql)?;
+        let deleted = stmt.execute([site.row_id.0])?;
+
+        Ok(deleted)
+    }
 }
 
 #[cfg(test)]

--- a/wp_mobile_cache_integration_tests/tests/test_post_types_mut.rs
+++ b/wp_mobile_cache_integration_tests/tests/test_post_types_mut.rs
@@ -1,0 +1,80 @@
+use wp_api::plugins::{
+    PluginCreateParams, PluginStatus, PluginUpdateParams, PluginWpOrgDirectorySlug,
+};
+use wp_mobile_cache_integration_tests::*;
+
+#[tokio::test]
+#[serial]
+// PostTypeCollectionWithEditContext should not return custom post types
+// after their plugin is deleted.
+async fn test_plugin_post_type_registration_and_removal() {
+    let ctx = create_test_context();
+
+    ctx.api
+        .plugins()
+        .create(&PluginCreateParams {
+            slug: PluginWpOrgDirectorySlug::from("newspack-newsletters"),
+            status: PluginStatus::Active,
+        })
+        .await
+        .expect("Failed to install Newspack Newsletters plugin");
+
+    let collection = ctx
+        .service
+        .post_types()
+        .create_post_type_collection_with_edit_context();
+
+    collection
+        .fetch()
+        .await
+        .expect("Failed to fetch post types after plugin installation");
+
+    let post_types = collection
+        .load_data()
+        .await
+        .expect("Failed to load post types from cache");
+
+    assert!(
+        post_types
+            .iter()
+            .any(|pt| pt.data.slug == "newspack_nl_cpt"),
+        "Newspack Newsletters custom post type should be present after plugin installation"
+    );
+
+    let slug =
+        wp_api::plugins::PluginSlug::new("newspack-newsletters/newspack-newsletters".to_string());
+    ctx.api
+        .plugins()
+        .update(
+            &slug,
+            &PluginUpdateParams {
+                status: PluginStatus::Inactive,
+            },
+        )
+        .await
+        .expect("Failed to deactivate Newspack Newsletters plugin");
+    ctx.api
+        .plugins()
+        .delete(&slug)
+        .await
+        .expect("Failed to uninstall Newspack Newsletters plugin");
+
+    collection
+        .fetch()
+        .await
+        .expect("Failed to fetch post types after plugin uninstallation");
+
+    let post_types = collection
+        .load_data()
+        .await
+        .expect("Failed to load post types from cache after plugin uninstallation");
+
+    assert!(
+        !post_types
+            .iter()
+            .any(|pt| pt.data.slug == "newspack_nl_cpt"),
+        "Newspack Newsletters custom post type should not be present after plugin uninstallation"
+    );
+
+    RestoreServer::all().await;
+}


### PR DESCRIPTION
The `fetch` only inserts. Considering the current solution always re-fetches post types, it's harmless to delete all the stored ones before inserting the fetched ones.