### PR TITLE
Add request URL and method to error types

### DIFF
--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/MockRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/MockRequestExecutor.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.delay
 import okio.FileNotFoundException
 import uniffi.wp_api.RequestContext
 import uniffi.wp_api.RequestExecutor
+import uniffi.wp_api.RequestMethod
 import uniffi.wp_api.WpMultipartFormRequest
 import uniffi.wp_api.WpNetworkHeaderMap
 import uniffi.wp_api.WpNetworkRequest
@@ -60,6 +61,7 @@ val WpNetworkResponse.Companion.empty: WpNetworkResponse
         200u,
         WpNetworkHeaderMap.empty,
         "",
+        RequestMethod.GET,
         WpNetworkHeaderMap.empty
     )
 
@@ -72,6 +74,7 @@ fun WpNetworkResponse.Companion.withApiRoot(url: String): WpNetworkResponse {
         200u,
         WpNetworkHeaderMap.fromMap(mapOf("Link" to "<$url>; rel=\"https://api.w.org/\"")),
         "",
+        RequestMethod.GET,
         WpNetworkHeaderMap.empty
     )
 }
@@ -88,6 +91,7 @@ fun WpNetworkResponse.Companion.jsonResponse(name: String): WpNetworkResponse {
         200u,
         WpNetworkHeaderMap.fromMap(mapOf("Content-Type" to "application/json")),
         "",
+        RequestMethod.GET,
         WpNetworkHeaderMap.empty
     )
 }
@@ -98,6 +102,7 @@ fun WpNetworkResponse.Companion.retryResponse(delay: ULong): WpNetworkResponse {
         429u,
         WpNetworkHeaderMap.fromMap(mapOf("Retry-After" to delay.toString())),
         "",
+        RequestMethod.GET,
         WpNetworkHeaderMap.empty
     )
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
@@ -6,12 +6,16 @@ fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequ
     when (apiException) {
         is WpApiException.InvalidHttpStatusCode -> WpRequestResult.InvalidHttpStatusCode<T>(
             statusCode = apiException.statusCode,
+            requestUrl = apiException.requestUrl,
+            requestMethod = apiException.requestMethod,
         )
 
         is WpApiException.RequestExecutionFailed -> WpRequestResult.RequestExecutionFailed<T>(
             statusCode = apiException.statusCode,
             redirects = apiException.redirects,
-            reason = apiException.reason
+            reason = apiException.reason,
+            requestUrl = apiException.requestUrl,
+            requestMethod = apiException.requestMethod,
         )
 
         is WpApiException.MediaFileNotFound -> WpRequestResult.MediaFileNotFound<T>(
@@ -21,6 +25,8 @@ fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequ
         is WpApiException.ResponseParsingException -> WpRequestResult.ResponseParsingError<T>(
             reason = apiException.reason,
             response = apiException.response,
+            requestUrl = apiException.requestUrl,
+            requestMethod = apiException.requestMethod,
         )
 
         is WpApiException.SiteUrlParsingException -> WpRequestResult.SiteUrlParsingError<T>(
@@ -30,6 +36,8 @@ fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequ
         is WpApiException.UnknownException -> WpRequestResult.UnknownError<T>(
             statusCode = apiException.statusCode,
             response = apiException.response,
+            requestUrl = apiException.requestUrl,
+            requestMethod = apiException.requestMethod,
         )
 
         is WpApiException.WpException -> WpRequestResult.WpError<T>(
@@ -37,5 +45,7 @@ fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequ
             errorMessage = apiException.errorMessage,
             statusCode = apiException.statusCode,
             response = apiException.response,
+            requestUrl = apiException.requestUrl,
+            requestMethod = apiException.requestMethod,
         )
     }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -76,7 +76,7 @@ class WpRequestExecutor @JvmOverloads constructor(
             addRequestHeaders(requestBuilder, request.headerMap())
             val urlRequest = requestBuilder.build()
 
-            executeRequestSafely(urlRequest, request.url(), request.headerMap())
+            executeRequestSafely(urlRequest, request.url(), request.method(), request.headerMap())
         }
 
     override suspend fun upload(request: WpMultipartFormRequest): WpNetworkResponse =
@@ -89,7 +89,13 @@ class WpRequestExecutor @JvmOverloads constructor(
             addRequestHeaders(requestBuilder, request.headerMap())
             val urlRequest = requestBuilder.build()
 
-            executeRequestSafely(urlRequest, request.url(), request.headerMap(), notifyUploadListener = true)
+            executeRequestSafely(
+                urlRequest,
+                request.url(),
+                request.method(),
+                request.headerMap(),
+                notifyUploadListener = true
+            )
         }
 
     private fun buildMultipartBody(request: WpMultipartFormRequest): MultipartBody {
@@ -157,6 +163,7 @@ class WpRequestExecutor @JvmOverloads constructor(
     private fun executeRequestSafely(
         urlRequest: Request,
         requestUrl: String,
+        requestMethod: RequestMethod,
         requestHeaderMap: WpNetworkHeaderMap,
         notifyUploadListener: Boolean = false
     ): WpNetworkResponse {
@@ -174,30 +181,49 @@ class WpRequestExecutor @JvmOverloads constructor(
                     statusCode = response.code.toUShort(),
                     responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
                     requestUrl = requestUrl,
+                    requestMethod = requestMethod,
                     requestHeaderMap = requestHeaderMap
                 )
             }
         } catch (e: SSLPeerUnverifiedException) {
             throw requestExecutionFailedWith(
-                RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url)
+                RequestExecutionErrorReason.invalidSSLError(e, urlRequest.url),
+                requestUrl,
+                requestMethod,
             )
         } catch (e: UnknownHostException) {
-            throw requestExecutionFailedWith(RequestExecutionErrorReason.unknownHost(e))
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.unknownHost(e),
+                requestUrl,
+                requestMethod,
+            )
         } catch (e: NoRouteToHostException) {
-            throw requestExecutionFailedWith(RequestExecutionErrorReason.noRouteToHost(e))
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.noRouteToHost(e),
+                requestUrl,
+                requestMethod,
+            )
         } catch (e: ConnectException) {
             throw requestExecutionFailedWith(
                 RequestExecutionErrorReason.HttpError(
                     reason = "Connection failed: ${e.localizedMessage}"
-                )
+                ),
+                requestUrl,
+                requestMethod,
             )
         } catch (e: SocketTimeoutException) {
-            throw requestExecutionFailedWith(RequestExecutionErrorReason.HttpTimeoutError)
+            throw requestExecutionFailedWith(
+                RequestExecutionErrorReason.HttpTimeoutError,
+                requestUrl,
+                requestMethod,
+            )
         } catch (e: Exception) {
             throw requestExecutionFailedWith(
                 RequestExecutionErrorReason.GenericError(
                     errorMessage = e.localizedMessage ?: e.toString()
-                )
+                ),
+                requestUrl,
+                requestMethod,
             )
         }
     }
