### PR TITLE
Add post formats endpoint

### DIFF
--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/App.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/App.kt
@@ -44,6 +44,7 @@ import rs.wordpress.example.shared.ui.users.UserListScreen
 import rs.wordpress.example.shared.ui.welcome.WelcomeScreen
 import rs.wordpress.example.shared.ui.wpcom.WpComBotConversationsScreen
 import rs.wordpress.example.shared.ui.wpcom.WpComMeScreen
+import rs.wordpress.example.shared.ui.wpcom.WpComPostFormatsScreen
 import rs.wordpress.example.shared.ui.wpcom.WpComSiteScreen
 import rs.wordpress.example.shared.ui.wpcom.WpComSupportConversationsScreen
 import uniffi.wp_api.PostEndpointType
@@ -363,8 +364,20 @@ fun App(authenticationEnabled: Boolean, authenticateSite: (String, onSuccess: ()
             composable("wpcom_site") {
                 WpComSiteScreen(
                     onMeClicked = { navController.navigate("wpcom_me") },
+                    onPostFormatsClicked = { navController.navigate("wpcom_post_formats") },
                     onSupportConversationsClicked = { navController.navigate("wpcom_support") },
                     onBotConversationsClicked = { navController.navigate("wpcom_bots") },
+                    onBackClicked = { navController.popBackStack() }
+                )
+            }
+            composable("wpcom_post_formats") {
+                val wpComClient = currentWpComClient
+                if (wpComClient == null) {
+                    ErrorMessage("No WordPress.com account connected")
+                    return@composable
+                }
+                WpComPostFormatsScreen(
+                    wpComApiClient = wpComClient,
                     onBackClicked = { navController.popBackStack() }
                 )
             }

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/wpcom/WpComPostFormatsScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/wpcom/WpComPostFormatsScreen.kt
@@ -1,0 +1,102 @@
+package rs.wordpress.example.shared.ui.wpcom
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Preview
+fun WpComPostFormatsScreen(
+    wpComApiClient: WpComApiClient,
+    onBackClicked: () -> Unit = {}
+) {
+    var formats by remember { mutableStateOf<Map<String, String>?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        when (val result = wpComApiClient.request { it.postFormats().get() }) {
+            is WpRequestResult.Success -> {
+                formats = result.response.data.formats
+                isLoading = false
+            }
+            else -> {
+                error = result.toString()
+                isLoading = false
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Post Formats") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClicked) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Error: $error",
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+            formats != null -> {
+                val sortedFormats = formats!!.entries.sortedBy { it.value }
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(paddingValues)
+                ) {
+                    items(sortedFormats) { (slug, label) ->
+                        ListItem(
+                            headlineContent = { Text(label) },
+                            supportingContent = { Text(slug) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/wpcom/WpComSiteScreen.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/wpcom/WpComSiteScreen.kt
@@ -23,6 +23,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun WpComSiteScreen(
     onMeClicked: () -> Unit,
+    onPostFormatsClicked: () -> Unit,
     onSupportConversationsClicked: () -> Unit,
     onBotConversationsClicked: () -> Unit,
     onBackClicked: () -> Unit = {}
@@ -49,6 +50,15 @@ fun WpComSiteScreen(
                         Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
                     },
                     modifier = Modifier.clickable(onClick = onMeClicked)
+                )
+            }
+            item {
+                ListItem(
+                    headlineContent = { Text("Post Formats") },
+                    trailingContent = {
+                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                    },
+                    modifier = Modifier.clickable(onClick = onPostFormatsClicked)
                 )
             }
             item {

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -551,6 +551,16 @@ fn post_status_from_string(s: String) -> PostStatus {
     PostStatus::from_str(&s).unwrap_or(PostStatus::Custom(s))
 }
 
+/// Parse a string into a PostFormat.
+///
+/// This is a helper function for platform code that can't access the `FromStr` trait
+/// directly due to UniFFI limitations. Unknown values are returned as `Custom`.
+#[uniffi::export]
+fn post_format_from_string(s: String) -> PostFormat {
+    use std::str::FromStr;
+    PostFormat::from_str(&s).unwrap_or(PostFormat::Custom(s))
+}
+
 #[derive(
     Debug,
     Clone,

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -5,6 +5,7 @@ use super::endpoint::{
     },
     me_endpoint::{MeRequestBuilder, MeRequestExecutor},
     oauth2::{Oauth2RequestBuilder, Oauth2RequestExecutor},
+    post_formats_endpoint::{PostFormatsRequestBuilder, PostFormatsRequestExecutor},
     stats_city_views_endpoint::{StatsCityViewsRequestBuilder, StatsCityViewsRequestExecutor},
     stats_clicks_endpoint::{StatsClicksRequestBuilder, StatsClicksRequestExecutor},
     stats_country_views_endpoint::{
@@ -60,6 +61,7 @@ pub struct WpComApiRequestBuilder {
     languages: Arc<LanguagesRequestBuilder>,
     me: Arc<MeRequestBuilder>,
     oauth2: Arc<Oauth2RequestBuilder>,
+    post_formats: Arc<PostFormatsRequestBuilder>,
     sites: Arc<SitesRequestBuilder>,
     stats_city_views: Arc<StatsCityViewsRequestBuilder>,
     stats_clicks: Arc<StatsClicksRequestBuilder>,
@@ -93,6 +95,7 @@ impl WpComApiRequestBuilder {
             languages,
             me,
             oauth2,
+            post_formats,
             sites,
             stats_city_views,
             stats_clicks,
@@ -137,6 +140,7 @@ pub struct WpComApiClient {
     languages: Arc<LanguagesRequestExecutor>,
     me: Arc<MeRequestExecutor>,
     oauth2: Arc<Oauth2RequestExecutor>,
+    post_formats: Arc<PostFormatsRequestExecutor>,
     sites: Arc<SitesRequestExecutor>,
     stats_city_views: Arc<StatsCityViewsRequestExecutor>,
     stats_clicks: Arc<StatsClicksRequestExecutor>,
@@ -171,6 +175,7 @@ impl WpComApiClient {
             languages,
             me,
             oauth2,
+            post_formats,
             sites,
             stats_city_views,
             stats_clicks,
@@ -198,6 +203,7 @@ api_client_generate_endpoint_impl!(WpComApi, jetpack_connection);
 api_client_generate_endpoint_impl!(WpComApi, languages);
 api_client_generate_endpoint_impl!(WpComApi, me);
 api_client_generate_endpoint_impl!(WpComApi, oauth2);
+api_client_generate_endpoint_impl!(WpComApi, post_formats);
 api_client_generate_endpoint_impl!(WpComApi, sites);
 api_client_generate_endpoint_impl!(WpComApi, stats_city_views);
 api_client_generate_endpoint_impl!(WpComApi, stats_clicks);

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -12,6 +12,7 @@ pub mod jetpack_connection_endpoint;
 pub mod languages_endpoint;
 pub mod me_endpoint;
 pub mod oauth2;
+pub mod post_formats_endpoint;
 pub mod sites_endpoint;
 pub mod stats_city_views_endpoint;
 pub mod stats_clicks_endpoint;

--- a/wp_api/src/wp_com/endpoint/post_formats_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/post_formats_endpoint.rs
@@ -1,0 +1,17 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{WpComNamespace, WpComSiteId},
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum PostFormatsRequest {
+    #[get(url = "/sites/<wp_com_site_id>/post-formats", output = crate::wp_com::post_formats::WpComPostFormatsResponse)]
+    Get,
+}
+
+impl DerivedRequest for PostFormatsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -10,6 +10,7 @@ pub mod jetpack_connection;
 pub mod language;
 pub mod me;
 pub mod oauth2;
+pub mod post_formats;
 pub mod sites;
 pub mod stats_city_views;
 pub mod stats_clicks;

--- a/wp_api/src/wp_com/post_formats.rs
+++ b/wp_api/src/wp_com/post_formats.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct WpComPostFormatsResponse {
+    pub formats: HashMap<String, String>,
+}


### PR DESCRIPTION
## Description

Adds support for retrieving a site's supported post formats from the WP.com REST API (`GET /rest/v1.1/sites/{siteId}/post-formats`), along with a demo screen in the Android app.

## Changes

1. New `WpComPostFormatsResponse` type with a `formats: HashMap<String, String>` (slug → label)
2. New `PostFormatsRequest` endpoint definition using `WpDerivedRequest`
3. Wired up `post_formats` in `WpComApiRequestBuilder`, `WpComApiClient`, and endpoint impl macro
4. Added `post_format_from_string` UniFFI helper in `posts.rs` for platform code to convert string keys to `PostFormat` enum values
5. Added `WpComPostFormatsScreen` to the Android demo app with navigation from the WP.com site menu

## Test plan

- [x] `cargo test --lib` — all 108 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p wp_api --all-features -- -D warnings` — clean
- [ ] Verify UniFFI bindings generate correctly with `make xcframework`
- [ ] Run the Android demo app → log in to a WP.com site → tap "Post Formats" → verify the list of formats loads