### PR TITLE
Add new APIs for deleting site data from WpApiCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Template Revisions](https://developer.wordpress.org/rest-api/reference/wp_template-revisions/) endpoint
 - WordPress.com Publicize endpoints (`/sites/<site>/publicize/connections` and `/sites/<site>/publicize/services`) for listing, creating, updating, and deleting Jetpack Social connections
 - WordPress.com `/me/connections` (keyring) endpoint for listing third-party OAuth connections used by Jetpack Social
+- `WpApiCache` APIs to remove cached data for a self-hosted site (by URL) or a WordPress.com site (by site ID), with matching Swift wrappers on `WordPressApiCache`
 - `WpDerivedRequest` now supports plain `get` requests
 - `WpDerivedRequest` now supports `additional_query_pairs`
 

--- a/native/swift/Sources/wordpress-api-cache/WordPressApiCache.swift
+++ b/native/swift/Sources/wordpress-api-cache/WordPressApiCache.swift
@@ -66,6 +66,25 @@ public final class WordPressApiCache: Sendable {
     }
     #endif
 
+    /// Remove a self-hosted site and all its cached data from the database.
+    ///
+    /// Returns `true` if the site was found and removed, `false` if no site
+    /// with the given URL exists.
+    @discardableResult
+    public func removeSelfHostedSite(url: URL) throws -> Bool {
+        let parsed = try ParsedUrl.parse(input: url.absoluteString)
+        return try self.cache.removeSelfHostedSite(url: parsed)
+    }
+
+    /// Remove a WordPress.com site and all its cached data from the database.
+    ///
+    /// Returns `true` if the site was found and removed, `false` if no site
+    /// with the given site ID exists.
+    @discardableResult
+    public func removeWordpressComSite(siteId: WpComSiteId) throws -> Bool {
+        try self.cache.removeWordpressComSite(siteId: siteId)
+    }
+
     deinit {
         self.cache.stopListeningForUpdates()
 

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -1,10 +1,13 @@
 use rusqlite::hooks::Action;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput};
 use rusqlite::{Connection, Result as SqliteResult, params};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::repository::entity_state::EntityStateRepository;
 use crate::repository::list_metadata::ListMetadataRepository;
+use crate::repository::sites::SiteRepository;
+use wp_api::parsed_url::ParsedUrl;
+use wp_api::wp_com::WpComSiteId;
 
 pub mod context;
 pub mod db_types;
@@ -347,6 +350,27 @@ impl WpApiCache {
             connection.update_hook(None::<fn(Action, &str, &str, i64)>);
         });
     }
+
+    /// Remove a self-hosted site and all its cached data from the database.
+    ///
+    /// Returns `true` if the site was found and removed, `false` if no site
+    /// with the given URL exists.
+    pub fn remove_self_hosted_site(&self, url: Arc<ParsedUrl>) -> Result<bool, SqliteDbError> {
+        let candidates = url_candidates(&url);
+        self.execute(|connection| {
+            SiteRepository.delete_self_hosted_site_by_url(connection, &candidates)
+        })
+    }
+
+    /// Remove a WordPress.com site and all its cached data from the database.
+    ///
+    /// Returns `true` if the site was found and removed, `false` if no site
+    /// with the given site ID exists.
+    pub fn remove_wordpress_com_site(&self, site_id: WpComSiteId) -> Result<bool, SqliteDbError> {
+        self.execute(|connection| {
+            SiteRepository.delete_wordpress_com_site_by_site_id(connection, site_id)
+        })
+    }
 }
 
 impl WpApiCache {
@@ -574,6 +598,17 @@ impl DBManager {
     }
 }
 
+fn url_candidates(url: &ParsedUrl) -> [String; 2] {
+    let s = url.url();
+    if s.ends_with('/') {
+        let stripped = s[..s.len() - 1].to_string();
+        [s, stripped]
+    } else {
+        let with_slash = format!("{}/", s);
+        [s, with_slash]
+    }
+}
+
 uniffi::setup_scaffolding!();
 
 #[cfg(test)]
