### PR TITLE
CMM-1258: Add extra endpoints for Traffic tab

### DIFF
--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -19,6 +19,9 @@ use super::endpoint::{
     stats_devices_screensize_endpoint::{
         StatsDevicesScreensizeRequestBuilder, StatsDevicesScreensizeRequestExecutor,
     },
+    stats_file_downloads_endpoint::{
+        StatsFileDownloadsRequestBuilder, StatsFileDownloadsRequestExecutor,
+    },
     stats_referrers_endpoint::{StatsReferrersRequestBuilder, StatsReferrersRequestExecutor},
     stats_region_views_endpoint::{
         StatsRegionViewsRequestBuilder, StatsRegionViewsRequestExecutor,
@@ -60,6 +63,7 @@ pub struct WpComApiRequestBuilder {
     sites: Arc<SitesRequestBuilder>,
     stats_city_views: Arc<StatsCityViewsRequestBuilder>,
     stats_clicks: Arc<StatsClicksRequestBuilder>,
+    stats_file_downloads: Arc<StatsFileDownloadsRequestBuilder>,
     stats_country_views: Arc<StatsCountryViewsRequestBuilder>,
     stats_devices_browser: Arc<StatsDevicesBrowserRequestBuilder>,
     stats_devices_platform: Arc<StatsDevicesPlatformRequestBuilder>,
@@ -92,6 +96,7 @@ impl WpComApiRequestBuilder {
             sites,
             stats_city_views,
             stats_clicks,
+            stats_file_downloads,
             stats_country_views,
             stats_devices_browser,
             stats_devices_platform,
@@ -135,6 +140,7 @@ pub struct WpComApiClient {
     sites: Arc<SitesRequestExecutor>,
     stats_city_views: Arc<StatsCityViewsRequestExecutor>,
     stats_clicks: Arc<StatsClicksRequestExecutor>,
+    stats_file_downloads: Arc<StatsFileDownloadsRequestExecutor>,
     stats_country_views: Arc<StatsCountryViewsRequestExecutor>,
     stats_devices_browser: Arc<StatsDevicesBrowserRequestExecutor>,
     stats_devices_platform: Arc<StatsDevicesPlatformRequestExecutor>,
@@ -168,6 +174,7 @@ impl WpComApiClient {
             sites,
             stats_city_views,
             stats_clicks,
+            stats_file_downloads,
             stats_country_views,
             stats_devices_browser,
             stats_devices_platform,
@@ -194,6 +201,7 @@ api_client_generate_endpoint_impl!(WpComApi, oauth2);
 api_client_generate_endpoint_impl!(WpComApi, sites);
 api_client_generate_endpoint_impl!(WpComApi, stats_city_views);
 api_client_generate_endpoint_impl!(WpComApi, stats_clicks);
+api_client_generate_endpoint_impl!(WpComApi, stats_file_downloads);
 api_client_generate_endpoint_impl!(WpComApi, stats_country_views);
 api_client_generate_endpoint_impl!(WpComApi, stats_devices_browser);
 api_client_generate_endpoint_impl!(WpComApi, stats_devices_platform);

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -6,6 +6,7 @@ use super::endpoint::{
     me_endpoint::{MeRequestBuilder, MeRequestExecutor},
     oauth2::{Oauth2RequestBuilder, Oauth2RequestExecutor},
     stats_city_views_endpoint::{StatsCityViewsRequestBuilder, StatsCityViewsRequestExecutor},
+    stats_clicks_endpoint::{StatsClicksRequestBuilder, StatsClicksRequestExecutor},
     stats_country_views_endpoint::{
         StatsCountryViewsRequestBuilder, StatsCountryViewsRequestExecutor,
     },
@@ -54,6 +55,7 @@ pub struct WpComApiRequestBuilder {
     oauth2: Arc<Oauth2RequestBuilder>,
     sites: Arc<SitesRequestBuilder>,
     stats_city_views: Arc<StatsCityViewsRequestBuilder>,
+    stats_clicks: Arc<StatsClicksRequestBuilder>,
     stats_country_views: Arc<StatsCountryViewsRequestBuilder>,
     stats_devices_browser: Arc<StatsDevicesBrowserRequestBuilder>,
     stats_devices_platform: Arc<StatsDevicesPlatformRequestBuilder>,
@@ -83,6 +85,7 @@ impl WpComApiRequestBuilder {
             oauth2,
             sites,
             stats_city_views,
+            stats_clicks,
             stats_country_views,
             stats_devices_browser,
             stats_devices_platform,
@@ -123,6 +126,7 @@ pub struct WpComApiClient {
     oauth2: Arc<Oauth2RequestExecutor>,
     sites: Arc<SitesRequestExecutor>,
     stats_city_views: Arc<StatsCityViewsRequestExecutor>,
+    stats_clicks: Arc<StatsClicksRequestExecutor>,
     stats_country_views: Arc<StatsCountryViewsRequestExecutor>,
     stats_devices_browser: Arc<StatsDevicesBrowserRequestExecutor>,
     stats_devices_platform: Arc<StatsDevicesPlatformRequestExecutor>,
@@ -153,6 +157,7 @@ impl WpComApiClient {
             oauth2,
             sites,
             stats_city_views,
+            stats_clicks,
             stats_country_views,
             stats_devices_browser,
             stats_devices_platform,
@@ -176,6 +181,7 @@ api_client_generate_endpoint_impl!(WpComApi, me);
 api_client_generate_endpoint_impl!(WpComApi, oauth2);
 api_client_generate_endpoint_impl!(WpComApi, sites);
 api_client_generate_endpoint_impl!(WpComApi, stats_city_views);
+api_client_generate_endpoint_impl!(WpComApi, stats_clicks);
 api_client_generate_endpoint_impl!(WpComApi, stats_country_views);
 api_client_generate_endpoint_impl!(WpComApi, stats_devices_browser);
 api_client_generate_endpoint_impl!(WpComApi, stats_devices_platform);

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -23,6 +23,9 @@ use super::endpoint::{
     stats_region_views_endpoint::{
         StatsRegionViewsRequestBuilder, StatsRegionViewsRequestExecutor,
     },
+    stats_search_terms_endpoint::{
+        StatsSearchTermsRequestBuilder, StatsSearchTermsRequestExecutor,
+    },
     stats_top_authors_endpoint::{StatsTopAuthorsRequestBuilder, StatsTopAuthorsRequestExecutor},
     stats_top_posts_endpoint::{StatsTopPostsRequestBuilder, StatsTopPostsRequestExecutor},
     stats_visits_endpoint::{StatsVisitsRequestBuilder, StatsVisitsRequestExecutor},
@@ -62,6 +65,7 @@ pub struct WpComApiRequestBuilder {
     stats_devices_screensize: Arc<StatsDevicesScreensizeRequestBuilder>,
     stats_referrers: Arc<StatsReferrersRequestBuilder>,
     stats_region_views: Arc<StatsRegionViewsRequestBuilder>,
+    stats_search_terms: Arc<StatsSearchTermsRequestBuilder>,
     stats_top_authors: Arc<StatsTopAuthorsRequestBuilder>,
     stats_top_posts: Arc<StatsTopPostsRequestBuilder>,
     stats_visits: Arc<StatsVisitsRequestBuilder>,
@@ -92,6 +96,7 @@ impl WpComApiRequestBuilder {
             stats_devices_screensize,
             stats_referrers,
             stats_region_views,
+            stats_search_terms,
             stats_top_authors,
             stats_top_posts,
             stats_visits,
@@ -133,6 +138,7 @@ pub struct WpComApiClient {
     stats_devices_screensize: Arc<StatsDevicesScreensizeRequestExecutor>,
     stats_referrers: Arc<StatsReferrersRequestExecutor>,
     stats_region_views: Arc<StatsRegionViewsRequestExecutor>,
+    stats_search_terms: Arc<StatsSearchTermsRequestExecutor>,
     stats_top_authors: Arc<StatsTopAuthorsRequestExecutor>,
     stats_top_posts: Arc<StatsTopPostsRequestExecutor>,
     stats_visits: Arc<StatsVisitsRequestExecutor>,
@@ -164,6 +170,7 @@ impl WpComApiClient {
             stats_devices_screensize,
             stats_referrers,
             stats_region_views,
+            stats_search_terms,
             stats_top_authors,
             stats_top_posts,
             stats_visits,
@@ -188,6 +195,7 @@ api_client_generate_endpoint_impl!(WpComApi, stats_devices_platform);
 api_client_generate_endpoint_impl!(WpComApi, stats_devices_screensize);
 api_client_generate_endpoint_impl!(WpComApi, stats_referrers);
 api_client_generate_endpoint_impl!(WpComApi, stats_region_views);
+api_client_generate_endpoint_impl!(WpComApi, stats_search_terms);
 api_client_generate_endpoint_impl!(WpComApi, stats_top_authors);
 api_client_generate_endpoint_impl!(WpComApi, stats_top_posts);
 api_client_generate_endpoint_impl!(WpComApi, stats_visits);

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -28,6 +28,7 @@ use super::endpoint::{
     },
     stats_top_authors_endpoint::{StatsTopAuthorsRequestBuilder, StatsTopAuthorsRequestExecutor},
     stats_top_posts_endpoint::{StatsTopPostsRequestBuilder, StatsTopPostsRequestExecutor},
+    stats_video_plays_endpoint::{StatsVideoPlaysRequestBuilder, StatsVideoPlaysRequestExecutor},
     stats_visits_endpoint::{StatsVisitsRequestBuilder, StatsVisitsRequestExecutor},
     subscribers_endpoint::{SubscribersRequestBuilder, SubscribersRequestExecutor},
     support_bots_endpoint::{SupportBotsRequestBuilder, SupportBotsRequestExecutor},
@@ -68,6 +69,7 @@ pub struct WpComApiRequestBuilder {
     stats_search_terms: Arc<StatsSearchTermsRequestBuilder>,
     stats_top_authors: Arc<StatsTopAuthorsRequestBuilder>,
     stats_top_posts: Arc<StatsTopPostsRequestBuilder>,
+    stats_video_plays: Arc<StatsVideoPlaysRequestBuilder>,
     stats_visits: Arc<StatsVisitsRequestBuilder>,
     subscribers: Arc<SubscribersRequestBuilder>,
     support_bots: Arc<SupportBotsRequestBuilder>,
@@ -99,6 +101,7 @@ impl WpComApiRequestBuilder {
             stats_search_terms,
             stats_top_authors,
             stats_top_posts,
+            stats_video_plays,
             stats_visits,
             subscribers,
             support_bots,
@@ -141,6 +144,7 @@ pub struct WpComApiClient {
     stats_search_terms: Arc<StatsSearchTermsRequestExecutor>,
     stats_top_authors: Arc<StatsTopAuthorsRequestExecutor>,
     stats_top_posts: Arc<StatsTopPostsRequestExecutor>,
+    stats_video_plays: Arc<StatsVideoPlaysRequestExecutor>,
     stats_visits: Arc<StatsVisitsRequestExecutor>,
     subscribers: Arc<SubscribersRequestExecutor>,
     support_bots: Arc<SupportBotsRequestExecutor>,
@@ -173,6 +177,7 @@ impl WpComApiClient {
             stats_search_terms,
             stats_top_authors,
             stats_top_posts,
+            stats_video_plays,
             stats_visits,
             subscribers,
             support_bots,
@@ -198,6 +203,7 @@ api_client_generate_endpoint_impl!(WpComApi, stats_region_views);
 api_client_generate_endpoint_impl!(WpComApi, stats_search_terms);
 api_client_generate_endpoint_impl!(WpComApi, stats_top_authors);
 api_client_generate_endpoint_impl!(WpComApi, stats_top_posts);
+api_client_generate_endpoint_impl!(WpComApi, stats_video_plays);
 api_client_generate_endpoint_impl!(WpComApi, stats_visits);
 api_client_generate_endpoint_impl!(WpComApi, subscribers);
 api_client_generate_endpoint_impl!(WpComApi, support_bots);

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -21,6 +21,7 @@ pub mod stats_devices_platform_endpoint;
 pub mod stats_devices_screensize_endpoint;
 pub mod stats_referrers_endpoint;
 pub mod stats_region_views_endpoint;
+pub mod stats_search_terms_endpoint;
 pub mod stats_top_authors_endpoint;
 pub mod stats_top_posts_endpoint;
 pub mod stats_visits_endpoint;

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -19,6 +19,7 @@ pub mod stats_country_views_endpoint;
 pub mod stats_devices_browser_endpoint;
 pub mod stats_devices_platform_endpoint;
 pub mod stats_devices_screensize_endpoint;
+pub mod stats_file_downloads_endpoint;
 pub mod stats_referrers_endpoint;
 pub mod stats_region_views_endpoint;
 pub mod stats_search_terms_endpoint;

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -24,6 +24,7 @@ pub mod stats_region_views_endpoint;
 pub mod stats_search_terms_endpoint;
 pub mod stats_top_authors_endpoint;
 pub mod stats_top_posts_endpoint;
+pub mod stats_video_plays_endpoint;
 pub mod stats_visits_endpoint;
 pub mod subscribers_endpoint;
 pub mod support_bots_endpoint;

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -14,6 +14,7 @@ pub mod me_endpoint;
 pub mod oauth2;
 pub mod sites_endpoint;
 pub mod stats_city_views_endpoint;
+pub mod stats_clicks_endpoint;
 pub mod stats_country_views_endpoint;
 pub mod stats_devices_browser_endpoint;
 pub mod stats_devices_platform_endpoint;

--- a/wp_api/src/wp_com/endpoint/stats_clicks_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_clicks_endpoint.rs
@@ -1,0 +1,20 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{
+        WpComNamespace, WpComSiteId,
+        stats_clicks::{StatsClicksParams, StatsClicksResponse},
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum StatsClicksRequest {
+    #[get(url = "/sites/<wp_com_site_id>/stats/clicks", params = &StatsClicksParams, output = StatsClicksResponse)]
+    GetStatsClicks,
+}
+
+impl DerivedRequest for StatsClicksRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/endpoint/stats_file_downloads_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_file_downloads_endpoint.rs
@@ -1,0 +1,20 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{
+        WpComNamespace, WpComSiteId,
+        stats_file_downloads::{StatsFileDownloadsParams, StatsFileDownloadsResponse},
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum StatsFileDownloadsRequest {
+    #[get(url = "/sites/<wp_com_site_id>/stats/file-downloads", params = &StatsFileDownloadsParams, output = StatsFileDownloadsResponse)]
+    GetStatsFileDownloads,
+}
+
+impl DerivedRequest for StatsFileDownloadsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/endpoint/stats_search_terms_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_search_terms_endpoint.rs
@@ -1,0 +1,20 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{
+        WpComNamespace, WpComSiteId,
+        stats_search_terms::{StatsSearchTermsParams, StatsSearchTermsResponse},
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum StatsSearchTermsRequest {
+    #[get(url = "/sites/<wp_com_site_id>/stats/search-terms", params = &StatsSearchTermsParams, output = StatsSearchTermsResponse)]
+    GetStatsSearchTerms,
+}
+
+impl DerivedRequest for StatsSearchTermsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/endpoint/stats_video_plays_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_video_plays_endpoint.rs
@@ -1,0 +1,20 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{
+        WpComNamespace, WpComSiteId,
+        stats_video_plays::{StatsVideoPlaysParams, StatsVideoPlaysResponse},
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum StatsVideoPlaysRequest {
+    #[get(url = "/sites/<wp_com_site_id>/stats/video-plays", params = &StatsVideoPlaysParams, output = StatsVideoPlaysResponse)]
+    GetStatsVideoPlays,
+}
+
+impl DerivedRequest for StatsVideoPlaysRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -15,6 +15,7 @@ pub mod stats_city_views;
 pub mod stats_clicks;
 pub mod stats_country_views;
 pub mod stats_devices;
+pub mod stats_file_downloads;
 pub mod stats_referrers;
 pub mod stats_region_views;
 pub mod stats_search_terms;

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -20,6 +20,7 @@ pub mod stats_region_views;
 pub mod stats_search_terms;
 pub mod stats_top_authors;
 pub mod stats_top_posts;
+pub mod stats_video_plays;
 pub mod stats_visits;
 pub mod subscribers;
 pub mod support_bots;

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -17,6 +17,7 @@ pub mod stats_country_views;
 pub mod stats_devices;
 pub mod stats_referrers;
 pub mod stats_region_views;
+pub mod stats_search_terms;
 pub mod stats_top_authors;
 pub mod stats_top_posts;
 pub mod stats_visits;

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -12,6 +12,7 @@ pub mod me;
 pub mod oauth2;
 pub mod sites;
 pub mod stats_city_views;
+pub mod stats_clicks;
 pub mod stats_country_views;
 pub mod stats_devices;
 pub mod stats_referrers;

--- a/wp_api/src/wp_com/stats_clicks.rs
+++ b/wp_api/src/wp_com/stats_clicks.rs
@@ -64,11 +64,10 @@ pub struct StatsClicksParams {
     pub summarize: bool,
     /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
     ///
-    /// - `Some(true)` (default): Archive pages are excluded from results
-    /// - `Some(false)`: Archive pages are included in results
-    /// - `None`: Parameter is not sent to the API
-    #[uniffi(default = Some(true))]
-    pub skip_archives: Option<bool>,
+    /// - `true` (default): Archive pages are excluded from results
+    /// - `false`: Archive pages are included in results
+    #[uniffi(default = true)]
+    pub skip_archives: bool,
 }
 
 impl Default for StatsClicksParams {
@@ -81,7 +80,7 @@ impl Default for StatsClicksParams {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         }
     }
 }
@@ -96,10 +95,7 @@ impl AppendUrlQueryPairs for StatsClicksParams {
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
-            .append_option_query_value_pair(
-                "skip_archives",
-                self.skip_archives.map(|b| b as u32).as_ref(),
-            );
+            .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
 }
 
@@ -187,7 +183,7 @@ mod tests {
             num: Some(30),
             locale: Some(WPComLanguage::English),
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -213,7 +209,7 @@ mod tests {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -226,29 +222,6 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_clicks_params_without_summarize_and_skip_archives() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
-                .expect("Failed to parse url");
-
-        let params = StatsClicksParams {
-            period: Some(StatsClicksPeriod::Day),
-            date: Some("2026-02-18".to_string()),
-            summarize: false,
-            skip_archives: None,
-            ..Default::default()
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&date=2026-02-18&summarize=0"
-        );
-    }
-
-    #[test]
     fn test_stats_clicks_params_with_false_values() {
         let mut url =
             url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
@@ -257,7 +230,7 @@ mod tests {
         let params = StatsClicksParams {
             period: Some(StatsClicksPeriod::Day),
             summarize: false,
-            skip_archives: Some(false),
+            skip_archives: false,
             ..Default::default()
         };
 

--- a/wp_api/src/wp_com/stats_clicks.rs
+++ b/wp_api/src/wp_com/stats_clicks.rs
@@ -1,0 +1,435 @@
+use crate::{
+    impl_as_query_value_from_to_string,
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    wp_com::language::WPComLanguage,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The time period for grouping clicks.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum StatsClicksPeriod {
+    #[default]
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl_as_query_value_from_to_string!(StatsClicksPeriod);
+
+/// Parameters for the stats clicks endpoint.
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct StatsClicksParams {
+    /// The time period for grouping stats.
+    #[uniffi(default = None)]
+    pub period: Option<StatsClicksPeriod>,
+    /// The date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub date: Option<String>,
+    /// The start date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub start_date: Option<String>,
+    /// The maximum number of clicks to return.
+    #[uniffi(default = None)]
+    pub max: Option<u32>,
+    /// The number of periods to include in the response.
+    #[uniffi(default = None)]
+    pub num: Option<u32>,
+    /// The locale for the response.
+    #[uniffi(default = None)]
+    pub locale: Option<WPComLanguage>,
+    /// Whether to return a summary of the data.
+    ///
+    /// - `true` (default): Response contains `summary` field with aggregated data
+    /// - `false`: Response contains `days` field with per-day breakdown
+    #[uniffi(default = true)]
+    pub summarize: bool,
+    /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
+    ///
+    /// - `Some(true)` (default): Archive pages are excluded from results
+    /// - `Some(false)`: Archive pages are included in results
+    /// - `None`: Parameter is not sent to the API
+    #[uniffi(default = Some(true))]
+    pub skip_archives: Option<bool>,
+}
+
+impl Default for StatsClicksParams {
+    fn default() -> Self {
+        Self {
+            period: None,
+            date: None,
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        }
+    }
+}
+
+impl AppendUrlQueryPairs for StatsClicksParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("period", self.period.as_ref())
+            .append_option_query_value_pair("date", self.date.as_ref())
+            .append_option_query_value_pair("start_date", self.start_date.as_ref())
+            .append_option_query_value_pair("max", self.max.as_ref())
+            .append_option_query_value_pair("num", self.num.as_ref())
+            .append_option_query_value_pair("locale", self.locale.as_ref())
+            .append_query_value_pair("summarize", &(self.summarize as u32))
+            .append_option_query_value_pair(
+                "skip_archives",
+                self.skip_archives.map(|b| b as u32).as_ref(),
+            );
+    }
+}
+
+/// Response from the stats clicks endpoint.
+///
+/// The response structure varies based on the `summarize` parameter:
+/// - When `summarize=1`: Contains `summary` field with aggregated data
+/// - When `summarize` is not set: Contains `days` field with per-day data
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsClicksResponse {
+    /// The date for the stats query.
+    pub date: String,
+    /// The time period used for grouping (present when summarize=1).
+    pub period: Option<String>,
+    /// Summary data with aggregated click groups (present when summarize=1).
+    pub summary: Option<StatsClicksSummaryData>,
+    /// Per-day stats data keyed by date string (present when summarize is not set).
+    pub days: Option<HashMap<String, StatsClicksDayData>>,
+}
+
+/// Summary data with aggregated click groups.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsClicksSummaryData {
+    /// The list of click entries.
+    pub clicks: Vec<StatsClicksEntry>,
+    /// Clicks from other sources not included in the list.
+    pub other_clicks: u64,
+    /// The total number of clicks.
+    pub total_clicks: u64,
+}
+
+/// Stats data for a single day.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsClicksDayData {
+    /// The list of click entries for this day.
+    pub clicks: Vec<StatsClicksEntry>,
+    /// Clicks from other sources not included in the list.
+    pub other_clicks: u64,
+    /// The total number of clicks for this day.
+    pub total_clicks: u64,
+}
+
+/// A click entry in the stats clicks response.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsClicksEntry {
+    /// The icon URL for the click source.
+    pub icon: Option<String>,
+    /// The URL of the click source.
+    pub url: Option<String>,
+    /// The display name of the click source.
+    pub name: Option<String>,
+    /// The number of views/clicks.
+    pub views: Option<u64>,
+    /// Child click entries (present when the source groups multiple URLs).
+    pub children: Option<Vec<StatsClicksChild>>,
+}
+
+/// A child click entry within a click group.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsClicksChild {
+    /// The URL of the child click.
+    pub url: Option<String>,
+    /// The display name of the child click.
+    pub name: Option<String>,
+    /// The number of views/clicks for this child.
+    pub views: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[test]
+    fn test_stats_clicks_params_serialization() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
+                .expect("Failed to parse url");
+
+        let params = StatsClicksParams {
+            period: Some(StatsClicksPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            start_date: Some("2026-02-18".to_string()),
+            max: Some(10),
+            num: Some(30),
+            locale: Some(WPComLanguage::English),
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_clicks_params_serialization_partial() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
+                .expect("Failed to parse url");
+
+        let params = StatsClicksParams {
+            period: Some(StatsClicksPeriod::Week),
+            date: Some("2026-02-18".to_string()),
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=week&date=2026-02-18&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_clicks_params_without_summarize_and_skip_archives() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
+                .expect("Failed to parse url");
+
+        let params = StatsClicksParams {
+            period: Some(StatsClicksPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            summarize: false,
+            skip_archives: None,
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&date=2026-02-18&summarize=0"
+        );
+    }
+
+    #[test]
+    fn test_stats_clicks_params_with_false_values() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks")
+                .expect("Failed to parse url");
+
+        let params = StatsClicksParams {
+            period: Some(StatsClicksPeriod::Day),
+            summarize: false,
+            skip_archives: Some(false),
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&summarize=0&skip_archives=0"
+        );
+    }
+
+    /// Tests deserialization of all stats clicks JSON fixtures.
+    ///
+    /// The `expect_summary` parameter indicates whether the response uses summarize=1
+    /// (has `summary` and `period` fields) or summarize=0 (has `days` field instead).
+    #[rstest]
+    #[case("tests/wpcom/stats_clicks/summarized-01-day.json", true)]
+    #[case("tests/wpcom/stats_clicks/no-summary-01.json", false)]
+    #[case("tests/wpcom/stats_clicks/summarized-02-day-with-nulls.json", true)]
+    #[case("tests/wpcom/stats_clicks/summarized-03-day-empty-response.json", true)]
+    fn test_stats_clicks_response_deserialization(
+        #[case] json_file_path: &str,
+        #[case] expect_summary: bool,
+    ) {
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsClicksResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        // Common assertion: date is always present
+        assert!(!response.date.is_empty());
+
+        if expect_summary {
+            // summarize=1 response: has period and summary, no days
+            assert!(
+                response.period.is_some(),
+                "Expected period for summarized response"
+            );
+            assert!(!response.period.as_ref().unwrap().is_empty());
+            assert!(
+                response.days.is_none(),
+                "Summarized response should not have days"
+            );
+
+            response
+                .summary
+                .as_ref()
+                .expect("Summary should be present for summarized response");
+        } else {
+            // summarize=0 response: has days, no summary
+            assert!(
+                response.summary.is_none(),
+                "Days response should not have summary"
+            );
+
+            let days = response
+                .days
+                .as_ref()
+                .expect("Days should be present for non-summarized response");
+            assert!(!days.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_stats_clicks_response_deserialization_summary() {
+        let json_file_path = "tests/wpcom/stats_clicks/summarized-01-day.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsClicksResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_clicks, 20);
+        assert_eq!(summary.other_clicks, 0);
+        assert_eq!(summary.clicks.len(), 2);
+
+        // Verify first click entry (with children)
+        let first_click = &summary.clicks[0];
+        assert_eq!(first_click.name, Some("href.li".to_string()));
+        assert!(first_click.url.is_none());
+        assert_eq!(first_click.views, Some(17));
+
+        let children = first_click
+            .children
+            .as_ref()
+            .expect("Children should be present");
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].views, Some(2));
+    }
+
+    #[test]
+    fn test_stats_clicks_response_deserialization_days() {
+        let json_file_path = "tests/wpcom/stats_clicks/no-summary-01.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsClicksResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert!(response.summary.is_none());
+
+        let days = response.days.as_ref().expect("Days should be present");
+        assert_eq!(days.len(), 2);
+
+        // Verify day with clicks
+        let day = days.get("2026-02-11").expect("2026-02-11 should exist");
+        assert_eq!(day.total_clicks, 1);
+        assert_eq!(day.other_clicks, 0);
+        assert_eq!(day.clicks.len(), 1);
+
+        let click = &day.clicks[0];
+        assert_eq!(click.name, Some("example.com/page".to_string()));
+        assert_eq!(click.views, Some(1));
+        assert!(click.children.is_none());
+
+        // Verify empty day
+        let empty_day = days.get("2026-02-18").expect("2026-02-18 should exist");
+        assert_eq!(empty_day.total_clicks, 0);
+        assert!(empty_day.clicks.is_empty());
+    }
+
+    #[test]
+    fn test_stats_clicks_with_null_values() {
+        let json_file_path = "tests/wpcom/stats_clicks/summarized-02-day-with-nulls.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsClicksResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON with null values");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_clicks, 5);
+        assert_eq!(summary.clicks.len(), 2);
+
+        // First entry: all nullable fields are null
+        let all_nulls = &summary.clicks[0];
+        assert!(all_nulls.icon.is_none());
+        assert!(all_nulls.url.is_none());
+        assert!(all_nulls.name.is_none());
+        assert!(all_nulls.views.is_none());
+        assert!(all_nulls.children.is_none());
+
+        // Second entry: has children with null values
+        let with_children = &summary.clicks[1];
+        assert_eq!(with_children.name, Some("example.com".to_string()));
+        assert_eq!(with_children.views, Some(5));
+
+        let children = with_children
+            .children
+            .as_ref()
+            .expect("Children should be present");
+        assert_eq!(children.len(), 2);
+
+        // First child: all nulls
+        assert!(children[0].url.is_none());
+        assert!(children[0].name.is_none());
+        assert!(children[0].views.is_none());
+
+        // Second child: all values
+        assert_eq!(
+            children[1].url,
+            Some("https://example.com/page".to_string())
+        );
+        assert_eq!(children[1].name, Some("example.com/page".to_string()));
+        assert_eq!(children[1].views, Some(3));
+    }
+}

--- a/wp_api/src/wp_com/stats_file_downloads.rs
+++ b/wp_api/src/wp_com/stats_file_downloads.rs
@@ -64,11 +64,10 @@ pub struct StatsFileDownloadsParams {
     pub summarize: bool,
     /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
     ///
-    /// - `Some(true)` (default): Archive pages are excluded from results
-    /// - `Some(false)`: Archive pages are included in results
-    /// - `None`: Parameter is not sent to the API
-    #[uniffi(default = Some(true))]
-    pub skip_archives: Option<bool>,
+    /// - `true` (default): Archive pages are excluded from results
+    /// - `false`: Archive pages are included in results
+    #[uniffi(default = true)]
+    pub skip_archives: bool,
 }
 
 impl Default for StatsFileDownloadsParams {
@@ -81,7 +80,7 @@ impl Default for StatsFileDownloadsParams {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         }
     }
 }
@@ -96,10 +95,7 @@ impl AppendUrlQueryPairs for StatsFileDownloadsParams {
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
-            .append_option_query_value_pair(
-                "skip_archives",
-                self.skip_archives.map(|b| b as u32).as_ref(),
-            );
+            .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
 }
 
@@ -175,7 +171,7 @@ mod tests {
             num: Some(30),
             locale: Some(WPComLanguage::English),
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -202,7 +198,7 @@ mod tests {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -211,30 +207,6 @@ mod tests {
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=week&date=2026-02-18&summarize=1&skip_archives=1"
-        );
-    }
-
-    #[test]
-    fn test_stats_file_downloads_params_without_summarize_and_skip_archives() {
-        let mut url = url::Url::parse(
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads",
-        )
-        .expect("Failed to parse url");
-
-        let params = StatsFileDownloadsParams {
-            period: Some(StatsFileDownloadsPeriod::Day),
-            date: Some("2026-02-18".to_string()),
-            summarize: false,
-            skip_archives: None,
-            ..Default::default()
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&date=2026-02-18&summarize=0"
         );
     }
 
@@ -248,7 +220,7 @@ mod tests {
         let params = StatsFileDownloadsParams {
             period: Some(StatsFileDownloadsPeriod::Day),
             summarize: false,
-            skip_archives: Some(false),
+            skip_archives: false,
             ..Default::default()
         };
 

--- a/wp_api/src/wp_com/stats_file_downloads.rs
+++ b/wp_api/src/wp_com/stats_file_downloads.rs
@@ -1,0 +1,407 @@
+use crate::{
+    impl_as_query_value_from_to_string,
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    wp_com::language::WPComLanguage,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The time period for grouping file downloads.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum StatsFileDownloadsPeriod {
+    #[default]
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl_as_query_value_from_to_string!(StatsFileDownloadsPeriod);
+
+/// Parameters for the stats file downloads endpoint.
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct StatsFileDownloadsParams {
+    /// The time period for grouping stats.
+    #[uniffi(default = None)]
+    pub period: Option<StatsFileDownloadsPeriod>,
+    /// The date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub date: Option<String>,
+    /// The start date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub start_date: Option<String>,
+    /// The maximum number of file downloads to return.
+    #[uniffi(default = None)]
+    pub max: Option<u32>,
+    /// The number of periods to include in the response.
+    #[uniffi(default = None)]
+    pub num: Option<u32>,
+    /// The locale for the response.
+    #[uniffi(default = None)]
+    pub locale: Option<WPComLanguage>,
+    /// Whether to return a summary of the data.
+    ///
+    /// - `true` (default): Response contains `summary` field with aggregated data
+    /// - `false`: Response contains `days` field with per-day breakdown
+    #[uniffi(default = true)]
+    pub summarize: bool,
+    /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
+    ///
+    /// - `Some(true)` (default): Archive pages are excluded from results
+    /// - `Some(false)`: Archive pages are included in results
+    /// - `None`: Parameter is not sent to the API
+    #[uniffi(default = Some(true))]
+    pub skip_archives: Option<bool>,
+}
+
+impl Default for StatsFileDownloadsParams {
+    fn default() -> Self {
+        Self {
+            period: None,
+            date: None,
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        }
+    }
+}
+
+impl AppendUrlQueryPairs for StatsFileDownloadsParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("period", self.period.as_ref())
+            .append_option_query_value_pair("date", self.date.as_ref())
+            .append_option_query_value_pair("start_date", self.start_date.as_ref())
+            .append_option_query_value_pair("max", self.max.as_ref())
+            .append_option_query_value_pair("num", self.num.as_ref())
+            .append_option_query_value_pair("locale", self.locale.as_ref())
+            .append_query_value_pair("summarize", &(self.summarize as u32))
+            .append_option_query_value_pair(
+                "skip_archives",
+                self.skip_archives.map(|b| b as u32).as_ref(),
+            );
+    }
+}
+
+/// Response from the stats file downloads endpoint.
+///
+/// The response structure varies based on the `summarize` parameter:
+/// - When `summarize=1`: Contains both `summary` and `days` fields
+/// - When `summarize=0`: Contains only `days` field with per-day data
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsFileDownloadsResponse {
+    /// The date for the stats query.
+    pub date: String,
+    /// The time period used for grouping.
+    pub period: Option<String>,
+    /// Summary data with aggregated file download entries (present when summarize=1).
+    pub summary: Option<StatsFileDownloadsSummaryData>,
+    /// Per-day stats data keyed by date string.
+    pub days: Option<HashMap<String, StatsFileDownloadsDayData>>,
+}
+
+/// Summary data with aggregated file download entries.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsFileDownloadsSummaryData {
+    /// The list of file download entries.
+    pub files: Vec<StatsFileDownloadsEntry>,
+    /// Downloads from other files not included in the list.
+    pub other_downloads: u64,
+    /// The total number of downloads.
+    pub total_downloads: u64,
+}
+
+/// Stats data for a single day.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsFileDownloadsDayData {
+    /// The list of file download entries for this day.
+    pub files: Vec<StatsFileDownloadsEntry>,
+    /// Downloads from other files not included in the list.
+    pub other_downloads: u64,
+    /// The total number of downloads for this day.
+    pub total_downloads: u64,
+}
+
+/// A file download entry in the stats file downloads response.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsFileDownloadsEntry {
+    /// The filename of the downloaded file.
+    pub filename: Option<String>,
+    /// The relative URL path of the file.
+    pub relative_url: Option<String>,
+    /// The full download URL of the file.
+    pub download_url: Option<String>,
+    /// The number of downloads.
+    pub downloads: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[test]
+    fn test_stats_file_downloads_params_serialization() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsFileDownloadsParams {
+            period: Some(StatsFileDownloadsPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            start_date: Some("2026-02-18".to_string()),
+            max: Some(10),
+            num: Some(30),
+            locale: Some(WPComLanguage::English),
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_file_downloads_params_serialization_partial() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsFileDownloadsParams {
+            period: Some(StatsFileDownloadsPeriod::Week),
+            date: Some("2026-02-18".to_string()),
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=week&date=2026-02-18&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_file_downloads_params_without_summarize_and_skip_archives() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsFileDownloadsParams {
+            period: Some(StatsFileDownloadsPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            summarize: false,
+            skip_archives: None,
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&date=2026-02-18&summarize=0"
+        );
+    }
+
+    #[test]
+    fn test_stats_file_downloads_params_with_false_values() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsFileDownloadsParams {
+            period: Some(StatsFileDownloadsPeriod::Day),
+            summarize: false,
+            skip_archives: Some(false),
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&summarize=0&skip_archives=0"
+        );
+    }
+
+    /// Tests deserialization of all stats file downloads JSON fixtures.
+    ///
+    /// The `expect_summary` parameter indicates whether the response uses summarize=1
+    /// (has `summary` and `days` fields) or summarize=0 (has only `days` field).
+    #[rstest]
+    #[case("tests/wpcom/stats_file_downloads/summarized-01-day.json", true)]
+    #[case("tests/wpcom/stats_file_downloads/no-summary-01.json", false)]
+    #[case(
+        "tests/wpcom/stats_file_downloads/summarized-02-day-with-nulls.json",
+        true
+    )]
+    #[case(
+        "tests/wpcom/stats_file_downloads/summarized-03-day-empty-response.json",
+        true
+    )]
+    fn test_stats_file_downloads_response_deserialization(
+        #[case] json_file_path: &str,
+        #[case] expect_summary: bool,
+    ) {
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsFileDownloadsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        // Common assertion: date is always present
+        assert!(!response.date.is_empty());
+
+        if expect_summary {
+            // summarize=1 response: has period and summary
+            assert!(
+                response.period.is_some(),
+                "Expected period for summarized response"
+            );
+            assert!(!response.period.as_ref().unwrap().is_empty());
+
+            response
+                .summary
+                .as_ref()
+                .expect("Summary should be present for summarized response");
+        } else {
+            // summarize=0 response: has days, no summary
+            assert!(
+                response.summary.is_none(),
+                "Days response should not have summary"
+            );
+
+            let days = response
+                .days
+                .as_ref()
+                .expect("Days should be present for non-summarized response");
+            assert!(!days.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_stats_file_downloads_response_deserialization_summary() {
+        let json_file_path = "tests/wpcom/stats_file_downloads/summarized-01-day.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsFileDownloadsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_downloads, 83);
+        assert_eq!(summary.other_downloads, 0);
+        assert_eq!(summary.files.len(), 5);
+
+        // Verify first file entry
+        let first_file = &summary.files[0];
+        assert_eq!(first_file.filename, Some("automattic-w-9.pdf".to_string()));
+        assert_eq!(
+            first_file.relative_url,
+            Some("/2025/01/automattic-w-9.pdf".to_string())
+        );
+        assert_eq!(first_file.downloads, Some(5));
+    }
+
+    #[test]
+    fn test_stats_file_downloads_response_deserialization_days() {
+        let json_file_path = "tests/wpcom/stats_file_downloads/no-summary-01.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsFileDownloadsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert!(response.summary.is_none());
+
+        let days = response.days.as_ref().expect("Days should be present");
+        assert_eq!(days.len(), 3);
+
+        // Verify day with files
+        let day = days.get("2026-02-18").expect("2026-02-18 should exist");
+        assert_eq!(day.total_downloads, 34);
+        assert_eq!(day.other_downloads, 0);
+        assert_eq!(day.files.len(), 3);
+
+        let file_entry = &day.files[0];
+        assert_eq!(file_entry.filename, Some("automattic-w-9.pdf".to_string()));
+        assert_eq!(file_entry.downloads, Some(4));
+
+        // Verify empty day
+        let empty_day = days.get("2026-02-14").expect("2026-02-14 should exist");
+        assert_eq!(empty_day.total_downloads, 0);
+        assert!(empty_day.files.is_empty());
+    }
+
+    #[test]
+    fn test_stats_file_downloads_with_null_values() {
+        let json_file_path = "tests/wpcom/stats_file_downloads/summarized-02-day-with-nulls.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsFileDownloadsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON with null values");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_downloads, 10);
+        assert_eq!(summary.files.len(), 2);
+
+        // First entry: all nullable fields are null
+        let all_nulls = &summary.files[0];
+        assert!(all_nulls.filename.is_none());
+        assert!(all_nulls.relative_url.is_none());
+        assert!(all_nulls.download_url.is_none());
+        assert!(all_nulls.downloads.is_none());
+
+        // Second entry: has values
+        let with_values = &summary.files[1];
+        assert_eq!(with_values.filename, Some("example-file.pdf".to_string()));
+        assert_eq!(
+            with_values.relative_url,
+            Some("/2026/02/example-file.pdf".to_string())
+        );
+        assert_eq!(with_values.downloads, Some(10));
+    }
+}

--- a/wp_api/src/wp_com/stats_search_terms.rs
+++ b/wp_api/src/wp_com/stats_search_terms.rs
@@ -64,11 +64,10 @@ pub struct StatsSearchTermsParams {
     pub summarize: bool,
     /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
     ///
-    /// - `Some(true)` (default): Archive pages are excluded from results
-    /// - `Some(false)`: Archive pages are included in results
-    /// - `None`: Parameter is not sent to the API
-    #[uniffi(default = Some(true))]
-    pub skip_archives: Option<bool>,
+    /// - `true` (default): Archive pages are excluded from results
+    /// - `false`: Archive pages are included in results
+    #[uniffi(default = true)]
+    pub skip_archives: bool,
 }
 
 impl Default for StatsSearchTermsParams {
@@ -81,7 +80,7 @@ impl Default for StatsSearchTermsParams {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         }
     }
 }
@@ -96,10 +95,7 @@ impl AppendUrlQueryPairs for StatsSearchTermsParams {
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
-            .append_option_query_value_pair(
-                "skip_archives",
-                self.skip_archives.map(|b| b as u32).as_ref(),
-            );
+            .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
 }
 
@@ -175,7 +171,7 @@ mod tests {
             num: Some(30),
             locale: Some(WPComLanguage::English),
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -202,7 +198,7 @@ mod tests {
             num: None,
             locale: None,
             summarize: true,
-            skip_archives: Some(true),
+            skip_archives: true,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -211,30 +207,6 @@ mod tests {
         assert_eq!(
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=week&date=2026-02-18&summarize=1&skip_archives=1"
-        );
-    }
-
-    #[test]
-    fn test_stats_search_terms_params_without_summarize_and_skip_archives() {
-        let mut url = url::Url::parse(
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms",
-        )
-        .expect("Failed to parse url");
-
-        let params = StatsSearchTermsParams {
-            period: Some(StatsSearchTermsPeriod::Day),
-            date: Some("2026-02-18".to_string()),
-            summarize: false,
-            skip_archives: None,
-            ..Default::default()
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&date=2026-02-18&summarize=0"
         );
     }
 
@@ -248,7 +220,7 @@ mod tests {
         let params = StatsSearchTermsParams {
             period: Some(StatsSearchTermsPeriod::Day),
             summarize: false,
-            skip_archives: Some(false),
+            skip_archives: false,
             ..Default::default()
         };
 

--- a/wp_api/src/wp_com/stats_search_terms.rs
+++ b/wp_api/src/wp_com/stats_search_terms.rs
@@ -1,0 +1,402 @@
+use crate::{
+    impl_as_query_value_from_to_string,
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    wp_com::language::WPComLanguage,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The time period for grouping search terms.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum StatsSearchTermsPeriod {
+    #[default]
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl_as_query_value_from_to_string!(StatsSearchTermsPeriod);
+
+/// Parameters for the stats search terms endpoint.
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct StatsSearchTermsParams {
+    /// The time period for grouping stats.
+    #[uniffi(default = None)]
+    pub period: Option<StatsSearchTermsPeriod>,
+    /// The date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub date: Option<String>,
+    /// The start date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub start_date: Option<String>,
+    /// The maximum number of search terms to return.
+    #[uniffi(default = None)]
+    pub max: Option<u32>,
+    /// The number of periods to include in the response.
+    #[uniffi(default = None)]
+    pub num: Option<u32>,
+    /// The locale for the response.
+    #[uniffi(default = None)]
+    pub locale: Option<WPComLanguage>,
+    /// Whether to return a summary of the data.
+    ///
+    /// - `true` (default): Response contains `summary` field with aggregated data
+    /// - `false`: Response contains `days` field with per-day breakdown
+    #[uniffi(default = true)]
+    pub summarize: bool,
+    /// Whether to skip archive pages (date-based archives, category archives, etc.) in the response.
+    ///
+    /// - `Some(true)` (default): Archive pages are excluded from results
+    /// - `Some(false)`: Archive pages are included in results
+    /// - `None`: Parameter is not sent to the API
+    #[uniffi(default = Some(true))]
+    pub skip_archives: Option<bool>,
+}
+
+impl Default for StatsSearchTermsParams {
+    fn default() -> Self {
+        Self {
+            period: None,
+            date: None,
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        }
+    }
+}
+
+impl AppendUrlQueryPairs for StatsSearchTermsParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("period", self.period.as_ref())
+            .append_option_query_value_pair("date", self.date.as_ref())
+            .append_option_query_value_pair("start_date", self.start_date.as_ref())
+            .append_option_query_value_pair("max", self.max.as_ref())
+            .append_option_query_value_pair("num", self.num.as_ref())
+            .append_option_query_value_pair("locale", self.locale.as_ref())
+            .append_query_value_pair("summarize", &(self.summarize as u32))
+            .append_option_query_value_pair(
+                "skip_archives",
+                self.skip_archives.map(|b| b as u32).as_ref(),
+            );
+    }
+}
+
+/// Response from the stats search terms endpoint.
+///
+/// The response structure varies based on the `summarize` parameter:
+/// - When `summarize=1`: Contains `summary` field with aggregated data
+/// - When `summarize` is not set: Contains `days` field with per-day data
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsSearchTermsResponse {
+    /// The date for the stats query.
+    pub date: String,
+    /// The time period used for grouping (present when summarize=1).
+    pub period: Option<String>,
+    /// Summary data with aggregated search terms (present when summarize=1).
+    pub summary: Option<StatsSearchTermsSummaryData>,
+    /// Per-day stats data keyed by date string (present when summarize is not set).
+    pub days: Option<HashMap<String, StatsSearchTermsDayData>>,
+}
+
+/// Summary data with aggregated search terms.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsSearchTermsSummaryData {
+    /// The list of search term entries.
+    pub search_terms: Vec<StatsSearchTermsEntry>,
+    /// The number of encrypted search terms.
+    pub encrypted_search_terms: i64,
+    /// The number of other search terms not included in the list.
+    pub other_search_terms: i64,
+    /// The total number of search terms.
+    pub total_search_terms: i64,
+}
+
+/// Stats data for a single day.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsSearchTermsDayData {
+    /// The list of search term entries for this day.
+    pub search_terms: Vec<StatsSearchTermsEntry>,
+    /// The number of encrypted search terms for this day.
+    pub encrypted_search_terms: i64,
+    /// The number of other search terms not included in the list for this day.
+    pub other_search_terms: i64,
+    /// The total number of search terms for this day.
+    pub total_search_terms: i64,
+}
+
+/// A search term entry in the stats search terms response.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsSearchTermsEntry {
+    /// The search term.
+    pub term: Option<String>,
+    /// The number of views from this search term.
+    pub views: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[test]
+    fn test_stats_search_terms_params_serialization() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsSearchTermsParams {
+            period: Some(StatsSearchTermsPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            start_date: Some("2026-02-18".to_string()),
+            max: Some(10),
+            num: Some(30),
+            locale: Some(WPComLanguage::English),
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_search_terms_params_serialization_partial() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsSearchTermsParams {
+            period: Some(StatsSearchTermsPeriod::Week),
+            date: Some("2026-02-18".to_string()),
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            skip_archives: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=week&date=2026-02-18&summarize=1&skip_archives=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_search_terms_params_without_summarize_and_skip_archives() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsSearchTermsParams {
+            period: Some(StatsSearchTermsPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            summarize: false,
+            skip_archives: None,
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&date=2026-02-18&summarize=0"
+        );
+    }
+
+    #[test]
+    fn test_stats_search_terms_params_with_false_values() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsSearchTermsParams {
+            period: Some(StatsSearchTermsPeriod::Day),
+            summarize: false,
+            skip_archives: Some(false),
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&summarize=0&skip_archives=0"
+        );
+    }
+
+    /// Tests deserialization of all stats search terms JSON fixtures.
+    ///
+    /// The `expect_summary` parameter indicates whether the response uses summarize=1
+    /// (has `summary` and `period` fields) or summarize=0 (has `days` field instead).
+    #[rstest]
+    #[case("tests/wpcom/stats_search_terms/summarized-01-day.json", true)]
+    #[case("tests/wpcom/stats_search_terms/no-summary-01.json", false)]
+    #[case(
+        "tests/wpcom/stats_search_terms/summarized-02-day-with-nulls.json",
+        true
+    )]
+    #[case(
+        "tests/wpcom/stats_search_terms/summarized-03-day-empty-response.json",
+        true
+    )]
+    fn test_stats_search_terms_response_deserialization(
+        #[case] json_file_path: &str,
+        #[case] expect_summary: bool,
+    ) {
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsSearchTermsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        // Common assertion: date is always present
+        assert!(!response.date.is_empty());
+
+        if expect_summary {
+            assert!(
+                response.period.is_some(),
+                "Expected period for summarized response"
+            );
+            assert!(!response.period.as_ref().unwrap().is_empty());
+            assert!(
+                response.days.is_none(),
+                "Summarized response should not have days"
+            );
+
+            response
+                .summary
+                .as_ref()
+                .expect("Summary should be present for summarized response");
+        } else {
+            assert!(
+                response.summary.is_none(),
+                "Days response should not have summary"
+            );
+
+            let days = response
+                .days
+                .as_ref()
+                .expect("Days should be present for non-summarized response");
+            assert!(!days.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_stats_search_terms_response_deserialization_summary() {
+        let json_file_path = "tests/wpcom/stats_search_terms/summarized-01-day.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsSearchTermsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_search_terms, 0);
+        assert_eq!(summary.encrypted_search_terms, 14);
+        assert_eq!(summary.other_search_terms, -429);
+        assert_eq!(summary.search_terms.len(), 3);
+
+        // Verify first search term
+        let first_term = &summary.search_terms[0];
+        assert_eq!(
+            first_term.term,
+            Some("https://example.com/support-tools/".to_string())
+        );
+        assert_eq!(first_term.views, Some(12));
+    }
+
+    #[test]
+    fn test_stats_search_terms_response_deserialization_days() {
+        let json_file_path = "tests/wpcom/stats_search_terms/no-summary-01.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsSearchTermsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert!(response.summary.is_none());
+
+        let days = response.days.as_ref().expect("Days should be present");
+        assert_eq!(days.len(), 2);
+
+        // Verify day with search terms
+        let day = days.get("2026-02-17").expect("2026-02-17 should exist");
+        assert_eq!(day.total_search_terms, 8);
+        assert_eq!(day.encrypted_search_terms, 2);
+        assert_eq!(day.other_search_terms, 1);
+        assert_eq!(day.search_terms.len(), 1);
+        assert_eq!(day.search_terms[0].term, Some("example search".to_string()));
+        assert_eq!(day.search_terms[0].views, Some(5));
+
+        // Verify empty day
+        let empty_day = days.get("2026-02-18").expect("2026-02-18 should exist");
+        assert_eq!(empty_day.total_search_terms, 0);
+        assert!(empty_day.search_terms.is_empty());
+    }
+
+    #[test]
+    fn test_stats_search_terms_with_null_values() {
+        let json_file_path = "tests/wpcom/stats_search_terms/summarized-02-day-with-nulls.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsSearchTermsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON with null values");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = response
+            .summary
+            .as_ref()
+            .expect("Summary should be present");
+        assert_eq!(summary.total_search_terms, 15);
+        assert_eq!(summary.search_terms.len(), 2);
+
+        // First entry: all nullable fields are null
+        let all_nulls = &summary.search_terms[0];
+        assert!(all_nulls.term.is_none());
+        assert!(all_nulls.views.is_none());
+
+        // Second entry: all fields have values
+        let with_values = &summary.search_terms[1];
+        assert_eq!(with_values.term, Some("example query".to_string()));
+        assert_eq!(with_values.views, Some(10));
+    }
+}

--- a/wp_api/src/wp_com/stats_video_plays.rs
+++ b/wp_api/src/wp_com/stats_video_plays.rs
@@ -1,0 +1,351 @@
+use crate::{
+    impl_as_query_value_from_to_string,
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    wp_com::language::WPComLanguage,
+};
+use serde::{Deserialize, Serialize};
+
+/// The time period for grouping video plays.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum StatsVideoPlaysPeriod {
+    #[default]
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl_as_query_value_from_to_string!(StatsVideoPlaysPeriod);
+
+/// Parameters for the stats video plays endpoint.
+#[derive(Debug, PartialEq, Eq, uniffi::Record)]
+pub struct StatsVideoPlaysParams {
+    /// The time period for grouping stats.
+    #[uniffi(default = None)]
+    pub period: Option<StatsVideoPlaysPeriod>,
+    /// The date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub date: Option<String>,
+    /// The start date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub start_date: Option<String>,
+    /// The maximum number of video plays to return.
+    #[uniffi(default = None)]
+    pub max: Option<u32>,
+    /// The number of periods to include in the response.
+    #[uniffi(default = None)]
+    pub num: Option<u32>,
+    /// The locale for the response.
+    #[uniffi(default = None)]
+    pub locale: Option<WPComLanguage>,
+    /// Whether to return a summary of the data.
+    ///
+    /// - `true` (default): Response contains summarized data
+    /// - `false`: Response contains per-day breakdown
+    #[uniffi(default = true)]
+    pub summarize: bool,
+    /// Whether to include complete stats (including zero-view videos).
+    ///
+    /// - `Some(true)` (default): Include all videos
+    /// - `Some(false)`: Only include videos with views
+    /// - `None`: Parameter is not sent to the API
+    #[uniffi(default = Some(true))]
+    pub complete_stats: Option<bool>,
+}
+
+impl Default for StatsVideoPlaysParams {
+    fn default() -> Self {
+        Self {
+            period: None,
+            date: None,
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            complete_stats: Some(true),
+        }
+    }
+}
+
+impl AppendUrlQueryPairs for StatsVideoPlaysParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("period", self.period.as_ref())
+            .append_option_query_value_pair("date", self.date.as_ref())
+            .append_option_query_value_pair("start_date", self.start_date.as_ref())
+            .append_option_query_value_pair("max", self.max.as_ref())
+            .append_option_query_value_pair("num", self.num.as_ref())
+            .append_option_query_value_pair("locale", self.locale.as_ref())
+            .append_query_value_pair("summarize", &(self.summarize as u32))
+            .append_option_query_value_pair(
+                "complete_stats",
+                self.complete_stats.map(|b| b as u32).as_ref(),
+            );
+    }
+}
+
+/// Response from the stats video plays endpoint.
+///
+/// The video plays endpoint always returns data inside `days.summary`,
+/// regardless of the `summarize` parameter.
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsVideoPlaysResponse {
+    /// The date for the stats query.
+    pub date: String,
+    /// The time period used for grouping.
+    pub period: Option<String>,
+    /// The days data containing the summary.
+    pub days: StatsVideoPlaysDays,
+}
+
+/// The days wrapper containing the summary data.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsVideoPlaysDays {
+    /// The summary data with video play entries and totals.
+    pub summary: StatsVideoPlaysSummaryData,
+}
+
+/// Summary data with video play entries and totals.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsVideoPlaysSummaryData {
+    /// The list of video play entries.
+    pub data: Vec<StatsVideoPlaysEntry>,
+    /// The total aggregated stats.
+    pub total: StatsVideoPlaysTotal,
+}
+
+/// A video play entry in the stats video plays response.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsVideoPlaysEntry {
+    /// The post ID of the video.
+    pub post_id: u64,
+    /// The title of the video.
+    pub title: Option<String>,
+    /// The number of views/plays.
+    pub views: Option<u64>,
+    /// The number of impressions.
+    pub impressions: Option<u64>,
+    /// The total watch time in hours.
+    pub watch_time: Option<f64>,
+    /// The retention rate percentage.
+    pub retention_rate: Option<f64>,
+}
+
+/// Total aggregated video play stats.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct StatsVideoPlaysTotal {
+    /// The total number of impressions.
+    pub impressions: u64,
+    /// The total number of views/plays.
+    pub views: u64,
+    /// The total watch time in hours.
+    pub watch_time: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[test]
+    fn test_stats_video_plays_params_serialization() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsVideoPlaysParams {
+            period: Some(StatsVideoPlaysPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            start_date: Some("2026-02-12".to_string()),
+            max: Some(10),
+            num: Some(30),
+            locale: Some(WPComLanguage::English),
+            summarize: true,
+            complete_stats: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=day&date=2026-02-18&start_date=2026-02-12&max=10&num=30&locale=en&summarize=1&complete_stats=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_video_plays_params_serialization_partial() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsVideoPlaysParams {
+            period: Some(StatsVideoPlaysPeriod::Week),
+            date: Some("2026-02-18".to_string()),
+            start_date: None,
+            max: None,
+            num: None,
+            locale: None,
+            summarize: true,
+            complete_stats: Some(true),
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=week&date=2026-02-18&summarize=1&complete_stats=1"
+        );
+    }
+
+    #[test]
+    fn test_stats_video_plays_params_without_summarize_and_complete_stats() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsVideoPlaysParams {
+            period: Some(StatsVideoPlaysPeriod::Day),
+            date: Some("2026-02-18".to_string()),
+            summarize: false,
+            complete_stats: None,
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=day&date=2026-02-18&summarize=0"
+        );
+    }
+
+    #[test]
+    fn test_stats_video_plays_params_with_false_values() {
+        let mut url = url::Url::parse(
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays",
+        )
+        .expect("Failed to parse url");
+
+        let params = StatsVideoPlaysParams {
+            period: Some(StatsVideoPlaysPeriod::Day),
+            summarize: false,
+            complete_stats: Some(false),
+            ..Default::default()
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=day&summarize=0&complete_stats=0"
+        );
+    }
+
+    /// Tests deserialization of all stats video plays JSON fixtures.
+    #[rstest]
+    #[case("tests/wpcom/stats_video_plays/summarized-01-day.json")]
+    #[case("tests/wpcom/stats_video_plays/no-summary-01.json")]
+    #[case("tests/wpcom/stats_video_plays/summarized-02-day-with-nulls.json")]
+    #[case("tests/wpcom/stats_video_plays/summarized-03-day-empty-response.json")]
+    fn test_stats_video_plays_response_deserialization(#[case] json_file_path: &str) {
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsVideoPlaysResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        // Common assertion: date is always present
+        assert!(!response.date.is_empty());
+        assert!(response.period.is_some());
+    }
+
+    #[test]
+    fn test_stats_video_plays_response_deserialization_summary() {
+        let json_file_path = "tests/wpcom/stats_video_plays/summarized-01-day.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsVideoPlaysResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(response.date, "2026-02-18");
+        assert_eq!(response.period, Some("day".to_string()));
+
+        let summary = &response.days.summary;
+        assert_eq!(summary.data.len(), 3);
+        assert_eq!(summary.total.impressions, 1172);
+        assert_eq!(summary.total.views, 31);
+        assert!((summary.total.watch_time - 0.6936111111111113).abs() < f64::EPSILON);
+
+        // Verify first video play entry
+        let first_entry = &summary.data[0];
+        assert_eq!(first_entry.post_id, 282653);
+        assert_eq!(first_entry.title, Some("example_video_1".to_string()));
+        assert_eq!(first_entry.views, Some(10));
+        assert_eq!(first_entry.impressions, Some(71));
+    }
+
+    #[test]
+    fn test_stats_video_plays_with_null_values() {
+        let json_file_path = "tests/wpcom/stats_video_plays/summarized-02-day-with-nulls.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsVideoPlaysResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON with null values");
+
+        assert_eq!(response.date, "2026-02-18");
+
+        let summary = &response.days.summary;
+        assert_eq!(summary.data.len(), 2);
+
+        // First entry: nullable fields are null
+        let null_entry = &summary.data[0];
+        assert_eq!(null_entry.post_id, 0);
+        assert!(null_entry.title.is_none());
+        assert!(null_entry.views.is_none());
+        assert!(null_entry.impressions.is_none());
+        assert!(null_entry.watch_time.is_none());
+        assert!(null_entry.retention_rate.is_none());
+
+        // Second entry: all fields have values
+        let valid_entry = &summary.data[1];
+        assert_eq!(valid_entry.post_id, 282653);
+        assert_eq!(valid_entry.title, Some("example_video".to_string()));
+        assert_eq!(valid_entry.views, Some(10));
+        assert_eq!(valid_entry.impressions, Some(71));
+    }
+
+    #[test]
+    fn test_stats_video_plays_empty_response() {
+        let json_file_path = "tests/wpcom/stats_video_plays/summarized-03-day-empty-response.json";
+        let file = std::fs::File::open(json_file_path).expect("Failed to open file");
+        let response: StatsVideoPlaysResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let summary = &response.days.summary;
+        assert!(summary.data.is_empty());
+        assert_eq!(summary.total.impressions, 0);
+        assert_eq!(summary.total.views, 0);
+        assert!((summary.total.watch_time - 0.0).abs() < f64::EPSILON);
+    }
+}

--- a/wp_api/tests/wpcom/stats_clicks/no-summary-01.json
+++ b/wp_api/tests/wpcom/stats_clicks/no-summary-01.json
@@ -1,0 +1,24 @@
+{
+    "date": "2026-02-18",
+    "days": {
+        "2026-02-18": {
+            "clicks": [],
+            "other_clicks": 0,
+            "total_clicks": 0
+        },
+        "2026-02-11": {
+            "clicks": [
+                {
+                    "icon": "https://secure.gravatar.com/blavatar/example1?s=48",
+                    "url": "https://href.li/?https://example.com/page",
+                    "name": "example.com/page",
+                    "views": 1,
+                    "children": null
+                }
+            ],
+            "other_clicks": 0,
+            "total_clicks": 1
+        }
+    },
+    "period": "day"
+}

--- a/wp_api/tests/wpcom/stats_clicks/summarized-01-day.json
+++ b/wp_api/tests/wpcom/stats_clicks/summarized-01-day.json
@@ -1,0 +1,46 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "clicks": [
+            {
+                "icon": "https://secure.gravatar.com/blavatar/example1?s=48",
+                "url": null,
+                "name": "href.li",
+                "views": 17,
+                "children": [
+                    {
+                        "url": "https://href.li/?https://www.example.com/page1",
+                        "name": "example.com/page1",
+                        "views": 2
+                    },
+                    {
+                        "url": "https://href.li/?https://www.example.com/page2",
+                        "name": "example.com/page2",
+                        "views": 1
+                    }
+                ]
+            },
+            {
+                "icon": "https://secure.gravatar.com/blavatar/example2?s=48",
+                "url": null,
+                "name": "example.automattic.com",
+                "views": 3,
+                "children": [
+                    {
+                        "url": "https://example.automattic.com/wp-content/uploads/2019/05/image.png",
+                        "name": "example.automattic.com/wp-content/uploads/2019/05/image.png",
+                        "views": 2
+                    },
+                    {
+                        "url": "https://example.automattic.com/wp-content/uploads/2019/05/image2.png",
+                        "name": "example.automattic.com/wp-content/uploads/2019/05/image2.png",
+                        "views": 1
+                    }
+                ]
+            }
+        ],
+        "other_clicks": 0,
+        "total_clicks": 20
+    }
+}

--- a/wp_api/tests/wpcom/stats_clicks/summarized-02-day-with-nulls.json
+++ b/wp_api/tests/wpcom/stats_clicks/summarized-02-day-with-nulls.json
@@ -1,0 +1,35 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "clicks": [
+            {
+                "icon": null,
+                "url": null,
+                "name": null,
+                "views": null,
+                "children": null
+            },
+            {
+                "icon": "https://example.com/icon.png",
+                "url": "https://example.com",
+                "name": "example.com",
+                "views": 5,
+                "children": [
+                    {
+                        "url": null,
+                        "name": null,
+                        "views": null
+                    },
+                    {
+                        "url": "https://example.com/page",
+                        "name": "example.com/page",
+                        "views": 3
+                    }
+                ]
+            }
+        ],
+        "other_clicks": 0,
+        "total_clicks": 5
+    }
+}

--- a/wp_api/tests/wpcom/stats_clicks/summarized-03-day-empty-response.json
+++ b/wp_api/tests/wpcom/stats_clicks/summarized-03-day-empty-response.json
@@ -1,0 +1,9 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "clicks": [],
+        "other_clicks": 0,
+        "total_clicks": 0
+    }
+}

--- a/wp_api/tests/wpcom/stats_file_downloads/no-summary-01.json
+++ b/wp_api/tests/wpcom/stats_file_downloads/no-summary-01.json
@@ -1,0 +1,47 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "2026-02-18": {
+            "files": [
+                {
+                    "filename": "automattic-w-9.pdf",
+                    "relative_url": "/2025/01/automattic-w-9.pdf",
+                    "download_url": "https://example.files.wordpress.com/2025/01/automattic-w-9.pdf",
+                    "downloads": 4
+                },
+                {
+                    "filename": "wpvip-w-9.pdf",
+                    "relative_url": "/2025/01/wpvip-w-9.pdf",
+                    "download_url": "https://example.files.wordpress.com/2025/01/wpvip-w-9.pdf",
+                    "downloads": 3
+                },
+                {
+                    "filename": "report.pdf",
+                    "relative_url": "/2026/02/report.pdf",
+                    "download_url": "https://example.files.wordpress.com/2026/02/report.pdf",
+                    "downloads": 2
+                }
+            ],
+            "other_downloads": 0,
+            "total_downloads": 34
+        },
+        "2026-02-14": {
+            "files": [],
+            "other_downloads": 0,
+            "total_downloads": 0
+        },
+        "2026-02-13": {
+            "files": [
+                {
+                    "filename": "contract.pdf",
+                    "relative_url": "/2023/07/contract.pdf",
+                    "download_url": "https://example.files.wordpress.com/2023/07/contract.pdf",
+                    "downloads": 3
+                }
+            ],
+            "other_downloads": 0,
+            "total_downloads": 14
+        }
+    }
+}

--- a/wp_api/tests/wpcom/stats_file_downloads/summarized-01-day.json
+++ b/wp_api/tests/wpcom/stats_file_downloads/summarized-01-day.json
@@ -1,0 +1,72 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "2026-02-18": {
+            "files": [
+                {
+                    "filename": "automattic-w-9.pdf",
+                    "relative_url": "/2025/01/automattic-w-9.pdf",
+                    "download_url": "https://example.files.wordpress.com/2025/01/automattic-w-9.pdf",
+                    "downloads": 4
+                },
+                {
+                    "filename": "wpvip-w-9.pdf",
+                    "relative_url": "/2025/01/wpvip-w-9.pdf",
+                    "download_url": "https://example.files.wordpress.com/2025/01/wpvip-w-9.pdf",
+                    "downloads": 3
+                }
+            ],
+            "other_downloads": 0,
+            "total_downloads": 7
+        },
+        "2026-02-17": {
+            "files": [
+                {
+                    "filename": "report.pdf",
+                    "relative_url": "/2026/02/report.pdf",
+                    "download_url": "https://example.files.wordpress.com/2026/02/report.pdf",
+                    "downloads": 2
+                }
+            ],
+            "other_downloads": 0,
+            "total_downloads": 2
+        }
+    },
+    "summary": {
+        "files": [
+            {
+                "filename": "automattic-w-9.pdf",
+                "relative_url": "/2025/01/automattic-w-9.pdf",
+                "download_url": "https://example.files.wordpress.com/2025/01/automattic-w-9.pdf",
+                "downloads": 5
+            },
+            {
+                "filename": "wpvip-w-9.pdf",
+                "relative_url": "/2025/01/wpvip-w-9.pdf",
+                "download_url": "https://example.files.wordpress.com/2025/01/wpvip-w-9.pdf",
+                "downloads": 5
+            },
+            {
+                "filename": "report.pdf",
+                "relative_url": "/2026/02/report.pdf",
+                "download_url": "https://example.files.wordpress.com/2026/02/report.pdf",
+                "downloads": 3
+            },
+            {
+                "filename": "archive.zip",
+                "relative_url": "/2025/05/archive.zip",
+                "download_url": "https://example.files.wordpress.com/2025/05/archive.zip",
+                "downloads": 1
+            },
+            {
+                "filename": "handbook.pdf",
+                "relative_url": "/2025/05/handbook.pdf",
+                "download_url": "https://example.files.wordpress.com/2025/05/handbook.pdf",
+                "downloads": 1
+            }
+        ],
+        "total_downloads": 83,
+        "other_downloads": 0
+    }
+}

--- a/wp_api/tests/wpcom/stats_file_downloads/summarized-02-day-with-nulls.json
+++ b/wp_api/tests/wpcom/stats_file_downloads/summarized-02-day-with-nulls.json
@@ -1,0 +1,22 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "files": [
+            {
+                "filename": null,
+                "relative_url": null,
+                "download_url": null,
+                "downloads": null
+            },
+            {
+                "filename": "example-file.pdf",
+                "relative_url": "/2026/02/example-file.pdf",
+                "download_url": "https://example.files.wordpress.com/2026/02/example-file.pdf",
+                "downloads": 10
+            }
+        ],
+        "other_downloads": 0,
+        "total_downloads": 10
+    }
+}

