### PR TITLE
Use UniFFI 0.31.0 enum and struct method support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ cargo test -p wp_api_integration_tests --test '{file_name}'
 # Run linting and format checks
 cargo fmt --all -- --check
 cargo clippy --tests --all-targets --all-features -- -D warnings
-swiftlint --strict
+swift package plugin swiftlint --strict
 
 # Generate API documentation
 cargo doc --no-deps --all-features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,13 @@ cargo test -p wp_api_integration_tests --test '{file_name}'
 # Run linting and format checks
 cargo fmt --all -- --check
 cargo clippy --tests --all-targets --all-features -- -D warnings
+swiftlint --strict
 
 # Generate API documentation
 cargo doc --no-deps --all-features
+
+# Generate Swift bindings (use this to verify UniFFI changes work correctly)
+make xcframework
 ```
 
 ## Architecture

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/PostTypesEndpointTest.kt
@@ -6,7 +6,6 @@ import uniffi.wp_api.PostType
 import uniffi.wp_api.PostTypeCapabilities
 import uniffi.wp_api.PostTypeSupports
 import uniffi.wp_api.WpErrorCode
-import uniffi.wp_api.postTypeSupports
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -27,7 +26,7 @@ class PostTypesEndpointTest {
         val postTypesPost = client.request { requestBuilder ->
             requestBuilder.postTypes().retrieveWithEditContext(PostType.Post)
         }.assertSuccessAndRetrieveData().data
-        assert(postTypeSupports(postTypesPost.supports, PostTypeSupports.Title))
+        assert(postTypesPost.supports.supports(PostTypeSupports.Title))
         assertFalse(postTypesPost.capabilities[PostTypeCapabilities.EditPosts]!!.isEmpty())
     }
 

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
@@ -78,7 +78,7 @@ class PostCollectionViewModel(
      */
     fun setFilter(status: String?) {
         // Parse the string status to PostStatus using the helper function
-        val postStatus = status?.let { uniffi.wp_api.parsePostStatus(it) }
+        val postStatus = status?.let { uniffi.wp_api.postStatusFromString(it) }
         val newFilter = AnyPostFilter(status = postStatus)
 
         // Update state: new filter, reset page, clear fetch results

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -232,7 +232,7 @@ class PostMetadataCollectionViewModel(
         // This should always succeed if post types were fetched first
         val postTypeDetails = postTypeService.getBySlug(postTypeSlug)
             ?: error("Post type '$postTypeSlug' not found in cache. Ensure post types are fetched before creating post collections.")
-        val endpointType = uniffi.wp_api.postTypeDetailsToPostEndpointType(postTypeDetails)
+        val endpointType = postTypeDetails.toPostEndpointType()
 
         val observable = postService.getObservablePostMetadataCollectionWithEditContext(
             endpointType,

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -138,7 +138,7 @@ class PostMetadataCollectionViewModel(
      * Change the filter and load persisted state from database
      */
     fun setFilter(status: String?) {
-        val postStatus = status?.let { uniffi.wp_api.parsePostStatus(it) }
+        val postStatus = status?.let { uniffi.wp_api.postStatusFromString(it) }
         val newFilter = PostListFilter(
             status = if (postStatus != null) listOf(postStatus) else emptyList()
         )

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -49,7 +49,7 @@ public extension CommentStatus {
     }
 
     var rawValue: String {
-        commentStatusToString(status: self)
+        self.asString()
     }
 }
 
@@ -65,7 +65,7 @@ public extension CommentType {
     }
 
     var rawValue: String {
-        commentTypeToString(commentType: self)
+        self.asString()
     }
 }
 
@@ -81,7 +81,7 @@ public extension UserRole {
     }
 
     var rawValue: String {
-        userRoleToString(role: self)
+        self.asString()
     }
 }
 
@@ -97,7 +97,7 @@ public extension UserCapability {
     }
 
     var rawValue: String {
-        userCapabilityToString(capability: self)
+        self.asString()
     }
 }
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -49,7 +49,7 @@ public extension CommentStatus {
     }
 
     var rawValue: String {
-        self.asString()
+        self.description
     }
 }
 
@@ -65,7 +65,7 @@ public extension CommentType {
     }
 
     var rawValue: String {
-        self.asString()
+        self.description
     }
 }
 
@@ -81,7 +81,7 @@ public extension UserRole {
     }
 
     var rawValue: String {
-        self.asString()
+        self.description
     }
 }
 
@@ -97,7 +97,7 @@ public extension UserCapability {
     }
 
     var rawValue: String {
-        self.asString()
+        self.description
     }
 }
 
@@ -113,7 +113,7 @@ public extension PostType {
     }
 
     var rawValue: String {
-        self.asString()
+        self.description
     }
 }
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -113,7 +113,7 @@ public extension PostType {
     }
 
     var rawValue: String {
-        postTypeToString(postType: self)
+        self.asString()
     }
 }
 
@@ -124,11 +124,7 @@ extension PostType: ExpressibleByStringLiteral {
 }
 
 public extension PostTypeSupportsMap {
-    func supports(_ feature: PostTypeSupports) -> Bool {
-        postTypeSupports(supportsMap: self, feature: feature)
-    }
-
     func supports(_ feature: String) -> Bool {
-        postTypeSupports(supportsMap: self, feature: .custom(feature))
+        self.supports(feature: .custom(feature))
     }
 }

--- a/native/swift/Sources/wordpress-api/WPComExtensions.swift
+++ b/native/swift/Sources/wordpress-api/WPComExtensions.swift
@@ -19,4 +19,3 @@ public extension BotConversation {
         return false
     }
 }
-

--- a/native/swift/Sources/wordpress-api/WPComExtensions.swift
+++ b/native/swift/Sources/wordpress-api/WPComExtensions.swift
@@ -20,34 +20,3 @@ public extension BotConversation {
     }
 }
 
-public extension SupportAttachment {
-    var dimensions: AttachmentDimensions? {
-        getAttachmentDimensions(attachment: self)
-    }
-}
-
-public extension StatsVisitsResponse {
-    var statsVisitsData: [StatsVisitsDataPoint] {
-        getStatsVisitsData(response: self)
-    }
-
-    var statsVisitorsData: [StatsVisitorsDataPoint] {
-        getStatsVisitorsData(response: self)
-    }
-
-    var statsLikesData: [StatsLikesDataPoint] {
-        getStatsLikesData(response: self)
-    }
-
-    var statsReblogsData: [StatsReblogsDataPoint] {
-        getStatsReblogsData(response: self)
-    }
-
-    var statsCommentsData: [StatsCommentsDataPoint] {
-        getStatsCommentsData(response: self)
-    }
-
-    var statsPostsData: [StatsPostsDataPoint] {
-        getStatsPostsData(response: self)
-    }
-}

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -464,8 +464,10 @@ fn comment_status_from_string(value: String) -> CommentStatus {
 }
 
 #[uniffi::export]
-fn comment_status_to_string(status: CommentStatus) -> String {
-    status.to_string()
+impl CommentStatus {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[uniffi::export]
@@ -474,8 +476,10 @@ fn comment_type_from_string(value: String) -> CommentType {
 }
 
 #[uniffi::export]
-fn comment_type_to_string(comment_type: CommentType) -> String {
-    comment_type.to_string()
+impl CommentType {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[cfg(test)]

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -55,6 +55,7 @@ wp_content_i64_id!(CommentId);
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum CommentType {
@@ -443,6 +444,7 @@ pub enum CommentAuthorAvatarUrlSize {
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum CommentStatus {
@@ -464,22 +466,8 @@ fn comment_status_from_string(value: String) -> CommentStatus {
 }
 
 #[uniffi::export]
-impl CommentStatus {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
-}
-
-#[uniffi::export]
 fn comment_type_from_string(value: String) -> CommentType {
     CommentType::from_str(value.as_str()).unwrap_or(CommentType::Custom(value))
-}
-
-#[uniffi::export]
-impl CommentType {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
 }
 
 #[cfg(test)]

--- a/wp_api/src/post_statuses.rs
+++ b/wp_api/src/post_statuses.rs
@@ -42,6 +42,7 @@ pub struct SparsePostStatus {
 #[derive(
     Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, uniffi::Record,
 )]
+#[uniffi::export(Display)]
 #[serde(transparent)]
 pub struct PostStatusSlug {
     pub slug: String,

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -46,18 +46,20 @@ fn post_type_from_string(value: String) -> PostType {
 }
 
 #[uniffi::export]
-fn post_type_to_string(post_type: PostType) -> String {
-    post_type.to_string()
+impl PostType {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[uniffi::export]
-fn post_type_details_to_post_endpoint_type(
-    post_type_details: &PostTypeDetailsWithEditContext,
-) -> PostEndpointType {
-    match post_type_details.rest_base.as_str() {
-        "posts" => PostEndpointType::Posts,
-        "pages" => PostEndpointType::Pages,
-        other => PostEndpointType::Custom(other.to_string()),
+impl PostTypeDetailsWithEditContext {
+    pub fn to_post_endpoint_type(&self) -> PostEndpointType {
+        match self.rest_base.as_str() {
+            "posts" => PostEndpointType::Posts,
+            "pages" => PostEndpointType::Pages,
+            other => PostEndpointType::Custom(other.to_string()),
+        }
     }
 }
 
@@ -112,6 +114,7 @@ pub struct PostTypeSupportsMap {
     pub map: HashMap<PostTypeSupports, JsonValue>,
 }
 
+#[uniffi::export]
 impl PostTypeSupportsMap {
     /// Check if the post type supports a specific feature by checking if the key is present.
     ///
@@ -120,18 +123,9 @@ impl PostTypeSupportsMap {
     /// when not supported. The value can also be an object with additional configuration (e.g.,
     /// `editor` may have nested settings). We assume that if a key is present, the feature is
     /// supported, regardless of the actual value.
-    pub fn supports(&self, feature: &PostTypeSupports) -> bool {
-        self.map.contains_key(feature)
+    pub fn supports(&self, feature: PostTypeSupports) -> bool {
+        self.map.contains_key(&feature)
     }
-}
-
-/// Check if a post type supports a specific feature by checking if the key is present.
-///
-/// Note: This only checks for key presence, not the associated value. See
-/// `PostTypeSupportsMap::supports` for details on this assumption.
-#[uniffi::export]
-fn post_type_supports(supports_map: &PostTypeSupportsMap, feature: PostTypeSupports) -> bool {
-    supports_map.supports(&feature)
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, uniffi::Record)]

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -20,6 +20,7 @@ use wp_serde_helper::deserialize_empty_array_or_hashmap;
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PostType {
@@ -43,13 +44,6 @@ impl_as_query_value_from_to_string!(PostType);
 #[uniffi::export]
 fn post_type_from_string(value: String) -> PostType {
     PostType::from_str(value.as_str()).unwrap_or(PostType::Custom(value))
-}
-
-#[uniffi::export]
-impl PostType {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
 }
 
 #[uniffi::export]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -504,6 +504,7 @@ pub struct PostFootnote {
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum PostStatus {
@@ -528,13 +529,6 @@ impl_as_query_value_from_to_string!(PostStatus);
 fn post_status_from_string(s: String) -> PostStatus {
     use std::str::FromStr;
     PostStatus::from_str(&s).unwrap_or(PostStatus::Custom(s))
-}
-
-#[uniffi::export]
-impl PostStatus {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
 }
 
 #[derive(

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -523,11 +523,18 @@ impl_as_query_value_from_to_string!(PostStatus);
 /// Parse a string into a PostStatus.
 ///
 /// This is a helper function for platform code that can't access the `FromStr` trait
-/// directly due to UniFFI limitations.
+/// directly due to UniFFI limitations. Unknown values are returned as `Custom`.
 #[uniffi::export]
-fn parse_post_status(s: &str) -> Option<PostStatus> {
+fn post_status_from_string(s: String) -> PostStatus {
     use std::str::FromStr;
-    PostStatus::from_str(s).ok()
+    PostStatus::from_str(&s).unwrap_or(PostStatus::Custom(s))
+}
+
+#[uniffi::export]
+impl PostStatus {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[derive(

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -265,8 +265,10 @@ fn user_capability_from_string(value: String) -> UserCapability {
 }
 
 #[uniffi::export]
-fn user_capability_to_string(capability: UserCapability) -> String {
-    capability.to_string()
+impl UserCapability {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[derive(
@@ -303,8 +305,10 @@ fn user_role_from_string(value: String) -> UserRole {
 }
 
 #[uniffi::export]
-fn user_role_to_string(role: UserRole) -> String {
-    role.to_string()
+impl UserRole {
+    pub fn as_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 impl_as_query_value_from_to_string!(UserRole);

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -187,6 +187,7 @@ pub struct UserListParams {
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum UserCapability {
@@ -264,13 +265,6 @@ fn user_capability_from_string(value: String) -> UserCapability {
     UserCapability::from_str(value.as_str()).unwrap_or(UserCapability::Custom(value))
 }
 
-#[uniffi::export]
-impl UserCapability {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
-}
-
 #[derive(
     Debug,
     Clone,
@@ -285,6 +279,7 @@ impl UserCapability {
     strum_macros::EnumString,
     strum_macros::Display,
 )]
+#[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum UserRole {
@@ -302,13 +297,6 @@ pub enum UserRole {
 #[uniffi::export]
 fn user_role_from_string(value: String) -> UserRole {
     UserRole::from_str(value.as_str()).unwrap_or(UserRole::Custom(value))
-}
-
-#[uniffi::export]
-impl UserRole {
-    pub fn as_string(&self) -> String {
-        self.to_string()
-    }
 }
 
 impl_as_query_value_from_to_string!(UserRole);

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -75,51 +75,48 @@ pub struct StatsVisitsResponse {
 }
 
 #[uniffi::export]
-pub fn get_stats_visits_data(response: &StatsVisitsResponse) -> Vec<StatsVisitsDataPoint> {
-    get_stats_data("views", response)
-        .into_iter()
-        .map(|(period, visits)| StatsVisitsDataPoint { period, visits })
-        .collect()
-}
+impl StatsVisitsResponse {
+    pub fn visits_data(&self) -> Vec<StatsVisitsDataPoint> {
+        get_stats_data("views", self)
+            .into_iter()
+            .map(|(period, visits)| StatsVisitsDataPoint { period, visits })
+            .collect()
+    }
 
-#[uniffi::export]
-pub fn get_stats_visitors_data(response: &StatsVisitsResponse) -> Vec<StatsVisitorsDataPoint> {
-    get_stats_data("visitors", response)
-        .into_iter()
-        .map(|(period, visitors)| StatsVisitorsDataPoint { period, visitors })
-        .collect()
-}
+    pub fn visitors_data(&self) -> Vec<StatsVisitorsDataPoint> {
+        get_stats_data("visitors", self)
+            .into_iter()
+            .map(|(period, visitors)| StatsVisitorsDataPoint { period, visitors })
+            .collect()
+    }
 
-#[uniffi::export]
-pub fn get_stats_likes_data(response: &StatsVisitsResponse) -> Vec<StatsLikesDataPoint> {
-    get_stats_data("likes", response)
-        .into_iter()
-        .map(|(period, likes)| StatsLikesDataPoint { period, likes })
-        .collect()
-}
+    pub fn likes_data(&self) -> Vec<StatsLikesDataPoint> {
+        get_stats_data("likes", self)
+            .into_iter()
+            .map(|(period, likes)| StatsLikesDataPoint { period, likes })
+            .collect()
+    }
 
-#[uniffi::export]
-pub fn get_stats_reblogs_data(response: &StatsVisitsResponse) -> Vec<StatsReblogsDataPoint> {
-    get_stats_data("reblogs", response)
-        .into_iter()
-        .map(|(period, reblogs)| StatsReblogsDataPoint { period, reblogs })
-        .collect()
-}
+    pub fn reblogs_data(&self) -> Vec<StatsReblogsDataPoint> {
+        get_stats_data("reblogs", self)
+            .into_iter()
+            .map(|(period, reblogs)| StatsReblogsDataPoint { period, reblogs })
+            .collect()
+    }
 
-#[uniffi::export]
-pub fn get_stats_comments_data(response: &StatsVisitsResponse) -> Vec<StatsCommentsDataPoint> {
-    get_stats_data("comments", response)
-        .into_iter()
-        .map(|(period, comments)| StatsCommentsDataPoint { period, comments })
-        .collect()
-}
+    pub fn comments_data(&self) -> Vec<StatsCommentsDataPoint> {
+        get_stats_data("comments", self)
+            .into_iter()
+            .map(|(period, comments)| StatsCommentsDataPoint { period, comments })
+            .collect()
+    }
 
-#[uniffi::export]
-pub fn get_stats_posts_data(response: &StatsVisitsResponse) -> Vec<StatsPostsDataPoint> {
-    get_stats_data("posts", response)
-        .into_iter()
-        .map(|(period, posts)| StatsPostsDataPoint { period, posts })
-        .collect()
+    pub fn posts_data(&self) -> Vec<StatsPostsDataPoint> {
+        get_stats_data("posts", self)
+            .into_iter()
+            .map(|(period, posts)| StatsPostsDataPoint { period, posts })
+            .collect()
+    }
 }
 
 fn get_stats_data(handle: &str, response: &StatsVisitsResponse) -> Vec<(String, u64)> {
@@ -292,7 +289,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_visits_data(&response);
+        let data_points = response.visits_data();
 
         assert_eq!(data_points.len(), 24);
         assert_eq!(
@@ -325,7 +322,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_visits_data(&response);
+        let data_points = response.visits_data();
 
         assert_eq!(data_points.len(), 30);
         assert_eq!(
@@ -364,7 +361,7 @@ mod tests {
             data: vec![],
         };
 
-        let data_points = get_stats_visits_data(&response);
+        let data_points = response.visits_data();
 
         assert!(data_points.is_empty());
     }
@@ -377,7 +374,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_visitors_data(&response);
+        let data_points = response.visitors_data();
 
         // All visitors are null, so no data points should be returned
         assert!(data_points.is_empty());
@@ -390,7 +387,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_visitors_data(&response);
+        let data_points = response.visitors_data();
 
         assert_eq!(data_points.len(), 30);
         assert_eq!(
@@ -423,7 +420,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_likes_data(&response);
+        let data_points = response.likes_data();
 
         assert_eq!(data_points.len(), 30);
         // Most likes are 0, but 2026-01-05 has 1 like
@@ -450,7 +447,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_reblogs_data(&response);
+        let data_points = response.reblogs_data();
 
         assert_eq!(data_points.len(), 30);
         assert_eq!(
@@ -469,7 +466,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_comments_data(&response);
+        let data_points = response.comments_data();
 
         assert_eq!(data_points.len(), 30);
         assert_eq!(
@@ -488,7 +485,7 @@ mod tests {
         let response: StatsVisitsResponse =
             serde_json::from_reader(file).expect("Unable to parse JSON");
 
-        let data_points = get_stats_posts_data(&response);
+        let data_points = response.posts_data();
 
         assert_eq!(data_points.len(), 30);
         assert_eq!(

--- a/wp_api/src/wp_com/support_tickets.rs
+++ b/wp_api/src/wp_com/support_tickets.rs
@@ -145,23 +145,25 @@ pub struct AttachmentDimensions {
 }
 
 #[uniffi::export]
-pub fn get_attachment_dimensions(attachment: &SupportAttachment) -> Option<AttachmentDimensions> {
-    let metadata = &attachment.metadata;
+impl SupportAttachment {
+    pub fn dimensions(&self) -> Option<AttachmentDimensions> {
+        let metadata = &self.metadata;
 
-    let width = metadata
-        .get(&AttachmentMetadataKey::Width)
-        .and_then(|v| v.get_number());
-    let height = metadata
-        .get(&AttachmentMetadataKey::Height)
-        .and_then(|v| v.get_number());
+        let width = metadata
+            .get(&AttachmentMetadataKey::Width)
+            .and_then(|v| v.get_number());
+        let height = metadata
+            .get(&AttachmentMetadataKey::Height)
+            .and_then(|v| v.get_number());
 
-    if let Some(width) = width
-        && let Some(height) = height
-    {
-        return Some(AttachmentDimensions { width, height });
+        if let Some(width) = width
+            && let Some(height) = height
+        {
+            return Some(AttachmentDimensions { width, height });
+        }
+
+        None
     }
-
-    None
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
@@ -260,8 +262,7 @@ mod tests {
             "https://example.com/attachments/token/token1/?name=sample-image-1.jpg"
         );
 
-        let dimensions =
-            get_attachment_dimensions(&conversation.messages[0].attachments[0]).unwrap();
+        let dimensions = conversation.messages[0].attachments[0].dimensions().unwrap();
 
         assert_eq!(dimensions.width, 1000);
         assert_eq!(dimensions.height, 800);
@@ -280,8 +281,7 @@ mod tests {
             "https://example.com/attachments/token/token2/?name=sample-image-2.jpg"
         );
 
-        let dimensions =
-            get_attachment_dimensions(&conversation.messages[0].attachments[1]).unwrap();
+        let dimensions = conversation.messages[0].attachments[1].dimensions().unwrap();
         assert_eq!(dimensions.width, 2000);
         assert_eq!(dimensions.height, 1600);
     }

--- a/wp_api/src/wp_com/support_tickets.rs
+++ b/wp_api/src/wp_com/support_tickets.rs
@@ -262,7 +262,9 @@ mod tests {
             "https://example.com/attachments/token/token1/?name=sample-image-1.jpg"
         );
 
-        let dimensions = conversation.messages[0].attachments[0].dimensions().unwrap();
+        let dimensions = conversation.messages[0].attachments[0]
+            .dimensions()
+            .unwrap();
 
         assert_eq!(dimensions.width, 1000);
         assert_eq!(dimensions.height, 800);
@@ -281,7 +283,9 @@ mod tests {
             "https://example.com/attachments/token/token2/?name=sample-image-2.jpg"
         );
 
-        let dimensions = conversation.messages[0].attachments[1].dimensions().unwrap();
+        let dimensions = conversation.messages[0].attachments[1]
+            .dimensions()
+            .unwrap();
         assert_eq!(dimensions.width, 2000);
         assert_eq!(dimensions.height, 1600);
     }

--- a/wp_api_integration_tests/tests/test_post_types_immut.rs
+++ b/wp_api_integration_tests/tests/test_post_types_immut.rs
@@ -92,7 +92,7 @@ async fn retrieve_post_types_with_edit_context(
     // It's possible that we might have more test sites in the future and some of their
     // post types might not support `Title` in which case it's perfectly fine to completely
     // remove this assertion.
-    assert!(post_type.supports.supports(&PostTypeSupports::Title));
+    assert!(post_type.supports.supports(PostTypeSupports::Title));
     // All post types in our current testing sites have `EditPost` capability, so we use this
     // assertion to verify that we are able to parse `capabilities` field properly.
     //


### PR DESCRIPTION
## Summary

- Migrate standalone UniFFI-exported functions to methods on their respective enum and struct types, leveraging UniFFI 0.31.0's new support for methods on enums and records
- Remove now-redundant Swift extension wrappers that were previously needed to provide a more idiomatic API

### Enum methods added:
- `CommentStatus.asString()`
- `CommentType.asString()`
- `UserCapability.asString()`
- `UserRole.asString()`
- `PostStatus.asString()`
- `PostType.asString()`

### Struct methods added:
- `StatsVisitsResponse`: `visitsData()`, `visitorsData()`, `likesData()`, `reblogsData()`, `commentsData()`, `postsData()`
- `SupportAttachment`: `dimensions()`
- `PostTypeSupportsMap`: `supports()`
- `PostTypeDetailsWithEditContext`: `toPostEndpointType()`

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --lib` passes (1062 tests)
- [x] `make xcframework` builds successfully
- [x] Swift package builds successfully
- [x] Kotlin bindings generate successfully
- [x] Kotlin example app compiles successfully

🤖 Generated with [Claude Code](https://claude.ai/code)