### PR TITLE
Generate `var` properties in Swift structs

### DIFF
--- a/wp_api/uniffi.toml
+++ b/wp_api/uniffi.toml
@@ -20,6 +20,6 @@ from_custom = "Int64({}.timeIntervalSince1970)"
 ffi_module_name = "libwordpressFFI"
 ffi_module_filename = "wp_api_uniffi"
 generate_module_map = false
-generate_immutable_records = true
+generate_immutable_records = false
 experimental_sendable_value_types = true
 omit_localized_error_conformance = true


### PR DESCRIPTION
I have made and discarded this change a few times now. I think we'll need it this time. Use `PostUpdateParams` as an example (see [this code](https://github.com/wordpress-mobile/WordPress-iOS/blob/da15e6df83db7aacca8f90c8eb72a34adf324daf/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift#L610-L628)), I want to avoid manually copying properties to a new `PostUpdateParams` instance when we need to modify a few properties.