### PR TITLE
Fix Swift CI failures on release builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,8 +109,8 @@ lane :release do |options|
 
   validate
   update_swift_package
-  publish_release_to_github
   publish_to_s3
+  publish_release_to_github
 end
 
 lane :validate do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,9 +156,15 @@ lane :publish_release_to_github do
     message: "Update Package.swift to use version #{version}"
   )
 
+  # Re-resolve Swift package dependencies so Package.resolved matches the
+  # updated Package.swift (which now points to the remote binary target).
+  sh "cd #{PROJECT_ROOT} && swift package resolve"
+
+  package_resolved_path = File.expand_path('./Package.resolved', PROJECT_ROOT)
   git_add(path: xcframework_bindings_file_path, force: true)
+  git_add(path: package_resolved_path)
   git_commit(
-    path: xcframework_bindings_file_path,
+    path: xcframework_bindings_file_path + [package_resolved_path],
     message: "Commit Swift Bindings for version #{version}"
   )
 


### PR DESCRIPTION
## Description

Release/alpha builds (e.g. [build #4919](https://buildkite.com/automattic/wordpress-rs/builds/4919)) fail on the `swift-validate-package-dot-resolved` and `swift-lint` CI steps. This happens because the release process updates `Package.swift` from `.local` to `.release(...)`, which changes how SPM resolves dependencies — but the committed `Package.resolved` still reflects the `.local` resolution.

## Changes

1. After committing the `Package.swift` update during release, run `swift package resolve` to regenerate `Package.resolved` for the new remote binary target configuration, and include it in the Swift bindings commit.
2. Reorder the release lane to run `publish_to_s3` before `publish_release_to_github`, since `swift package resolve` needs to download the xcframework from S3.

## Test plan

We triggered two test alpha builds from this branch to validate the fix:

- [Build #4942](https://buildkite.com/automattic/wordpress-rs/builds/4942) (`alpha-test-20260226`) — validated that the `swift-lint` and `swift-validate-package-dot-resolved` steps now pass (22/23 passed). The release step failed because `swift package resolve` ran before the S3 upload — which led to commit 2.
- [Build #4948](https://buildkite.com/automattic/wordpress-rs/builds/4948) (`alpha-test-20260226-2`) — **all 23 jobs passed**, including the full release step with S3 upload, `swift package resolve`, and GitHub release creation.

Cleanup: the `alpha-test-20260226-2` tag/release (and possibly `alpha-test-20260226`) should be deleted after merge.