### PR TITLE
Show error and empty states in Android example app

### DIFF
--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/applicationpasswords/ApplicationPasswordListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/applicationpasswords/ApplicationPasswordListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun ApplicationPasswordListScreen(
 ) {
     val applicationPasswords by viewModel.applicationPasswords.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun ApplicationPasswordListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (applicationPasswords.isEmpty()) {
+            EmptyState("No application passwords found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/applicationpasswords/ApplicationPasswordListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/applicationpasswords/ApplicationPasswordListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.ApplicationPasswordWithEditContext
 
 class ApplicationPasswordListViewModel(private val apiClient: WpApiClient) {
@@ -19,6 +20,9 @@ class ApplicationPasswordListViewModel(private val apiClient: WpApiClient) {
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     init {
         loadApplicationPasswords()
@@ -32,6 +36,7 @@ class ApplicationPasswordListViewModel(private val apiClient: WpApiClient) {
             val userId = when (meResult) {
                 is WpRequestResult.Success -> meResult.response.data.id
                 else -> {
+                    _error.value = meResult.errorDescription()
                     _isLoading.value = false
                     return@launch
                 }
@@ -42,7 +47,10 @@ class ApplicationPasswordListViewModel(private val apiClient: WpApiClient) {
             }
             when (result) {
                 is WpRequestResult.Success -> _applicationPasswords.value = result.response.data
-                else -> _applicationPasswords.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _applicationPasswords.value = emptyList()
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/comments/CommentListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/comments/CommentListScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -38,6 +40,7 @@ fun CommentListScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -68,6 +71,10 @@ fun CommentListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && comments.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (comments.isEmpty()) {
+            EmptyState("No comments found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -82,7 +89,11 @@ fun CommentListScreen(
                         overlineContent = { Text(comment.status.toString()) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/comments/CommentListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/comments/CommentListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.CommentListParams
 import uniffi.wp_api.CommentWithEditContext
 
@@ -17,6 +18,9 @@ class CommentListViewModel(private val apiClient: WpApiClient) {
 
     private val _comments = MutableStateFlow<List<CommentWithEditContext>>(emptyList())
     val comments: StateFlow<List<CommentWithEditContext>> = _comments.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -44,7 +48,10 @@ class CommentListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _comments.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _comments.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -64,7 +71,7 @@ class CommentListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/components/ErrorMessage.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/components/ErrorMessage.kt
@@ -1,0 +1,78 @@
+package rs.wordpress.example.shared.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.WpErrorCode
+
+fun <T> WpRequestResult<T>.errorDescription(): String = when (this) {
+    is WpRequestResult.Success -> ""
+    is WpRequestResult.WpError ->
+        "$errorMessage (${errorCode.displayName()})\n$requestMethod $requestUrl"
+    is WpRequestResult.RequestExecutionFailed ->
+        "${reason.description()}\n$requestMethod $requestUrl"
+    is WpRequestResult.InvalidHttpStatusCode ->
+        "Unexpected HTTP status: $statusCode\n$requestMethod $requestUrl"
+    is WpRequestResult.ResponseParsingError ->
+        "Failed to parse response: $reason\n$requestMethod $requestUrl"
+    is WpRequestResult.SiteUrlParsingError -> "Invalid site URL: $reason"
+    is WpRequestResult.MediaFileNotFound -> "File not found: $filePath"
+    is WpRequestResult.UnknownError ->
+        "Unknown error (HTTP $statusCode)\n$requestMethod $requestUrl"
+}
+
+private fun WpErrorCode.displayName(): String = when (this) {
+    is WpErrorCode.CustomException -> v1
+    else -> this::class.simpleName ?: "Unknown"
+}
+
+private fun RequestExecutionErrorReason.description(): String = when (this) {
+    is RequestExecutionErrorReason.DeviceIsOfflineError -> "Device is offline: $errorMessage"
+    is RequestExecutionErrorReason.HttpTimeoutError -> "Request timed out"
+    is RequestExecutionErrorReason.InvalidSslError -> "SSL error: $reason"
+    is RequestExecutionErrorReason.NonExistentSiteError -> errorMessage ?: "Site not found"
+    is RequestExecutionErrorReason.HttpAuthenticationRequiredError -> "Authentication required for $hostname"
+    is RequestExecutionErrorReason.HttpAuthenticationRejectedError -> "Authentication rejected for $hostname"
+    is RequestExecutionErrorReason.HttpForbiddenError -> "Access forbidden for $hostname"
+    is RequestExecutionErrorReason.MisconfiguredHttpAuthenticationError -> "HTTP authentication misconfigured: $issue"
+    is RequestExecutionErrorReason.MisconfiguredRateLimitError -> "Rate limit misconfigured"
+    is RequestExecutionErrorReason.CancellationError -> "Request cancelled"
+    is RequestExecutionErrorReason.HttpError -> "HTTP error: $reason"
+    is RequestExecutionErrorReason.GenericError -> errorMessage
+}
+
+@Composable
+fun ErrorMessage(message: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize().padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+@Composable
+fun EmptyState(message: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize().padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/media/MediaListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/media/MediaListScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -38,6 +40,7 @@ fun MediaListScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -68,6 +71,10 @@ fun MediaListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && media.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (media.isEmpty()) {
+            EmptyState("No media found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -80,7 +87,11 @@ fun MediaListScreen(
                         overlineContent = { Text(item.sourceUrl) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/media/MediaListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/media/MediaListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.MediaListParams
 import uniffi.wp_api.MediaWithEditContext
 
@@ -17,6 +18,9 @@ class MediaListViewModel(private val apiClient: WpApiClient) {
 
     private val _media = MutableStateFlow<List<MediaWithEditContext>>(emptyList())
     val media: StateFlow<List<MediaWithEditContext>> = _media.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -44,7 +48,10 @@ class MediaListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _media.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _media.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -64,7 +71,7 @@ class MediaListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/menulocations/MenuLocationListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/menulocations/MenuLocationListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun MenuLocationListScreen(
 ) {
     val menuLocations by viewModel.menuLocations.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun MenuLocationListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (menuLocations.isEmpty()) {
+            EmptyState("No menu locations found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/menulocations/MenuLocationListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/menulocations/MenuLocationListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.MenuLocationWithEditContext
 
 class MenuLocationListViewModel(private val apiClient: WpApiClient) {
@@ -19,6 +20,9 @@ class MenuLocationListViewModel(private val apiClient: WpApiClient) {
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     init {
         loadMenuLocations()
@@ -33,7 +37,10 @@ class MenuLocationListViewModel(private val apiClient: WpApiClient) {
                 is WpRequestResult.Success -> {
                     _menuLocations.value = result.response.data.locations.values.toList()
                 }
-                else -> _menuLocations.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _menuLocations.value = emptyList()
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navigations/NavigationListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navigations/NavigationListScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -38,6 +40,7 @@ fun NavigationListScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -68,6 +71,10 @@ fun NavigationListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && navigations.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (navigations.isEmpty()) {
+            EmptyState("No navigations found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -79,7 +86,11 @@ fun NavigationListScreen(
                         supportingContent = { Text(navigation.status.toString()) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navigations/NavigationListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navigations/NavigationListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.NavigationListParams
 import uniffi.wp_api.NavigationWithEditContext
 
@@ -17,6 +18,9 @@ class NavigationListViewModel(private val apiClient: WpApiClient) {
 
     private val _navigations = MutableStateFlow<List<NavigationWithEditContext>>(emptyList())
     val navigations: StateFlow<List<NavigationWithEditContext>> = _navigations.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -44,7 +48,10 @@ class NavigationListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _navigations.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _navigations.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -64,7 +71,7 @@ class NavigationListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenuitems/NavMenuItemListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenuitems/NavMenuItemListScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -38,6 +40,7 @@ fun NavMenuItemListScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -68,6 +71,10 @@ fun NavMenuItemListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && navMenuItems.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (navMenuItems.isEmpty()) {
+            EmptyState("No menu items found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -80,7 +87,11 @@ fun NavMenuItemListScreen(
                         overlineContent = { Text(navMenuItem.url) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenuitems/NavMenuItemListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenuitems/NavMenuItemListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.NavMenuItemListParams
 import uniffi.wp_api.NavMenuItemWithEditContext
 
@@ -17,6 +18,9 @@ class NavMenuItemListViewModel(private val apiClient: WpApiClient) {
 
     private val _navMenuItems = MutableStateFlow<List<NavMenuItemWithEditContext>>(emptyList())
     val navMenuItems: StateFlow<List<NavMenuItemWithEditContext>> = _navMenuItems.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -44,7 +48,10 @@ class NavMenuItemListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _navMenuItems.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _navMenuItems.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -64,7 +71,7 @@ class NavMenuItemListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenus/NavMenuListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenus/NavMenuListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun NavMenuListScreen(
 ) {
     val navMenus by viewModel.navMenus.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun NavMenuListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (navMenus.isEmpty()) {
+            EmptyState("No menus found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenus/NavMenuListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/navmenus/NavMenuListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.NavMenuListParams
 import uniffi.wp_api.NavMenuWithEditContext
 
@@ -21,6 +22,9 @@ class NavMenuListViewModel(private val apiClient: WpApiClient) {
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         loadNavMenus()
     }
@@ -32,7 +36,10 @@ class NavMenuListViewModel(private val apiClient: WpApiClient) {
             }
             when (result) {
                 is WpRequestResult.Success -> _navMenus.value = result.response.data
-                else -> _navMenus.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _navMenus.value = emptyList()
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun PluginListScreen(
 ) {
     val plugins by viewModel.plugins.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun PluginListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (plugins.isEmpty()) {
+            EmptyState("No plugins found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/plugins/PluginListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.PluginListParams
 import uniffi.wp_api.PluginWithEditContext
 
@@ -21,6 +22,9 @@ class PluginListViewModel(private val apiClient: WpApiClient) {
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         loadPlugins()
     }
@@ -32,7 +36,10 @@ class PluginListViewModel(private val apiClient: WpApiClient) {
             }
             when (pluginsResult) {
                 is WpRequestResult.Success -> _plugins.value = pluginsResult.response.data
-                else -> _plugins.value = emptyList()
+                else -> {
+                    _error.value = pluginsResult.errorDescription()
+                    _plugins.value = emptyList()
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posts/PostListByTypeScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posts/PostListByTypeScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 import uniffi.wp_api.PostEndpointType
@@ -43,6 +45,7 @@ fun PostListByTypeScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -73,6 +76,10 @@ fun PostListByTypeScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && posts.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (posts.isEmpty()) {
+            EmptyState("No posts found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -85,7 +92,11 @@ fun PostListByTypeScreen(
                         overlineContent = { Text(post.date) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posts/PostListByTypeViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/posts/PostListByTypeViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.AnyPostWithEditContext
 import uniffi.wp_api.PostEndpointType
 import uniffi.wp_api.PostListParams
@@ -21,6 +22,9 @@ class PostListByTypeViewModel(
 
     private val _posts = MutableStateFlow<List<AnyPostWithEditContext>>(emptyList())
     val posts: StateFlow<List<AnyPostWithEditContext>> = _posts.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -51,7 +55,10 @@ class PostListByTypeViewModel(
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _posts.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _posts.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -74,7 +81,7 @@ class PostListByTypeViewModel(
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/search/SearchScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/search/SearchScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -44,6 +46,8 @@ fun SearchScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val hasSearched by viewModel.hasSearched.collectAsState()
     var query by remember { mutableStateOf("") }
 
     val listState = rememberLazyListState()
@@ -88,6 +92,10 @@ fun SearchScreen(
             )
             if (isLoading) {
                 LoadingIndicator()
+            } else if (error != null && results.isEmpty()) {
+                ErrorMessage(error!!)
+            } else if (results.isEmpty() && hasSearched) {
+                EmptyState("No results found")
             } else {
                 LazyColumn(
                     state = listState,
@@ -103,7 +111,11 @@ fun SearchScreen(
                             }
                         )
                     }
-                    if (isLoadingMore) {
+                    if (error != null) {
+                        item {
+                            ErrorMessage(error!!)
+                        }
+                    } else if (isLoadingMore) {
                         item { LoadingMoreIndicator() }
                     }
                 }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/search/SearchViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/search/SearchViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.SearchListParams
 import uniffi.wp_api.SearchResultWithViewContext
 
@@ -27,6 +28,12 @@ class SearchViewModel(private val apiClient: WpApiClient) {
     private val _canLoadMore = MutableStateFlow(false)
     val canLoadMore: StateFlow<Boolean> = _canLoadMore.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _hasSearched = MutableStateFlow(false)
+    val hasSearched: StateFlow<Boolean> = _hasSearched.asStateFlow()
+
     private var nextPageParams: SearchListParams? = null
 
     fun search(query: String) {
@@ -36,6 +43,8 @@ class SearchViewModel(private val apiClient: WpApiClient) {
             _canLoadMore.value = false
             return
         }
+        _error.value = null
+        _hasSearched.value = true
         _isLoading.value = true
         nextPageParams = null
         _canLoadMore.value = false
@@ -49,7 +58,10 @@ class SearchViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _results.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _results.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -69,7 +81,7 @@ class SearchViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/settings/SiteSettingsScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/settings/SiteSettingsScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -31,6 +33,7 @@ fun SiteSettingsScreen(
 ) {
     val settings by viewModel.settings.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -46,6 +49,10 @@ fun SiteSettingsScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (settings == null) {
+            EmptyState("No settings available", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/settings/SiteSettingsViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/settings/SiteSettingsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.SiteSettingsWithEditContext
 
 class SiteSettingsViewModel(private val apiClient: WpApiClient) {
@@ -19,6 +20,9 @@ class SiteSettingsViewModel(private val apiClient: WpApiClient) {
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     init {
         loadSettings()
@@ -31,7 +35,10 @@ class SiteSettingsViewModel(private val apiClient: WpApiClient) {
             }
             when (result) {
                 is WpRequestResult.Success -> _settings.value = result.response.data
-                else -> _settings.value = null
+                else -> {
+                    _error.value = result.errorDescription()
+                    _settings.value = null
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,6 +53,7 @@ fun SiteScreen(
     val postTypes by viewModel.postTypes.collectAsState()
     val taxonomies by viewModel.taxonomies.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -71,6 +73,17 @@ fun SiteScreen(
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)
             ) {
+                if (error != null) {
+                    item {
+                        Text(
+                            text = error!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                }
+
                 // Posts
                 item { SectionHeader("Posts") }
                 items(postTypes) { postType ->

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/site/SiteViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.PostTypeSupports
 import uniffi.wp_api.TaxonomyListParams
 
@@ -33,6 +34,9 @@ class SiteViewModel(private val apiClient: WpApiClient) {
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private var postTypesLoaded = false
     private var taxonomiesLoaded = false
@@ -59,7 +63,10 @@ class SiteViewModel(private val apiClient: WpApiClient) {
                         }
                         .map { SitePostType(name = it.name, restBase = it.restBase) }
                 }
-                else -> _postTypes.value = emptyList()
+                else -> {
+                    if (_error.value == null) _error.value = result.errorDescription()
+                    _postTypes.value = emptyList()
+                }
             }
             postTypesLoaded = true
             if (taxonomiesLoaded) _isLoading.value = false
@@ -78,7 +85,10 @@ class SiteViewModel(private val apiClient: WpApiClient) {
                         .filter { it.visibility?.showInNavMenus == true }
                         .map { SiteTaxonomy(name = it.name, restBase = it.restBase) }
                 }
-                else -> _taxonomies.value = emptyList()
+                else -> {
+                    if (_error.value == null) _error.value = result.errorDescription()
+                    _taxonomies.value = emptyList()
+                }
             }
             taxonomiesLoaded = true
             if (postTypesLoaded) _isLoading.value = false

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/sitehealth/SiteHealthScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/sitehealth/SiteHealthScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun SiteHealthScreen(
 ) {
     val tests by viewModel.tests.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun SiteHealthScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (tests.isEmpty()) {
+            EmptyState("No site health tests available", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/sitehealth/SiteHealthViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/sitehealth/SiteHealthViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.WpSiteHealthTest
 
 class SiteHealthViewModel(private val apiClient: WpApiClient) {
@@ -21,50 +22,59 @@ class SiteHealthViewModel(private val apiClient: WpApiClient) {
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         loadTests()
     }
 
     private fun loadTests() {
         viewModelScope.launch(Dispatchers.IO) {
+            var lastError: String? = null
+
             val backgroundUpdates = async {
                 when (val r = apiClient.request { it.wpSiteHealthTests().backgroundUpdates() }) {
                     is WpRequestResult.Success -> r.response.data
-                    else -> null
+                    else -> { lastError = r.errorDescription(); null }
                 }
             }
             val loopbackRequests = async {
                 when (val r = apiClient.request { it.wpSiteHealthTests().loopbackRequests() }) {
                     is WpRequestResult.Success -> r.response.data
-                    else -> null
+                    else -> { lastError = r.errorDescription(); null }
                 }
             }
             val httpsStatus = async {
                 when (val r = apiClient.request { it.wpSiteHealthTests().httpsStatus() }) {
                     is WpRequestResult.Success -> r.response.data
-                    else -> null
+                    else -> { lastError = r.errorDescription(); null }
                 }
             }
             val dotorgCommunication = async {
                 when (val r = apiClient.request { it.wpSiteHealthTests().dotorgCommunication() }) {
                     is WpRequestResult.Success -> r.response.data
-                    else -> null
+                    else -> { lastError = r.errorDescription(); null }
                 }
             }
             val authorizationHeader = async {
                 when (val r = apiClient.request { it.wpSiteHealthTests().authorizationHeader() }) {
                     is WpRequestResult.Success -> r.response.data
-                    else -> null
+                    else -> { lastError = r.errorDescription(); null }
                 }
             }
 
-            _tests.value = listOfNotNull(
+            val results = listOfNotNull(
                 backgroundUpdates.await(),
                 loopbackRequests.await(),
                 httpsStatus.await(),
                 dotorgCommunication.await(),
                 authorizationHeader.await()
             )
+            _tests.value = results
+            if (results.isEmpty()) {
+                _error.value = lastError
+            }
             _isLoading.value = false
         }
     }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/terms/TermListByTypeScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/terms/TermListByTypeScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 import uniffi.wp_api.TermEndpointType
@@ -43,6 +45,7 @@ fun TermListByTypeScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -73,6 +76,10 @@ fun TermListByTypeScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && terms.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (terms.isEmpty()) {
+            EmptyState("No terms found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -85,7 +92,11 @@ fun TermListByTypeScreen(
                         overlineContent = { Text(term.slug) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/terms/TermListByTypeViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/terms/TermListByTypeViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.AnyTermWithEditContext
 import uniffi.wp_api.TermEndpointType
 import uniffi.wp_api.TermListParams
@@ -21,6 +22,9 @@ class TermListByTypeViewModel(
 
     private val _terms = MutableStateFlow<List<AnyTermWithEditContext>>(emptyList())
     val terms: StateFlow<List<AnyTermWithEditContext>> = _terms.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -51,7 +55,10 @@ class TermListByTypeViewModel(
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _terms.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _terms.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -74,7 +81,7 @@ class TermListByTypeViewModel(
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/themes/ThemeListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/themes/ThemeListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +34,7 @@ fun ThemeListScreen(
 ) {
     val themes by viewModel.themes.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     Scaffold(
         topBar = {
@@ -47,6 +50,10 @@ fun ThemeListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (themes.isEmpty()) {
+            EmptyState("No themes found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(paddingValues)

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/themes/ThemeListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/themes/ThemeListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.ThemeListParams
 import uniffi.wp_api.ThemeWithEditContext
 
@@ -21,6 +22,9 @@ class ThemeListViewModel(private val apiClient: WpApiClient) {
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     init {
         loadThemes()
     }
@@ -32,7 +36,10 @@ class ThemeListViewModel(private val apiClient: WpApiClient) {
             }
             when (result) {
                 is WpRequestResult.Success -> _themes.value = result.response.data
-                else -> _themes.value = emptyList()
+                else -> {
+                    _error.value = result.errorDescription()
+                    _themes.value = emptyList()
+                }
             }
             _isLoading.value = false
         }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import rs.wordpress.api.kotlin.WpApiClient
+import rs.wordpress.example.shared.ui.components.EmptyState
+import rs.wordpress.example.shared.ui.components.ErrorMessage
 import rs.wordpress.example.shared.ui.components.LoadingIndicator
 import rs.wordpress.example.shared.ui.components.LoadingMoreIndicator
 
@@ -38,6 +40,7 @@ fun UserListScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val canLoadMore by viewModel.canLoadMore.collectAsState()
+    val error by viewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
     val shouldLoadMore by remember {
@@ -68,6 +71,10 @@ fun UserListScreen(
     ) { paddingValues ->
         if (isLoading) {
             LoadingIndicator(modifier = Modifier.padding(paddingValues))
+        } else if (error != null && users.isEmpty()) {
+            ErrorMessage(error!!, modifier = Modifier.padding(paddingValues))
+        } else if (users.isEmpty()) {
+            EmptyState("No users found", modifier = Modifier.padding(paddingValues))
         } else {
             LazyColumn(
                 state = listState,
@@ -79,7 +86,11 @@ fun UserListScreen(
                         supportingContent = { Text(user.email) }
                     )
                 }
-                if (isLoadingMore) {
+                if (error != null) {
+                    item {
+                        ErrorMessage(error!!)
+                    }
+                } else if (isLoadingMore) {
                     item { LoadingMoreIndicator() }
                 }
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/users/UserListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import rs.wordpress.api.kotlin.WpApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
+import rs.wordpress.example.shared.ui.components.errorDescription
 import uniffi.wp_api.UserListParams
 import uniffi.wp_api.UserWithEditContext
 
@@ -17,6 +18,9 @@ class UserListViewModel(private val apiClient: WpApiClient) {
 
     private val _users = MutableStateFlow<List<UserWithEditContext>>(emptyList())
     val users: StateFlow<List<UserWithEditContext>> = _users.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -44,7 +48,10 @@ class UserListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = usersResult.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> _users.value = emptyList()
+                else -> {
+                    _error.value = usersResult.errorDescription()
+                    _users.value = emptyList()
+                }
             }
             _isLoading.value = false
         }
@@ -64,7 +71,7 @@ class UserListViewModel(private val apiClient: WpApiClient) {
                     nextPageParams = result.response.nextPageParams
                     _canLoadMore.value = nextPageParams != null
                 }
-                else -> {}
+                else -> _error.value = result.errorDescription()
             }
             _isLoadingMore.value = false
         }


### PR DESCRIPTION
## Summary
- Add shared `ErrorMessage` and `EmptyState` composables with `WpRequestResult.errorDescription()` for human-readable error messages
- Add `error` StateFlow to all 16 view models to capture API failures instead of silently discarding them
- Update all 16 screens to show error messages when requests fail and empty state text when results are empty
- Paginated screens preserve existing data on `loadMore()` errors

Depends on #1187.

## Test plan
- [x] Android example app builds (`./gradlew :example:composeApp:assembleDebug`)
- [ ] Verify error messages appear when API requests fail (e.g. with invalid credentials)
- [ ] Verify empty state text appears for screens with no data

🤖 Generated with [Claude Code](https://claude.com/claude-code)