### PR TITLE
Update get_csv implementation to support URL encoded by WordPress core

### DIFF
--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -145,28 +145,30 @@ impl<'a> UrlQueryPairsMap<'a> {
     /// When an array parameter like `status=["draft", "publish"]` is serialized,
     /// PHP produces `status[0]=draft&status[1]=publish` instead of `status=draft,publish`.
     ///
-    /// This function handles that format by looking up `key[0]`, `key[1]`, etc.
-    /// in sequence, stopping when a gap is encountered.
+    /// This function handles that format by scanning all keys matching `key[$int]`,
+    /// where `$int` is any valid integer. Non-sequential indices are supported.
     ///
     /// See:
     /// - <https://github.com/WordPress/wordpress-develop/blob/6.9.0/src/wp-includes/functions.php#L1064>
     /// - <https://www.php.net/manual/en/function.http-build-query.php>
     fn get_php_array_values<T: FromStr>(&self, key: &str) -> Vec<T> {
-        let mut result = Vec::new();
-        let mut index = 0;
-        loop {
-            let array_key = format!("{key}[{index}]");
-            match self.inner.get(array_key.as_str()) {
-                Some(v) => {
-                    if let Ok(parsed) = T::from_str(v) {
-                        result.push(parsed);
-                    }
-                    index += 1;
+        let mut indexed_values: Vec<(i64, T)> = self
+            .inner
+            .iter()
+            .filter_map(|(k, v)| {
+                let k_str = k.as_ref();
+                let open_bracket = k_str.find('[')?;
+                let close_bracket = k_str.find(']')?;
+                if &k_str[..open_bracket] != key || close_bracket != k_str.len() - 1 {
+                    return None;
                 }
-                None => break,
-            }
-        }
-        result
+                let index: i64 = k_str[open_bracket + 1..close_bracket].parse().ok()?;
+                let parsed = T::from_str(v).ok()?;
+                Some((index, parsed))
+            })
+            .collect();
+        indexed_values.sort_by_key(|(index, _)| *index);
+        indexed_values.into_iter().map(|(_, v)| v).collect()
     }
 
     pub(crate) fn get_wp_date_time<'b>(&self, key: impl Into<&'b str>) -> Option<WpGmtDateTime> {
@@ -327,14 +329,22 @@ mod tests {
     }
 
     #[test]
-    fn test_get_csv_with_php_array_stops_at_gap() {
+    fn test_get_csv_with_php_array_with_gaps() {
         let mut pairs = HashMap::new();
         pairs.insert(Cow::Borrowed("status[0]"), Cow::Borrowed("draft"));
         pairs.insert(Cow::Borrowed("status[2]"), Cow::Borrowed("publish"));
+        pairs.insert(Cow::Borrowed("status[4]"), Cow::Borrowed("trash"));
 
         let map = UrlQueryPairsMap::new(pairs);
         let statuses: Vec<String> = map.get_csv("status");
-        assert_eq!(statuses, vec!["draft".to_string()]);
+        assert_eq!(
+            statuses,
+            vec![
+                "draft".to_string(),
+                "publish".to_string(),
+                "trash".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -124,14 +124,49 @@ impl<'a> UrlQueryPairsMap<'a> {
     }
 
     pub(crate) fn get_csv<'b, T: FromStr>(&self, key: impl Into<&'b str>) -> Vec<T> {
-        self.inner
-            .get(key.into())
-            .and_then(|v| {
-                v.split(',')
-                    .map(|s| T::from_str(s).ok())
-                    .collect::<Option<Vec<_>>>()
-            })
-            .unwrap_or_default()
+        // If the `key` exists as a regular CSV value, parse and return it.
+        let key = key.into();
+        let result = self.inner.get(key).and_then(|v| {
+            v.split(',')
+                .map(|s| T::from_str(s).ok())
+                .collect::<Option<Vec<_>>>()
+        });
+        if let Some(values) = result {
+            return values;
+        }
+
+        // Otherwise, try to get values from PHP-style array parameters: `foo[0]=a&foo[1]=b`.
+        self.get_php_array_values(key)
+    }
+
+    /// Retrieves values from PHP-style array query parameters.
+    ///
+    /// WordPress uses PHP's `http_build_query` to generate pagination Link headers.
+    /// When an array parameter like `status=["draft", "publish"]` is serialized,
+    /// PHP produces `status[0]=draft&status[1]=publish` instead of `status=draft,publish`.
+    ///
+    /// This function handles that format by looking up `key[0]`, `key[1]`, etc.
+    /// in sequence, stopping when a gap is encountered.
+    ///
+    /// See:
+    /// - <https://github.com/WordPress/wordpress-develop/blob/6.9.0/src/wp-includes/functions.php#L1064>
+    /// - <https://www.php.net/manual/en/function.http-build-query.php>
+    fn get_php_array_values<T: FromStr>(&self, key: &str) -> Vec<T> {
+        let mut result = Vec::new();
+        let mut index = 0;
+        loop {
+            let array_key = format!("{key}[{index}]");
+            match self.inner.get(array_key.as_str()) {
+                Some(v) => {
+                    if let Ok(parsed) = T::from_str(v) {
+                        result.push(parsed);
+                    }
+                    index += 1;
+                }
+                None => break,
+            }
+        }
+        result
     }
 
     pub(crate) fn get_wp_date_time<'b>(&self, key: impl Into<&'b str>) -> Option<WpGmtDateTime> {
@@ -254,5 +289,76 @@ mod tests {
         url.query_pairs_mut()
             .append_vec_query_value_pair(key, &value);
         assert_eq!(url.query(), Some(expected_str));
+    }
+
+    #[test]
+    fn test_get_csv_with_regular_csv_value() {
+        let mut pairs = HashMap::new();
+        pairs.insert(Cow::Borrowed("status"), Cow::Borrowed("draft,publish"));
+        pairs.insert(Cow::Borrowed("page"), Cow::Borrowed("1"));
+
+        let map = UrlQueryPairsMap::new(pairs);
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["draft".to_string(), "publish".to_string()]);
+    }
+
+    #[test]
+    fn test_get_csv_with_php_array_single_value() {
+        let mut pairs = HashMap::new();
+        pairs.insert(Cow::Borrowed("status[0]"), Cow::Borrowed("any"));
+        pairs.insert(Cow::Borrowed("page"), Cow::Borrowed("2"));
+
+        let map = UrlQueryPairsMap::new(pairs);
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["any".to_string()]);
+        assert_eq!(map.get::<u32>("page"), Some(2));
+    }
+
+    #[test]
+    fn test_get_csv_with_php_array_multiple_values() {
+        let mut pairs = HashMap::new();
+        pairs.insert(Cow::Borrowed("status[0]"), Cow::Borrowed("draft"));
+        pairs.insert(Cow::Borrowed("status[1]"), Cow::Borrowed("publish"));
+        pairs.insert(Cow::Borrowed("page"), Cow::Borrowed("1"));
+
+        let map = UrlQueryPairsMap::new(pairs);
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["draft".to_string(), "publish".to_string()]);
+    }
+
+    #[test]
+    fn test_get_csv_with_php_array_stops_at_gap() {
+        let mut pairs = HashMap::new();
+        pairs.insert(Cow::Borrowed("status[0]"), Cow::Borrowed("draft"));
+        pairs.insert(Cow::Borrowed("status[2]"), Cow::Borrowed("publish"));
+
+        let map = UrlQueryPairsMap::new(pairs);
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["draft".to_string()]);
+    }
+
+    #[test]
+    fn test_get_csv_prefers_regular_key_over_php_array() {
+        let mut pairs = HashMap::new();
+        pairs.insert(Cow::Borrowed("status"), Cow::Borrowed("private"));
+        pairs.insert(Cow::Borrowed("status[0]"), Cow::Borrowed("draft"));
+
+        let map = UrlQueryPairsMap::new(pairs);
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["private".to_string()]);
+    }
+
+    #[test]
+    fn test_get_csv_with_php_array_from_url() {
+        let url =
+            Url::parse("http://localhost/wp-json/wp/v2/posts?status%5B0%5D=any&per_page=60&page=2")
+                .unwrap();
+        let pairs: HashMap<_, _> = url.query_pairs().into_iter().collect();
+        let map = UrlQueryPairsMap::new(pairs);
+
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(statuses, vec!["any".to_string()]);
+        assert_eq!(map.get::<u32>("page"), Some(2));
+        assert_eq!(map.get::<u32>("per_page"), Some(60));
     }
 }