@@ -309,9 +335,15 @@ private fun RequestExecutionErrorReason.Companion.invalidSSLError(
     }
 }
 
-private fun requestExecutionFailedWith(reason: RequestExecutionErrorReason) =
+private fun requestExecutionFailedWith(
+    reason: RequestExecutionErrorReason,
+    requestUrl: String,
+    requestMethod: RequestMethod,
+) =
     RequestExecutionException.RequestExecutionFailed(
         statusCode = null,
         redirects = null,
-        reason = reason
+        reason = reason,
+        requestUrl = requestUrl,
+        requestMethod = requestMethod,
     )

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -1,6 +1,7 @@
 package rs.wordpress.api.kotlin
 
 import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.RequestMethod
 import uniffi.wp_api.WpErrorCode
 import uniffi.wp_api.WpRedirect
 
@@ -11,16 +12,22 @@ sealed class WpRequestResult<T> {
         val errorMessage: String,
         val statusCode: UShort,
         val response: String,
+        val requestUrl: String,
+        val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class InvalidHttpStatusCode<T>(
-        val statusCode: UShort
+        val statusCode: UShort,
+        val requestUrl: String,
+        val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class RequestExecutionFailed<T>(
         val statusCode: UShort?,
         val redirects: List<WpRedirect>?,
         val reason: RequestExecutionErrorReason,
+        val requestUrl: String,
+        val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class MediaFileNotFound<T>(
@@ -34,11 +41,15 @@ sealed class WpRequestResult<T> {
     data class ResponseParsingError<T>(
         val reason: String,
         val response: String,
+        val requestUrl: String,
+        val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class UnknownError<T>(
         val statusCode: UShort,
         val response: String,
+        val requestUrl: String,
+        val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     fun successfulResponse(): T? =

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -22,6 +22,7 @@ extension WpNetworkResponse {
             statusCode: UInt16(response.statusCode),
             responseHeaderMap: try WpNetworkHeaderMap.fromMap(hashMap: response.httpHeaders),
             requestUrl: request.url(),
+            requestMethod: request.method(),
             requestHeaderMap: request.headerMap()
         )
     }
@@ -35,7 +36,10 @@ extension MiddlewarePipeline {
 
 extension WpApiError {
     public var isCancellationError: Bool {
-        if case .RequestExecutionFailed(statusCode: _, redirects: _, reason: .cancellationError) = self {
+        if case .RequestExecutionFailed(
+            statusCode: _, redirects: _, reason: .cancellationError,
+            requestUrl: _, requestMethod: _
+        ) = self {
             return true
         }
         return false

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -99,21 +99,25 @@ public final class WpRequestExecutor: SafeRequestExecutor {
             }
 
             if errorIsDeviceIsOffline(error) {
-                return handleDeviceIsOfflineError(error)
+                return handleDeviceIsOfflineError(error, for: request)
             }
 
             if let urlError = error as? URLError, urlError.code == .cancelled {
                 return .failure(.RequestExecutionFailed(
                     statusCode: nil,
                     redirects: nil,
-                    reason: .cancellationError
+                    reason: .cancellationError,
+                    requestUrl: request.url(),
+                    requestMethod: request.method()
                 ))
             }
 
             return .failure(.RequestExecutionFailed(
                 statusCode: nil,
                 redirects: nil,
-                reason: .genericError(errorMessage: error.localizedDescription)
+                reason: .genericError(errorMessage: error.localizedDescription),
+                requestUrl: request.url(),
+                requestMethod: request.method()
             ))
        }
     }
@@ -172,7 +176,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
             return .failure(.RequestExecutionFailed(
                  statusCode: nil,
                  redirects: executorDelegate.redirects(for: request.requestId()),
-                 reason: .invalidSslError(reason: InvalidSslErrorReason.genericSslError)
+                 reason: .invalidSslError(reason: InvalidSslErrorReason.genericSslError),
+                 requestUrl: request.url(),
+                 requestMethod: request.method()
             ))
         }
 
@@ -186,7 +192,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                     hostname: URL(string: request.url())?.host ?? "unknown host",
                     presentedHostnames: [siteCertificate.commonName()]
                 )
-             )
+             ),
+             requestUrl: request.url(),
+             requestMethod: request.method()
          ))
     }
 
@@ -201,7 +209,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 reason: .nonExistentSiteError(
                     errorMessage: error.localizedDescription,
                     suggestedAction: (error as NSError).localizedRecoverySuggestion
-                )
+                ),
+                requestUrl: request.url(),
+                requestMethod: request.method()
             )
         )
     }
