### PR TITLE
Speed up Android CI builds

### DIFF
--- a/.buildkite/build-android-rust-target.sh
+++ b/.buildkite/build-android-rust-target.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+GRADLE_TARGET=$1
+
+echo "--- :rust: Installing Rust"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
+
+source "$HOME/.cargo/env"
+
+echo "--- :package: Installing Rust Target"
+
+# Map Gradle target name to Rust target triple
+case "$GRADLE_TARGET" in
+    arm)    RUST_TARGET="armv7-linux-androideabi" ;;
+    arm64)  RUST_TARGET="aarch64-linux-android" ;;
+    x86)    RUST_TARGET="i686-linux-android" ;;
+    x86_64) RUST_TARGET="x86_64-linux-android" ;;
+    *)      echo "Unknown target: $GRADLE_TARGET"; exit 1 ;;
+esac
+
+# Only install the single target needed — no Apple targets or nightly toolchain
+rustup target add "$RUST_TARGET"
+
+# This is a temporary step until we implement a more graceful way to handle missing credentials
+printf "site_url\nadmin_username\nadmin_password\nadmin_password_uuid\nsubscriber_username\nsubscriber_password\nsubscriber_password_uuid\n" > test_credentials
+
+echo "--- :rust: Cross-compiling for $GRADLE_TARGET"
+./native/kotlin/gradlew -p native/kotlin -PcargoTarget="$GRADLE_TARGET" :api:android:cargoBuild

--- a/.buildkite/download-android-jni-libs.sh
+++ b/.buildkite/download-android-jni-libs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- :arrow_down: Downloading pre-built Android JNI libraries"
+buildkite-agent artifact download 'native/kotlin/api/android/build/rustJniLibs/android/**/*' .

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -186,9 +186,41 @@ steps:
           ./gradlew detektMain detektTest
         agents:
           queue: android
+      - label: ":rust: Build host library"
+        key: "rust-build-host"
+        artifact_paths:
+          - "target/release/libwp_mobile.so"
+        command: |
+          echo "--- :rust: Installing Rust"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
+
+          source "$$HOME/.cargo/env"
+
+          echo "--- :package: Installing Rust Toolchains"
+          make setup-rust
+
+          echo "--- :rust: Building host library"
+          cargo build --package wp_mobile --release
+        agents:
+          queue: android
+      - label: ":rust: Build Android {{matrix}}"
+        key: "rust-build-android"
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "native/kotlin/api/android/build/rustJniLibs/android/**/*"
+        command: .buildkite/build-android-rust-target.sh {{matrix}}
+        matrix:
+          - "arm"
+          - "arm64"
+          - "x86"
+          - "x86_64"
+        agents:
+          queue: android
       - label: ":kotlin: Publish `rs.wordpress.api:kotlin`"
         key: "publish-wp-api-kotlin"
         plugins: [$CI_TOOLKIT]
+        depends_on:
+          - "rust-build-host"
         command: |
           echo "--- :rust: Installing Rust"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
@@ -207,6 +239,7 @@ steps:
         plugins: [$CI_TOOLKIT]
         depends_on:
           - "publish-wp-api-kotlin"
+          - "rust-build-android"
         command: |
           echo "--- :rust: Installing Rust"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
@@ -215,7 +248,6 @@ steps:
 
           echo "--- :package: Installing Rust Toolchains"
           make setup-rust
-          make setup-rust-android-targets
 
           echo "--- :kotlin: Publishing `rs.wordpress.api:android`"
           .buildkite/publish-wp-api-android.sh
@@ -224,18 +256,17 @@ steps:
 
       - label: ":android: Build Example App"
         plugins: [$CI_TOOLKIT]
+        depends_on:
+          - "publish-wp-api-android"
         command: |
-          echo "--- :rust: Installing Rust"
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
-
-          source "$$HOME/.cargo/env"
-
-          echo "--- :package: Installing Rust Toolchains"
-          make setup-rust
-          make setup-rust-android-targets
+          PUBLISHED_WP_API_KOTLIN_VERSION=$$(buildkite-agent meta-data get "PUBLISHED_WP_API_KOTLIN_VERSION")
+          PUBLISHED_WP_API_ANDROID_VERSION=$$(buildkite-agent meta-data get "PUBLISHED_WP_API_ANDROID_VERSION")
 
           echo "--- :android: Building Sample App"