--- a/wp_api/tests/wpcom/stats_file_downloads/summarized-03-day-empty-response.json
+++ b/wp_api/tests/wpcom/stats_file_downloads/summarized-03-day-empty-response.json
@@ -1,0 +1,9 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "files": [],
+        "other_downloads": 0,
+        "total_downloads": 0
+    }
+}

--- a/wp_api/tests/wpcom/stats_search_terms/no-summary-01.json
+++ b/wp_api/tests/wpcom/stats_search_terms/no-summary-01.json
@@ -1,0 +1,23 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "2026-02-18": {
+            "search_terms": [],
+            "encrypted_search_terms": 0,
+            "other_search_terms": 0,
+            "total_search_terms": 0
+        },
+        "2026-02-17": {
+            "search_terms": [
+                {
+                    "term": "example search",
+                    "views": 5
+                }
+            ],
+            "encrypted_search_terms": 2,
+            "other_search_terms": 1,
+            "total_search_terms": 8
+        }
+    }
+}

--- a/wp_api/tests/wpcom/stats_search_terms/summarized-01-day.json
+++ b/wp_api/tests/wpcom/stats_search_terms/summarized-01-day.json
@@ -1,0 +1,23 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "search_terms": [
+            {
+                "term": "https://example.com/support-tools/",
+                "views": 12
+            },
+            {
+                "term": "https://example.com/security-best-practices/",
+                "views": 11
+            },
+            {
+                "term": "search query example",
+                "views": 4
+            }
+        ],
+        "encrypted_search_terms": 14,
+        "other_search_terms": -429,
+        "total_search_terms": 0
+    }
+}