@@ -242,7 +252,8 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     private func handleDeviceIsOfflineError(
-        _ error: Error
+        _ error: Error,
+        for request: NetworkRequestContent
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
         .failure(
             .RequestExecutionFailed(
@@ -250,7 +261,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 redirects: nil,
                 reason: .deviceIsOfflineError(
                     errorMessage: error.localizedDescription
-                )
+                ),
+                requestUrl: request.url(),
+                requestMethod: request.method()
             )
         )
     }

--- a/native/swift/Tests/integration-tests/CancellationTests.swift
+++ b/native/swift/Tests/integration-tests/CancellationTests.swift
@@ -16,9 +16,7 @@ struct CancellationTests {
         let content = try String(data: Data(contentsOf: file).base64EncodedData(), encoding: .utf8)!
 
         let title = UUID().uuidString
-        await #expect(
-            throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError),
-            performing: {
+        let error = await #expect(throws: WpApiError.self, performing: {
                 let task = Task {
                     let params = PostCreateParams(
                         title: title,
@@ -35,6 +33,7 @@ struct CancellationTests {
                 try await task.value
             }
         )
+        #expect(error?.isCancellationError == true)
 
         try await restoreTestServer()
     }

--- a/native/swift/Tests/integration-tests/MediaTests.swift
+++ b/native/swift/Tests/integration-tests/MediaTests.swift
@@ -57,9 +57,7 @@ struct MediaTests {
         #expect(progress.fractionCompleted == 0)
 
         let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
-        await #expect(
-            throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError),
-            performing: {
+        let error = await #expect(throws: WpApiError.self, performing: {
                 let task = Task {
                     _ = try await api.uploadMedia(
                         params: .init(filePath: file.path),
@@ -76,6 +74,7 @@ struct MediaTests {
                 try await task.value
             }
         )
+        #expect(error?.isCancellationError == true)
 
         try await restoreTestServer()
     }
@@ -85,9 +84,7 @@ struct MediaTests {
         let progress = Progress.discreteProgress(totalUnitCount: 100)
         #expect(progress.fractionCompleted == 0)
         let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))
-        await #expect(
-            throws: WpApiError.RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .cancellationError),
-            performing: {
+        let error = await #expect(throws: WpApiError.self, performing: {
                 let task = Task {
                     _ = try await api.uploadMedia(
                         params: .init(filePath: file.path),
@@ -104,6 +101,7 @@ struct MediaTests {
                 try await task.value
             }
         )
+        #expect(error?.isCancellationError == true)
 
         try await restoreTestServer()
     }

--- a/native/swift/Tests/wordpress-api/LoginTests.swift
+++ b/native/swift/Tests/wordpress-api/LoginTests.swift
@@ -359,7 +359,7 @@ class LoginTests {
 
         if let failure = try getFindApiRootFailure(from: error) {
             if case .fetchHomepage(let transportError) = failure {
-                if case .RequestExecutionFailed(_, _, let reason) = transportError {
+                if case .RequestExecutionFailed(_, _, let reason, _, _) = transportError {
                     return reason
                 }
             }
@@ -367,7 +367,7 @@ class LoginTests {
 
         if let failure = try getFetchAndParseApiRootFailure(from: error) {
             if case .fetchApiRoot(let transportError) = failure {
-                if case .RequestExecutionFailed(_, _, let reason) = transportError {
+                if case .RequestExecutionFailed(_, _, let reason, _, _) = transportError {
                     return reason
                 }
             }

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -38,12 +38,24 @@ final class HTTPStubs: SafeRequestExecutor {
         case .failure:
             // TODO: Translate error into the Rust type
             return .failure(
-                .RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .genericError(errorMessage: ""))
+                .RequestExecutionFailed(
+                    statusCode: nil,
+                    redirects: nil,
+                    reason: .genericError(errorMessage: ""),
+                    requestUrl: request.url(),
+                    requestMethod: request.method()
+                )
             )
         default:
             // TODO: Translate error into the Rust type
             return .failure(
-                .RequestExecutionFailed(statusCode: nil, redirects: nil, reason: .genericError(errorMessage: ""))
+                .RequestExecutionFailed(
+                    statusCode: nil,
+                    redirects: nil,
+                    reason: .genericError(errorMessage: ""),
+                    requestUrl: request.url(),
+                    requestMethod: request.method()
+                )
             )
         }
     }
@@ -102,6 +114,7 @@ extension WpNetworkResponse {
             statusCode: 200,
             responseHeaderMap: try WpNetworkHeaderMap.fromMap(hashMap: ["Content-Type": "application/json"]),
             requestUrl: "https://example.com",
+            requestMethod: .get,
             requestHeaderMap: .empty
         )
     }
@@ -120,6 +133,7 @@ extension WpNetworkResponse {
             statusCode: statusCode,
             responseHeaderMap: try WpNetworkHeaderMap.fromMap(hashMap: ["Content-Type": "application/json"]),
             requestUrl: "https://example.com",
+            requestMethod: .get,
             requestHeaderMap: .empty
         )
     }
@@ -130,6 +144,7 @@ extension WpNetworkResponse {
             statusCode: 429,
             responseHeaderMap: try WpNetworkHeaderMap.fromMap(hashMap: ["Retry-After": String(Int(after))]),
             requestUrl: "https://example.com",
+            requestMethod: .get,
             requestHeaderMap: .empty
         )
     }
@@ -142,6 +157,7 @@ extension WpNetworkResponse {
                 "Link": "<\(url)>; rel=\"https://api.w.org/\""
             ]),
             requestUrl: url,
+            requestMethod: .get,
             requestHeaderMap: .empty
         )
     }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -1,5 +1,7 @@
 use crate::request::WpRedirect;
