### PR TITLE
Rework WP.com e2e tests to remove custom test harness and run in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ common_params:
     # - '6.4'
     # - '6.5'
     # - '6.6'
-    - '6.8.1'
+    - "6.8.1"
 
 steps:
   #
@@ -255,7 +255,7 @@ steps:
         matrix: *wordpress_version_matrix
         plugins:
           - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
+          - $TEST_COLLECTOR:
               files: "native/kotlin/api/kotlin/build/test-results/integrationTest/*.xml"
               format: "junit"
         artifact_paths:
@@ -266,6 +266,20 @@ steps:
         env:
           WORDPRESS_VERSION: "{{matrix}}"
         matrix: *wordpress_version_matrix
+
+      - label: ":wordpress: WordPress.com e2e Tests"
+        command: |
+          echo "--- :rust: Installing Rust"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
+          source "$$HOME/.cargo/env"
+
+          echo "--- :package: Installing Rust Toolchains"
+          make setup-rust
+
+          echo "--- 🧪 Run e2e Tests"
+          cargo run --bin wp_com_e2e
+        agents:
+          queue: android
 
   - label: ":rocket: Publish Swift release $NEW_VERSION"
     command: .buildkite/release.sh $NEW_VERSION

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2121,18 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "escape8259",
 ]
 
 [[package]]
@@ -5219,14 +5237,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap",
- "colored",
- "csv",
- "futures",
+ "libtest-mimic",
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "uuid",
  "wp_api",
 ]

--- a/wp_com_e2e/Cargo.toml
+++ b/wp_com_e2e/Cargo.toml
@@ -6,14 +6,10 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-clap = { workspace = true, features = ["derive", "env"] }
-colored = { workspace = true }
-csv = { workspace = true }
-futures = { workspace = true }
+libtest-mimic = "0.8"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-stream = { workspace = true }
 uuid = { workspace = true }
 wp_api = { path = "../wp_api", features = [ "reqwest-request-executor" ] }
 

