### PR TITLE
Default interceptors to empty list in Android constructors

### DIFF
--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpLoginClient.kt
@@ -24,7 +24,7 @@ class WpLoginClient @JvmOverloads constructor(
      */
     @JvmOverloads
     constructor(
-        interceptors: List<Interceptor>,
+        interceptors: List<Interceptor> = listOf(),
         middlewarePipeline: WpApiMiddlewarePipeline = WpApiMiddlewarePipeline(listOf()),
         dispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : this(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -48,7 +48,7 @@ class WpRequestExecutor @JvmOverloads constructor(
      */
     @JvmOverloads
     constructor(
-        interceptors: List<Interceptor>,
+        interceptors: List<Interceptor> = listOf(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         fileResolver: FileResolver = DefaultFileResolver(),
         uploadListener: UploadListener? = null


### PR DESCRIPTION
## Description

The `interceptors` parameter in the secondary constructors of `WpLoginClient` and `WpRequestExecutor` was the only parameter without a default value, requiring callers to always pass it explicitly even when no interceptors are needed.

## Changes

- Add `= listOf()` default value for `interceptors` in `WpLoginClient` secondary constructor
- Add `= listOf()` default value for `interceptors` in `WpRequestExecutor` secondary constructor

## Test plan

- Verify existing callers that pass interceptors explicitly still compile and work
- Verify callers can now omit the `interceptors` parameter