-          ./native/kotlin/gradlew -p native/kotlin :example:composeApp:assembleDebug
+          ./native/kotlin/gradlew -p native/kotlin \
+            -PwpApiKotlinVersion="$$PUBLISHED_WP_API_KOTLIN_VERSION" \
+            -PwpApiAndroidVersion="$$PUBLISHED_WP_API_ANDROID_VERSION" \
+            :example:composeApp:assembleDebug
         agents:
           queue: android
 

--- a/.buildkite/publish-wp-api-android.sh
+++ b/.buildkite/publish-wp-api-android.sh
@@ -2,16 +2,19 @@
 
 set -euo pipefail
 
+# Download pre-built Android JNI libraries from the cross-compile step
+.buildkite/download-android-jni-libs.sh
+
 # Retrieve data from previous steps
 PUBLISHED_WP_API_KOTLIN_VERSION=$(buildkite-agent meta-data get "PUBLISHED_WP_API_KOTLIN_VERSION")
 
 cd ./native/kotlin
 
 # Calculate the version that would be published
-VERSION=$(./gradlew -q :api:android:calculateVersionName $(prepare_to_publish_to_s3_params))
+VERSION=$(./gradlew -q -x cargoBuild :api:android:calculateVersionName $(prepare_to_publish_to_s3_params))
 
 # Check if this version is already in S3