--- a/wp_com_e2e/README.md
+++ b/wp_com_e2e/README.md
@@ -1,0 +1,104 @@
+# wp_com_e2e
+
+End-to-end test runner for WordPress.com REST API endpoints.
+
+## Overview
+
+This module provides a test harness for validating WordPress.com API functionality. It uses [libtest-mimic](https://crates.io/crates/libtest-mimic) to provide a familiar cargo-test-like CLI experience with filtering, listing, and selective test execution.
+
+## Setup
+
+Set the `WP_COM_API_KEY` environment variable with a valid WordPress.com OAuth2 bearer token:
+
+```bash
+export WP_COM_API_KEY=your_token_here
+```
+
+## Building
+
+```bash
+cargo build -p wp_com_e2e
+```
+
+## Usage
+
+### Run read-only tests (default)
+
+```bash
+./target/debug/wp_com_e2e
+```
+
+By default, only read-only tests run. Write tests (creating conversations, tickets, etc.) are marked as "ignored" and skipped.
+
+### Run all tests including writes
+
+```bash
+./target/debug/wp_com_e2e --include-ignored
+```
+
+### Run only write tests
+
+```bash
+./target/debug/wp_com_e2e --ignored
+```
+
+### List all tests
+
+```bash
+./target/debug/wp_com_e2e --list
+```
+
+### Filter tests by name
+
+```bash
+# Run all sites tests
+./target/debug/wp_com_e2e sites
+
+# Run a specific test
+./target/debug/wp_com_e2e "me::get_user_info"
+
+# Run tests matching a pattern
+./target/debug/wp_com_e2e support_bots
+```
+
+### Other options
+
+```bash
+# Show help
+./target/debug/wp_com_e2e --help
+
+# Run tests with exact name match
+./target/debug/wp_com_e2e --exact "me::get_user_info"
+
+# Disable output capture (show test output)
+./target/debug/wp_com_e2e --nocapture
+```
+
+## Test Modules
+
+| Module | Description | Write Tests |
+|--------|-------------|-------------|
+| `me_tests` | Current user info and OAuth2 token validation | No |
+| `sites_tests` | Site listing and retrieval by ID/slug | No |
+| `support_bot_tests` | Bot conversation listing and retrieval | Yes |
+| `support_eligibility_test` | Support eligibility check | No |
+| `support_tickets_test` | Support ticket listing and retrieval | Yes |
+
+## Dynamic Tests
+
+Some test modules generate tests dynamically based on API responses:
+
+- **sites_tests**: Creates a test for each site in the user's account
+- **support_bot_tests**: Creates a test for each existing bot conversation
+- **support_tickets_test**: Creates a test for each existing support conversation
+
+## Write Tests
+
+Write tests are marked with the "ignored" flag and include:
+
+- `support_bots::create_conversation` - Creates a new bot conversation
+- `support_bots::create_and_add_message` - Creates a conversation and adds a message
+- `support_tickets::create_ticket` - Creates a new support ticket
+- `support_tickets::create_and_add_message` - Creates a ticket and adds a message
+
+These tests create real data in the WordPress.com system and should be run sparingly.

--- a/wp_com_e2e/README.md
+++ b/wp_com_e2e/README.md
@@ -14,18 +14,12 @@ Set the `WP_COM_API_KEY` environment variable with a valid WordPress.com OAuth2 
 export WP_COM_API_KEY=your_token_here
 ```
 
-## Building
-
-```bash
-cargo build -p wp_com_e2e
-```
-
 ## Usage
 
 ### Run read-only tests (default)
 
 ```bash
-./target/debug/wp_com_e2e
+cargo run -p wp_com_e2e
 ```
 
 By default, only read-only tests run. Write tests (creating conversations, tickets, etc.) are marked as "ignored" and skipped.
@@ -33,45 +27,45 @@ By default, only read-only tests run. Write tests (creating conversations, ticke
 ### Run all tests including writes
 
 ```bash
-./target/debug/wp_com_e2e --include-ignored
+cargo run -p wp_com_e2e -- --include-ignored
 ```
 
 ### Run only write tests
 
 ```bash
-./target/debug/wp_com_e2e --ignored
+cargo run -p wp_com_e2e -- --ignored
 ```
 
 ### List all tests
 
 ```bash
-./target/debug/wp_com_e2e --list
+cargo run -p wp_com_e2e -- --list
 ```
 
 ### Filter tests by name
 
 ```bash
 # Run all sites tests
-./target/debug/wp_com_e2e sites
+cargo run -p wp_com_e2e -- sites
 
 # Run a specific test
-./target/debug/wp_com_e2e "me::get_user_info"
+cargo run -p wp_com_e2e -- "me::get_user_info"
 
 # Run tests matching a pattern
-./target/debug/wp_com_e2e support_bots
+cargo run -p wp_com_e2e -- support_bots
 ```
 
 ### Other options
 
 ```bash
 # Show help
-./target/debug/wp_com_e2e --help
+cargo run -p wp_com_e2e -- --help
 
 # Run tests with exact name match
-./target/debug/wp_com_e2e --exact "me::get_user_info"
+cargo run -p wp_com_e2e -- --exact "me::get_user_info"
 
 # Disable output capture (show test output)
-./target/debug/wp_com_e2e --nocapture
+cargo run -p wp_com_e2e -- --nocapture
 ```
 
 ## Test Modules

--- a/wp_com_e2e/src/context.rs
+++ b/wp_com_e2e/src/context.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use wp_api::{prelude::*, wp_com::client::WpComApiClient};
+
+pub struct TestContext {
+    pub client: WpComApiClient,
+    pub token: String,
+    pub runtime: Runtime,
+}
+
+#[derive(Debug)]
+struct EmptyAppNotifier;
+
+#[async_trait]
+impl WpAppNotifier for EmptyAppNotifier {
+    async fn requested_with_invalid_authentication(&self, _request_url: String) {
+        // no-op
+    }
+}
+
+impl TestContext {
+    pub fn new(token: String) -> Self {
+        let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+
+        let delegate = WpApiClientDelegate {
+            auth_provider: WpAuthenticationProvider::static_with_auth(WpAuthentication::Bearer {
+                token: token.clone(),
+            })
+            .into(),
+            request_executor: Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60))),
+            middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
+            app_notifier: Arc::new(EmptyAppNotifier),
+        };
+
+        let client = WpComApiClient::new(delegate);
+
+        Self {
+            client,
+            token,
+            runtime,
+        }
+    }
+}

--- a/wp_com_e2e/src/main.rs
+++ b/wp_com_e2e/src/main.rs
@@ -1,97 +1,34 @@
-use anyhow::Result;
-use async_trait::async_trait;
-use clap::{Parser, Subcommand};
-use std::{sync::Arc, time::Duration};
-use wp_api::{prelude::*, wp_com::client::WpComApiClient};
+use libtest_mimic::{Arguments, Trial, run};
+use std::env;
+use std::sync::Arc;
 
+mod context;
 mod me_tests;
 mod sites_tests;
 mod support_bot_tests;
 mod support_eligibility_test;
 mod support_tickets_test;
 
-#[derive(Parser)]
-#[command(author, version, about, long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
+use context::TestContext;
+
+fn main() {
+    let token =
+        env::var("WP_COM_API_KEY").expect("WP_COM_API_KEY environment variable must be set");
+
+    let args = Arguments::from_args();
+    let ctx = Arc::new(TestContext::new(token));
+
+    let tests = collect_tests(Arc::clone(&ctx));
+
+    run(&args, tests).exit();
 }
 
-#[derive(Subcommand)]
-enum Commands {
-    Test {
-        #[arg(short = 'w', long = "allow-writes", default_value_t = false)]
-        allow_writes: bool,
-
-        #[arg(short = 't', long = "token", env = "WP_COM_API_KEY")]
-        token: String,
-    },
-}
-
-#[derive(Debug)]
-pub struct EmptyAppNotifier;
-
-#[async_trait]
-impl WpAppNotifier for EmptyAppNotifier {
-    async fn requested_with_invalid_authentication(&self, _request_url: String) {
-        // no-op
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
-    let cli = Cli::parse();
-
-    match cli.command {
-        Commands::Test {
-            token,
-            allow_writes,
-        } => {
-            // Writes to bots can take a while, so we need to increase the timeout
-            let test_timeout = if allow_writes {
-                Duration::from_secs(60)
-            } else {
-                Duration::from_secs(20)
-            };
-
-            let delegate = WpApiClientDelegate {
-                auth_provider: WpAuthenticationProvider::static_with_auth(
-                    WpAuthentication::Bearer {
-                        token: token.clone(),
-                    },
-                )
-                .into(),
-                request_executor: Arc::new(ReqwestRequestExecutor::new(false, test_timeout)),
-                middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
-                app_notifier: Arc::new(EmptyAppNotifier),
-            };
-
-            let client = WpComApiClient::new(delegate);
-
-            println!("== Running Tests ==");
-
-            if let Err(err) = run_tests(&client, token.clone(), allow_writes).await {
-                eprintln!("ERROR: {}", err);
-                err.chain()
-                    .skip(1)
-                    .for_each(|cause| eprintln!("because: {}", cause));
-                std::process::exit(1);
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn run_tests(
-    client: &WpComApiClient,
-    token: String,
-    allow_writes: bool,
-) -> Result<(), anyhow::Error> {
-    me_tests::me_test(client, token.clone()).await?;
-    sites_tests::sites_test(client).await?;
-    support_bot_tests::support_bots_test(client, allow_writes).await?;
-    support_eligibility_test::support_eligibility_test(client).await?;
-    support_tickets_test::support_tickets_test(client, allow_writes).await?;
-    Ok(())
+fn collect_tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut tests = vec![];
+    tests.extend(me_tests::tests(Arc::clone(&ctx)));
+    tests.extend(sites_tests::tests(Arc::clone(&ctx)));
+    tests.extend(support_bot_tests::tests(Arc::clone(&ctx)));
+    tests.extend(support_eligibility_test::tests(Arc::clone(&ctx)));
+    tests.extend(support_tickets_test::tests(Arc::clone(&ctx)));
+    tests
 }

--- a/wp_com_e2e/src/me_tests.rs
+++ b/wp_com_e2e/src/me_tests.rs
@@ -1,22 +1,46 @@
-use wp_api::wp_com::{client::WpComApiClient, oauth2::TokenValidationParameters};
+use libtest_mimic::Trial;
+use std::sync::Arc;
+use wp_api::wp_com::oauth2::TokenValidationParameters;
 
-pub async fn me_test(client: &WpComApiClient, token: String) -> anyhow::Result<()> {
-    println!("== Current User Info Test ==");
+use crate::context::TestContext;
 
-    let user_info = client.me().get().await?.data;
-    println!("✅ Get Current User Info");
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut trials = vec![];
 
-    if let Some(client_id) = user_info.token_client_id {
-        println!("== OAuth 2 Token Test ==");
-        client
-            .oauth2()
-            .fetch_info(&TokenValidationParameters {
-                client_id,
-                token: token.clone(),
+    // Pre-fetch user info to determine if we can run OAuth2 test
+    let user_info = ctx.runtime.block_on(async { ctx.client.me().get().await });
+
+    trials.push(Trial::test("me::get_user_info", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                ctx.client.me().get().await.map_err(|e| e.to_string())?;
+                Ok(())
             })
-            .await?;
-        println!("✅ Get OAuth 2 Token Info");
+        }
+    }));
+
+    // Only add OAuth2 test if we have a client_id
+    if let Ok(response) = user_info
+        && let Some(client_id) = response.data.token_client_id
+    {
+        trials.push(Trial::test("me::oauth2_token_info", {
+            let ctx = Arc::clone(&ctx);
+            move || {
+                ctx.runtime.block_on(async {
+                    ctx.client
+                        .oauth2()
+                        .fetch_info(&TokenValidationParameters {
+                            client_id,
+                            token: ctx.token.clone(),
+                        })
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok(())
+                })
+            }
+        }));
     }
 
-    Ok(())
+    trials
 }

--- a/wp_com_e2e/src/sites_tests.rs
+++ b/wp_com_e2e/src/sites_tests.rs
@@ -1,42 +1,71 @@
-use wp_api::wp_com::{client::WpComApiClient, sites::SitesListParams};
+use libtest_mimic::Trial;
+use std::sync::Arc;
+use wp_api::wp_com::sites::SitesListParams;
 
-pub async fn sites_test(client: &WpComApiClient) -> anyhow::Result<()> {
-    println!("== Sites Test ==");
+use crate::context::TestContext;
 
-    let sites = client
-        .sites()
-        .get(&SitesListParams::default())
-        .await?
-        .data
-        .sites;
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut trials = vec![];
 
-    println!("✅ Get Sites: Found {} sites", sites.len());
+    // Pre-fetch sites during test collection
+    let sites_result = ctx
+        .runtime
+        .block_on(async { ctx.client.sites().get(&SitesListParams::default()).await });
 
-    for site in sites.as_slice() {
-        if let Err(e) = client.sites().get_site_by_id(&site.id).await {
-            println!("❌ Get Site by ID: {} Error: {}", site.id, e);
-            return Err(e.into());
-        } else {
-            println!("✅ Get Site by ID: {}", site.id);
+    trials.push(Trial::test("sites::list", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                ctx.client
+                    .sites()
+                    .get(&SitesListParams::default())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            })
+        }
+    }));
+
+    if let Ok(response) = sites_result {
+        let sites = response.data.sites;
+
+        for site in &sites {
+            let site_id = site.id;
+            trials.push(Trial::test(format!("sites::get_by_id::{}", site_id), {
+                let ctx = Arc::clone(&ctx);
+                move || {
+                    ctx.runtime.block_on(async {
+                        ctx.client
+                            .sites()
+                            .get_site_by_id(&site_id)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        Ok(())
+                    })
+                }
+            }));
+        }
+
+        for site in &sites {
+            if let Some(slug) = &site.slug {
+                let slug = slug.clone();
+                trials.push(Trial::test(format!("sites::get_by_slug::{}", slug), {
+                    let ctx = Arc::clone(&ctx);
+                    let slug = slug.clone();
+                    move || {
+                        ctx.runtime.block_on(async {
+                            ctx.client
+                                .sites()
+                                .get_site_by_slug(&slug)
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        })
+                    }
+                }));
+            }
         }
     }
 
-    for site in sites.as_slice() {
-        if let Err(e) = client
-            .sites()
-            .get_site_by_slug(site.slug.as_ref().unwrap())
-            .await
-        {
-            println!(
-                "❌ Get Site by Handle: {} Error: {}",
-                site.slug.as_ref().unwrap(),
-                e
-            );
-            return Err(e.into());
-        } else {
-            println!("✅ Get Site by Handle: {}", site.slug.as_ref().unwrap());
-        }
-    }
-
-    Ok(())
+    trials
 }

--- a/wp_com_e2e/src/support_bot_tests.rs
+++ b/wp_com_e2e/src/support_bot_tests.rs
@@ -1,93 +1,139 @@
+use libtest_mimic::Trial;
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use wp_api::wp_com::{
-    client::WpComApiClient,
-    support_bots::{
-        AddMessageToBotConversationParams, BotConversation, BotId, ChatId,
-        CreateBotConversationParams, GetBotConversationParams, ListBotConversationsParams,
-    },
+use wp_api::wp_com::support_bots::{
+    AddMessageToBotConversationParams, BotId, ChatId, CreateBotConversationParams,
+    GetBotConversationParams, ListBotConversationsParams,
 };
 
-pub async fn support_bots_test(client: &WpComApiClient, allow_writes: bool) -> anyhow::Result<()> {
-    let bot_id = BotId("jetpack-chat-mobile".to_string());
-    println!("== Support Bots Test ==");
+use crate::context::TestContext;
 
-    let conversations = client
-        .support_bots()
-        .get_bot_conversation_list(&bot_id, &ListBotConversationsParams::default())
-        .await?
-        .data;
+const BOT_ID: &str = "jetpack-chat-mobile";
 
-    println!(
-        "✅ Fetch Conversation List: Found {} conversations",
-        conversations.len()
-    );
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut trials = vec![];
 
-    for conversation in conversations {
-        let chat_id = ChatId(conversation.chat_id);
+    let bot_id = BotId(BOT_ID.to_string());
 
-        if let Err(e) = client
+    // Pre-fetch conversations during test collection
+    let conversations_result = ctx.runtime.block_on(async {
+        ctx.client
             .support_bots()
-            .get_bot_conversation(&bot_id, &chat_id, &GetBotConversationParams::default())
+            .get_bot_conversation_list(&bot_id, &ListBotConversationsParams::default())
             .await
-        {
-            println!(
-                "❌ Fetch Conversation: {} Error: {}",
-                conversation.chat_id, e
-            );
-            return Err(e.into());
-        } else {
-            println!("✅ Fetch Conversation: {}", conversation.chat_id);
+    });
+
+    trials.push(Trial::test("support_bots::list_conversations", {
+        let ctx = Arc::clone(&ctx);
+        let bot_id = bot_id.clone();
+        move || {
+            ctx.runtime.block_on(async {
+                ctx.client
+                    .support_bots()
+                    .get_bot_conversation_list(&bot_id, &ListBotConversationsParams::default())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            })
+        }
+    }));
+
+    if let Ok(response) = conversations_result {
+        for conversation in response.data {
+            let chat_id = ChatId(conversation.chat_id);
+            trials.push(Trial::test(
+                format!("support_bots::get_conversation::{}", conversation.chat_id),
+                {
+                    let ctx = Arc::clone(&ctx);
+                    let bot_id = bot_id.clone();
+                    move || {
+                        ctx.runtime.block_on(async {
+                            ctx.client
+                                .support_bots()
+                                .get_bot_conversation(
+                                    &bot_id,
+                                    &chat_id,
+                                    &GetBotConversationParams::default(),
+                                )
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        })
+                    }
+                },
+            ));
         }
     }
 
-    if allow_writes {
-        let new_conversation = create_conversation(client, &bot_id).await?;
-        let chat_id = ChatId(new_conversation.chat_id);
-        add_message_to_conversation(client, &bot_id, chat_id).await?;
-    }
+    // Write tests - marked as ignored (run with --ignored or --include-ignored)
+    trials.push(
+        Trial::test("support_bots::create_conversation", {
+            let ctx = Arc::clone(&ctx);
+            let bot_id = bot_id.clone();
+            move || {
+                ctx.runtime.block_on(async {
+                    ctx.client
+                        .support_bots()
+                        .create_bot_conversation(
+                            &bot_id,
+                            &CreateBotConversationParams {
+                                message: "This is a test – it can be deleted without replying."
+                                    .to_string(),
+                                user_id: None,
+                            },
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok(())
+                })
+            }
+        })
+        .with_ignored_flag(true),
+    );
 
-    Ok(())
-}
+    trials.push(
+        Trial::test("support_bots::create_and_add_message", {
+            let ctx = Arc::clone(&ctx);
+            let bot_id = bot_id.clone();
+            move || {
+                ctx.runtime.block_on(async {
+                    // Create a new conversation
+                    let new_conversation = ctx
+                        .client
+                        .support_bots()
+                        .create_bot_conversation(
+                            &bot_id,
+                            &CreateBotConversationParams {
+                                message: "This is a test – it can be deleted without replying."
+                                    .to_string(),
+                                user_id: None,
+                            },
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
 
-async fn create_conversation(
-    client: &WpComApiClient,
-    bot_id: &BotId,
-) -> anyhow::Result<BotConversation> {
-    let new_conversation = client
-        .support_bots()
-        .create_bot_conversation(
-            bot_id,
-            &CreateBotConversationParams {
-                message: "This is a test – it can be deleted without replying.".to_string(),
-                user_id: None,
-            },
-        )
-        .await?
-        .data;
+                    let chat_id = ChatId(new_conversation.data.chat_id);
 
-    println!("✅ Create Conversation");
+                    // Add a message to the conversation
+                    ctx.client
+                        .support_bots()
+                        .add_message_to_bot_conversation(
+                            &bot_id,
+                            &chat_id,
+                            &AddMessageToBotConversationParams {
+                                message: "Test Message".to_string(),
+                                context: HashMap::new(),
+                            },
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok(())
+                })
+            }
+        })
+        .with_ignored_flag(true),
+    );
 
-    Ok(new_conversation)
-}
-
-async fn add_message_to_conversation(
-    client: &WpComApiClient,
-    bot_id: &BotId,
-    conversation_id: ChatId,
-) -> anyhow::Result<()> {
-    client
-        .support_bots()
-        .add_message_to_bot_conversation(
-            bot_id,
-            &conversation_id,
-            &AddMessageToBotConversationParams {
-                message: "Test Message".to_string(),
-                context: HashMap::new(),
-            },
-        )
-        .await?;
-
-    println!("✅ Add Message to Conversation");
-    Ok(())
+    trials
 }

--- a/wp_com_e2e/src/support_eligibility_test.rs
+++ b/wp_com_e2e/src/support_eligibility_test.rs
@@ -1,12 +1,20 @@
-use wp_api::wp_com::client::WpComApiClient;
+use libtest_mimic::Trial;
+use std::sync::Arc;
 
-pub async fn support_eligibility_test(client: &WpComApiClient) -> anyhow::Result<()> {
-    println!("== Support Eligibility Test ==");
-    client
-        .support_eligibility()
-        .get_support_eligibility()
-        .await?;
-    println!("✅ Get Support Eligibility");
+use crate::context::TestContext;
 
-    Ok(())
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    vec![Trial::test("support_eligibility::get", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                ctx.client
+                    .support_eligibility()
+                    .get_support_eligibility()
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            })
+        }
+    })]
 }

--- a/wp_com_e2e/src/support_tickets_test.rs
+++ b/wp_com_e2e/src/support_tickets_test.rs
@@ -1,83 +1,127 @@
+use libtest_mimic::Trial;
+use std::sync::Arc;
 use uuid::Uuid;
-use wp_api::wp_com::{
-    client::WpComApiClient,
-    support_tickets::{
-        AddMessageToSupportConversationParams, ConversationId, CreateSupportTicketParams,
-        SupportConversation,
-    },
+
+use wp_api::wp_com::support_tickets::{
+    AddMessageToSupportConversationParams, CreateSupportTicketParams,
 };
 
-pub async fn support_tickets_test(
-    client: &WpComApiClient,
-    allow_writes: bool,
-) -> anyhow::Result<()> {
-    println!("== Support Tickets Test ==");
+use crate::context::TestContext;
 
-    let conversations = client
-        .support_tickets()
-        .get_support_conversation_list()
-        .await?
-        .data;
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut trials = vec![];
 
-    println!(
-        "✅ Fetch Conversation List: Found {} conversations",
-        conversations.len()
-    );
-
-    for conversation in conversations {
-        if let Err(e) = client
+    // Pre-fetch conversations during test collection
+    let conversations_result = ctx.runtime.block_on(async {
+        ctx.client
             .support_tickets()
-            .get_support_conversation(&conversation.id)
+            .get_support_conversation_list()
             .await
-        {
-            println!("❌ Fetch Conversation: {} Error: {}", conversation.id, e);
-            return Err(e.into());
-        } else {
-            println!("✅ Fetch Conversation: {}", conversation.id);
+    });
+
+    trials.push(Trial::test("support_tickets::list_conversations", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                ctx.client
+                    .support_tickets()
+                    .get_support_conversation_list()
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            })
+        }
+    }));
+
+    if let Ok(response) = conversations_result {
+        for conversation in response.data {
+            let conversation_id = conversation.id;
+            trials.push(Trial::test(
+                format!("support_tickets::get_conversation::{}", conversation_id),
+                {
+                    let ctx = Arc::clone(&ctx);
+                    move || {
+                        ctx.runtime.block_on(async {
+                            ctx.client
+                                .support_tickets()
+                                .get_support_conversation(&conversation_id)
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        })
+                    }
+                },
+            ));
         }
     }
 
-    if allow_writes {
-        let new_conversation = create_conversation(client).await?;
-        add_message_to_conversation(client, new_conversation.id).await?;
-    }
-
-    Ok(())
-}
-
-async fn create_conversation(client: &WpComApiClient) -> anyhow::Result<SupportConversation> {
-    let new_conversation = client
-        .support_tickets()
-        .create_support_ticket(&CreateSupportTicketParams {
-            subject: "Mobile Support Test Message".to_string(),
-            message: "This is a test – it can be deleted without replying.".to_string(),
-            application: "jetpack".to_string(),
-            wpcom_site_id: None,
-            tags: vec!["jetpack_mobile".to_string(), "test".to_string()],
-            attachments: vec![],
-            encrypted_log_ids: vec![Uuid::new_v4().to_string()],
+    // Write tests - marked as ignored (run with --ignored or --include-ignored)
+    trials.push(
+        Trial::test("support_tickets::create_ticket", {
+            let ctx = Arc::clone(&ctx);
+            move || {
+                ctx.runtime.block_on(async {
+                    ctx.client
+                        .support_tickets()
+                        .create_support_ticket(&CreateSupportTicketParams {
+                            subject: "Mobile Support Test Message".to_string(),
+                            message: "This is a test – it can be deleted without replying."
+                                .to_string(),
+                            application: "jetpack".to_string(),
+                            wpcom_site_id: None,
+                            tags: vec!["jetpack_mobile".to_string(), "test".to_string()],
+                            attachments: vec![],
+                            encrypted_log_ids: vec![Uuid::new_v4().to_string()],
+                        })
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok(())
+                })
+            }
         })
-        .await?
-        .data;
-    println!("✅ Create Conversation");
+        .with_ignored_flag(true),
+    );
 
-    Ok(new_conversation)
-}
+    trials.push(
+        Trial::test("support_tickets::create_and_add_message", {
+            let ctx = Arc::clone(&ctx);
+            move || {
+                ctx.runtime.block_on(async {
+                    // Create a new ticket
+                    let new_conversation = ctx
+                        .client
+                        .support_tickets()
+                        .create_support_ticket(&CreateSupportTicketParams {
+                            subject: "Mobile Support Test Message".to_string(),
+                            message: "This is a test – it can be deleted without replying."
+                                .to_string(),
+                            application: "jetpack".to_string(),
+                            wpcom_site_id: None,
+                            tags: vec!["jetpack_mobile".to_string(), "test".to_string()],
+                            attachments: vec![],
+                            encrypted_log_ids: vec![Uuid::new_v4().to_string()],
+                        })
+                        .await
+                        .map_err(|e| e.to_string())?;
 
-async fn add_message_to_conversation(
-    client: &WpComApiClient,
-    conversation_id: ConversationId,
-) -> anyhow::Result<()> {
-    client
-        .support_tickets()
-        .add_message_to_support_conversation(
-            &conversation_id,
-            &AddMessageToSupportConversationParams {
-                message: "Test Message".to_string(),
-                attachments: vec![],
-            },
-        )
-        .await?;
-    println!("✅ Add Message to Conversation");
-    Ok(())
+                    // Add a message to the conversation
+                    ctx.client
+                        .support_tickets()
+                        .add_message_to_support_conversation(
+                            &new_conversation.data.id,
+                            &AddMessageToSupportConversationParams {
+                                message: "Test Message".to_string(),
+                                attachments: vec![],
+                            },
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok(())
+                })
+            }
+        })
+        .with_ignored_flag(true),
+    );
+
+    trials
 }


### PR DESCRIPTION
## Summary                                                                                                               
- Refactor WordPress.com e2e tests to use `libtest-mimic` for a cargo-test-like CLI experience                             
- Add WordPress.com e2e tests to the Buildkite CI pipeline                                                               
                                                                                                                       
## Test plan                                                                                                             
- [ ] Run `cargo build -p wp_com_e2e` to verify the refactored test runner compiles                                      
- [ ] Run `./target/debug/wp_com_e2e --list` to verify test discovery works                                              
- [ ] Run `./target/debug/wp_com_e2e` with `WP_COM_API_KEY` set to verify read-only tests pass                           
- [ ] Verify the new Buildkite pipeline step executes successfully                                                       
                                                                                                                       
---                                                                                                                      
                                                                                                                       
### Changes                                                                                                              
                                                                                                                       
The main refactor replaces the ad-hoc test execution in `wp_com_e2e` with [libtest-mimic](https://crates.io/crates/libtest-mimic), providing:                                                      
                                                                                                                       
- Standard test CLI flags (`--list`, `--ignored`, `--include-ignored`, `--exact`, `--nocapture`)                         
- Test filtering by name/pattern                                                                                         
- Separation of read-only vs write tests (write tests are ignored by default)                                            
- Shared `TestContext` for API client reuse across tests                                                                 
- Dynamic test generation based on API responses (per-site, per-conversation tests)                                      
                                                                                                                       
The CI addition runs the read-only e2e tests on the `android` queue after installing Rust toolchains. 

We'll run the new tests as not-required for now to see how it goes and will make them required for a PR to land in the future.