### PR TITLE
Fix site settings parsing issues

### DIFF
--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -102,8 +102,10 @@ pub struct SparseSiteSettings {
     #[WpContext(edit, embed, view)]
     pub page_for_posts: Option<u64>,
     #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
     pub default_ping_status: Option<SiteSettingsPingStatus>,
     #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
     pub default_comment_status: Option<SiteSettingsCommentStatus>,
     #[WpContext(edit, embed, view)]
     #[WpContextualOption]
@@ -153,5 +155,148 @@ impl Display for SiteSettingsCommentStatus {
             Self::Custom(name) => name.as_str(),
         };
         write!(f, "{s}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    // Reproduces the API response from the error report.
+    // `default_ping_status` is null, which previously caused a parsing failure
+    // because serde's untagged enum variant prevented Option from handling null.
+    const RESPONSE_WITH_NULL_PING_STATUS: &str = r#"{
+        "title": "Test Site",
+        "description": "",
+        "url": "https://example.com",
+        "email": "test@example.com",
+        "timezone": "",
+        "date_format": "F j, Y",
+        "time_format": "g:i a",
+        "start_of_week": 1,
+        "language": "en_US",
+        "use_smilies": true,
+        "default_category": 1,
+        "default_post_format": "aside",
+        "posts_per_page": 10,
+        "show_on_front": "page",
+        "page_on_front": 10,
+        "page_for_posts": 0,
+        "default_ping_status": null,
+        "default_comment_status": "open",
+        "site_logo": null,
+        "site_icon": 0
+    }"#;
+
+    fn json_with_statuses(ping: &str, comment: &str) -> String {
+        RESPONSE_WITH_NULL_PING_STATUS
+            .replace(
+                r#""default_ping_status": null"#,
+                &format!(r#""default_ping_status": {ping}"#),
+            )
+            .replace(
+                r#""default_comment_status": "open""#,
+                &format!(r#""default_comment_status": {comment}"#),
+            )
+    }
+
+    // Test all three generated contextual types with null status values,
+    // since WpContextual macro strips the Option wrapper unless
+    // #[WpContextualOption] is present.
+    #[test]
+    fn test_parse_view_context_with_null_ping_status() {
+        let settings: SiteSettingsWithViewContext =
+            serde_json::from_str(RESPONSE_WITH_NULL_PING_STATUS).unwrap();
+        assert_eq!(settings.default_ping_status, None);
+        assert_eq!(
+            settings.default_comment_status,
+            Some(SiteSettingsCommentStatus::Open)
+        );
+    }
+
+    #[test]
+    fn test_parse_edit_context_with_null_ping_status() {
+        let settings: SiteSettingsWithEditContext =
+            serde_json::from_str(RESPONSE_WITH_NULL_PING_STATUS).unwrap();
+        assert_eq!(settings.default_ping_status, None);
+        assert_eq!(
+            settings.default_comment_status,
+            Some(SiteSettingsCommentStatus::Open)
+        );
+    }
+
+    #[test]
+    fn test_parse_embed_context_with_null_ping_status() {
+        let settings: SiteSettingsWithEmbedContext =
+            serde_json::from_str(RESPONSE_WITH_NULL_PING_STATUS).unwrap();
+        assert_eq!(settings.default_ping_status, None);
+        assert_eq!(
+            settings.default_comment_status,
+            Some(SiteSettingsCommentStatus::Open)
+        );
+    }
+
+    #[test]
+    fn test_parse_view_context_with_both_statuses_null() {
+        let json = json_with_statuses("null", "null");
+        let settings: SiteSettingsWithViewContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(settings.default_ping_status, None);
+        assert_eq!(settings.default_comment_status, None);
+    }
+
+    #[rstest]
+    #[case("\"open\"", Some(SiteSettingsPingStatus::Open))]
+    #[case("\"closed\"", Some(SiteSettingsPingStatus::Closed))]
+    #[case("\"custom_value\"", Some(SiteSettingsPingStatus::Custom("custom_value".to_string())))]
+    #[case("null", None)]
+    fn test_parse_view_context_ping_status_values(
+        #[case] json_value: &str,
+        #[case] expected: Option<SiteSettingsPingStatus>,
+    ) {
+        let json = json_with_statuses(json_value, "\"open\"");
+        let settings: SiteSettingsWithViewContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(settings.default_ping_status, expected);
+    }
+
+    #[rstest]
+    #[case("\"open\"", Some(SiteSettingsCommentStatus::Open))]
+    #[case("\"closed\"", Some(SiteSettingsCommentStatus::Closed))]
+    #[case("\"custom_value\"", Some(SiteSettingsCommentStatus::Custom("custom_value".to_string())))]
+    #[case("null", None)]
+    fn test_parse_view_context_comment_status_values(
+        #[case] json_value: &str,
+        #[case] expected: Option<SiteSettingsCommentStatus>,
+    ) {
+        let json = json_with_statuses("\"open\"", json_value);
+        let settings: SiteSettingsWithViewContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(settings.default_comment_status, expected);
+    }
+
+    #[test]
+    fn test_parse_sparse_with_missing_ping_status_field() {
+        let json = r#"{
+            "title": "Test Site",
+            "description": "",
+            "url": "https://example.com",
+            "email": "test@example.com",
+            "timezone": "",
+            "date_format": "F j, Y",
+            "time_format": "g:i a",
+            "start_of_week": 1,
+            "language": "en_US",
+            "use_smilies": true,
+            "default_category": 1,
+            "default_post_format": "aside",
+            "posts_per_page": 10,
+            "show_on_front": "page",
+            "page_on_front": 10,
+            "page_for_posts": 0,
+            "default_comment_status": "open",
+            "site_logo": null,
+            "site_icon": 0
+        }"#;
+        let settings: SparseSiteSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.default_ping_status, None);
     }
 }


### PR DESCRIPTION
## Description

The `default_ping_status` and `default_comment_status` values may be `null`, which causes parsing errors at the moment. This PR fixes the issue by declaring them as `WpContextualOption`.

Please note: This PR branch is branched off the `alpha-20260313` tag, which is the commit that the iOS app 26.8 uses. I'll publish a new version to patch the `alpha-20260313` release and use it in the iOS app.

```
           trunk                         alpha-20260313          patch/ios-26.8 (this PR)
             |                                |                       |
    dc86c7a6 * (Bump core-ktx)                |                       |
    de468e58 * (Bump json)                    |                       |
    feb144d3 * (swift-format)                 |                       |
    262a778e * (stats tags)                   |                       |
             |  ...                           |                       |
    7b5d3433 * (Subscribers)                  |                       |
             |                      cde2fda8  * (Swift Bindings)      |
             |                      9eb33494  * (Package.swift)       |
             |                                |             0261d312  * (Fix site settings parsing)
              \                              /                       /
               `---------.------------------'  ---------------------'
                         |
               8571ead3  * (Fix Swift CI failures on release builds)
                         |
               3f253bde  * (Allow changing per_page)
                         |
```