--- a/wp_api/tests/wpcom/stats_search_terms/summarized-02-day-with-nulls.json
+++ b/wp_api/tests/wpcom/stats_search_terms/summarized-02-day-with-nulls.json
@@ -1,0 +1,19 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "search_terms": [
+            {
+                "term": null,
+                "views": null
+            },
+            {
+                "term": "example query",
+                "views": 10
+            }
+        ],
+        "encrypted_search_terms": 5,
+        "other_search_terms": 0,
+        "total_search_terms": 15
+    }
+}

--- a/wp_api/tests/wpcom/stats_search_terms/summarized-03-day-empty-response.json
+++ b/wp_api/tests/wpcom/stats_search_terms/summarized-03-day-empty-response.json
@@ -1,0 +1,10 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "summary": {
+        "search_terms": [],
+        "encrypted_search_terms": 0,
+        "other_search_terms": 0,
+        "total_search_terms": 0
+    }
+}

--- a/wp_api/tests/wpcom/stats_video_plays/no-summary-01.json
+++ b/wp_api/tests/wpcom/stats_video_plays/no-summary-01.json
@@ -1,0 +1,23 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "summary": {
+            "data": [
+                {
+                    "post_id": 282653,
+                    "title": "example_video_1",
+                    "views": 10,
+                    "impressions": 71,
+                    "watch_time": 0.06972222222222223,
+                    "retention_rate": 33.0
+                }
+            ],
+            "total": {
+                "impressions": 71,
+                "views": 10,
+                "watch_time": 0.06972222222222223
+            }
+        }
+    }
+}