--- a/wp_api/src/url_query.rs
+++ b/wp_api/src/url_query.rs
@@ -371,4 +371,24 @@ mod tests {
         assert_eq!(map.get::<u32>("page"), Some(2));
         assert_eq!(map.get::<u32>("per_page"), Some(60));
     }
+
+    #[test]
+    fn test_get_csv_with_php_array_from_url_with_shuffled_indices() {
+        let url = Url::parse(
+            "http://localhost/wp-json/wp/v2/posts?status%5B4%5D=pending&status%5B0%5D=draft&status%5B2%5D=publish&per_page=60&page=2",
+        )
+        .unwrap();
+        let pairs: HashMap<_, _> = url.query_pairs().into_iter().collect();
+        let map = UrlQueryPairsMap::new(pairs);
+
+        let statuses: Vec<String> = map.get_csv("status");
+        assert_eq!(
+            statuses,
+            vec![
+                "draft".to_string(),
+                "publish".to_string(),
+                "pending".to_string()
+            ]
+        );
+    }
 }

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -229,6 +229,38 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[tokio::test]
 #[rstest]
 #[parallel]
+#[case(PostListParams { per_page: Some(60), ..Default::default() })]
+#[case(PostListParams { per_page: Some(60), status: vec![PostStatus::Custom("any".to_string())], ..Default::default() })]
+async fn paginate_list_all_posts(#[case] params: PostListParams) {
+    // The `per_page` parameter is a magic number between published posts and draft posts total.
+
+    let client = api_client();
+    let mut all_posts = Vec::new();
+    let mut current_params = params;
+
+    loop {
+        let response = client
+            .posts()
+            .list_with_edit_context(&PostEndpointType::Posts, &current_params)
+            .await
+            .assert_response();
+
+        let total_posts = response.header_map.wp_total().unwrap();
+        all_posts.extend(response.data);
+
+        match response.next_page_params {
+            Some(next_params) => current_params = next_params,
+            None => {
+                assert_eq!(all_posts.len(), total_posts as usize);
+                break;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[rstest]
+#[parallel]
 #[case(PostEndpointType::Posts)]
 #[case(PostEndpointType::Pages)]
 // This test ensures that we can list & parse the given post type with default params


### PR DESCRIPTION
Relates to https://github.com/wordpress-mobile/GutenbergKit/pull/299#discussion_r2737781423.

`wp/v2/posts?status=any` response's "next link" is not parsed correctly at the moment. The "next link" contains "status[0]=any", whereas the library (the `get_csv` function specifically) looks for the `status` key. This results in the `status` query being lost.

I have added an integration test to this PR, and Claude Code added some unit test to verify the fix.