### PR TITLE
Pin faraday >= 1.10.5 for security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem 'fastlane', '~> 2.232'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.0'
 gem 'fluent-tools', '~> 0.3'
 gem "openssl", "~> 4.0.0"
+
+# Security: https://github.com/lostisland/faraday/pull/1665
+# Faraday 2.0 is not compatible with Fastlane
+gem 'faraday', '~> 1.10', '>= 1.10.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  faraday (~> 1.10, >= 1.10.5)
   fastlane (~> 2.232)
   fastlane-plugin-wpmreleasetoolkit (~> 14.0)
   fluent-tools (~> 0.3)


### PR DESCRIPTION
## Summary

- Pins `faraday` to `~> 1.10, >= 1.10.5` to address a security vulnerability.
- See [faraday#1665](https://github.com/lostisland/faraday/pull/1665) for the fix.
- Tracked in [AINFRA-1976](https://linear.app/a8c/issue/AINFRA-1976/track-security-alert-upgrade-fastlane-to-use-faraday-2x).

## Test plan

- [ ] CI passes — no functional change, only a transitive dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*