### PR TITLE
Parallelize XCFramework builds by Apple platform

### DIFF
--- a/.buildkite/assemble-xcframework.sh
+++ b/.buildkite/assemble-xcframework.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- :arrow_down: Downloading pre-built Apple libraries"
+buildkite-agent artifact download 'target/*/release/libwp_mobile.a' .
+buildkite-agent artifact download 'target/*/release/swift-bindings/**' .
+buildkite-agent artifact download 'native/swift/Sources/wordpress-api-wrapper/*.swift' .
+
+echo "--- :swift: Assembling XCFramework"
+make xcframework-assemble
+
+echo "--- :package: Packaging XCFramework"
+rm -rf target/libwordpressFFI.xcframework.zip
+ditto -c -k --sequesterRsrc --keepParent target/libwordpressFFI.xcframework/ target/libwordpressFFI.xcframework.zip

--- a/.buildkite/build-apple-platform.sh
+++ b/.buildkite/build-apple-platform.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PLATFORM=$1
+
+echo "--- :rust: Installing Rust"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
+
+source "$HOME/.cargo/env"
+
+echo "--- :package: Installing Rust Toolchains"
+make setup-rust
+
+echo "--- :rust: Building $PLATFORM targets"
+make build-apple-$PLATFORM

--- a/.buildkite/build-apple-platform.sh
+++ b/.buildkite/build-apple-platform.sh
@@ -10,7 +10,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
 source "$HOME/.cargo/env"
 
 echo "--- :package: Installing Rust Toolchains"
-make setup-rust
+make setup-rust-$PLATFORM
 
 echo "--- :rust: Building $PLATFORM targets"
 make build-apple-$PLATFORM

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,24 +58,37 @@ steps:
   - group: ":swift: Swift Wrapper"
     key: "swift"
     steps:
-      - label: ":swift: :darwin: Build xcframework"
+      - label: ":rust: :darwin: Build {{matrix}}"
+        key: "apple-build"
+        command: .buildkite/build-apple-platform.sh {{matrix}}
+        artifact_paths:
+          - "target/*/release/libwp_mobile.a"
+          - "target/*/release/swift-bindings/**"
+          - "native/swift/Sources/wordpress-api-wrapper/*.swift"
+        matrix:
+          - "macos"
+          - "ios"
+          - "tvos"
+          - "watchos"
+        plugins: [$CI_TOOLKIT]
+        agents:
+          queue: mac
+      - label: ":swift: :darwin: Assemble xcframework"
         key: "xcframework"
+        depends_on: "apple-build"
         command: |
           echo "--- :rust: Installing Rust"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y
 
           source "/Users/builder/.cargo/env"
 
-          echo "--- :package: Installing Rust Toolchains"
-          make setup-rust
-
           echo "--- :ruby: Installing Ruby tools"
           install_gems
           echo "--- :xcode: Setting up code signing"
           bundle exec fastlane set_up_signing_release
 
-          echo "--- :swift: Building XCFramework"
-          make xcframework-package
+          echo "--- :swift: Assembling XCFramework"
+          .buildkite/assemble-xcframework.sh
           make xcframework-package-checksum
           make xcframework-sign
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,10 +66,10 @@ steps:
           - "target/*/release/swift-bindings/**"
           - "native/swift/Sources/wordpress-api-wrapper/*.swift"
         matrix:
-          - "macos"
-          - "ios"
-          - "tvos"
-          - "watchos"
+          - "macOS"
+          - "iOS"
+          - "tvOS"
+          - "watchOS"
         plugins: [$CI_TOOLKIT]
         agents:
           queue: mac

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,20 @@ setup-rust-toolchain:
 		x86_64-apple-darwin \
 		aarch64-apple-ios-sim
 