--- a/wp_api/tests/wpcom/stats_video_plays/summarized-01-day.json
+++ b/wp_api/tests/wpcom/stats_video_plays/summarized-01-day.json
@@ -1,0 +1,39 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "summary": {
+            "data": [
+                {
+                    "post_id": 282653,
+                    "title": "example_video_1",
+                    "views": 10,
+                    "impressions": 71,
+                    "watch_time": 0.06972222222222223,
+                    "retention_rate": 33.0
+                },
+                {
+                    "post_id": 11602,
+                    "title": "Example Video 2",
+                    "views": 7,
+                    "impressions": 859,
+                    "watch_time": 0.12194444444444444,
+                    "retention_rate": 78.4
+                },
+                {
+                    "post_id": 143268,
+                    "title": "example-video-3",
+                    "views": 2,
+                    "impressions": 5,
+                    "watch_time": 0.013333333333333334,
+                    "retention_rate": 61.5
+                }
+            ],
+            "total": {
+                "impressions": 1172,
+                "views": 31,
+                "watch_time": 0.6936111111111113
+            }
+        }
+    }
+}

--- a/wp_api/tests/wpcom/stats_video_plays/summarized-02-day-with-nulls.json
+++ b/wp_api/tests/wpcom/stats_video_plays/summarized-02-day-with-nulls.json
@@ -1,0 +1,31 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "summary": {
+            "data": [
+                {
+                    "post_id": 0,
+                    "title": null,
+                    "views": null,
+                    "impressions": null,
+                    "watch_time": null,
+                    "retention_rate": null
+                },
+                {
+                    "post_id": 282653,
+                    "title": "example_video",
+                    "views": 10,
+                    "impressions": 71,
+                    "watch_time": 0.07,
+                    "retention_rate": 33.0
+                }
+            ],
+            "total": {
+                "impressions": 71,
+                "views": 10,
+                "watch_time": 0.07
+            }
+        }
+    }
+}

