### PR TITLE
Add `PostStatus::Trash`

### DIFF
--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -514,6 +514,7 @@ pub enum PostStatus {
     Private,
     #[default]
     Publish,
+    Trash,
     #[serde(untagged)]
     #[strum(default)]
     Custom(String),

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -156,7 +156,7 @@ async fn trash_post() {
     assert!(trashed_post.is_some(), "Can't find the trashed post");
     assert_eq!(
         trashed_post.unwrap().post_status,
-        "trash",
+        PostStatus::Trash.to_string(),
         "Post wasn't trashed"
     );
 
@@ -428,6 +428,7 @@ generate_update_post_status_test!(Draft);
 generate_update_post_status_test!(Pending);
 generate_update_post_status_test!(Private);
 generate_update_post_status_test!(Publish);
+generate_update_post_status_test!(Trash);
 
 generate_update_post_format_test!(Standard);
 generate_update_post_format_test!(Aside);

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -424,11 +424,13 @@ async fn update_status_to_future() {
 }
 
 // See `update_status_to_future` test case for `PostStatus::Future`
+// Note: `PostStatus::Trash` is not tested here because WordPress doesn't allow setting
+// a post's status to "trash" via the update endpoint. Use the trash endpoint instead
+// (tested in `trash_post` test).
 generate_update_post_status_test!(Draft);
 generate_update_post_status_test!(Pending);
 generate_update_post_status_test!(Private);
 generate_update_post_status_test!(Publish);
-generate_update_post_status_test!(Trash);
 
 generate_update_post_format_test!(Standard);
 generate_update_post_format_test!(Aside);


### PR DESCRIPTION
I'm not sure why the trash status was not there. I hope I didn't miss anything...