-IS_PUBLISHED=$(./gradlew -q :api:android:isVersionPublishedToS3 \
+IS_PUBLISHED=$(./gradlew -q -x cargoBuild :api:android:isVersionPublishedToS3 \
     --published-group-id=rs.wordpress.api \
     --published-artifact-id=android \
     --version-name="$VERSION")
@@ -21,6 +24,10 @@ if [ "$IS_PUBLISHED" = "true" ]; then
 else
     ./gradlew \
         -PwpApiKotlinVersion="$PUBLISHED_WP_API_KOTLIN_VERSION" \
+        -x cargoBuild \
         :api:android:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
         :api:android:publish
 fi
+
+# Add meta-data for the published version so we can use it in subsequent steps
+buildkite-agent meta-data set "PUBLISHED_WP_API_ANDROID_VERSION" < ./api/android/build/published-version.txt

--- a/.buildkite/publish-wp-api-kotlin.sh
+++ b/.buildkite/publish-wp-api-kotlin.sh
@@ -2,13 +2,16 @@
 
 set -euo pipefail
 
+echo "--- :arrow_down: Downloading pre-built host library"
+buildkite-agent artifact download 'target/release/libwp_mobile.so' . --step "rust-build-host"
+
 cd ./native/kotlin
 
 # Calculate the version that would be published
-VERSION=$(./gradlew -q :api:kotlin:calculateVersionName $(prepare_to_publish_to_s3_params))
+VERSION=$(./gradlew -q -x cargoBuildLibraryRelease :api:kotlin:calculateVersionName $(prepare_to_publish_to_s3_params))
 
 # Check if this version is already in S3
-IS_PUBLISHED=$(./gradlew -q :api:kotlin:isVersionPublishedToS3 \
+IS_PUBLISHED=$(./gradlew -q -x cargoBuildLibraryRelease :api:kotlin:isVersionPublishedToS3 \
     --published-group-id=rs.wordpress.api \
     --published-artifact-id=kotlin \
     --version-name="$VERSION")
@@ -17,6 +20,7 @@ if [ "$IS_PUBLISHED" = "true" ]; then
     echo "Version '$VERSION' is already published to S3. Skipping."
 else
     ./gradlew \
+        -x cargoBuildLibraryRelease \
         :api:kotlin:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
         :api:kotlin:publish
 fi

--- a/native/kotlin/api/android/build.gradle.kts
+++ b/native/kotlin/api/android/build.gradle.kts
@@ -91,7 +91,11 @@ cargo {
     module = "$cargoProjectRoot/$moduleName/"
     libname = moduleName
     profile = "release"
-    targets = listOf("arm", "arm64", "x86", "x86_64")
+    targets = if (project.hasProperty("cargoTarget")) {
+        listOf(project.property("cargoTarget").toString())
+    } else {
+        listOf("arm", "arm64", "x86", "x86_64")
+    }
     targetDirectory = "$cargoProjectRoot/target"
     exec = { spec: ExecSpec, _: com.nishtahir.Toolchain ->
         // https://doc.rust-lang.org/rustc/command-line-arguments.html#-g-include-debug-information

--- a/native/kotlin/example/composeApp/build.gradle.kts
+++ b/native/kotlin/example/composeApp/build.gradle.kts
@@ -50,7 +50,11 @@ kotlin {
             implementation(libs.navigation.compose)
             implementation(libs.navigation.fragment.ktx)
             implementation(libs.navigation.ui.ktx)
-            implementation(project(":api:android"))
+            if (project.hasProperty("wpApiAndroidVersion")) {
+                implementation("rs.wordpress.api:android:${project.properties["wpApiAndroidVersion"]}")
+            } else {
+                implementation(project(":api:android"))
+            }
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -65,11 +69,19 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.landscapist.coil)
             implementation(libs.lifecycle.viewmodel)
-            compileOnly(project(":api:kotlin"))
+            if (project.hasProperty("wpApiKotlinVersion")) {
+                compileOnly("rs.wordpress.api:kotlin:${project.properties["wpApiKotlinVersion"]}")
+            } else {
+                compileOnly(project(":api:kotlin"))
+            }
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
-            implementation(project(":api:kotlin"))
+            if (project.hasProperty("wpApiKotlinVersion")) {
+                implementation("rs.wordpress.api:kotlin:${project.properties["wpApiKotlinVersion"]}")
+            } else {
+                implementation(project(":api:kotlin"))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Parallelize Rust cross-compilation in the Kotlin/Android CI pipeline to reduce wall-clock build time by ~30%.

### Changes

1. **Split the single sequential Rust build step into parallel agents** — Replace the "Build Rust libraries" step (which built all 5 targets sequentially on one agent) with 5 independent steps: 1 host build + 4 Android architecture builds via a Buildkite matrix. Each runs on its own agent and installs only the single Rust target it needs.

2. **Skip redundant Rust builds in publish and packaging steps** — Kotlin Publish downloads the pre-built host `.so` via artifact and passes `-x cargoBuildLibraryRelease` to Gradle. Android Publish downloads the 4 pre-built JNI libraries and passes `-x cargoBuild`. Both skip rebuilding Rust entirely.

3. **Build Example App from published S3 artifacts** — Instead of building all Rust targets from source (~45 min), the Example App step now consumes the artifacts published by the upstream Kotlin/Android publish steps via `-PwpApiKotlinVersion` and `-PwpApiAndroidVersion` Gradle properties. The Gradle build files conditionally resolve these as Maven coordinates when the properties are set, falling back to project references for local development.

4. **Make Gradle cargo targets configurable** — `build.gradle.kts` reads `-PcargoTarget` to build a single architecture, defaulting to all 4 when unset.

5. **Export published Android version as Buildkite meta-data** — Android Publish writes its version to meta-data so the Example App step can consume it.

### Timing

Baseline (build #4946) vs optimized builds:

| Metric | Baseline (#4946) | Optimized (#4959) | Change |
|--------|----------|--------|--------|
| **Wall-clock time** | 49.8 min | 36.8 min | **-13.0 min (-26%)** |
| **Total agent-minutes** | 281 min | 252 min | **-29 min (-10%)** |
| **Kotlin group critical path** | 45.4 min | 31.4 min | **-14.0 min (-31%)** |

The overall build is now bottlenecked by Swift e2e tests (~34 min), not the Kotlin group.

## Test plan

- [x] All 4 Android `.so` files correctly downloaded in Android Publish (verified: "Found 4 artifacts")
- [x] Example App builds successfully from published artifacts
- [x] Kotlin Publish downloads pre-built host binary and skips cargo build
- [x] Android matrix variants only install the single needed Rust target (verified in build logs)
- [x] Full CI build passes (builds #4955, #4959)

🤖 Generated with [Claude Code](https://claude.com/claude-code)