### PR TITLE
Add UserCapabilitiesMap to handle non-boolean capability values

### DIFF
--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -1,5 +1,5 @@
 use crate::{
-    EnumFromStrParsingError, OptionFromStr, WpApiParamOrder, WpResponseString,
+    EnumFromStrParsingError, JsonValue, OptionFromStr, WpApiParamOrder, WpResponseString,
     impl_as_query_value_from_to_string,
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
@@ -260,6 +260,27 @@ pub enum UserCapability {
 
 impl_as_query_value_from_to_string!(UserCapability);
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
+#[serde(transparent)]
+pub struct UserCapabilitiesMap {
+    #[serde(deserialize_with = "wp_serde_helper::deserialize_empty_array_or_hashmap")]
+    #[serde(flatten)]
+    #[serde(rename = "capabilities")]
+    pub map: HashMap<UserCapability, JsonValue>,
+}
+
+#[uniffi::export]
+impl UserCapabilitiesMap {
+    /// Check if the user has a specific capability.
+    ///
+    /// Returns `true` only if the capability is present and its value is a boolean `true`.
+    /// Capabilities with non-boolean values (e.g., strings like "custom" or "any" added by
+    /// plugins such as WPBakery) return `false`.
+    pub fn has_cap(&self, capability: UserCapability) -> bool {
+        self.map.get(&capability) == Some(&JsonValue::Bool(true))
+    }
+}
+
 #[uniffi::export]
 fn user_capability_from_string(value: String) -> UserCapability {
     UserCapability::from_str(value.as_str()).unwrap_or(UserCapability::Custom(value))
@@ -488,7 +509,7 @@ pub struct SparseUser {
     #[WpContext(edit)]
     pub roles: Option<Vec<UserRole>>,
     #[WpContext(edit)]
-    pub capabilities: Option<HashMap<UserCapability, bool>>,
+    pub capabilities: Option<UserCapabilitiesMap>,
     #[WpContext(edit)]
     pub extra_capabilities: Option<HashMap<String, bool>>,
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -608,6 +608,18 @@ mod tests {
         assert_eq!(UserCapability::from_str(expected_str), Ok(capability));
     }
 
+    #[test]
+    fn test_user_capabilities_map_with_non_boolean_values() {
+        let json = r#"{
+            "edit_posts": true,
+            "edit_users": false,
+            "vc_access_rules_post_types": "custom"
+        }"#;
+        let caps: UserCapabilitiesMap = serde_json::from_str(json)
+            .expect("Failed to deserialize capabilities with non-boolean values");
+        assert_eq!(caps.map.len(), 3);
+    }
+
     #[rstest]
     #[case(UserRole::SuperAdmin, "super_admin")]
     #[case(UserRole::Administrator, "administrator")]

--- a/wp_api/src/wp_com/sites.rs
+++ b/wp_api/src/wp_com/sites.rs
@@ -433,25 +433,6 @@ mod tests {
         assert_eq!(site_list.sites.len(), expected_count);
     }
 
-    #[test]
-    fn test_wpcom_site_capabilities_with_non_boolean_values() {
-        let json = test_json("v1.2-me-sites-01.json").expect("Failed to read JSON file");
-        let site_list: WPComSiteListResponse =
-            serde_json::from_slice(json.as_slice()).expect("Failed to deserialize site list");
-        let site = &site_list.sites[0];
-
-        // Standard boolean capabilities
-        assert!(site.capabilities.has_cap(crate::users::UserCapability::EditPosts));
-        assert!(!site.capabilities.has_cap(crate::users::UserCapability::EditUsers));
-
-        // WPBakery-style string capability should not be treated as granted
-        assert!(!site
-            .capabilities
-            .has_cap(crate::users::UserCapability::Custom(
-                "vc_access_rules_post_types".to_string()
-            )));
-    }
-
     #[rstest]
     #[case("v1.2-sites-01.json", 100001003)]
     fn test_wpcom_site_single_response_deserialization(

--- a/wp_api/src/wp_com/sites.rs
+++ b/wp_api/src/wp_com/sites.rs
@@ -3,7 +3,7 @@ use crate::{
     url_query::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
-    users::UserCapability,
+    users::UserCapabilitiesMap,
     wp_com::{WpComSiteId, me::WpComUserId},
     wp_content_string_id,
 };
@@ -138,7 +138,7 @@ pub struct WPComSite {
     pub url: String,
 
     /// The user's capabilities for the site.
-    pub capabilities: HashMap<UserCapability, bool>,
+    pub capabilities: UserCapabilitiesMap,
 
     /// Whether the site is a Jetpack site.
     pub jetpack: bool,
@@ -431,6 +431,25 @@ mod tests {
         let site_list: WPComSiteListResponse =
             serde_json::from_slice(json.as_slice()).expect("Failed to deserialize user info");
         assert_eq!(site_list.sites.len(), expected_count);
+    }
+
+    #[test]
+    fn test_wpcom_site_capabilities_with_non_boolean_values() {
+        let json = test_json("v1.2-me-sites-01.json").expect("Failed to read JSON file");
+        let site_list: WPComSiteListResponse =
+            serde_json::from_slice(json.as_slice()).expect("Failed to deserialize site list");
+        let site = &site_list.sites[0];
+
+        // Standard boolean capabilities
+        assert!(site.capabilities.has_cap(crate::users::UserCapability::EditPosts));
+        assert!(!site.capabilities.has_cap(crate::users::UserCapability::EditUsers));
+
+        // WPBakery-style string capability should not be treated as granted
+        assert!(!site
+            .capabilities
+            .has_cap(crate::users::UserCapability::Custom(
+                "vc_access_rules_post_types".to_string()
+            )));
     }
 
     #[rstest]

--- a/wp_api/tests/wpcom/sites/v1.2-me-sites-01.json
+++ b/wp_api/tests/wpcom/sites/v1.2-me-sites-01.json
@@ -31,8 +31,7 @@
           "activate_plugins": true,
           "update_plugins": false,
           "export": true,
-          "import": true,
-          "vc_access_rules_post_types": "custom"
+          "import": true
         },
         "jetpack": false,
         "jetpack_connection": false,

--- a/wp_api/tests/wpcom/sites/v1.2-me-sites-01.json
+++ b/wp_api/tests/wpcom/sites/v1.2-me-sites-01.json
@@ -31,7 +31,8 @@
           "activate_plugins": true,
           "update_plugins": false,
           "export": true,
-          "import": true
+          "import": true,
+          "vc_access_rules_post_types": "custom"
         },
         "jetpack": false,
         "jetpack_connection": false,


### PR DESCRIPTION
## Description

Fix [CMM-2013: Issue decoding site capabilities with non-boolean values](https://linear.app/a8c/issue/CMM-2013/issue-decoding-site-capabilities-with-non-boolean-values).

## Changes

  - Add `UserCapabilitiesMap` type that stores capabilities as `HashMap<UserCapability, JsonValue>` instead of
  `HashMap<UserCapability, bool>`, fixing deserialization failures when plugins (e.g., WPBakery) add capabilities with
   non-boolean values like `"custom"` or `"any"`
  - Add `has_cap(capability)` method exported via UniFFI that returns `true` only for boolean `true` values
  - Update `WPComSite.capabilities` and `SparseUser.capabilities` to use the new type


I used the suggested naming. The usage from Swift should presumably look like this.

```swift
 // Check a known capability
  site.capabilities.hasCap(capability: .editPosts)    // true
  site.capabilities.hasCap(capability: .editUsers)     // false

  // WPBakery-style string value → false
  site.capabilities.hasCap(capability: .custom("vc_access_rules_post_types")) // false

  // Raw map access still available
  site.capabilities.map  // [UserCapability: JsonValue]
```



## Test plan

The change is covered with a unit tests that adds a `WPBakery` capability key under question.
