### PR TITLE
Add a migration script to ensure custom terms are re-fetched

### DIFF
--- a/wp_mobile_cache/migrations/0012-invalidate-post-entity-states.sql
+++ b/wp_mobile_cache/migrations/0012-invalidate-post-entity-states.sql
@@ -1,0 +1,8 @@
+-- Migration 0011 added the additional_fields column to post tables but
+-- didn't invalidate existing cached posts. This UPDATE should have been
+-- part of 0011, but due to oversight, we need this separate migration.
+--
+-- Existing cached posts have NULL for additional_fields, which doesn't
+-- reflect the server state. Mark all Fresh post entity states as Stale
+-- so they get re-fetched on the next sync.
+UPDATE entity_state SET state = 3 WHERE entity_type = 0 AND state = 2;

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -412,7 +412,7 @@ impl From<Connection> for WpApiCache {
     }
 }
 
-static MIGRATION_QUERIES: [&str; 11] = [
+static MIGRATION_QUERIES: [&str; 12] = [
     include_str!("../migrations/0001-create-sites-table.sql"),
     include_str!("../migrations/0002-create-posts-table.sql"),
     include_str!("../migrations/0003-create-term-relationships.sql"),
@@ -424,6 +424,7 @@ static MIGRATION_QUERIES: [&str; 11] = [
     include_str!("../migrations/0009-create-entity-state-table.sql"),
     include_str!("../migrations/0010-create-wordpress-com-sites-table.sql"),
     include_str!("../migrations/0011-add-additional-fields-to-posts-tables.sql"),
+    include_str!("../migrations/0012-invalidate-post-entity-states.sql"),
 ];
 
 pub struct MigrationManager<'a> {


### PR DESCRIPTION
## Description

The comment in the migration script should explain why it's needed.

The issue caused in the app was:
1. An older version of wprs stores posts without custom terms.
2. The new version after `additional_fields` is introduced in [the 0011 migration script](https://github.com/Automattic/wordpress-rs/blob/53a592f4642fe7a2d08c1415a6e0512bf2b1a5af/wp_mobile_cache/migrations/0011-add-additional-fields-to-posts-tables.sql) is able to store custom terms.
3. The app update to the newer version, which automatically sets the stored posts' `additional_fields` to null.
4. The posts will not be refreshed, because their state is "fresh". That means the app shows they don't have any custom terms, which may be incorrect.