--- a/wp_api/tests/wpcom/stats_video_plays/summarized-03-day-empty-response.json
+++ b/wp_api/tests/wpcom/stats_video_plays/summarized-03-day-empty-response.json
@@ -1,0 +1,14 @@
+{
+    "date": "2026-02-18",
+    "period": "day",
+    "days": {
+        "summary": {
+            "data": [],
+            "total": {
+                "impressions": 0,
+                "views": 0,
+                "watch_time": 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add four new WordPress.com stats REST API endpoints for the Traffic tab:
- `/stats/clicks` - Track clicks on content
- `/stats/search-terms` - View search terms that drive traffic
- `/stats/video-plays` - Monitor video playback metrics
- `/stats/file-downloads` - Track file download statistics

These endpoints follow the same patterns as existing stats endpoints (top posts, referrers) with support for both summarized (aggregate) and daily breakdowns.

## Changes

- **Stats Clicks endpoint**: New type file with click entries supporting hierarchical grouping via children arrays, plus endpoint definition and 4 JSON test fixtures
- **Stats Search Terms endpoint**: New type file with search term entries, encrypted/other term counts, plus endpoint definition and 4 JSON test fixtures
- **Stats Video Plays endpoint**: New type file with unique response structure (data always in `days.summary`), video metrics (views, impressions, watch_time, retention_rate), plus endpoint definition and 4 JSON test fixtures
- **Stats File Downloads endpoint**: New type file with file download entries (filename, relative_url, download_url, downloads), plus endpoint definition and 4 JSON test fixtures
- Updated module declarations in `mod.rs` and `endpoint.rs` to export new types
- Updated `client.rs` to wire all 4 endpoints into the request builder and executor structs

## Test plan

- ✅ All 44 new unit tests pass (parameter serialization + JSON fixture deserialization)
- ✅ Cargo fmt check passes (no formatting issues)
- ✅ Cargo clippy passes (no clippy warnings in new code)
- Generated code compiles cleanly with uniffi bindings
- All 4 endpoints follow established patterns from existing stats endpoints (top posts, referrers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)