### PR TITLE
Add an error variant for discarded load more call

### DIFF
--- a/wp_mobile/src/collection/fetch_error.rs
+++ b/wp_mobile/src/collection/fetch_error.rs
@@ -14,6 +14,10 @@ pub enum FetchError {
 
     /// Database error during cache upsert
     Database { err_message: String },
+
+    /// A list refresh occurred while a load-more fetch was in-flight,
+    /// making the paginated results stale.
+    StaleLoadMore,
 }
 
 impl From<WpApiError> for FetchError {
@@ -45,6 +49,9 @@ impl WpSupportsLocalization for FetchError {
             FetchError::Database { err_message } => {
                 WpMessages::database_generic_message(err_message)
             }
+            FetchError::StaleLoadMore => WpMessages::database_generic_message(
+                "List was refreshed during load more, discarding results",
+            ),
         }
     }
 }

--- a/wp_mobile/src/service/metadata.rs
+++ b/wp_mobile/src/service/metadata.rs
@@ -534,9 +534,7 @@ impl MetadataService {
             // Version mismatch means refresh was called while we were fetching (race condition).
             // Don't modify state - whoever called refresh owns the state transition.
             // Our fetched data is stale, so just discard it and return an error.
-            return Err(FetchError::Database {
-                err_message: "List was refreshed during load more, discarding results".to_string(),
-            });
+            return Err(FetchError::StaleLoadMore);
         }
 
         // 4. Append metadata to existing items


### PR DESCRIPTION
## Description

The updated error "List was refreshed during load more, discarding results" occurs in the following scenario:
1. User enters a list: call `refresh` to load the first page, then call `loadNextPage` to load the next page.
2. User backs out of the list. The `loadNextPage` is still going.
3. User enters the same list: call `refresh` to load the first page. Meanwhile, the `loadNextPage` call comes back.

This PR adds a dedicated variant for this error, so that the client can ignore the error, which is safe.
