### PR TITLE
Fix unsafe row indexing and remove unnecessary Hash in stats endpoints

### DIFF
--- a/wp_api/src/wp_com/stats_city_views.rs
+++ b/wp_api/src/wp_com/stats_city_views.rs
@@ -17,7 +17,6 @@ use wp_serde_helper::deserialize_option_empty_array_or_hashmap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_clicks.rs
+++ b/wp_api/src/wp_com/stats_clicks.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_country_views.rs
+++ b/wp_api/src/wp_com/stats_country_views.rs
@@ -17,7 +17,6 @@ use wp_serde_helper::deserialize_option_empty_array_or_hashmap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_devices.rs
+++ b/wp_api/src/wp_com/stats_devices.rs
@@ -16,7 +16,6 @@ use wp_serde_helper::deserialize_empty_array_or_hashmap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_file_downloads.rs
+++ b/wp_api/src/wp_com/stats_file_downloads.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_referrers.rs
+++ b/wp_api/src/wp_com/stats_referrers.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_region_views.rs
+++ b/wp_api/src/wp_com/stats_region_views.rs
@@ -17,7 +17,6 @@ use wp_serde_helper::deserialize_option_empty_array_or_hashmap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_search_terms.rs
+++ b/wp_api/src/wp_com/stats_search_terms.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_top_authors.rs
+++ b/wp_api/src/wp_com/stats_top_authors.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_top_posts.rs
+++ b/wp_api/src/wp_com/stats_top_posts.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_video_plays.rs
+++ b/wp_api/src/wp_com/stats_video_plays.rs
@@ -15,7 +15,6 @@ use serde::{Deserialize, Serialize};
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -15,7 +15,6 @@ use serde::{Deserialize, Serialize};
     Eq,
     PartialOrd,
     Ord,
-    Hash,
     Serialize,
     Deserialize,
     uniffi::Enum,
@@ -63,7 +62,7 @@ impl AppendUrlQueryPairs for StatsVisitsParams {
 }
 
 /// Response from the stats visits endpoint.
-#[derive(Debug, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsVisitsResponse {
     /// The date for the stats query.
     pub date: String,
@@ -121,65 +120,68 @@ impl StatsVisitsResponse {
 }
 
 fn get_stats_data(handle: &str, response: &StatsVisitsResponse) -> Vec<(String, u64)> {
-    let field_index = response
-        .fields
-        .iter()
-        .position(|field| field == handle)
-        .unwrap();
+    let period_index = match response.fields.iter().position(|f| f == "period") {
+        Some(i) => i,
+        None => return vec![],
+    };
+
+    let field_index = match response.fields.iter().position(|field| field == handle) {
+        Some(index) => index,
+        None => return vec![],
+    };
 
     response
         .data
         .iter()
         .filter_map(|row| {
-            if let Some(period) = row[0].as_string()
-                && let Some(value) = row[field_index].as_number()
+            if let Some(period) = row.get(period_index).and_then(|v| v.as_string())
+                && let Some(value) = row.get(field_index).and_then(|v| v.as_number())
             {
                 return Some((period.clone(), value));
             }
-
             None
         })
         .collect()
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsVisitsDataPoint {
     pub period: String,
     pub visits: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsVisitorsDataPoint {
     pub period: String,
     pub visitors: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsLikesDataPoint {
     pub period: String,
     pub likes: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsReblogsDataPoint {
     pub period: String,
     pub reblogs: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsCommentsDataPoint {
     pub period: String,
     pub comments: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsPostsDataPoint {
     pub period: String,
     pub posts: u64,
 }
 
 /// A value in the stats visits data array (can be string, number, or null).
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Enum)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, uniffi::Enum)]
 #[serde(untagged)]
 pub enum StatsVisitsDataValue {
     String(String),


### PR DESCRIPTION
## Description

Addresses two issues flagged in PR #1200 review that also exist in the current codebase. These improvements enhance safety and code quality across all stats endpoints.

## Changes

1. **Fix unsafe row indexing in `stats_visits.rs`**: The `get_stats_data()` function hard-coded `row[0]` to access the period field and used `.unwrap()` on `position()`. Now it safely looks up both the "period" and data field indices using `position()`, and uses `.get()` for bounds-safe access instead of direct indexing, which would panic on out-of-bounds access.

2. **Remove unnecessary `Hash` derives**: Removed `Hash` from 12 stats Period/Unit enums and 8 DataPoint/Response types across all stats files. Analysis showed none of these types are used as HashMap/HashSet keys anywhere in the codebase—`Hash` was blindly copied from other types. The only type genuinely requiring `Hash` is `AttachmentMetadataKey` (used as a HashMap key in `support_tickets.rs`), which was correctly retained.

## Test plan

- All 1256 unit tests pass
- `cargo build` succeeds with no errors
- No new clippy warnings introduced (pre-existing warnings in other files remain)