### PR TITLE
Skip S3 publish when artifact version already exists

### DIFF
--- a/.buildkite/publish-wp-api-android.sh
+++ b/.buildkite/publish-wp-api-android.sh
@@ -6,7 +6,21 @@ set -euo pipefail
 PUBLISHED_WP_API_KOTLIN_VERSION=$(buildkite-agent meta-data get "PUBLISHED_WP_API_KOTLIN_VERSION")
 
 cd ./native/kotlin
-./gradlew \
-    -PwpApiKotlinVersion="$PUBLISHED_WP_API_KOTLIN_VERSION" \
-    :api:android:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
-    :api:android:publish
+
+# Calculate the version that would be published
+VERSION=$(./gradlew -q :api:android:calculateVersionName $(prepare_to_publish_to_s3_params))
+
+# Check if this version is already in S3
+IS_PUBLISHED=$(./gradlew -q :api:android:isVersionPublishedToS3 \
+    --published-group-id=rs.wordpress.api \
+    --published-artifact-id=android \
+    --version-name="$VERSION")
+
+if [ "$IS_PUBLISHED" = "true" ]; then
+    echo "Version '$VERSION' is already published to S3. Skipping."
+else
+    ./gradlew \
+        -PwpApiKotlinVersion="$PUBLISHED_WP_API_KOTLIN_VERSION" \
+        :api:android:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+        :api:android:publish
+fi

--- a/.buildkite/publish-wp-api-kotlin.sh
+++ b/.buildkite/publish-wp-api-kotlin.sh
@@ -3,9 +3,23 @@
 set -euo pipefail
 
 cd ./native/kotlin
-./gradlew \
-    :api:kotlin:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
-    :api:kotlin:publish
+
+# Calculate the version that would be published
+VERSION=$(./gradlew -q :api:kotlin:calculateVersionName $(prepare_to_publish_to_s3_params))
+
+# Check if this version is already in S3
+IS_PUBLISHED=$(./gradlew -q :api:kotlin:isVersionPublishedToS3 \
+    --published-group-id=rs.wordpress.api \
+    --published-artifact-id=kotlin \
+    --version-name="$VERSION")
+
+if [ "$IS_PUBLISHED" = "true" ]; then
+    echo "Version '$VERSION' is already published to S3. Skipping."
+else
+    ./gradlew \
+        :api:kotlin:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+        :api:kotlin:publish
+fi
 
 # Add meta-data for the published version so we can use it in subsequent steps
-buildkite-agent meta-data set "PUBLISHED_WP_API_KOTLIN_VERSION" < ./api/kotlin/build/published-version.txt
+buildkite-agent meta-data set "PUBLISHED_WP_API_KOTLIN_VERSION" "$VERSION"


### PR DESCRIPTION
## Description

Fix CI failures during releases caused by duplicate Android/Kotlin artifact uploads to S3.

When a release is triggered via `make release-on-ci`, the Kotlin/Android publish steps fail because the [`publish-to-s3` Gradle plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) checks whether the artifact already exists in S3 and throws `IllegalStateException` if it does. The trunk merge build already publishes `trunk-{sha1}` artifacts, and the release build (same branch + commit) tries to re-publish them.

### How the plugin versions artifacts

From [`BuildEnvironment.kt`](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/publish/BuildEnvironment.kt) in the plugin:

- **Branch builds**: `{branchName}-{sha1}` (e.g. `trunk-abc1234`)
- **Tag builds**: `{tagName}` (e.g. `alpha-20260226`)
- **PR builds**: `{prNumber}-{sha1}`

### Why the duplicate happens

1. A commit merges to `trunk` → Buildkite build publishes `trunk-{sha1}` to S3
2. `make release-on-ci` triggers a new build on `trunk` with the same commit → `prepareToPublishToS3` computes the same `trunk-{sha1}` version, checks S3, finds it already exists, and throws

Tag-triggered builds (from the git tag pushed by `release.sh`) don't conflict because the plugin uses `FromTag` and generates a different version string like `alpha-20260226`.

## Changes

Updated `publish-wp-api-kotlin.sh` and `publish-wp-api-android.sh` to check S3 before publishing, using two existing tasks from the plugin that were already available but unused:

1. **`calculateVersionName`** — computes the version string without touching S3
2. **`isVersionPublishedToS3`** — does a HEAD request against the S3 POM URL and returns `true`/`false`

If the version already exists, the script logs a message and exits successfully instead of failing. No plugin changes required.

## Test plan

- [x] Build #4943 — first build on the branch, artifacts published normally
- [x] Build #4950 — second build on the same branch+commit, both Kotlin and Android publish steps detected the existing artifacts and skipped:
  ```
  Version 'jkmassel_fix-duplicate-s3-artifacts-4dee2efd...' is already published to S3. Skipping.
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)