### PR TITLE
Group Kotlin, Compose, and Koin in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
     directory: "native/kotlin" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      kotlin-ecosystem:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.compose"
+          - "io.insert-koin:*"
 
   - package-ecosystem: "bundler"
     directory: "/" # Location of package manifests


### PR DESCRIPTION
## Summary

- Groups `org.jetbrains.kotlin*`, `org.jetbrains.compose`, and `io.insert-koin:*` into a single Dependabot PR
- These have tight version coupling (e.g. Koin 4.2.0 requires Kotlin 2.3+, which requires Compose 1.11+)
- Prevents orphaned PRs like #1242 where Koin was bumped alone and broke the build

## Test plan

- [ ] Verify Dependabot creates grouped PRs on next schedule run

🤖 Generated with [Claude Code](https://claude.com/claude-code)