@@ -750,6 +785,23 @@ mod tests {
         assert!(
             result.is_err(),
             "Expected error when migration index exceeds available migrations"
+        );
+    }
+
+    #[test]
+    fn test_url_candidates_with_trailing_slash() {
+        let url = ParsedUrl::parse("https://example.com/").unwrap();
+        let candidates = url_candidates(&url);
+        assert_eq!(candidates, ["https://example.com/", "https://example.com"]);
+    }
+
+    #[test]
+    fn test_url_candidates_without_trailing_slash() {
+        let url = ParsedUrl::parse("https://example.com/path").unwrap();
+        let candidates = url_candidates(&url);
+        assert_eq!(
+            candidates,
+            ["https://example.com/path", "https://example.com/path/"]
         );
     }
 }

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -600,8 +600,8 @@ impl DBManager {
 
 fn url_candidates(url: &ParsedUrl) -> [String; 2] {
     let s = url.url();
-    if s.ends_with('/') {
-        let stripped = s[..s.len() - 1].to_string();
+    if let Some(stripped) = s.strip_suffix('/') {
+        let stripped = stripped.to_string();
         [s, stripped]
     } else {
         let with_slash = format!("{}/", s);

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -237,7 +237,16 @@ impl SiteRepository {
             }
         };
 
-        // Delete from sites table
+        // Explicitly delete entity_state rows — this table has no CASCADE
+        // constraint on db_site_id.
+        let sql = format!(
+            "DELETE FROM {} WHERE db_site_id = ?",
+            DbTable::EntityState.table_name()
+        );
+        tx.execute(&sql, [site.row_id])?;
+
+        // Delete from sites table (CASCADE removes posts, post types,
+        // term relationships, and list metadata)
         let sites_deleted = {
             let sql = format!(
                 "DELETE FROM {} WHERE rowid = ?",
@@ -250,20 +259,23 @@ impl SiteRepository {
         Ok(sites_deleted > 0)
     }
 
-    /// Delete a self-hosted site by URL (convenience wrapper).
+    /// Delete a self-hosted site by trying multiple URL candidates.
     ///
-    /// Returns `true` if a site was deleted, `false` if no site with that URL exists.
+    /// Useful when the caller's URL representation may differ from the stored
+    /// form (e.g. trailing slash normalization). Returns `true` if a site was
+    /// deleted, `false` if none of the candidates matched.
     pub fn delete_self_hosted_site_by_url(
         &self,
         transaction_manager: &mut impl TransactionManager,
-        url: &str,
+        url_candidates: &[String],
     ) -> Result<bool, SqliteDbError> {
-        let site_data = self.select_self_hosted_site_by_url(transaction_manager, url)?;
-
-        match site_data {
-            Some(full_entity) => self.delete_site(transaction_manager, &full_entity.data.0),
-            None => Ok(false),
+        for candidate in url_candidates {
+            let site_data = self.select_self_hosted_site_by_url(transaction_manager, candidate)?;
+            if let Some(full_entity) = site_data {
+                return self.delete_site(transaction_manager, &full_entity.data.0);
+            }
         }
+        Ok(false)
     }
 
     /// Upsert a WordPress.com site and return its EntityId (atomic transaction).
@@ -818,27 +830,46 @@ mod tests {
             api_root: "https://example.com/wp-json".to_string(),
         };
 
-        // Create site
         repo.upsert_self_hosted_site(&mut test_conn, &site)
             .expect("Failed to upsert site");
 
-        // Verify site exists
-        let before_delete = repo
-            .select_self_hosted_site_by_url(&test_conn, url)
-            .expect("Failed to select site by URL");
-        assert!(before_delete.is_some());
-
-        // Delete by URL
         let deleted = repo
-            .delete_self_hosted_site_by_url(&mut test_conn, url)
-            .expect("Failed to delete site by URL");
+            .delete_self_hosted_site_by_url(&mut test_conn, &[url.to_string(), format!("{}/", url)])
+            .expect("Failed to delete site");
         assert!(deleted, "Should return true when site is deleted");
 
-        // Verify site is gone
         let after_delete = repo
             .select_self_hosted_site_by_url(&test_conn, url)
             .expect("Failed to select site by URL");
         assert_eq!(after_delete, None, "Site should be deleted");
+    }
+
+    #[rstest]
+    fn test_delete_self_hosted_site_by_url_with_trailing_slash_mismatch(mut test_conn: Connection) {
+        let repo = SiteRepository;
+        // Store WITHOUT trailing slash
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+
+        repo.upsert_self_hosted_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        // Delete WITH trailing slash first (as ParsedUrl would produce)
+        let deleted = repo
+            .delete_self_hosted_site_by_url(
+                &mut test_conn,
+                &[
+                    "https://example.com/".to_string(),
+                    "https://example.com".to_string(),
+                ],
+            )
+            .expect("Failed to delete site");
+        assert!(
+            deleted,
+            "Should find and delete site despite trailing slash mismatch"
+        );
     }
 
     #[rstest]
@@ -848,8 +879,14 @@ mod tests {
         let repo = SiteRepository;
 
         let deleted = repo
-            .delete_self_hosted_site_by_url(&mut test_conn, "https://non-existent.com")
-            .expect("Failed to delete site by URL");
+            .delete_self_hosted_site_by_url(
+                &mut test_conn,
+                &[
+                    "https://non-existent.com".to_string(),
+                    "https://non-existent.com/".to_string(),
+                ],
+            )
+            .expect("Failed to delete site");
         assert!(!deleted, "Should return false when site doesn't exist");
     }
 

--- a/wp_mobile_integration_tests/src/lib.rs
+++ b/wp_mobile_integration_tests/src/lib.rs
@@ -63,6 +63,18 @@ pub fn create_test_context() -> TestContext {
     }
 }
 
+/// Count rows in a table filtered by `db_site_id`.
+pub fn count_rows_for_site(cache: &WpApiCache, table: &str, db_site_id: i64) -> usize {
+    cache.execute(|conn| {
+        let sql = format!("SELECT COUNT(*) FROM {} WHERE db_site_id = ?", table);
+        let mut stmt = conn.prepare(&sql).expect("Failed to prepare count query");
+        let count: i64 = stmt
+            .query_row([db_site_id], |row| row.get(0))
+            .expect("Failed to count rows");
+        count as usize
+    })
+}
+
 pub fn create_test_context_with_site(
     site_url: &str,
     username: &str,

--- a/wp_mobile_integration_tests/tests/test_remove_site.rs
+++ b/wp_mobile_integration_tests/tests/test_remove_site.rs
@@ -3,21 +3,8 @@ use wp_api::parsed_url::ParsedUrl;
 use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
 use wp_api::wp_com::WpComSiteId;
 use wp_mobile::filters::PostListFilter;
-use wp_mobile_cache::WpApiCache;
 use wp_mobile_cache::repository::sites::SiteRepository;
 use wp_mobile_integration_tests::*;
-
-/// Helper to count rows in a table filtered by db_site_id.
-fn count_rows_for_site(cache: &WpApiCache, table: &str, db_site_id: i64) -> usize {
-    cache.execute(|conn| {
-        let sql = format!("SELECT COUNT(*) FROM {} WHERE db_site_id = ?", table);
-        let mut stmt = conn.prepare(&sql).expect("Failed to prepare count query");
-        let count: i64 = stmt
-            .query_row([db_site_id], |row| row.get(0))
-            .expect("Failed to count rows");
-        count as usize
-    })
-}
 
 #[tokio::test]
 #[serial]

--- a/wp_mobile_integration_tests/tests/test_remove_site.rs
+++ b/wp_mobile_integration_tests/tests/test_remove_site.rs
@@ -1,0 +1,198 @@
+use std::sync::Arc;
+use wp_api::parsed_url::ParsedUrl;
+use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
+use wp_api::wp_com::WpComSiteId;
+use wp_mobile::filters::PostListFilter;
+use wp_mobile_cache::WpApiCache;
+use wp_mobile_cache::repository::sites::SiteRepository;
+use wp_mobile_integration_tests::*;
+
+/// Helper to count rows in a table filtered by db_site_id.
+fn count_rows_for_site(cache: &WpApiCache, table: &str, db_site_id: i64) -> usize {
+    cache.execute(|conn| {
+        let sql = format!("SELECT COUNT(*) FROM {} WHERE db_site_id = ?", table);
+        let mut stmt = conn.prepare(&sql).expect("Failed to prepare count query");
+        let count: i64 = stmt
+            .query_row([db_site_id], |row| row.get(0))
+            .expect("Failed to count rows");
+        count as usize
+    })
+}
+
+#[tokio::test]
+#[serial]
+async fn test_remove_self_hosted_site_deletes_all_cached_data() {
+    let ctx = create_test_context();
+    let site_url = TestCredentials::instance().site_url.to_string();
+
+    // Sync some posts to populate the cache
+    let collection = ctx
+        .service
+        .posts()
+        .create_post_metadata_collection_with_edit_context(
+            PostEndpointType::Posts,
+            PostListFilter::default(),
+            10,
+        );
+    let result = collection.refresh().await;
+    assert!(result.is_ok(), "refresh should succeed: {:?}", result.err());
+
+    let items = collection
+        .load_items()
+        .await
+        .expect("load_items should succeed");
+    assert!(!items.is_empty(), "should have loaded some items");
+
+    // Verify data exists in cache before removal
+    let db_site_id = ctx.cache.execute(|conn| {
+        let site = SiteRepository
+            .select_self_hosted_site_by_url(conn, &site_url)
+            .expect("select should succeed")
+            .expect("site should exist");
+        site.data.0.row_id.0
+    });
+    assert!(
+        count_rows_for_site(&ctx.cache, "posts_edit_context", db_site_id) > 0,
+        "posts should be cached before removal"
+    );
+
+    // Remove the site
+    let removed = ctx
+        .cache
+        .remove_self_hosted_site(Arc::new(ParsedUrl::parse(&site_url).unwrap()))
+        .expect("remove should succeed");
+    assert!(removed, "should return true when site existed");
+
+    // Verify all data is gone
+    assert_eq!(
+        count_rows_for_site(&ctx.cache, "posts_edit_context", db_site_id),
+        0,
+        "posts_edit_context should be empty after removal"
+    );
+    assert_eq!(
+        count_rows_for_site(&ctx.cache, "list_metadata", db_site_id),
+        0,
+        "list_metadata should be empty after removal"
+    );
+    assert_eq!(
+        count_rows_for_site(&ctx.cache, "entity_state", db_site_id),
+        0,
+        "entity_state should be empty after removal"
+    );
+
+    // Verify the site itself is gone
+    ctx.cache.execute(|conn| {
+        let site = SiteRepository
+            .select_self_hosted_site_by_url(conn, &site_url)
+            .expect("select should succeed");
+        assert!(site.is_none(), "site should no longer exist");
+    });
+}
+
+#[tokio::test]
+#[serial]
+async fn test_remove_non_existent_self_hosted_site_returns_false() {
+    let ctx = create_test_context();
+
+    let removed = ctx
+        .cache
+        .remove_self_hosted_site(Arc::new(
+            ParsedUrl::parse("https://non-existent-site.example.com").unwrap(),
+        ))
+        .expect("remove should succeed");
+    assert!(!removed, "should return false for non-existent site");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_remove_non_existent_wordpress_com_site_returns_false() {
+    let ctx = create_test_context();
+
+    let removed = ctx
+        .cache
+        .remove_wordpress_com_site(WpComSiteId(99999999))
+        .expect("remove should succeed");
+    assert!(!removed, "should return false for non-existent site");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_remove_site_preserves_other_sites_data() {
+    let ctx = create_test_context();
+
+    let site_url_1 = TestCredentials::instance().site_url.to_string();
+    let site_url_2 = "https://other-site.example.com";
+
+    let collection = ctx
+        .service
+        .posts()
+        .create_post_metadata_collection_with_edit_context(
+            PostEndpointType::Posts,
+            PostListFilter::default(),
+            10,
+        );
+    let result = collection.refresh().await;
+    assert!(result.is_ok(), "refresh should succeed: {:?}", result.err());
+
+    // Create site 2 (just the site entry, no actual data sync needed)
+    let _db_site_2 = ctx.cache.execute(|conn| {
+        use wp_mobile_cache::db_types::self_hosted_site::SelfHostedSite;
+        let site = SelfHostedSite {
+            url: site_url_2.to_string(),
+            api_root: format!("{}/wp-json", site_url_2),
+        };
+        SiteRepository
+            .upsert_self_hosted_site(conn, &site)
+            .expect("upsert should succeed")
+    });
+
+    // Verify both sites exist
+    let site_count = ctx.cache.execute(|conn| {
+        SiteRepository
+            .count_all_db_sites(conn)
+            .expect("count should succeed")
+    });
+    assert_eq!(site_count, 2, "should have two sites");
+
+    // Get site 1's db_site_id for verification
+    let db_site_id_1 = ctx.cache.execute(|conn| {
+        let site = SiteRepository
+            .select_self_hosted_site_by_url(conn, &site_url_1)
+            .expect("select should succeed")
+            .expect("site should exist");
+        site.data.0.row_id.0
+    });
+
+    let posts_before = count_rows_for_site(&ctx.cache, "posts_edit_context", db_site_id_1);
+    assert!(posts_before > 0, "site 1 should have cached posts");
+
+    // Remove site 2
+    let removed = ctx
+        .cache
+        .remove_self_hosted_site(Arc::new(ParsedUrl::parse(site_url_2).unwrap()))
+        .expect("remove should succeed");
+    assert!(removed, "site 2 should have been removed");
+
+    // Verify site 1's data is intact
+    let posts_after = count_rows_for_site(&ctx.cache, "posts_edit_context", db_site_id_1);
+    assert_eq!(
+        posts_before, posts_after,
+        "site 1's posts should be preserved after removing site 2"
+    );
+
+    // Verify site 1 still exists
+    ctx.cache.execute(|conn| {
+        let site = SiteRepository
+            .select_self_hosted_site_by_url(conn, &site_url_1)
+            .expect("select should succeed");
+        assert!(site.is_some(), "site 1 should still exist");
+    });
+
+    // Verify site 2 is gone
+    ctx.cache.execute(|conn| {
+        let site = SiteRepository
+            .select_self_hosted_site_by_url(conn, site_url_2)
+            .expect("select should succeed");
+        assert!(site.is_none(), "site 2 should no longer exist");
+    });
+}


### PR DESCRIPTION
## Description

The new APIs can be used when a site is removed from the mobile apps.