### PR TITLE
Publish XCFramework snapshots for PR and trunk builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,6 +93,13 @@ steps:
         agents:
           queue: mac
         if: build.pull_request.id != null
+      - label: ":swift: :package: Publish trunk XCFramework"
+        command: .buildkite/publish-trunk-xcframework.sh
+        depends_on: xcframework
+        plugins: [$CI_TOOLKIT]
+        agents:
+          queue: mac
+        if: build.branch == "trunk" && build.env("NEW_VERSION") == null
       - label: ":swift: Build Docs"
         command: |
           .buildkite/download-xcframework.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,6 +86,13 @@ steps:
         plugins: [$CI_TOOLKIT]
         agents:
           queue: mac
+      - label: ":swift: :package: Publish PR XCFramework"
+        command: .buildkite/publish-pr-xcframework.sh
+        depends_on: xcframework
+        plugins: [$CI_TOOLKIT]
+        agents:
+          queue: mac
+        if: build.pull_request.id != null
       - label: ":swift: Build Docs"
         command: |
           .buildkite/download-xcframework.sh

--- a/.buildkite/publish-pr-xcframework.sh
+++ b/.buildkite/publish-pr-xcframework.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Only run for PR builds
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  echo "Not a PR build, skipping PR xcframework publish"
+  exit 0
+fi
+
+PR_NUMBER="$BUILDKITE_PULL_REQUEST"
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo "--- :arrow_down: Downloading XCFramework artifacts"
+buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
+buildkite-agent artifact download target/libwordpressFFI.xcframework.zip.checksum.txt . --step "xcframework"
+buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :rocket: Publishing PR build for PR #${PR_NUMBER}"
+bundle exec fastlane publish_pr_xcframework pr_number:"$PR_NUMBER"

--- a/.buildkite/publish-trunk-xcframework.sh
+++ b/.buildkite/publish-trunk-xcframework.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo "--- :arrow_down: Downloading XCFramework artifacts"
+buildkite-agent artifact download target/libwordpressFFI.xcframework.zip . --step "xcframework"
+buildkite-agent artifact download target/libwordpressFFI.xcframework.zip.checksum.txt . --step "xcframework"
+buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' . --step "xcframework"
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :rocket: Publishing trunk build for ${BUILDKITE_COMMIT}"
+bundle exec fastlane publish_trunk_xcframework commit_sha:"$BUILDKITE_COMMIT"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -194,6 +194,57 @@ lane :publish_to_s3 do
   )
 end
 
+lane :publish_pr_xcframework do |options|
+  pr_number = options[:pr_number] || UI.user_error!('pr_number is required')
+  version = "pr-builds/#{pr_number}"
+
+  # Upload xcframework and checksum to S3
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: File.join('wordpress-rs', version, File.basename(xcframework_file_path)),
+    file: xcframework_file_path,
+    auto_prefix: false,
+    if_exists: :replace
+  )
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: File.join('wordpress-rs', version, File.basename(xcframework_checksum_file_path)),
+    file: xcframework_checksum_file_path,
+    auto_prefix: false,
+    if_exists: :replace
+  )
+
+  # Update Package.swift to point to the S3 build
+  file_path = File.expand_path('./Package.swift', PROJECT_ROOT)
+  lines = File.readlines(file_path).map do |line|
+    if line.start_with?('let libwordpressFFIVersion: WordPressRSVersion =')
+      "let libwordpressFFIVersion: WordPressRSVersion = .release(version: \"#{version}\", checksum: \"#{xcframework_checksum}\")"
+    else
+      line
+    end
+  end
+  File.open(file_path, 'w') { |file| file.puts lines }
+
+  # Create pr-build branch and commit changes
+  branch_name = "pr-build/#{pr_number}"
+  sh "git checkout -B #{branch_name}"
+
+  git_commit(
+    path: file_path,
+    message: "Update Package.swift for PR ##{pr_number} build"
+  )
+
+  git_add(path: xcframework_bindings_file_path, force: true)
+  git_commit(
+    path: xcframework_bindings_file_path,
+    message: "Update Swift bindings for PR ##{pr_number} build",
+    allow_nothing_to_commit: true
+  )
+
+  sh "git push -f origin #{branch_name}"
+end
+
 # Converts the English Fluent localization file to PO format for translation
 #
 # The resulting PO file is saved as the source file (.pot) for translations and is synced to GlotPress.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -196,7 +196,25 @@ end
 
 lane :publish_pr_xcframework do |options|
   pr_number = options[:pr_number] || UI.user_error!('pr_number is required')