-use crate::request::{HttpAuthMethod, HttpAuthMethodParsingError, WpNetworkResponse};
+use crate::request::{
+    HttpAuthMethod, HttpAuthMethodParsingError, RequestMethod, WpNetworkResponse,
+};
 use serde::Deserialize;
 use wp_localization::{MessageBundle, WpMessages, WpSupportsLocalization};
 use wp_localization_macro::WpDeriveLocalizable;
@@ -9,7 +11,12 @@ where
     Self: Sized,
 {
     fn try_parse(response: &WpNetworkResponse) -> Option<Self>;
-    fn as_parse_error(reason: String, response: String) -> Self;
+    fn as_parse_error(
+        reason: String,
+        response: String,
+        request_url: String,
+        request_method: RequestMethod,
+    ) -> Self;
 }
 
 pub trait MaybeWpError {
@@ -22,11 +29,15 @@ pub trait MaybeWpError {
 pub enum WpApiError {
     InvalidHttpStatusCode {
         status_code: u16,
+        request_url: String,
+        request_method: RequestMethod,
     },
     RequestExecutionFailed {
         status_code: Option<u16>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
+        request_url: String,
+        request_method: RequestMethod,
     },
     MediaFileNotFound {
         file_path: String,
@@ -34,6 +45,8 @@ pub enum WpApiError {
     ResponseParsingError {
         reason: String,
         response: String,
+        request_url: String,
+        request_method: RequestMethod,
     },
     SiteUrlParsingError {
         reason: String,
@@ -41,12 +54,16 @@ pub enum WpApiError {
     UnknownError {
         status_code: u16,
         response: String,
+        request_url: String,
+        request_method: RequestMethod,
     },
     WpError {
         error_code: WpErrorCode,
         error_message: String,
         status_code: u16,
         response: String,
+        request_url: String,
+        request_method: RequestMethod,
     },
 }
 
@@ -83,7 +100,7 @@ where
 impl WpSupportsLocalization for WpApiError {
     fn message_bundle(&self) -> MessageBundle<'_> {
         match self {
-            WpApiError::InvalidHttpStatusCode { status_code } => {
+            WpApiError::InvalidHttpStatusCode { status_code, .. } => {
                 WpMessages::invalid_http_status_code(status_code)
             }
             WpApiError::RequestExecutionFailed { reason, .. } => reason.message_bundle(),
@@ -104,12 +121,16 @@ impl WpSupportsLocalization for WpApiError {
 
 impl ParsedRequestError for WpApiError {
     fn try_parse(response: &WpNetworkResponse) -> Option<Self> {
+        let request_url = response.request_url.0.clone();
+        let request_method = response.request_method.clone();
         if let Some(wp_error) = WpError::try_parse(&response.body) {
             Some(Self::WpError {
                 error_code: wp_error.code,
                 error_message: wp_error.message,
                 status_code: response.status_code,
                 response: response.body_as_string(),
+                request_url,
+                request_method,
             })
         } else {
             if let Some(reason) = RequestExecutionErrorReason::try_from_response(response) {
@@ -117,6 +138,8 @@ impl ParsedRequestError for WpApiError {
                     status_code: Some(response.status_code),
                     redirects: None,
                     reason,
+                    request_url,
+                    request_method,
                 });
             }
 
@@ -126,6 +149,8 @@ impl ParsedRequestError for WpApiError {
                         Some(Self::UnknownError {
                             status_code: response.status_code,
                             response: response.body_as_string(),
+                            request_url,
+                            request_method,
                         })
                     } else {
                         None
@@ -133,13 +158,25 @@ impl ParsedRequestError for WpApiError {
                 }
                 Err(_) => Some(WpApiError::InvalidHttpStatusCode {
                     status_code: response.status_code,
+                    request_url,
+                    request_method,
                 }),
             }
         }
     }
 
-    fn as_parse_error(reason: String, response: String) -> Self {
-        Self::ResponseParsingError { reason, response }
+    fn as_parse_error(
+        reason: String,
+        response: String,
+        request_url: String,
+        request_method: RequestMethod,
+    ) -> Self {
+        Self::ResponseParsingError {
+            reason,
+            response,
+            request_url,
+            request_method,
+        }
     }
 }
 
@@ -539,6 +576,8 @@ pub enum RequestExecutionError {
         status_code: Option<u16>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
+        request_url: String,
+        request_method: RequestMethod,
     },
     MediaFileNotFound {
         file_path: String,
@@ -708,26 +747,18 @@ impl From<RequestExecutionError> for WpApiError {
                 status_code,
                 redirects,
                 reason,
+                request_url,
+                request_method,
             } => Self::RequestExecutionFailed {
                 status_code,
                 redirects,
                 reason,
+                request_url,
+                request_method,
             },
             RequestExecutionError::MediaFileNotFound { file_path } => {
                 Self::MediaFileNotFound { file_path }
             }
-        }
-    }
-}
-
-impl From<HttpAuthMethodParsingError> for WpApiError {
-    fn from(value: HttpAuthMethodParsingError) -> Self {
-        WpApiError::RequestExecutionFailed {
-            status_code: None,
-            redirects: None,
-            reason: RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError {
-                issue: value,
-            },
         }
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -1154,6 +1154,5 @@ mod tests {
                 site_icon_url: None,
             }
         }
-
     }
 }

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -342,6 +342,10 @@ impl ParseHomepageResult {
     }
 }
 
+// RequestExecutionError (216 bytes) is much larger than the other variants, but this enum is only
+// created on login failure and never in hot paths or large collections. Kept consistent with
+// FindApiRootFailure and XmlrpcDiscoveryError which can't use indirection due to UniFFI.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum FetchWpJsonFailure {
     ParseSiteUrl {
@@ -429,6 +433,10 @@ impl WpSupportsLocalization for AutoDiscoveryAttemptFailure {
     }
 }
 
+// RequestExecutionError (216 bytes) is much larger than the unit variants, but this enum is only
+// created on login failure and never in hot paths or large collections. UniFFI doesn't support
+// Box or Arc for non-Object types, so indirection isn't possible here.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, uniffi::Enum)]
 pub enum FindApiRootFailure {
     FetchHomepage { error: RequestExecutionError },
@@ -698,6 +706,10 @@ impl WpSupportsLocalization for FetchApiDetailsError {
     }
 }
 
+// RequestExecutionError (216 bytes) is much larger than the other variants, but this enum is only
+// created during XMLRPC discovery failures and never in hot paths. UniFFI doesn't support Box or
+// Arc for non-Object types, so indirection isn't possible here.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]
 pub enum XmlrpcDiscoveryError {
     FetchHomepage { error: RequestExecutionError },
@@ -804,6 +816,7 @@ impl ParseApiRootFailureReason {
 mod tests {
     use super::AutoDiscoveryAttempt as A;
     use super::*;
+    use crate::request::RequestMethod;
     use rstest::*;
 
     #[rstest]
@@ -1122,6 +1135,8 @@ mod tests {
                 status_code: None,
                 redirects: None,
                 reason: RequestExecutionErrorReason::MisconfiguredRateLimitError,
+                request_url: "https://example.com".to_string(),
+                request_method: RequestMethod::GET,
             }
         }
 
@@ -1139,5 +1154,6 @@ mod tests {
                 site_icon_url: None,
             }
         }
+
     }
 }

--- a/wp_api/src/middleware.rs
+++ b/wp_api/src/middleware.rs
@@ -119,6 +119,8 @@ pub trait PerformsRequests {
                 status_code: Some(response.status_code),
                 redirects: None,
                 reason,
+                request_url: response.request_url.0.clone(),
+                request_method: response.request_method.clone(),
             });
         }
 
@@ -141,6 +143,8 @@ pub trait PerformsRequests {
                 status_code: Some(response.status_code),
                 redirects: None,
                 reason,
+                request_url: response.request_url.0.clone(),
+                request_method: response.request_method.clone(),
             });
         }
 
@@ -202,6 +206,8 @@ impl WpApiMiddleware for RetryAfterMiddleware {
                 status_code: Some(response.status_code),
                 redirects: None,
                 reason: RequestExecutionErrorReason::MisconfiguredRateLimitError {},
+                request_url: response.request_url.0.clone(),
+                request_method: response.request_method.clone(),
             });
         }
         if let Some(retry_after) = response.get_retry_after() {
@@ -281,7 +287,7 @@ mod tests {
     use super::*;
 
     mod api_discovery_authentication_middleware {
-        use crate::request::{WpNetworkHeaderMap, endpoint::WpEndpointUrl};
+        use crate::request::{RequestMethod, WpNetworkHeaderMap, endpoint::WpEndpointUrl};
 
         use super::*;
         use async_trait::async_trait;
@@ -364,6 +370,7 @@ mod tests {
                         status_code: 204,
                         response_header_map: Arc::new(WpNetworkHeaderMap::default()),
                         request_url: WpEndpointUrl("http://example.com".to_string()),
+                        request_method: RequestMethod::GET,
                         request_header_map: Arc::new(WpNetworkHeaderMap::default()),
                     })
                 },
@@ -397,6 +404,7 @@ mod tests {
                         status_code: initial_response_status_code,
                         response_header_map: Arc::new(WpNetworkHeaderMap::default()),
                         request_url: WpEndpointUrl("http://example.com".to_string()),
+                        request_method: RequestMethod::GET,
                         request_header_map: Arc::new(map.into()),
                     },
                     WpNetworkRequest::get(WpEndpointUrl("unused".to_string())).into(),
@@ -408,7 +416,9 @@ mod tests {
 
     mod retry_after_middleware {
         use super::*;
-        use crate::request::{WpNetworkHeaderMap, endpoint::WpEndpointUrl};
+        use crate::request::{
+            NetworkRequestAccessor, RequestMethod, WpNetworkHeaderMap, endpoint::WpEndpointUrl,
+        };
         use async_trait::async_trait;
         use http::HeaderMap;
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -423,7 +433,7 @@ mod tests {
         impl RequestExecutor for FooExecutor {
             async fn execute(
                 &self,
-                _: Arc<WpNetworkRequest>,
+                request: Arc<WpNetworkRequest>,
             ) -> Result<WpNetworkResponse, RequestExecutionError> {
                 if self.first_request.load(Ordering::Relaxed) {
                     println!("First mock request; returning 429..");
@@ -435,7 +445,8 @@ mod tests {
                         body: vec![],
                         status_code: 200,
                         response_header_map: WpNetworkHeaderMap::default().into(),
-                        request_url: WpEndpointUrl("http://example.com".to_string()),
+                        request_url: request.url(),
+                        request_method: request.method(),
                         request_header_map: Arc::new(WpNetworkHeaderMap::default()),
                     })
                 }
@@ -443,7 +454,7 @@ mod tests {
 
             async fn upload(
                 &self,
-                _request: Arc<WpMultipartFormRequest>,
+                request: Arc<WpMultipartFormRequest>,
             ) -> Result<WpNetworkResponse, RequestExecutionError> {
                 Err(RequestExecutionError::RequestExecutionFailed {
                     status_code: None,
@@ -451,6 +462,8 @@ mod tests {
                     reason: RequestExecutionErrorReason::GenericError {
                         error_message: "upload_media is not used".to_string(),
                     },
+                    request_url: request.url().0,
+                    request_method: request.method(),
                 })
             }
 
@@ -477,6 +490,7 @@ mod tests {
                     status_code: Some(429),
                     redirects: None,
                     reason: RequestExecutionErrorReason::MisconfiguredRateLimitError,
+                    ..
                 })
             ));
         }
@@ -509,6 +523,7 @@ mod tests {
                 status_code: 429,
                 response_header_map: Arc::new(map.into()),
                 request_url: WpEndpointUrl("http://example.com".to_string()),
+                request_method: RequestMethod::GET,
                 request_header_map: Arc::new(WpNetworkHeaderMap::default()),
             }
         }

--- a/wp_api/src/prelude.rs
+++ b/wp_api/src/prelude.rs
@@ -12,8 +12,8 @@ pub use crate::{
     middleware::WpApiMiddlewarePipeline,
     parsed_url::{ParseUrlError, ParsedUrl},
     request::{
-        NetworkRequestAccessor, RequestExecutor, WpNetworkHeaderMap, WpNetworkRequest,
-        WpNetworkResponse,
+        NetworkRequestAccessor, RequestExecutor, RequestMethod, WpNetworkHeaderMap,
+        WpNetworkRequest, WpNetworkResponse,
         endpoint::{ApiUrlResolver, WpOrgSiteApiUrlResolver},
     },
     uuid::{WpUuid, WpUuidParseError},

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -1,9 +1,6 @@
 use self::endpoint::WpEndpointUrl;
 use crate::{
-    api_error::{
-        ParsedRequestError, RequestExecutionError, RequestExecutionErrorReason, WpApiError,
-        WpErrorCode,
-    },
+    api_error::{ParsedRequestError, RequestExecutionError, WpApiError, WpErrorCode},
     auth::WpAuthenticationProvider,
     url_query::{FromUrlQueryPairs, UrlQueryPairsMap},
 };
@@ -468,6 +465,7 @@ pub struct WpNetworkResponse {
     pub status_code: u16,
     pub response_header_map: Arc<WpNetworkHeaderMap>,
     pub request_url: WpEndpointUrl,
+    pub request_method: RequestMethod,
     pub request_header_map: Arc<WpNetworkHeaderMap>,
 }
 
@@ -652,8 +650,17 @@ impl WpNetworkResponse {
             return Err(err);
         }
 
+        let parse_error_url = self.request_url.0.clone();
+        let parse_error_method = self.request_method.clone();
         serde_json::from_slice(&self.body)
-            .map_err(|err| E::as_parse_error(err.to_string(), self.body_as_string()))
+            .map_err(|err| {
+                E::as_parse_error(
+                    err.to_string(),
+                    self.body_as_string(),
+                    parse_error_url,
+                    parse_error_method,
+                )
+            })
             .map(|x| {
                 let mut parsed_response = ParsedResponse::<DataType, ParamsType>::from(x);
                 if ParamsType::supports_pagination() {
@@ -739,7 +746,7 @@ struct HttpRetryDuration {
 /// Parser based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
 ///
 impl FromStr for HttpRetryDuration {
-    type Err = WpApiError;
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Handle the simple case where the header is a number of seconds
@@ -748,12 +755,7 @@ impl FromStr for HttpRetryDuration {
         }
 
         // Handle the case where the header is a date string
-        let parsed =
-            DateTime::parse_from_rfc2822(s).map_err(|_| WpApiError::RequestExecutionFailed {
-                status_code: None,
-                redirects: None,
-                reason: RequestExecutionErrorReason::MisconfiguredRateLimitError {},
-            })?;
+        let parsed = DateTime::parse_from_rfc2822(s).map_err(|_| ())?;
 
         let now = Utc::now();
         let duration = parsed.signed_duration_since(now);
@@ -1212,6 +1214,7 @@ mod tests {
                     .unwrap(),
             ),
             request_url: WpEndpointUrl("http://example.com".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: Arc::new(WpNetworkHeaderMap::default()),
         };
         assert_eq!(
@@ -1340,6 +1343,7 @@ mod tests {
             status_code: 401,
             response_header_map: Arc::new(header_map),
             request_url: WpEndpointUrl("http://example.com".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: Arc::new(WpNetworkHeaderMap::default()),
         };
 
@@ -1361,6 +1365,7 @@ mod tests {
             status_code: 429,
             response_header_map: Arc::new(header_map),
             request_url: WpEndpointUrl("http://example.com".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: Arc::new(WpNetworkHeaderMap::default()),
         };
 

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -90,6 +90,7 @@ impl ReqwestRequestExecutor {
             body: body.to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(response_header_map)),
             request_url: wp_request.url(),
+            request_method: wp_request.method(),
             request_header_map: wp_request.header_map(),
         })
     }
@@ -111,7 +112,11 @@ impl RequestExecutor for ReqwestRequestExecutor {
         &self,
         request: Arc<WpNetworkRequest>,
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
-        self.async_request(request).await.map_err(|e| e.into())
+        let url = request.url().0.clone();
+        let method = request.method();
+        self.async_request(request)
+            .await
+            .map_err(|e| request_execution_error_from_reqwest(e, url, method))
     }
 
     async fn upload(
@@ -150,8 +155,13 @@ impl RequestExecutor for ReqwestRequestExecutor {
             }
         }
 
+        let url = upload_request.url().0.clone();
+        let method = upload_request.method();
         let request = request.multipart(form);
-        let mut response = request.send().await?;
+        let mut response = request
+            .send()
+            .await
+            .map_err(|e| request_execution_error_from_reqwest(e, url, method))?;
 
         let header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
@@ -159,6 +169,7 @@ impl RequestExecutor for ReqwestRequestExecutor {
             body: response.bytes().await.unwrap().to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
             request_url: upload_request.url(),
+            request_method: upload_request.method(),
             request_header_map: upload_request.header_map(),
         })
     }
@@ -172,83 +183,46 @@ impl RequestExecutor for ReqwestRequestExecutor {
     }
 }
 
-impl From<reqwest::Error> for RequestExecutionError {
-    fn from(error: reqwest::Error) -> Self {
-        let status_code = error.status().map(|s| s.as_u16());
-        if error.is_timeout() {
-            return RequestExecutionError::RequestExecutionFailed {
-                status_code,
-                redirects: None,
-                reason: RequestExecutionErrorReason::HttpTimeoutError,
-            };
-        }
-
-        if let Some(tls_error) = error.as_tls_error() {
-            return RequestExecutionError::RequestExecutionFailed {
-                status_code,
-                redirects: None,
-                reason: tls_error.into(),
-            };
-        }
-
-        if let Some(io_error) = error.as_io_error() {
-            match io_error.kind() {
-                std::io::ErrorKind::UnexpectedEof => {
-                    // Server terminated the connection unexpectedly
-                    return RequestExecutionError::RequestExecutionFailed {
-                        status_code,
-                        redirects: None,
-                        reason: RequestExecutionErrorReason::HttpError {
-                            reason: "The server terminated the connection unexpectedly".to_string(),
-                        },
-                    };
-                }
-                _ => {
-                    return RequestExecutionError::RequestExecutionFailed {
-                        status_code,
-                        redirects: None,
-                        reason: RequestExecutionErrorReason::HttpError {
-                            reason: io_error.to_string(),
-                        },
-                    };
-                }
-            }
-        }
-
-        if let Some(hyper_error) = error.as_hyper_error() {
-            return RequestExecutionError::RequestExecutionFailed {
-                status_code,
-                redirects: None,
-                reason: hyper_error.into(),
-            };
-        }
-
-        if let Some(dns_error) = error.as_dns_error() {
-            return RequestExecutionError::RequestExecutionFailed {
-                status_code,
-                redirects: None,
-                reason: dns_error.into(),
-            };
-        }
-
-        if error.is_connect() {
-            return RequestExecutionError::RequestExecutionFailed {
-                status_code,
-                redirects: None,
-                reason: RequestExecutionErrorReason::NonExistentSiteError {
-                    error_message: Some(error.to_string()),
-                    suggested_action: None,
-                },
-            };
-        }
-
-        RequestExecutionError::RequestExecutionFailed {
-            status_code,
-            redirects: None,
-            reason: RequestExecutionErrorReason::GenericError {
-                error_message: error.to_string(),
+fn request_execution_error_from_reqwest(
+    error: reqwest::Error,
+    request_url: String,
+    request_method: RequestMethod,
+) -> RequestExecutionError {
+    let status_code = error.status().map(|s| s.as_u16());
+    let reason = if error.is_timeout() {
+        RequestExecutionErrorReason::HttpTimeoutError
+    } else if let Some(tls_error) = error.as_tls_error() {
+        tls_error.into()
+    } else if let Some(io_error) = error.as_io_error() {
+        match io_error.kind() {
+            std::io::ErrorKind::UnexpectedEof => RequestExecutionErrorReason::HttpError {
+                reason: "The server terminated the connection unexpectedly".to_string(),
+            },
+            _ => RequestExecutionErrorReason::HttpError {
+                reason: io_error.to_string(),
             },
         }
+    } else if let Some(hyper_error) = error.as_hyper_error() {
+        hyper_error.into()
+    } else if let Some(dns_error) = error.as_dns_error() {
+        dns_error.into()
+    } else if error.is_connect() {
+        RequestExecutionErrorReason::NonExistentSiteError {
+            error_message: Some(error.to_string()),
+            suggested_action: None,
+        }
+    } else {
+        RequestExecutionErrorReason::GenericError {
+            error_message: error.to_string(),
+        }
+    };
+
+    RequestExecutionError::RequestExecutionFailed {
+        status_code,
+        redirects: None,
+        reason,
+        request_url,
+        request_method,
     }
 }
 

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -1,6 +1,6 @@
 use crate::{
     date::WpGmtDateTime,
-    request::{WpNetworkHeaderMap, WpNetworkResponse, endpoint::WpEndpointUrl},
+    request::{RequestMethod, WpNetworkHeaderMap, WpNetworkResponse, endpoint::WpEndpointUrl},
     url_query::{AppendUrlQueryPairs, FromUrlQueryPairs, UrlQueryPairsMap},
 };
 use std::sync::Arc;
@@ -49,6 +49,7 @@ pub fn wp_network_response_from_json(json: &str, status_code: u16) -> WpNetworkR
         status_code,
         response_header_map: Arc::new(WpNetworkHeaderMap::default()),
         request_url: WpEndpointUrl("http://example.com".to_string()),
+        request_method: RequestMethod::GET,
         request_header_map: Arc::new(WpNetworkHeaderMap::default()),
     }
 }

--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -239,6 +239,7 @@ impl From<RequestExecutionError> for WordPressOrgApiClientError {
                 status_code,
                 redirects,
                 reason,
+                ..
             } => WordPressOrgApiClientError::RequestExecutionFailed {
                 status_code,
                 redirects,

--- a/wp_api_integration_tests/src/mock.rs
+++ b/wp_api_integration_tests/src/mock.rs
@@ -42,7 +42,9 @@ impl RequestExecutor for MockExecutor {
 pub mod response_helpers {
     use http::{HeaderMap, header::HeaderValue};
     use std::{fs, path::PathBuf, sync::Arc};
-    use wp_api::request::{WpNetworkHeaderMap, WpNetworkResponse, endpoint::WpEndpointUrl};
+    use wp_api::request::{
+        RequestMethod, WpNetworkHeaderMap, WpNetworkResponse, endpoint::WpEndpointUrl,
+    };
 
     pub fn with_api_root(url: &str) -> WpNetworkResponse {
         let mut map = HeaderMap::new();
@@ -56,6 +58,7 @@ pub mod response_helpers {
             status_code: 200,
             response_header_map: Arc::new(map.into()),
             request_url: WpEndpointUrl("".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: WpNetworkHeaderMap::default().into(),
         }
     }
@@ -82,6 +85,7 @@ pub mod response_helpers {
             status_code: 200,
             response_header_map: Arc::new(map.into()),
             request_url: WpEndpointUrl("".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: WpNetworkHeaderMap::default().into(),
         }
     }
@@ -98,6 +102,7 @@ pub mod response_helpers {
             status_code: 429,
             response_header_map: Arc::new(map.into()),
             request_url: WpEndpointUrl("".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: WpNetworkHeaderMap::default().into(),
         }
     }
@@ -108,6 +113,7 @@ pub mod response_helpers {
             status_code,
             response_header_map: WpNetworkHeaderMap::default().into(),
             request_url: WpEndpointUrl("".to_string()),
+            request_method: RequestMethod::GET,
             request_header_map: WpNetworkHeaderMap::default().into(),
         }
     }

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -194,7 +194,7 @@ impl MediaErrNetworking {
 impl RequestExecutor for MediaErrNetworking {
     async fn execute(
         &self,
-        _request: Arc<WpNetworkRequest>,
+        request: Arc<WpNetworkRequest>,
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
         Err(RequestExecutionError::RequestExecutionFailed {
             status_code: None,
@@ -202,6 +202,8 @@ impl RequestExecutor for MediaErrNetworking {
             reason: RequestExecutionErrorReason::GenericError {
                 error_message: "Execute function is not necessary for these tests".to_string(),
             },
+            request_url: request.url().0,
+            request_method: request.method(),
         })
     }
 
@@ -234,7 +236,19 @@ impl RequestExecutor for MediaErrNetworking {
         }
 
         let request = request.multipart(form);
-        let mut response = request.send().await?;
+        let mut response =
+            request
+                .send()
+                .await
+                .map_err(|e| RequestExecutionError::RequestExecutionFailed {
+                    status_code: e.status().map(|s| s.as_u16()),
+                    redirects: None,
+                    reason: RequestExecutionErrorReason::GenericError {
+                        error_message: e.to_string(),
+                    },
+                    request_url: upload_request.url().0.clone(),
+                    request_method: upload_request.method(),
+                })?;
 
         let header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
@@ -242,6 +256,7 @@ impl RequestExecutor for MediaErrNetworking {
             body: response.bytes().await.unwrap().to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
             request_url: upload_request.url(),
+            request_method: upload_request.method(),
             request_header_map: upload_request.header_map(),
         })
     }

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -1391,13 +1391,15 @@ mod tests {
 
     /// Helper to create a PostService with mock network error
     fn service_with_network_error() -> PostService {
-        let mock_executor = Arc::new(MockExecutor::with_execute_fn(|_| {
+        let mock_executor = Arc::new(MockExecutor::with_execute_fn(|request| {
             Err(RequestExecutionError::RequestExecutionFailed {
                 status_code: None,
                 redirects: None,
                 reason: RequestExecutionErrorReason::GenericError {
                     error_message: "Network timeout".to_string(),
                 },
+                request_url: request.url().0,
+                request_method: request.method(),
             })
         }));
 


### PR DESCRIPTION
## Summary

Error messages from the WordPress API are much more useful when they include which request failed. Previously, errors like `RequestExecutionFailed` or `InvalidHttpStatusCode` carried no information about the originating request, making it difficult to debug failures — especially when multiple requests are in flight.

- Add `request_url` and `request_method` fields to `WpApiError`, `RequestExecutionError`, and `WpNetworkResponse`
- `RequestMethod` is non-optional everywhere since errors always originate from a known HTTP request
- Propagate the new fields through the Kotlin bindings (`WpRequestResult`, `WpRequestExecutor`, `ApiClientHelpers`)
- Propagate the new fields through the Swift bindings (`SafeRequestExecutor`, `Extensions`, test helpers)
- Fix pre-existing Swift `LoginTests` compilation error by updating from removed `findLoginUrl(forSite:)` to current `details(ofSite:)` API

## Test plan
- [x] `cargo test --lib` passes (108 tests)
- [x] Android example app builds (`./gradlew :example:composeApp:assembleDebug`)
- [x] `swift build` succeeds
- [x] `swift build --build-tests` succeeds
- [ ] Integration tests pass against test server

🤖 Generated with [Claude Code](https://claude.com/claude-code)