### PR TITLE
Fix a crash after using a higher versioned database

### DIFF
--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -465,6 +465,12 @@ impl<'a> MigrationManager<'a> {
         }
 
         let next_migration_id = self.get_next_migration_index()?;
+        if next_migration_id > MIGRATION_QUERIES.len() {
+            return Err(rusqlite::Error::InvalidParameterName(format!(
+                "next migration index ({next_migration_id}) exceeds available migrations ({})",
+                MIGRATION_QUERIES.len()
+            )));
+        }
         for (index, migration) in MIGRATION_QUERIES[next_migration_id..].iter().enumerate() {
             for query in migration
                 .split(";")
@@ -723,6 +729,24 @@ mod tests {
             error_count, 0,
             "Race condition detected: {} tasks failed",
             error_count
+        );
+    }
+
+    #[test]
+    fn test_migration_returns_error_when_index_exceeds_available_migrations() {
+        let connection = Connection::open_in_memory().unwrap();
+        let mut migration_manager = MigrationManager::new(&connection).unwrap();
+
+        migration_manager.create_migrations_table().unwrap();
+
+        // Insert a migration ID beyond the number of available migrations
+        let beyond_max = MIGRATION_QUERIES.len() as i64 + 1;
+        migration_manager.insert_migration(beyond_max).unwrap();
+
+        let result = migration_manager.perform_migrations();
+        assert!(
+            result.is_err(),
+            "Expected error when migration index exceeds available migrations"
         );
     }
 }


### PR DESCRIPTION
## Description

The changes are for the purpose of helping with local development. During development, we may use a version of this library with a higher database schema version, then switch to an older version that uses a lower version of the database schema. The `MIGRATION_QUERIES[next_migration_id..]` would crash in that case, due to being out of bounds.
