### PR TITLE
Rename `WpSelfHostedService` and add WP.com sites support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5452,6 +5452,8 @@ dependencies = [
  "tokio",
  "uuid",
  "wp_api",
+ "wp_mobile",
+ "wp_mobile_cache",
 ]
 
 [[package]]

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/IntegrationTestHelpers.kt
@@ -2,15 +2,13 @@ package rs.wordpress.api.kotlin
 
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.UserId
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAuthenticationProvider
 import uniffi.wp_api.WpErrorCode
-import uniffi.wp_api.WpOrgSiteApiUrlResolver
 import uniffi.wp_mobile.MockPostService
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 import rs.wordpress.cache.kotlin.WordPressApiCache
 
 const val FIRST_USER_ID: UserId = 1
@@ -32,7 +30,7 @@ fun defaultApiClient(): WpApiClient {
 }
 
 data class TestServiceContext(
-    val service: WpSelfHostedService,
+    val service: WpService,
     val mockPostService: MockPostService
 )
 
@@ -54,10 +52,9 @@ fun createTestServiceContext(): TestServiceContext {
     val siteUrl = apiRootUrl.removeSuffix("/wp-json")
 
     // Create self-hosted service
-    val service = WpSelfHostedService(
+    val service = WpService.selfHosted(
         siteUrl = siteUrl,
         apiRoot = apiRootUrl,
-        apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(apiRootUrl)),
         delegate = WpApiClientDelegate(
             authProvider,
             requestExecutor = WpRequestExecutor(emptyList()),

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WordPressApiCacheTest.kt
@@ -10,6 +10,6 @@ class WordPressApiCacheTest {
 
     @Test
     fun testThatMigrationsWork() = runTest {
-        assertEquals(9, WordPressApiCache().performMigrations())
+        assertEquals(10, WordPressApiCache().performMigrations())
     }
 }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/di/AppModule.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/di/AppModule.kt
@@ -14,13 +14,12 @@ import rs.wordpress.example.shared.ui.posttypes.PostTypesViewModel
 import rs.wordpress.example.shared.ui.stresstest.StressTestViewModel
 import rs.wordpress.example.shared.ui.users.UserListViewModel
 import rs.wordpress.example.shared.ui.welcome.WelcomeViewModel
-import uniffi.wp_api.ParsedUrl
 import uniffi.wp_api.WpApiClientDelegate
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAuthenticationProvider
-import uniffi.wp_api.WpOrgSiteApiUrlResolver
 import uniffi.wp_mobile.MockPostService
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.SiteInfo
+import uniffi.wp_mobile.WpService
 import java.io.File
 
 val authModule = module {
@@ -52,15 +51,20 @@ val cacheModule = module {
 val mockServiceModule = module {
     single {
         val cache = get<WordPressApiCache>()
-        val selfHostedService = get<WpSelfHostedService>()
+        val wpService = get<WpService>()
 
-        // Use the exact same site_url and api_root as WpSelfHostedService
-        val siteInfo = selfHostedService.sites().getCurrentSiteInfo()
+        // Use the exact same site_url and api_root as WpService
+        val siteInfo = wpService.sites().getCurrentSiteInfo()
+
+        val (siteUrl, apiRoot) = when (siteInfo) {
+            is SiteInfo.SelfHosted -> siteInfo.siteUrl to siteInfo.apiRoot
+            is SiteInfo.WordPressCom -> error("MockPostService requires a self-hosted site")
+        }
 
         MockPostService(
             cache.cache,
-            siteInfo.siteUrl,
-            siteInfo.apiRoot
+            siteUrl,
+            apiRoot
         )
     }
 }
@@ -83,12 +87,9 @@ val selfHostedServiceModule = module {
         val siteUrl = localTestSiteUrl().siteUrl
         val apiRoot = "$siteUrl/wp-json"
 
-        WpSelfHostedService(
+        WpService.selfHosted(
             siteUrl = siteUrl,
             apiRoot = apiRoot,
-            apiUrlResolver = WpOrgSiteApiUrlResolver(
-                apiRootUrl = ParsedUrl.parse(apiRoot)
-            ),
             delegate = WpApiClientDelegate(
                 authProvider,
                 requestExecutor = WpRequestExecutor(emptyList()),

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postcollection/PostCollectionViewModel.kt
@@ -15,7 +15,7 @@ import uniffi.wp_mobile.AnyPostFilter
 import uniffi.wp_mobile.FetchResult
 import uniffi.wp_mobile.FullEntityAnyPostWithEditContext
 import uniffi.wp_mobile.PostCollectionWithEditContext
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 
 /**
  * UI state for the post collection screen
@@ -50,7 +50,7 @@ data class CollectionState(
 }
 
 class PostCollectionViewModel(
-    private val selfHostedService: WpSelfHostedService
+    private val selfHostedService: WpService
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 import uniffi.wp_mobile.PostItemState
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 import uniffi.wp_mobile_cache.ListState
 
 @Composable
@@ -44,7 +44,7 @@ import uniffi.wp_mobile_cache.ListState
 fun PostMetadataCollectionScreen(
     postTypeSlug: String = "post",
     viewModel: PostMetadataCollectionViewModel = run {
-        val service = koinInject<WpSelfHostedService>()
+        val service = koinInject<WpService>()
         PostMetadataCollectionViewModel(service, postTypeSlug)
     },
     onBackClicked: (() -> Unit)? = null

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/postmetadatacollection/PostMetadataCollectionViewModel.kt
@@ -18,7 +18,7 @@ import uniffi.wp_mobile.PostItemState
 import uniffi.wp_mobile.PostListFilter
 import uniffi.wp_mobile.PostMetadataCollectionItem
 import uniffi.wp_mobile.SyncResult
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 import uniffi.wp_mobile_cache.ListState
 
 /**
@@ -111,7 +111,7 @@ data class PostItemDisplayData(
 }
 
 class PostMetadataCollectionViewModel(
-    private val selfHostedService: WpSelfHostedService,
+    private val selfHostedService: WpService,
     private val postTypeSlug: String = "post"
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posttypes/PostTypesViewModel.kt
@@ -12,7 +12,7 @@ import rs.wordpress.cache.kotlin.ObservableCollection
 import rs.wordpress.cache.kotlin.getObservablePostTypeCollectionWithEditContext
 import uniffi.wp_mobile.FullEntityPostTypeDetailsWithEditContext
 import uniffi.wp_mobile.PostTypeCollectionWithEditContext
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 
 /**
  * UI state for the post types screen
@@ -48,7 +48,7 @@ data class PostTypeDisplayData(
 }
 
 class PostTypesViewModel(
-    private val selfHostedService: WpSelfHostedService
+    private val selfHostedService: WpService
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/stresstest/StressTestViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/stresstest/StressTestViewModel.kt
@@ -14,7 +14,7 @@ import rs.wordpress.cache.kotlin.getObservablePostCollectionWithEditContext
 import uniffi.wp_mobile.AnyPostFilter
 import uniffi.wp_mobile.MockPostService
 import uniffi.wp_mobile.StressTestHandle
-import uniffi.wp_mobile.WpSelfHostedService
+import uniffi.wp_mobile.WpService
 import kotlin.math.roundToInt
 
 data class PerformanceMetrics(
@@ -28,7 +28,7 @@ data class PerformanceMetrics(
 
 class StressTestViewModel(
     private val mockPostService: MockPostService,
-    private val selfHostedService: WpSelfHostedService,
+    private val selfHostedService: WpService,
     private val cache: WordPressApiCache
 ) {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -32,7 +32,7 @@ public typealias UserCapability = WordPressAPIInternal.UserCapability
 public typealias UserRole = WordPressAPIInternal.UserRole
 
 // MARK: - Service Layer
-public typealias WpSelfHostedService = WordPressAPIInternal.WpSelfHostedService
+public typealias WpService = WordPressAPIInternal.WpService
 public typealias AnyPostFilter = WordPressAPIInternal.AnyPostFilter
 public typealias WpApiCache = WordPressAPIInternal.WpApiCache
 

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -147,15 +147,18 @@ public final class WordPressAPI: Sendable {
         self.requestExecutor = executor
     }
 
-    public func createSelfHostedService(cache: WordPressApiCache) throws -> WpSelfHostedService {
+    public func createSelfHostedService(cache: WordPressApiCache) throws -> WpService {
         let apiURL = apiUrlResolver.resolve(namespace: "", endpointSegments: []).asURL()
-        return try WpSelfHostedService(
+        return try WpService.selfHosted(
             siteUrl: apiURL.deletingLastPathComponent().absoluteString,
             apiRoot: apiURL.absoluteString,
-            apiUrlResolver: apiUrlResolver,
             delegate: apiClientDelegate,
             cache: cache.cache
         )
+    }
+
+    public func createWordPressComService(siteId: WpComSiteId, cache: WordPressApiCache) throws -> WpService {
+        try WpService.wordpressCom(siteId: siteId, delegate: apiClientDelegate, cache: cache.cache)
     }
 
     public var users: UsersRequestExecutor {

--- a/wp_com_e2e/Cargo.toml
+++ b/wp_com_e2e/Cargo.toml
@@ -13,6 +13,8 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true }
 wp_api = { path = "../wp_api", features = [ "reqwest-request-executor" ] }
+wp_mobile = { path = "../wp_mobile" }
+wp_mobile_cache = { path = "../wp_mobile_cache" }
 
 [[bin]]
 name = "wp_com_e2e"

--- a/wp_com_e2e/src/context.rs
+++ b/wp_com_e2e/src/context.rs
@@ -44,6 +44,8 @@ impl TestContext {
         let client = WpComApiClient::new(delegate.clone());
 
         let site_id = WpComTestCredentials::instance().site_id;
+        // Use a test site on the test account used in CI.
+        let site_id = if site_id == 0 { 229889220 } else { site_id };
 
         let cache = Arc::new(WpApiCache::new(None).expect("Failed to create in-memory cache"));
         cache

--- a/wp_com_e2e/src/context.rs
+++ b/wp_com_e2e/src/context.rs
@@ -1,11 +1,18 @@
 use async_trait::async_trait;
+use integration_test_credentials::WpComTestCredentials;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
-use wp_api::{prelude::*, wp_com::client::WpComApiClient};
+use wp_api::{
+    prelude::*,
+    wp_com::{WpComSiteId, client::WpComApiClient},
+};
+use wp_mobile::service::WpService;
+use wp_mobile_cache::WpApiCache;
 
 pub struct TestContext {
     pub client: WpComApiClient,
+    pub service: WpService,
     pub token: String,
     pub runtime: Runtime,
 }
@@ -34,10 +41,21 @@ impl TestContext {
             app_notifier: Arc::new(EmptyAppNotifier),
         };
 
-        let client = WpComApiClient::new(delegate);
+        let client = WpComApiClient::new(delegate.clone());
+
+        let site_id = WpComTestCredentials::instance().site_id;
+
+        let cache = Arc::new(WpApiCache::new(None).expect("Failed to create in-memory cache"));
+        cache
+            .perform_migrations()
+            .expect("Migrations should succeed");
+
+        let service = WpService::new_wordpress_com(WpComSiteId(site_id), delegate, cache.clone())
+            .expect("Failed to create WpService");
 
         Self {
             client,
+            service,
             token,
             runtime,
         }

--- a/wp_com_e2e/src/main.rs
+++ b/wp_com_e2e/src/main.rs
@@ -13,6 +13,7 @@ mod stats_top_posts_tests;
 mod support_bot_tests;
 mod support_eligibility_test;
 mod support_tickets_test;
+mod wp_service_tests;
 
 use context::TestContext;
 
@@ -46,5 +47,6 @@ fn collect_tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     tests.extend(support_eligibility_test::tests(Arc::clone(&ctx)));
     tests.extend(support_tickets_test::tests(Arc::clone(&ctx)));
     tests.extend(stats_top_posts_tests::tests(Arc::clone(&ctx)));
+    tests.extend(wp_service_tests::tests(Arc::clone(&ctx)));
     tests
 }

--- a/wp_com_e2e/src/wp_service_tests.rs
+++ b/wp_com_e2e/src/wp_service_tests.rs
@@ -1,0 +1,43 @@
+use libtest_mimic::Trial;
+use std::sync::Arc;
+use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
+use wp_mobile::collection::PostItemState;
+use wp_mobile::filters::PostListFilter;
+
+use crate::context::TestContext;
+
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    vec![Trial::test("wp_service::refresh_posts", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let collection = ctx
+                    .service
+                    .posts()
+                    .create_post_metadata_collection_with_edit_context(
+                        PostEndpointType::Posts,
+                        PostListFilter::default(),
+                        10,
+                    );
+
+                let result = collection.refresh().await.map_err(|e| format!("{:?}", e))?;
+                assert!(result.total_items > 0, "should have fetched some posts");
+
+                let items = collection
+                    .load_items()
+                    .await
+                    .map_err(|e| format!("{:?}", e))?;
+                assert!(!items.is_empty(), "should have loaded some items");
+
+                for item in &items {
+                    assert!(
+                        matches!(item.state, PostItemState::Fresh { .. }),
+                        "all items should be Fresh after refresh"
+                    );
+                }
+
+                Ok(())
+            })
+        }
+    })]
+}

--- a/wp_mobile/src/service/mod.rs
+++ b/wp_mobile/src/service/mod.rs
@@ -1,7 +1,10 @@
 use crate::service::{post_types::PostTypeService, posts::PostService, sites::SiteService};
 use std::sync::Arc;
-use wp_api::prelude::{ApiUrlResolver, WpApiClient, WpApiClientDelegate};
-use wp_mobile_cache::WpApiCache;
+use wp_api::prelude::{
+    ApiUrlResolver, ParsedUrl, WpApiClient, WpApiClientDelegate, WpOrgSiteApiUrlResolver,
+};
+use wp_api::wp_com::{WpComBaseUrl, WpComSiteId, endpoint::WpComDotOrgApiUrlResolver};
+use wp_mobile_cache::{WpApiCache, db_types::db_site::DbSite};
 
 pub mod entity_state_service;
 pub mod metadata;
@@ -15,6 +18,9 @@ pub enum WpServiceError {
     #[error("Database error: {err_message}")]
     DatabaseError { err_message: String },
 
+    #[error("Invalid URL: {err_message}")]
+    InvalidUrl { err_message: String },
+
     #[error("Site not found in cache")]
     SiteNotFound,
 }
@@ -27,44 +33,27 @@ impl From<wp_mobile_cache::SqliteDbError> for WpServiceError {
     }
 }
 
-/// Service for self-hosted WordPress sites
+/// Service for a WordPress site
 ///
 /// This service coordinates between the API client and cache for a specific
-/// self-hosted WordPress site. It provides access to domain-specific services
-/// like PostService, PostTypeService, CommentService, etc.
+/// WordPress site (self-hosted or WordPress.com). It provides access to
+/// domain-specific services like PostService, PostTypeService, etc.
 #[derive(uniffi::Object)]
-pub struct WpSelfHostedService {
+pub struct WpService {
     posts: Arc<PostService>,
     post_types: Arc<PostTypeService>,
     sites: Arc<SiteService>,
 }
 
-#[uniffi::export]
-impl WpSelfHostedService {
-    /// Create a new service for a self-hosted WordPress site
-    ///
-    /// This will look up the site in the cache or create it if it doesn't exist.
-    ///
-    /// # Arguments
-    /// * `site_url` - The base site URL (e.g., "https://example.com")
-    /// * `api_root` - The API root URL (e.g., "https://example.com/wp-json")
-    /// * `api_url_resolver` - URL resolver for building API endpoint URLs
-    /// * `delegate` - API client delegate with auth provider, request executor, etc.
-    /// * `cache` - The cache instance for database operations
-    #[uniffi::constructor]
-    pub fn new(
-        site_url: String,
-        api_root: String,
+impl WpService {
+    fn build_services(
         api_url_resolver: Arc<dyn ApiUrlResolver>,
         delegate: WpApiClientDelegate,
         cache: Arc<WpApiCache>,
-    ) -> Result<Self, WpServiceError> {
+        db_site: DbSite,
+        site_service: Arc<SiteService>,
+    ) -> Self {
         let api_client = Arc::new(WpApiClient::new(api_url_resolver, delegate));
-
-        // Get or create the DbSite
-        let db_site =
-            SiteService::get_or_create_self_hosted_site(cache.clone(), site_url, api_root)?;
-
         let db_site_arc = Arc::new(db_site);
 
         let posts = Arc::new(PostService::new(
@@ -72,18 +61,79 @@ impl WpSelfHostedService {
             db_site_arc.clone(),
             cache.clone(),
         ));
-        let post_types = Arc::new(PostTypeService::new(
-            api_client,
-            db_site_arc.clone(),
-            cache.clone(),
-        ));
-        let sites = Arc::new(SiteService::new(cache, db_site));
+        let post_types = Arc::new(PostTypeService::new(api_client, db_site_arc, cache));
 
-        Ok(Self {
+        Self {
             posts,
             post_types,
+            sites: site_service,
+        }
+    }
+}
+
+#[uniffi::export]
+impl WpService {
+    /// Create a new service for a self-hosted WordPress site
+    ///
+    /// This will look up the site in the cache or create it if it doesn't exist.
+    ///
+    /// # Arguments
+    /// * `site_url` - The base site URL (e.g., "https://example.com")
+    /// * `api_root` - The API root URL (e.g., "https://example.com/wp-json")
+    /// * `delegate` - API client delegate with auth provider, request executor, etc.
+    /// * `cache` - The cache instance for database operations
+    #[uniffi::constructor(name = "selfHosted")]
+    pub fn new_self_hosted(
+        site_url: String,
+        api_root: String,
+        delegate: WpApiClientDelegate,
+        cache: Arc<WpApiCache>,
+    ) -> Result<Self, WpServiceError> {
+        let api_root_url =
+            ParsedUrl::parse(&api_root).map_err(|e| WpServiceError::InvalidUrl {
+                err_message: e.to_string(),
+            })?;
+        let api_url_resolver: Arc<dyn ApiUrlResolver> =
+            Arc::new(WpOrgSiteApiUrlResolver::new(Arc::new(api_root_url)));
+        let db_site =
+            SiteService::get_or_create_self_hosted_site(cache.clone(), site_url, api_root)?;
+        let sites = Arc::new(SiteService::new(cache.clone(), db_site));
+        Ok(Self::build_services(
+            api_url_resolver,
+            delegate,
+            cache,
+            db_site,
             sites,
-        })
+        ))
+    }
+
+    /// Create a new service for a WordPress.com site
+    ///
+    /// This will look up the site in the cache or create it if it doesn't exist.
+    ///
+    /// # Arguments
+    /// * `site_id` - The WordPress.com site ID
+    /// * `delegate` - API client delegate with auth provider, request executor, etc.
+    /// * `cache` - The cache instance for database operations
+    #[uniffi::constructor(name = "wordpressCom")]
+    pub fn new_wordpress_com(
+        site_id: WpComSiteId,
+        delegate: WpApiClientDelegate,
+        cache: Arc<WpApiCache>,
+    ) -> Result<Self, WpServiceError> {
+        let api_url_resolver: Arc<dyn ApiUrlResolver> = Arc::new(WpComDotOrgApiUrlResolver::new(
+            site_id.to_string(),
+            WpComBaseUrl::default(),
+        ));
+        let db_site = SiteService::get_or_create_wordpress_com_site(cache.clone(), site_id)?;
+        let sites = Arc::new(SiteService::new(cache.clone(), db_site));
+        Ok(Self::build_services(
+            api_url_resolver,
+            delegate,
+            cache,
+            db_site,
+            sites,
+        ))
     }
 
     /// Get the post service for this WordPress site

--- a/wp_mobile/src/service/mod.rs
+++ b/wp_mobile/src/service/mod.rs
@@ -89,10 +89,9 @@ impl WpService {
         delegate: WpApiClientDelegate,
         cache: Arc<WpApiCache>,
     ) -> Result<Self, WpServiceError> {
-        let api_root_url =
-            ParsedUrl::parse(&api_root).map_err(|e| WpServiceError::InvalidUrl {
-                err_message: e.to_string(),
-            })?;
+        let api_root_url = ParsedUrl::parse(&api_root).map_err(|e| WpServiceError::InvalidUrl {
+            err_message: e.to_string(),
+        })?;
         let api_url_resolver: Arc<dyn ApiUrlResolver> =
             Arc::new(WpOrgSiteApiUrlResolver::new(Arc::new(api_root_url)));
         let db_site =

--- a/wp_mobile/src/service/sites.rs
+++ b/wp_mobile/src/service/sites.rs
@@ -1,16 +1,20 @@
 use crate::service::WpServiceError;
 use std::sync::Arc;
+use wp_api::wp_com::WpComSiteId;
 use wp_mobile_cache::{
-    DbTable, SqliteDbError, WpApiCache, db_types::db_site::DbSite,
-    db_types::self_hosted_site::SelfHostedSite, entity::EntityId,
+    DbTable, SqliteDbError, WpApiCache,
+    db_types::db_site::{DbSite, DbSiteType},
+    db_types::self_hosted_site::SelfHostedSite,
+    db_types::wordpress_com_site::WordPressComSite,
+    entity::EntityId,
     repository::sites::SiteRepository,
 };
 
-/// Information about a site's URLs
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct SiteInfo {
-    pub site_url: String,
-    pub api_root: String,
+/// Information about a site
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum SiteInfo {
+    SelfHosted { site_url: String, api_root: String },
+    WordPressCom { site_id: WpComSiteId },
 }
 
 /// Service for site-related operations
@@ -28,7 +32,7 @@ impl SiteService {
     /// Get or create a DbSite for a self-hosted WordPress site
     ///
     /// Looks up an existing site by URL, or creates it if not found.
-    /// This is an internal helper called by WpSelfHostedService::new().
+    /// This is an internal helper called by WpService::new_self_hosted().
     ///
     /// # Arguments
     /// * `cache` - The cache instance to use for database operations
@@ -62,42 +66,82 @@ impl SiteService {
             Ok(entity_id.db_site)
         })
     }
+
+    /// Get or create a DbSite for a WordPress.com site
+    ///
+    /// Looks up an existing site by site_id, or creates it if not found.
+    /// This is an internal helper called by WpService::new_wordpress_com().
+    pub(crate) fn get_or_create_wordpress_com_site(
+        cache: Arc<WpApiCache>,
+        site_id: WpComSiteId,
+    ) -> Result<DbSite, SqliteDbError> {
+        let site_repository = SiteRepository;
+
+        cache.execute(|conn| {
+            if let Some(full_entity) =
+                site_repository.select_wordpress_com_site_by_site_id(conn, site_id)?
+            {
+                return Ok(full_entity.data.0);
+            }
+
+            let wp_com_site = WordPressComSite { site_id };
+
+            let entity_id = site_repository.upsert_wordpress_com_site(conn, &wp_com_site)?;
+            Ok(entity_id.db_site)
+        })
+    }
 }
 
 #[uniffi::export]
 impl SiteService {
-    /// Get site information (URLs) for the current site
+    /// Get site information for the current site
     ///
-    /// Returns the site URL and API root for the site associated with this service.
-    /// This is useful when you need to display or use the site's URLs in the UI or
-    /// for other services that need to work with the same site.
+    /// Returns the site information variant depending on the site type.
     ///
     /// # Returns
-    /// - `Ok(SiteInfo)` with the site's URLs
+    /// - `Ok(SiteInfo::SelfHosted { .. })` for self-hosted sites
+    /// - `Ok(SiteInfo::WordPressCom { .. })` for WordPress.com sites
     /// - `Err(WpServiceError::DatabaseError)` if a database error occurs
     /// - `Err(WpServiceError::SiteNotFound)` if the site doesn't exist in the database
-    ///
-    /// # Note
-    /// Since the `SiteService` is constructed with a valid `DbSite`, the site should
-    /// normally exist in the database. A `SiteNotFound` error indicates a data
-    /// inconsistency (e.g., site was deleted but entities still reference it).
     pub fn get_current_site_info(&self) -> Result<SiteInfo, WpServiceError> {
-        let site_repository = SiteRepository;
-        let entity_id = EntityId {
-            db_site: self.db_site,
-            table: DbTable::SelfHostedSites,
-            rowid: self.db_site.mapped_site_id,
-        };
+        match self.db_site.site_type {
+            DbSiteType::SelfHosted => {
+                let site_repository = SiteRepository;
+                let entity_id = EntityId {
+                    db_site: self.db_site,
+                    table: DbTable::SelfHostedSites,
+                    rowid: self.db_site.mapped_site_id,
+                };
 
-        let full_entity = self
-            .cache
-            .execute(|conn| site_repository.select_self_hosted_site(conn, &entity_id))?;
+                let full_entity = self
+                    .cache
+                    .execute(|conn| site_repository.select_self_hosted_site(conn, &entity_id))?;
 
-        full_entity
-            .ok_or(WpServiceError::SiteNotFound)
-            .map(|entity| SiteInfo {
-                site_url: entity.data.url,
-                api_root: entity.data.api_root,
-            })
+                full_entity
+                    .ok_or(WpServiceError::SiteNotFound)
+                    .map(|entity| SiteInfo::SelfHosted {
+                        site_url: entity.data.url,
+                        api_root: entity.data.api_root,
+                    })
+            }
+            DbSiteType::WordPressCom => {
+                let site_repository = SiteRepository;
+                let entity_id = EntityId {
+                    db_site: self.db_site,
+                    table: DbTable::WordPressComSites,
+                    rowid: self.db_site.mapped_site_id,
+                };
+
+                let full_entity = self
+                    .cache
+                    .execute(|conn| site_repository.select_wordpress_com_site(conn, &entity_id))?;
+
+                full_entity
+                    .ok_or(WpServiceError::SiteNotFound)
+                    .map(|entity| SiteInfo::WordPressCom {
+                        site_id: entity.data.site_id,
+                    })
+            }
+        }
     }
 }

--- a/wp_mobile_cache/migrations/0010-create-wordpress-com-sites-table.sql
+++ b/wp_mobile_cache/migrations/0010-create-wordpress-com-sites-table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `wordpress_com_sites` (
+  `rowid` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `site_id` INTEGER NOT NULL UNIQUE
+) STRICT;
+
+CREATE INDEX idx_wordpress_com_sites_site_id ON wordpress_com_sites(site_id);

--- a/wp_mobile_cache/src/db_types.rs
+++ b/wp_mobile_cache/src/db_types.rs
@@ -6,3 +6,4 @@ pub mod post_types;
 pub mod posts;
 pub mod row_ext;
 pub mod self_hosted_site;
+pub mod wordpress_com_site;

--- a/wp_mobile_cache/src/db_types/wordpress_com_site.rs
+++ b/wp_mobile_cache/src/db_types/wordpress_com_site.rs
@@ -1,0 +1,35 @@
+use crate::{RowId, db_types::row_ext::ColumnIndex};
+use wp_api::wp_com::WpComSiteId;
+
+/// Column indexes for wordpress_com_sites table.
+/// These must match the order of columns in the CREATE TABLE statement.
+#[repr(usize)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DbWordPressComSiteColumn {
+    Rowid = 0,
+    SiteId = 1,
+}
+
+impl ColumnIndex for DbWordPressComSiteColumn {
+    fn as_index(&self) -> usize {
+        *self as usize
+    }
+}
+
+/// Represents a WordPress.com site (domain model).
+///
+/// This type contains the site data without database metadata.
+/// Use this when creating or updating sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WordPressComSite {
+    pub site_id: WpComSiteId,
+}
+
+/// Represents a WordPress.com site in the database.
+///
+/// This type includes the database rowid along with the site data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbWordPressComSite {
+    pub row_id: RowId,
+    pub site_id: WpComSiteId,
+}

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -95,6 +95,8 @@ pub enum DbTable {
     ListMetadataState,
     /// Entity state tracking (missing, fetching, cached, stale, failed)
     EntityState,
+    /// WordPress.com sites
+    WordPressComSites,
 }
 
 impl DbTable {
@@ -115,6 +117,7 @@ impl DbTable {
             DbTable::ListMetadataItems => "list_metadata_items",
             DbTable::ListMetadataState => "list_metadata_state",
             DbTable::EntityState => "entity_state",
+            DbTable::WordPressComSites => "wordpress_com_sites",
         }
     }
 }
@@ -148,6 +151,7 @@ impl TryFrom<&str> for DbTable {
             "list_metadata_items" => Ok(DbTable::ListMetadataItems),
             "list_metadata_state" => Ok(DbTable::ListMetadataState),
             "entity_state" => Ok(DbTable::EntityState),
+            "wordpress_com_sites" => Ok(DbTable::WordPressComSites),
             _ => Err(DbTableError::UnknownTable(table_name.to_string())),
         }
     }
@@ -408,7 +412,7 @@ impl From<Connection> for WpApiCache {
     }
 }
 
-static MIGRATION_QUERIES: [&str; 9] = [
+static MIGRATION_QUERIES: [&str; 10] = [
     include_str!("../migrations/0001-create-sites-table.sql"),
     include_str!("../migrations/0002-create-posts-table.sql"),
     include_str!("../migrations/0003-create-term-relationships.sql"),
@@ -418,6 +422,7 @@ static MIGRATION_QUERIES: [&str; 9] = [
     include_str!("../migrations/0007-create-list-metadata-tables.sql"),
     include_str!("../migrations/0008-create-post-types-table.sql"),
     include_str!("../migrations/0009-create-entity-state-table.sql"),
+    include_str!("../migrations/0010-create-wordpress-com-sites-table.sql"),
 ];
 
 pub struct MigrationManager<'a> {

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -4,12 +4,14 @@ use crate::{
         db_site::{DbSite, DbSiteType},
         row_ext::RowExt,
         self_hosted_site::{DbSelfHostedSite, DbSelfHostedSiteColumn, SelfHostedSite},
+        wordpress_com_site::{DbWordPressComSite, DbWordPressComSiteColumn, WordPressComSite},
     },
     entity::{EntityId, FullEntity},
     repository::{QueryExecutor, TransactionManager},
 };
 use rusqlite::OptionalExtension;
 use std::sync::Arc;
+use wp_api::wp_com::WpComSiteId;
 
 pub struct SiteRepository;
 
@@ -227,7 +229,11 @@ impl SiteRepository {
                 tx.execute(&sql, [site.mapped_site_id])?;
             }
             DbSiteType::WordPressCom => {
-                panic!("WordPress.com site deletion is not yet implemented")
+                let sql = format!(
+                    "DELETE FROM {} WHERE rowid = ?",
+                    DbTable::WordPressComSites.table_name()
+                );
+                tx.execute(&sql, [site.mapped_site_id])?;
             }
         };
 
@@ -259,13 +265,192 @@ impl SiteRepository {
             None => Ok(false),
         }
     }
+
+    /// Upsert a WordPress.com site and return its EntityId (atomic transaction).
+    ///
+    /// If a site with the given site_id already exists, reuses it. Otherwise creates a new one.
+    /// Uses SQLite's RETURNING clause to get the inserted/updated rowid.
+    pub fn upsert_wordpress_com_site(
+        &self,
+        transaction_manager: &mut impl TransactionManager,
+        site: &WordPressComSite,
+    ) -> Result<EntityId, SqliteDbError> {
+        let tx = transaction_manager.transaction()?;
+
+        let wp_com_site_id: RowId = {
+            let sql = format!(
+                "INSERT INTO {} (site_id) VALUES (?)
+                 ON CONFLICT(site_id) DO UPDATE SET site_id = excluded.site_id
+                 RETURNING rowid",
+                DbTable::WordPressComSites.table_name()
+            );
+
+            let mut stmt = tx.prepare(&sql)?;
+            stmt.query_row([site.site_id.0], |row| row.get(0))
+                .map_err(SqliteDbError::from)?
+        };
+
+        let site_id: RowId = {
+            let sql = format!(
+                "INSERT INTO {} (site_type, mapped_site_id) VALUES (?, ?)
+                 ON CONFLICT(site_type, mapped_site_id) DO UPDATE SET
+                    site_type = excluded.site_type
+                 RETURNING rowid",
+                DbTable::DbSites.table_name()
+            );
+
+            let mut stmt = tx.prepare(&sql)?;
+            stmt.query_row((DbSiteType::WordPressCom, wp_com_site_id), |row| row.get(0))
+                .map_err(SqliteDbError::from)?
+        };
+
+        let db_site = DbSite {
+            row_id: site_id,
+            site_type: DbSiteType::WordPressCom,
+            mapped_site_id: wp_com_site_id,
+        };
+
+        tx.commit().map_err(SqliteDbError::from)?;
+        Ok(EntityId::new(
+            db_site,
+            DbTable::WordPressComSites,
+            wp_com_site_id,
+        ))
+    }
+
+    /// Select a WordPress.com site by its EntityId.
+    ///
+    /// Returns the site data paired with its EntityId.
+    /// Returns an error if the EntityId's table name doesn't match "wordpress_com_sites".
+    /// Returns None if the site doesn't exist or isn't a WordPress.com site.
+    pub fn select_wordpress_com_site(
+        &self,
+        executor: &impl QueryExecutor,
+        entity_id: &EntityId,
+    ) -> Result<Option<FullEntity<DbWordPressComSite>>, SqliteDbError> {
+        entity_id.validate_table(DbTable::WordPressComSites)?;
+
+        if entity_id.db_site.site_type != DbSiteType::WordPressCom {
+            return Ok(None);
+        }
+
+        let sql = format!(
+            "SELECT * FROM {} WHERE rowid = ?",
+            DbTable::WordPressComSites.table_name()
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        let db_wp_com_site = stmt
+            .query_row([entity_id.db_site.mapped_site_id], |row| {
+                Ok(DbWordPressComSite {
+                    row_id: row.get_column(DbWordPressComSiteColumn::Rowid)?,
+                    site_id: WpComSiteId(row.get_column(DbWordPressComSiteColumn::SiteId)?),
+                })
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        Ok(db_wp_com_site.map(|db_wp_com_site| {
+            let entity_id = Arc::new(*entity_id);
+            FullEntity::new(entity_id, db_wp_com_site)
+        }))
+    }
+
+    /// Select a WordPress.com site by site_id.
+    ///
+    /// Returns the site data (DbSite and DbWordPressComSite) paired with its EntityId.
+    pub fn select_wordpress_com_site_by_site_id(
+        &self,
+        executor: &impl QueryExecutor,
+        site_id: WpComSiteId,
+    ) -> Result<Option<FullEntity<(DbSite, DbWordPressComSite)>>, SqliteDbError> {
+        let sql = format!(
+            "SELECT * FROM {} WHERE site_id = ?",
+            DbTable::WordPressComSites.table_name()
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        let wp_com_site: Option<DbWordPressComSite> = stmt
+            .query_row([site_id.0], |row| {
+                Ok(DbWordPressComSite {
+                    row_id: row.get_column(DbWordPressComSiteColumn::Rowid)?,
+                    site_id: WpComSiteId(row.get_column(DbWordPressComSiteColumn::SiteId)?),
+                })
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        let Some(wp_com_site) = wp_com_site else {
+            return Ok(None);
+        };
+
+        let sql = format!(
+            "SELECT rowid, site_type, mapped_site_id FROM {}
+             WHERE site_type = ? AND mapped_site_id = ?",
+            DbTable::DbSites.table_name()
+        );
+        let mut stmt = executor.prepare(&sql)?;
+
+        let db_site: Option<DbSite> = stmt
+            .query_row((DbSiteType::WordPressCom, wp_com_site.row_id), |row| {
+                Ok(DbSite {
+                    row_id: row.get(0)?,
+                    site_type: row.get(1)?,
+                    mapped_site_id: row.get(2)?,
+                })
+            })
+            .optional()
+            .map_err(SqliteDbError::from)?;
+
+        Ok(db_site.map(|db_site| {
+            let entity_id = Arc::new(EntityId::new(
+                db_site,
+                DbTable::WordPressComSites,
+                wp_com_site.row_id,
+            ));
+            FullEntity::new(entity_id, (db_site, wp_com_site))
+        }))
+    }
+
+    /// Delete a WordPress.com site by site_id (convenience wrapper).
+    ///
+    /// Returns `true` if a site was deleted, `false` if no site with that site_id exists.
+    pub fn delete_wordpress_com_site_by_site_id(
+        &self,
+        transaction_manager: &mut impl TransactionManager,
+        site_id: WpComSiteId,
+    ) -> Result<bool, SqliteDbError> {
+        let site_data = self.select_wordpress_com_site_by_site_id(transaction_manager, site_id)?;
+
+        match site_data {
+            Some(full_entity) => self.delete_site(transaction_manager, &full_entity.data.0),
+            None => Ok(false),
+        }
+    }
+
+    /// Count all WordPress.com sites in the database.
+    ///
+    /// This is primarily useful for testing to verify database state.
+    pub fn count_all_wordpress_com_sites(
+        &self,
+        executor: &impl QueryExecutor,
+    ) -> Result<usize, SqliteDbError> {
+        let sql = format!(
+            "SELECT COUNT(*) FROM {}",
+            DbTable::WordPressComSites.table_name()
+        );
+        let mut stmt = executor.prepare(&sql)?;
+        let count: i64 = stmt.query_row([], |row| row.get(0))?;
+        Ok(count as usize)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        MigrationManager, db_types::row_ext::ColumnIndex, entity::EntityId,
+        MigrationManager, db_types::row_ext::ColumnIndex,
+        db_types::wordpress_com_site::DbWordPressComSiteColumn, entity::EntityId,
         test_fixtures::get_table_column_names,
     };
     use rstest::*;
@@ -666,5 +851,248 @@ mod tests {
             .delete_self_hosted_site_by_url(&mut test_conn, "https://non-existent.com")
             .expect("Failed to delete site by URL");
         assert!(!deleted, "Should return false when site doesn't exist");
+    }
+
+    // WordPress.com site tests
+
+    #[rstest]
+    fn test_wordpress_com_site_column_enum_matches_schema(test_conn: Connection) {
+        use DbWordPressComSiteColumn::*;
+
+        let columns = get_table_column_names(&test_conn, "wordpress_com_sites");
+
+        assert_eq!(columns[Rowid.as_index()], "rowid");
+        assert_eq!(columns[SiteId.as_index()], "site_id");
+
+        assert_eq!(columns.len(), SiteId.as_index() + 1);
+    }
+
+    #[rstest]
+    fn test_upsert_wordpress_com_site_inserts_new_site(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let entity_id = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        assert_eq!(entity_id.table, DbTable::WordPressComSites);
+        assert_eq!(entity_id.db_site.site_type, DbSiteType::WordPressCom);
+        assert_eq!(entity_id.db_site.mapped_site_id, entity_id.rowid);
+    }
+
+    #[rstest]
+    fn test_upsert_wordpress_com_site_does_not_create_duplicates(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let entity_id1 = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("First upsert failed");
+        let entity_id2 = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Second upsert failed");
+        let entity_id3 = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Third upsert failed");
+
+        assert_eq!(entity_id1, entity_id2);
+        assert_eq!(entity_id2, entity_id3);
+
+        let count = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites");
+        assert_eq!(
+            count, 1,
+            "Multiple upserts should not create duplicate sites table entries"
+        );
+    }
+
+    #[rstest]
+    fn test_select_wordpress_com_site_by_entity_id(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let entity_id = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        let retrieved = repo
+            .select_wordpress_com_site(&test_conn, &entity_id)
+            .expect("Failed to select site")
+            .expect("Site should exist");
+
+        assert_eq!(retrieved.data.site_id, site.site_id);
+    }
+
+    #[rstest]
+    fn test_select_wordpress_com_site_returns_none_for_wrong_site_type(test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let non_wp_com_site = DbSite {
+            row_id: RowId(999),
+            site_type: DbSiteType::SelfHosted,
+            mapped_site_id: RowId(999),
+        };
+
+        let entity_id = EntityId::new(non_wp_com_site, DbTable::WordPressComSites, RowId(999));
+
+        let result = repo
+            .select_wordpress_com_site(&test_conn, &entity_id)
+            .expect("Query should succeed");
+
+        assert_eq!(
+            result, None,
+            "Should return None for non-WordPressCom site type"
+        );
+    }
+
+    #[rstest]
+    fn test_select_wordpress_com_site_by_site_id(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let entity_id = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        let retrieved = repo
+            .select_wordpress_com_site_by_site_id(&test_conn, site.site_id)
+            .expect("Failed to select site")
+            .expect("Site should exist");
+
+        assert_eq!(retrieved.entity_id.as_ref(), &entity_id);
+        assert_eq!(retrieved.data.0, entity_id.db_site);
+        assert_eq!(retrieved.data.1.site_id, site.site_id);
+    }
+
+    #[rstest]
+    fn test_select_wordpress_com_site_by_site_id_returns_none_for_non_existent(
+        test_conn: Connection,
+    ) {
+        let repo = SiteRepository;
+
+        let result = repo
+            .select_wordpress_com_site_by_site_id(&test_conn, WpComSiteId(99999))
+            .expect("Query should succeed");
+
+        assert_eq!(result, None, "Should return None for non-existent site_id");
+    }
+
+    #[rstest]
+    fn test_delete_wordpress_com_site_removes_both_tables(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let entity_id = repo
+            .upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        let count_sites = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites");
+        let count_wp_com = repo
+            .count_all_wordpress_com_sites(&test_conn)
+            .expect("Failed to count wordpress_com_sites");
+        assert_eq!(count_sites, 1);
+        assert_eq!(count_wp_com, 1);
+
+        let deleted = repo
+            .delete_site(&mut test_conn, &entity_id.db_site)
+            .expect("Failed to delete site");
+        assert!(deleted, "Should return true when site is deleted");
+
+        let count_sites_after = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites after delete");
+        let count_wp_com_after = repo
+            .count_all_wordpress_com_sites(&test_conn)
+            .expect("Failed to count wordpress_com_sites after delete");
+        assert_eq!(
+            count_sites_after, 0,
+            "Site should be deleted from sites table"
+        );
+        assert_eq!(
+            count_wp_com_after, 0,
+            "Site should be deleted from wordpress_com_sites table"
+        );
+    }
+
+    #[rstest]
+    fn test_delete_wordpress_com_site_by_site_id(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        let site_id = WpComSiteId(12345);
+        let site = WordPressComSite { site_id };
+
+        repo.upsert_wordpress_com_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        let deleted = repo
+            .delete_wordpress_com_site_by_site_id(&mut test_conn, site_id)
+            .expect("Failed to delete site by site_id");
+        assert!(deleted, "Should return true when site is deleted");
+
+        let after_delete = repo
+            .select_wordpress_com_site_by_site_id(&test_conn, site_id)
+            .expect("Failed to select site");
+        assert_eq!(after_delete, None, "Site should be deleted");
+    }
+
+    #[rstest]
+    fn test_delete_wordpress_com_site_by_site_id_returns_false_for_non_existent(
+        mut test_conn: Connection,
+    ) {
+        let repo = SiteRepository;
+
+        let deleted = repo
+            .delete_wordpress_com_site_by_site_id(&mut test_conn, WpComSiteId(99999))
+            .expect("Failed to delete site by site_id");
+        assert!(!deleted, "Should return false when site doesn't exist");
+    }
+
+    #[rstest]
+    fn test_self_hosted_and_wordpress_com_sites_can_coexist(mut test_conn: Connection) {
+        let repo = SiteRepository;
+
+        let self_hosted = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+        let wp_com = WordPressComSite {
+            site_id: WpComSiteId(12345),
+        };
+
+        let self_hosted_id = repo
+            .upsert_self_hosted_site(&mut test_conn, &self_hosted)
+            .expect("Failed to upsert self-hosted site");
+        let wp_com_id = repo
+            .upsert_wordpress_com_site(&mut test_conn, &wp_com)
+            .expect("Failed to upsert WP.com site");
+
+        assert_ne!(self_hosted_id, wp_com_id);
+
+        let count = repo
+            .count_all_db_sites(&test_conn)
+            .expect("Failed to count db_sites");
+        assert_eq!(count, 2, "Both sites should exist");
+
+        let count_self_hosted = repo
+            .count_all_self_hosted_sites(&test_conn)
+            .expect("Failed to count self_hosted_sites");
+        let count_wp_com = repo
+            .count_all_wordpress_com_sites(&test_conn)
+            .expect("Failed to count wordpress_com_sites");
+        assert_eq!(count_self_hosted, 1);
+        assert_eq!(count_wp_com, 1);
     }
 }

--- a/wp_mobile_integration_tests/src/lib.rs
+++ b/wp_mobile_integration_tests/src/lib.rs
@@ -6,7 +6,7 @@ pub use serial_test::{parallel, serial};
 use url::Url;
 use wp_api::{EmptyAppNotifier, prelude::*, reqwest_request_executor::ReqwestRequestExecutor};
 pub use wp_api_integration_tests::backend::{Backend, RestoreServer};
-use wp_mobile::service::WpSelfHostedService;
+use wp_mobile::service::WpService;
 use wp_mobile_cache::WpApiCache;
 
 pub fn test_site_url() -> ParsedUrl {
@@ -36,7 +36,7 @@ pub fn api_client_delegate() -> WpApiClientDelegate {
 
 pub struct TestContext {
     pub api: WpApiClient,
-    pub service: WpSelfHostedService,
+    pub service: WpService,
     pub cache: Arc<WpApiCache>,
 }
 
@@ -46,14 +46,13 @@ pub fn create_test_context() -> TestContext {
         .perform_migrations()
         .expect("Migrations should succeed");
 
-    let service = WpSelfHostedService::new(
+    let service = WpService::new_self_hosted(
         TestCredentials::instance().site_url.to_string(),
         test_site_url().to_string(),
-        test_site_api_url_resolver(),
         api_client_delegate(),
         cache.clone(),
     )
-    .expect("Failed to create WpSelfHostedService");
+    .expect("Failed to create WpService");
 
     let api = WpApiClient::new(test_site_api_url_resolver(), api_client_delegate());
 
@@ -92,14 +91,13 @@ pub fn create_test_context_with_site(
         .perform_migrations()
         .expect("Migrations should succeed");
 
-    let service = WpSelfHostedService::new(
+    let service = WpService::new_self_hosted(
         site_url.to_string(),
         api_root,
-        api_url_resolver.clone(),
         delegate.clone(),
         cache.clone(),
     )
-    .expect("Failed to create WpSelfHostedService");
+    .expect("Failed to create WpService");
 
     let api = WpApiClient::new(api_url_resolver.clone(), delegate.clone());
 


### PR DESCRIPTION
Context: p1770902854097129-slack-C06S1QS55K9

Adds a new `WpService.wordPressCom` constructor, which accepts a site id.

@nbradbury The CI job will publish an artifact, which you can try and see if there is any issue.