### PR TITLE
Remove conflicting serde attributes from single-field structs

### DIFF
--- a/wp_api/src/menu_locations.rs
+++ b/wp_api/src/menu_locations.rs
@@ -6,7 +6,6 @@ use wp_contextual::WpContextual;
 wp_content_string_id!(MenuLocation);
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
-#[serde(transparent)]
 pub struct SparseMenuLocationsResponse {
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/post_statuses.rs
+++ b/wp_api/src/post_statuses.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, fmt::Display};
 use wp_contextual::WpContextual;
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
-#[serde(transparent)]
 pub struct SparsePostStatusesResponse {
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/post_types.rs
+++ b/wp_api/src/post_types.rs
@@ -58,7 +58,6 @@ impl PostTypeDetailsWithEditContext {
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
-#[serde(transparent)]
 pub struct SparsePostTypesResponse {
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]
@@ -100,11 +99,9 @@ pub struct SparsePostTypeDetails {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
-#[serde(transparent)]
 pub struct PostTypeSupportsMap {
     #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
     #[serde(flatten)]
-    #[serde(rename = "supports")]
     pub map: HashMap<PostTypeSupports, JsonValue>,
 }
 

--- a/wp_api/src/taxonomies.rs
+++ b/wp_api/src/taxonomies.rs
@@ -118,7 +118,6 @@ pub struct TaxonomyListParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record, WpContextual)]
-#[serde(transparent)]
 pub struct SparseTaxonomyTypesResponse {
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]

--- a/wp_api/src/users.rs
+++ b/wp_api/src/users.rs
@@ -261,11 +261,9 @@ pub enum UserCapability {
 impl_as_query_value_from_to_string!(UserCapability);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, uniffi::Record)]
-#[serde(transparent)]
 pub struct UserCapabilitiesMap {
     #[serde(deserialize_with = "wp_serde_helper::deserialize_empty_array_or_hashmap")]
     #[serde(flatten)]
-    #[serde(rename = "capabilities")]
     pub map: HashMap<UserCapability, JsonValue>,
 }
 


### PR DESCRIPTION
## Summary

Removed `#[serde(transparent)]` and conflicting `#[serde(rename)]` attributes from single-field wrapper structs.

## Changes

- Removed `#[serde(transparent)]` from 6 structs:
  - `UserCapabilitiesMap`
  - `PostTypeSupportsMap`
  - `SparsePostTypesResponse`
  - `SparseTaxonomyTypesResponse`
  - `SparseMenuLocationsResponse`
  - `SparsePostStatusesResponse`

- Removed `#[serde(rename)]` from `UserCapabilitiesMap` and `PostTypeSupportsMap`

## Rationale

For single-field structs, `#[serde(flatten)]` on the field is functionally equivalent to `#[serde(transparent)]` on the struct.

`#[serde(transparent)]` is not supported by:
- `WpContextual` (generates concrete types without `transparent`)
- `WpDeserialize` (explicitly rejects `transparent` attribute)

`#[serde(rename)]` conflicts with `#[serde(flatten)]` which takes all keys from the parent object.
