### PR TITLE
Allow changing the `per_page` argument

### DIFF
--- a/wp_mobile/src/collection/post_metadata_collection.rs
+++ b/wp_mobile/src/collection/post_metadata_collection.rs
@@ -159,6 +159,13 @@ impl PostMetadataCollectionWithEditContext {
     pub async fn refresh(&self) -> Result<SyncResult, FetchError> {
         log::debug!("PostMetadataCollection: Refreshing collection");
 
+        // If the per_page configuration changed since this list was created,
+        // delete the stale list so it gets recreated with the correct per_page.
+        // This is safe because refresh replaces all list content anyway.
+        self.service
+            .metadata_service
+            .delete_list_if_per_page_changed(self.core.key(), self.core.per_page())?;
+
         let result = self
             .service
             .sync_list(

--- a/wp_mobile/src/service/metadata.rs
+++ b/wp_mobile/src/service/metadata.rs
@@ -189,6 +189,35 @@ impl MetadataService {
         })
     }
 
+    /// Delete a list if its stored `per_page` doesn't match the expected value.
+    ///
+    /// When the app updates the `per_page` configuration for a collection,
+    /// the existing list in the DB becomes incompatible because page boundaries
+    /// are derived from `per_page`. This deletes the stale list so the next
+    /// refresh recreates it with the correct `per_page`.
+    ///
+    /// No-op if the list doesn't exist or already has the expected `per_page`.
+    pub(crate) fn delete_list_if_per_page_changed(
+        &self,
+        key: &ListKey,
+        per_page: u32,
+    ) -> Result<(), WpServiceError> {
+        self.cache.execute(|conn| {
+            if let Some(header) = ListMetadataRepository::get_header(conn, &self.db_site, key)?
+                && header.per_page != per_page as i64
+            {
+                log::info!(
+                    "per_page changed for key={} (stored={}, expected={}), deleting old list",
+                    key,
+                    header.per_page,
+                    per_page
+                );
+                ListMetadataRepository::delete_list(conn, &self.db_site, key)?;
+            }
+            Ok(())
+        })
+    }
+
     /// Get the current version for concurrency checking.
     fn get_version(&self, key: &ListKey) -> Result<i64, WpServiceError> {
         self.cache


### PR DESCRIPTION
## Description

After using the collection to show a paginated post list, the per_page argument can not be changed for the same filter, and the collection returns a `PerPageMismatch` error.

Of course, it's safe and reasonable to change the per_page. We can simply discard the stored data in the `list_metadata` table.

## Changes

Add a check at the beginning of the `refresh` call to check if the per_page value is different than the one stored in the database. Discard the database value if they are different.