-  version = "pr-builds/#{pr_number}"
+  branch_name = "pr-build/#{pr_number}"
+  publish_xcframework_snapshot(
+    version: "pr-builds/#{pr_number}",
+    branch_name: branch_name
+  )
+  update_pr_xcframework_comment(pr_number: pr_number, branch_name: branch_name)
+end
+
+lane :publish_trunk_xcframework do |options|
+  commit_sha = options[:commit_sha] || UI.user_error!('commit_sha is required')
+  publish_xcframework_snapshot(
+    version: "trunk-builds/#{commit_sha}",
+    branch_name: 'trunk-build'
+  )
+end
+
+lane :publish_xcframework_snapshot do |options|
+  version = options[:version] || UI.user_error!('version is required')
+  branch_name = options[:branch_name] || UI.user_error!('branch_name is required')
 
   # Upload xcframework and checksum to S3
   upload_to_s3(
@@ -226,23 +244,26 @@ lane :publish_pr_xcframework do |options|
   end
   File.open(file_path, 'w') { |file| file.puts lines }
 
-  # Create pr-build branch and commit changes
-  branch_name = "pr-build/#{pr_number}"
+  # Create snapshot branch and commit changes
   sh "git checkout -B #{branch_name}"
 
   git_commit(
     path: file_path,
-    message: "Update Package.swift for PR ##{pr_number} build"
+    message: "Update Package.swift for #{version}"
   )
 
   git_add(path: xcframework_bindings_file_path, force: true)
   git_commit(
     path: xcframework_bindings_file_path,
-    message: "Update Swift bindings for PR ##{pr_number} build",
+    message: "Update Swift bindings for #{version}",
     allow_nothing_to_commit: true
   )
 
   sh "git push -f origin #{branch_name}"
+
+  UI.success("Published snapshot build to branch '#{branch_name}'")
+  UI.success("To use this build, add to your Package.swift:")
+  UI.success("  .package(url: \"https://github.com/#{GITHUB_REPO}\", branch: \"#{branch_name}\")")
 end
 
 # Converts the English Fluent localization file to PO format for translation
@@ -483,6 +504,62 @@ lane :set_up_signing_release do |readonly: true|
 end
 
 # Utils
+
+XCFRAMEWORK_COMMENT_MARKER = '<!-- wordpress-rs-xcframework-build -->'
+
+def update_pr_xcframework_comment(pr_number:, branch_name:)
+  github_token = ENV['GITHUB_TOKEN']
+  unless github_token
+    UI.important('GITHUB_TOKEN not set, skipping PR comment')
+    return
+  end
+
+  commit_sha = ENV['BUILDKITE_COMMIT'] || 'unknown'
+  short_sha = commit_sha[0, 8]
+
+  comment_body = <<~MARKDOWN
+    #{XCFRAMEWORK_COMMENT_MARKER}
+    ## XCFramework Build
+
+    This PR's XCFramework is available for testing. Add to your `Package.swift`:
+
+    ```swift
+    .package(url: "https://github.com/#{GITHUB_REPO}", branch: "#{branch_name}")
+    ```
+
+    <sub>Built from #{short_sha}</sub>
+  MARKDOWN
+
+  # Find existing comment with our marker
+  result = github_api(
+    server_url: 'https://api.github.com',
+    api_token: github_token,
+    http_method: 'GET',
+    path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments?per_page=100"
+  )
+
+  existing_comment = result[:json]&.find { |c| c['body']&.include?(XCFRAMEWORK_COMMENT_MARKER) }
+
+  if existing_comment
+    github_api(
+      server_url: 'https://api.github.com',
+      api_token: github_token,
+      http_method: 'PATCH',
+      path: "/repos/#{GITHUB_REPO}/issues/comments/#{existing_comment['id']}",
+      body: { body: comment_body }
+    )
+    UI.success("Updated XCFramework build comment on PR ##{pr_number}")
+  else
+    github_api(
+      server_url: 'https://api.github.com',
+      api_token: github_token,
+      http_method: 'POST',
+      path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments",
+      body: { body: comment_body }
+    )
+    UI.success("Created XCFramework build comment on PR ##{pr_number}")
+  end
+end
 
 def xcframework_checksum
   File.read(xcframework_checksum_file_path).strip!


### PR DESCRIPTION
## Description

Adds per-PR and per-trunk-commit XCFramework artifacts for iOS, matching how Android already works with the `publish-to-s3` Gradle plugin. Each build uploads the xcframework to S3, updates `Package.swift` with the URL and checksum, and pushes a consumable branch.

## Changes

- New generic `publish_xcframework_snapshot` Fastlane lane that handles S3 upload, `Package.swift` update, and branch creation
- `publish_pr_xcframework` wrapper: uploads to `wordpress-rs/pr-builds/{number}/` and pushes `pr-build/{number}` branch
- `publish_trunk_xcframework` wrapper: uploads to `wordpress-rs/trunk-builds/{sha}/` and force-pushes `trunk-build` branch
- Auto-updating GitHub PR comment with consumer usage instructions (uses hidden HTML marker to avoid duplicates)
- Two new Buildkite steps in the Swift Wrapper group:
  - **Publish PR XCFramework** — runs on PR builds (`build.pull_request.id != null`)
  - **Publish trunk XCFramework** — runs on trunk commits (`build.branch == "trunk"`, skipped during releases)
- New shell scripts: `.buildkite/publish-pr-xcframework.sh`, `.buildkite/publish-trunk-xcframework.sh`

## Consumer usage

**PR builds:**
```swift
.package(url: "https://github.com/Automattic/wordpress-rs", branch: "pr-build/123")
```

**Trunk builds (latest commit on trunk):**
```swift
.package(url: "https://github.com/Automattic/wordpress-rs", branch: "trunk-build")
```

## Testing

- [x] PR publish step passes — [build #4935](https://buildkite.com/automattic/wordpress-rs/builds/4935), "Publish PR XCFramework" step
- [x] `pr-build/1199` branch exists with updated `Package.swift` and Swift bindings
- [x] S3 artifacts uploaded at `wordpress-rs/pr-builds/1199/`
- [x] End-to-end SPM consumption verified — `swift build` + `swift run` succeeded against `pr-build/1199`
- [x] Auto-updating PR comment posted (see comments below)
- [x] Trunk publish step passes — [build #4944](https://buildkite.com/automattic/wordpress-rs/builds/4944), "Publish trunk XCFramework" step (triggered manually with `branch: trunk` to validate)
- [x] `trunk-build` branch created with updated `Package.swift` and Swift bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)