+# Platform-specific Rust setup (only installs what each platform needs in CI)
+setup-rust-macos:
+	rustup toolchain install stable
+	rustup target add --toolchain stable x86_64-apple-darwin aarch64-apple-darwin
+
+setup-rust-ios:
+	rustup toolchain install stable
+	rustup target add --toolchain stable aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+
+setup-rust-tvos setup-rust-watchos:
+	rustup toolchain install stable
+	rustup toolchain install $(rust_nightly_toolchain)
+	rustup component add rust-src --toolchain $(rust_nightly_toolchain)
+
 setup-rust-android-targets:
 	rustup target add \
 		x86_64-linux-android \

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ build-apple-platform-ios := $(addprefix _build-apple-,$(apple-platform-targets-i
 build-apple-platform-tvos := $(addprefix _build-apple-,$(apple-platform-targets-tvos))
 build-apple-platform-watchos := $(addprefix _build-apple-,$(apple-platform-targets-watchos))
 
+# Build all targets for a specific platform (without creating xcframework).
+build-apple-macos: $(build-apple-platform-macos)
+build-apple-ios: $(build-apple-platform-ios)
+build-apple-tvos: $(build-apple-platform-tvos)
+build-apple-watchos: $(build-apple-platform-watchos)
+
 # Creating xcframework for one single platform, including real device and simulator.
 xcframework-only-macos: $(build-apple-platform-macos)
 xcframework-only-ios: $(build-apple-platform-ios)
@@ -120,6 +126,10 @@ xcframework-only-tvos: $(build-apple-platform-tvos)
 xcframework-only-watchos: $(build-apple-platform-watchos)
 xcframework-only-%:
 	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-$*)
+
+# Assemble pre-built targets into an xcframework (without building targets).
+xcframework-assemble:
+	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets)
 
 # Creating xcframework for all platforms.
 xcframework-all: $(build-apple-platform-macos) $(build-apple-platform-ios) $(build-apple-platform-tvos) $(build-apple-platform-watchos)

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ build-apple-platform-tvos := $(addprefix _build-apple-,$(apple-platform-targets-
 build-apple-platform-watchos := $(addprefix _build-apple-,$(apple-platform-targets-watchos))
 
 # Build all targets for a specific platform (without creating xcframework).
-build-apple-macos: $(build-apple-platform-macos)
-build-apple-ios: $(build-apple-platform-ios)
-build-apple-tvos: $(build-apple-platform-tvos)
-build-apple-watchos: $(build-apple-platform-watchos)
+build-apple-macOS: $(build-apple-platform-macos)
+build-apple-iOS: $(build-apple-platform-ios)
+build-apple-tvOS: $(build-apple-platform-tvos)
+build-apple-watchOS: $(build-apple-platform-watchos)
 
 # Creating xcframework for one single platform, including real device and simulator.
 xcframework-only-macos: $(build-apple-platform-macos)
@@ -283,15 +283,15 @@ setup-rust-toolchain:
 		aarch64-apple-ios-sim
 
 # Platform-specific Rust setup (only installs what each platform needs in CI)
-setup-rust-macos:
+setup-rust-macOS:
 	rustup toolchain install stable
 	rustup target add --toolchain stable x86_64-apple-darwin aarch64-apple-darwin
 
-setup-rust-ios:
+setup-rust-iOS:
 	rustup toolchain install stable
 	rustup target add --toolchain stable aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 
-setup-rust-tvos setup-rust-watchos:
+setup-rust-tvOS setup-rust-watchOS:
 	rustup toolchain install stable
 	rustup toolchain install $(rust_nightly_toolchain)
 	rustup component add rust-src --toolchain $(rust_nightly_toolchain)


### PR DESCRIPTION
## Description

Parallelize the XCFramework CI build by splitting it into per-platform jobs (macOS, iOS, tvOS, watchOS) that run concurrently on separate Mac agents, then assembling the final XCFramework from artifacts. This is the Swift/Apple counterpart to #1203 which did the same for Android.

## Changes

- Split the single sequential `xcframework` Buildkite step into a matrix of 4 parallel platform builds + an assembly step
- Added `.buildkite/build-apple-platform.sh` – builds all Rust targets for a single Apple platform
- Added `.buildkite/assemble-xcframework.sh` – downloads pre-built artifacts and assembles the XCFramework
- Added per-platform Makefile targets (`build-apple-macOS`, `build-apple-iOS`, etc.) and `xcframework-assemble`
- Added platform-specific Rust setup targets (`setup-rust-macOS`, `setup-rust-iOS`, etc.) so each agent only installs the toolchains it needs
- The assemble step retains `key: "xcframework"` so all downstream `depends_on` references continue to work unchanged

## Build timing comparison

| Metric | Before ([#4957](https://buildkite.com/automattic/wordpress-rs/builds/4957)) | After ([#4964](https://buildkite.com/automattic/wordpress-rs/builds/4964)) |
|--------|--------|-------|
| XCFramework total (wall clock) | 26 min 27 sec | 14 min 29 sec |
| macOS | — | 8 min 55 sec |
| iOS | — | 10 min 37 sec |
| tvOS | — | 9 min 3 sec |
| watchOS | — | 10 min 55 sec |
| Assemble | — | 3 min 24 sec |
| **Improvement** | — | **45% faster** |

Note: Build #4964 has one unrelated failure in the "WordPress 6.8.1" Rust integration test (e2e group). All Swift group steps passed.

## Test plan

- [x] All 4 platform build steps pass ([build #4964](https://buildkite.com/automattic/wordpress-rs/builds/4964))
- [x] XCFramework assembly step passes
- [x] All downstream Swift steps pass (docs, simulator tests, device build, lint, Package.resolved, example apps)
- [x] Artifact upload/download works correctly between build and assemble steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)