### PR TITLE
Fix loading trashed post by ids

### DIFF
--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -533,6 +533,7 @@ pub enum PostStatus {
     #[default]
     Publish,
     Trash,
+    Any,
     #[serde(untagged)]
     #[strum(default)]
     Custom(String),

--- a/wp_api_integration_tests/tests/test_posts_immut.rs
+++ b/wp_api_integration_tests/tests/test_posts_immut.rs
@@ -230,7 +230,7 @@ async fn paginate_list_posts_with_edit_context(#[case] params: PostListParams) {
 #[rstest]
 #[parallel]
 #[case(PostListParams { per_page: Some(60), ..Default::default() })]
-#[case(PostListParams { per_page: Some(60), status: vec![PostStatus::Custom("any".to_string())], ..Default::default() })]
+#[case(PostListParams { per_page: Some(60), status: vec![PostStatus::Any], ..Default::default() })]
 async fn paginate_list_all_posts(#[case] params: PostListParams) {
     // The `per_page` parameter is a magic number between published posts and draft posts total.
 

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -523,7 +523,7 @@ impl PostService {
             // Use "any" to match all post statuses (including custom ones), plus
             // "trash" which WordPress excludes from "any" because it has
             // `internal: true` (and therefore `exclude_from_search: true`).
-            status: vec![PostStatus::Trash, PostStatus::Custom("any".to_string())],
+            status: vec![PostStatus::Trash, PostStatus::Any],
             ..Default::default()
         };
 

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -520,18 +520,10 @@ impl PostService {
             // Ensure we get all requested posts regardless of default per_page
             per_page: Some(BATCH_FETCH_SIZE as u32),
             // Request all available post statuses as defined in the WordPress REST API.
-            // See: https://developer.wordpress.org/rest-api/reference/posts/#arguments
-            // The API defaults to 'publish' only, so we must explicitly list all statuses
-            // to fetch posts by ID regardless of their status (drafts, pending, etc.).
-            // Note: 'trash' is not included in the API's allowed status values.
-            // Note: This will not work with custom statuses and may need special handling.
-            status: vec![
-                PostStatus::Publish,
-                PostStatus::Draft,
-                PostStatus::Pending,
-                PostStatus::Private,
-                PostStatus::Future,
-            ],
+            // Use "any" to match all post statuses (including custom ones), plus
+            // "trash" which WordPress excludes from "any" because it has
+            // `internal: true` (and therefore `exclude_from_search: true`).
+            status: vec![PostStatus::Trash, PostStatus::Custom("any".to_string())],
             ..Default::default()
         };
 

--- a/wp_mobile_integration_tests/tests/test_posts_immut.rs
+++ b/wp_mobile_integration_tests/tests/test_posts_immut.rs
@@ -51,7 +51,7 @@ async fn test_fetch_all_posts_with_any_status() {
     let filter = PostListFilter {
         order: Some(WpApiParamOrder::Desc),
         orderby: Some(WpApiParamPostsOrderBy::Date),
-        status: vec![PostStatus::Custom("any".to_string())],
+        status: vec![PostStatus::Any],
         ..Default::default()
     };
 

--- a/wp_mobile_integration_tests/tests/test_posts_mut.rs
+++ b/wp_mobile_integration_tests/tests/test_posts_mut.rs
@@ -453,3 +453,147 @@ async fn test_delete_permanently_removes_from_collection() {
 
     RestoreServer::db().await;
 }
+
+#[tokio::test]
+#[serial]
+async fn test_load_posts_by_ids_includes_trashed_post() {
+    // 1. Create a draft post, then trash it.
+    // 2. Call `load_posts_by_ids` with the trashed post's ID.
+    //
+    // Expected result: the trashed post is returned successfully and
+    // its status in the cache is `PostStatus::Trash`.
+
+    let ctx = create_test_context();
+
+    let created = ctx
+        .service
+        .posts()
+        .create_post(
+            &PostEndpointType::Posts,
+            &PostCreateParams {
+                title: Some("Post To Trash Then Load By ID".to_string()),
+                status: Some(PostStatus::Draft),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_post should succeed");
+
+    let trashed = ctx
+        .service
+        .posts()
+        .trash_post(&PostEndpointType::Posts, &created.id)
+        .await
+        .expect("trash_post should succeed");
+    assert_eq!(trashed.status, PostStatus::Trash);
+
+    let result = ctx
+        .service
+        .posts()
+        .load_posts_by_ids(&PostEndpointType::Posts, vec![created.id])
+        .await
+        .expect("load_posts_by_ids should succeed");
+
+    assert_eq!(result.entity_ids.len(), 1, "should load 1 post");
+    assert_eq!(result.failed_count, 0, "no posts should fail to load");
+
+    let cached_posts = ctx
+        .service
+        .posts()
+        .read_posts_by_ids_from_db(&[created.id.0])
+        .expect("read_posts_by_ids_from_db should succeed");
+    assert_eq!(cached_posts.len(), 1, "should have 1 cached post");
+    assert_eq!(
+        cached_posts[0].data.status,
+        PostStatus::Trash,
+        "cached post should have Trash status"
+    );
+
+    RestoreServer::db().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_load_posts_by_ids_includes_mixed_status_posts() {
+    // 1. Create a draft post.
+    // 2. Create another post and trash it.
+    // 3. Call `load_posts_by_ids` with both IDs.
+    //
+    // Expected result: both posts are returned—one with Draft status and
+    // one with Trash status.
+
+    let ctx = create_test_context();
+
+    let draft = ctx
+        .service
+        .posts()
+        .create_post(
+            &PostEndpointType::Posts,
+            &PostCreateParams {
+                title: Some("Draft Post For Mixed Status Test".to_string()),
+                status: Some(PostStatus::Draft),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create draft should succeed");
+
+    let to_trash = ctx
+        .service
+        .posts()
+        .create_post(
+            &PostEndpointType::Posts,
+            &PostCreateParams {
+                title: Some("Post To Trash For Mixed Status Test".to_string()),
+                status: Some(PostStatus::Draft),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create post to trash should succeed");
+
+    ctx.service
+        .posts()
+        .trash_post(&PostEndpointType::Posts, &to_trash.id)
+        .await
+        .expect("trash_post should succeed");
+
+    let result = ctx
+        .service
+        .posts()
+        .load_posts_by_ids(&PostEndpointType::Posts, vec![draft.id, to_trash.id])
+        .await
+        .expect("load_posts_by_ids should succeed");
+
+    assert_eq!(result.entity_ids.len(), 2, "should load 2 posts");
+    assert_eq!(result.failed_count, 0, "no posts should fail to load");
+
+    let cached_posts = ctx
+        .service
+        .posts()
+        .read_posts_by_ids_from_db(&[draft.id.0, to_trash.id.0])
+        .expect("read_posts_by_ids_from_db should succeed");
+    assert_eq!(cached_posts.len(), 2, "should have 2 cached posts");
+
+    let draft_post = cached_posts
+        .iter()
+        .find(|p| p.data.id == draft.id)
+        .expect("draft post should be in cache");
+    let trashed_post = cached_posts
+        .iter()
+        .find(|p| p.data.id == to_trash.id)
+        .expect("trashed post should be in cache");
+
+    assert_eq!(
+        draft_post.data.status,
+        PostStatus::Draft,
+        "draft post should have Draft status"
+    );
+    assert_eq!(
+        trashed_post.data.status,
+        PostStatus::Trash,
+        "trashed post should have Trash status"
+    );
+
+    RestoreServer::db().await;
+}


### PR DESCRIPTION
## Description

Trashed post couldn't be loaded, because the "trash" status is not in the hard-coded list. This PR changes the `status` query value from an allowed list (publish,pending,private,draft,...) to just "any,trash". The "any,trash" should include custom post status too.

<img width="400" src="https://github.com/user-attachments/assets/90f64b6e-0ec9-436a-b7f8-6e41be3da147" />

[Brief description of what this PR changes and why]