### PR TITLE
Change `StatsUtmKeys` to `Vec<StatsUtmKey>` newtype

### DIFF
--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -130,14 +130,34 @@ impl ApiUrlResolver for WpComApiClientInternalUrlResolver {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
-    use rstest::rstest;
+    use crate::{request::endpoint::ApiEndpointUrl, wp_com::WpComNamespace};
+    use rstest::*;
+    use std::sync::Arc;
+
+    const WP_COM_BASE_URL: &str = "https://public-api.wordpress.com";
+
+    #[fixture]
+    pub fn fixture_wp_com_api_url_resolver() -> Arc<dyn ApiUrlResolver> {
+        Arc::new(WpComApiClientInternalUrlResolver::default())
+    }
+
+    pub fn validate_wp_com_rest_v1_1_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
+        validate_endpoint(WpComNamespace::RestV1_1, endpoint_url, path);
+    }
+
+    fn validate_endpoint(namespace: WpComNamespace, endpoint_url: ApiEndpointUrl, path: &str) {
+        assert_eq!(
+            endpoint_url.as_str(),
+            format!("{}{}{}", WP_COM_BASE_URL, namespace.namespace_value(), path)
+        );
+    }
 
     #[rstest]
-    #[case("/wp/v2", vec!["posts".to_string()], "https://public-api.wordpress.com/wp/v2/sites/example.wordpress.com/posts")]
+    #[case(WpNamespace::WpV2, vec!["posts".to_string()], "https://public-api.wordpress.com/wp/v2/sites/example.wordpress.com/posts")]
     fn wp_com_dot_org_api_url_resolver(
-        #[case] namespace: &str,
+        #[case] namespace: WpNamespace,
         #[case] endpoint_segments: Vec<String>,
         #[case] expected_url: &str,
     ) {
@@ -147,7 +167,7 @@ mod tests {
         );
         assert_eq!(
             resolver
-                .resolve(namespace.to_string(), endpoint_segments)
+                .resolve(namespace.namespace_value().to_string(), endpoint_segments)
                 .url(),
             expected_url
         );

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -155,9 +155,9 @@ pub(crate) mod tests {
     }
 
     #[rstest]
-    #[case(WpNamespace::WpV2, vec!["posts".to_string()], "https://public-api.wordpress.com/wp/v2/sites/example.wordpress.com/posts")]
+    #[case("/wp/v2", vec!["posts".to_string()], "https://public-api.wordpress.com/wp/v2/sites/example.wordpress.com/posts")]
     fn wp_com_dot_org_api_url_resolver(
-        #[case] namespace: WpNamespace,
+        #[case] namespace: &str,
         #[case] endpoint_segments: Vec<String>,
         #[case] expected_url: &str,
     ) {
@@ -167,7 +167,7 @@ pub(crate) mod tests {
         );
         assert_eq!(
             resolver
-                .resolve(namespace.namespace_value().to_string(), endpoint_segments)
+                .resolve(namespace.to_string(), endpoint_segments)
                 .url(),
             expected_url
         );

--- a/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
@@ -47,7 +47,7 @@ mod tests {
     )]
     #[case(
         vec![StatsUtmKey::UtmCampaign, StatsUtmKey::UtmSource, StatsUtmKey::UtmMedium],
-        "/sites/12345/stats/utm/utm_campaign,utm_source,utm_medium?query_top_posts=1"
+        "/sites/12345/stats/utm/utm_source,utm_medium,utm_campaign?query_top_posts=1"
     )]
     #[case(
         vec![],

--- a/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
@@ -18,3 +18,76 @@ impl DerivedRequest for StatsUtmRequest {
         WpComNamespace::RestV1_1
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request::endpoint::ApiUrlResolver,
+        wp_com::{
+            endpoint::tests::{
+                fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
+            },
+            stats_utm::{StatsUtmKey, StatsUtmParams},
+        },
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    const SITE_ID: u64 = 12345;
+
+    #[rstest]
+    #[case(
+        vec![StatsUtmKey::UtmSource],
+        "/sites/12345/stats/utm/utm_source?query_top_posts=1"
+    )]
+    #[case(
+        vec![StatsUtmKey::UtmSource, StatsUtmKey::UtmMedium],
+        "/sites/12345/stats/utm/utm_source,utm_medium?query_top_posts=1"
+    )]
+    #[case(
+        vec![StatsUtmKey::UtmCampaign, StatsUtmKey::UtmSource, StatsUtmKey::UtmMedium],
+        "/sites/12345/stats/utm/utm_campaign,utm_source,utm_medium?query_top_posts=1"
+    )]
+    #[case(
+        vec![],
+        "/sites/12345/stats/utm/utm_source,utm_medium,utm_campaign?query_top_posts=1"
+    )]
+    fn get_stats_utm(
+        endpoint: StatsUtmRequestEndpoint,
+        #[case] keys: Vec<StatsUtmKey>,
+        #[case] expected_path: &str,
+    ) {
+        let site_id = WpComSiteId(SITE_ID);
+        let utm_keys = StatsUtmKeys(keys);
+        let params = StatsUtmParams::default();
+        validate_wp_com_rest_v1_1_endpoint(
+            endpoint.get_stats_utm(&site_id, &utm_keys, &params),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    fn get_stats_utm_with_params(endpoint: StatsUtmRequestEndpoint) {
+        let site_id = WpComSiteId(SITE_ID);
+        let utm_keys = StatsUtmKeys(vec![StatsUtmKey::UtmSource]);
+        let params = StatsUtmParams {
+            max: Some(10),
+            date: Some("2026-03-24".to_string()),
+            days: Some(30),
+            start_date: Some("2026-02-22".to_string()),
+            query_top_posts: false,
+        };
+        validate_wp_com_rest_v1_1_endpoint(
+            endpoint.get_stats_utm(&site_id, &utm_keys, &params),
+            "/sites/12345/stats/utm/utm_source?max=10&date=2026-03-24&days=30&start_date=2026-02-22&query_top_posts=0",
+        );
+    }
+
+    #[fixture]
+    fn endpoint(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> StatsUtmRequestEndpoint {
+        StatsUtmRequestEndpoint::new(fixture_wp_com_api_url_resolver)
+    }
+}

--- a/wp_api/src/wp_com/stats_utm.rs
+++ b/wp_api/src/wp_com/stats_utm.rs
@@ -40,11 +40,14 @@ pub struct StatsUtmKeys(pub Vec<StatsUtmKey>);
 
 impl std::fmt::Display for StatsUtmKeys {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let keys = if self.0.is_empty() {
+        let mut keys: Vec<StatsUtmKey> = if self.0.is_empty() {
             StatsUtmKey::iter().collect()
         } else {
             self.0.clone()
         };
+        // Sorted for dedup
+        keys.sort();
+        keys.dedup();
         let joined: Vec<_> = keys.iter().map(|k| k.to_string()).collect();
         write!(f, "{}", joined.join(","))
     }
@@ -144,7 +147,17 @@ mod tests {
             StatsUtmKey::UtmSource,
             StatsUtmKey::UtmMedium,
         ]);
-        assert_eq!(keys.to_string(), "utm_campaign,utm_source,utm_medium");
+        assert_eq!(keys.to_string(), "utm_source,utm_medium,utm_campaign");
+    }
+
+    #[test]
+    fn test_stats_utm_keys_deduplicates() {
+        let keys = StatsUtmKeys(vec![
+            StatsUtmKey::UtmSource,
+            StatsUtmKey::UtmMedium,
+            StatsUtmKey::UtmSource,
+        ]);
+        assert_eq!(keys.to_string(), "utm_source,utm_medium");
     }
 
     #[test]

--- a/wp_api/src/wp_com/stats_utm.rs
+++ b/wp_api/src/wp_com/stats_utm.rs
@@ -1,6 +1,7 @@
 use crate::url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use strum::IntoEnumIterator;
 use wp_serde_helper::deserialize_empty_array_or_hashmap;
 
 /// A single UTM key that can be used in the stats UTM endpoint path.
@@ -17,6 +18,7 @@ use wp_serde_helper::deserialize_empty_array_or_hashmap;
     uniffi::Enum,
     strum_macros::EnumString,
     strum_macros::Display,
+    strum_macros::EnumIter,
 )]
 pub enum StatsUtmKey {
     #[strum(serialize = "utm_source")]
@@ -30,29 +32,21 @@ pub enum StatsUtmKey {
     UtmCampaign,
 }
 
-uniffi::custom_newtype!(StatsUtmKeys, String);
-/// Comma-separated UTM keys used as a URL path segment.
-///
-/// For example, `"utm_source,utm_medium"` or `"utm_campaign"`.
-/// Construct from a list of `StatsUtmKey` using `StatsUtmKeys::new`.
+uniffi::custom_newtype!(StatsUtmKeys, Vec<StatsUtmKey>);
+/// UTM keys to query in the stats UTM endpoint.
+/// An empty vec defaults to all UTM keys.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatsUtmKeys(pub String);
-
-impl StatsUtmKeys {
-    pub fn new(keys: &[StatsUtmKey]) -> Self {
-        assert!(!keys.is_empty(), "At least one UTM key must be provided");
-        Self(
-            keys.iter()
-                .map(|k| k.to_string())
-                .collect::<Vec<_>>()
-                .join(","),
-        )
-    }
-}
+pub struct StatsUtmKeys(pub Vec<StatsUtmKey>);
 
 impl std::fmt::Display for StatsUtmKeys {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        let keys = if self.0.is_empty() {
+            StatsUtmKey::iter().collect()
+        } else {
+            self.0.clone()
+        };
+        let joined: Vec<_> = keys.iter().map(|k| k.to_string()).collect();
+        write!(f, "{}", joined.join(","))
     }
 }
 
@@ -133,19 +127,19 @@ mod tests {
 
     #[test]
     fn test_stats_utm_keys_single() {
-        let keys = StatsUtmKeys::new(&[StatsUtmKey::UtmSource]);
+        let keys = StatsUtmKeys(vec![StatsUtmKey::UtmSource]);
         assert_eq!(keys.to_string(), "utm_source");
     }
 
     #[test]
     fn test_stats_utm_keys_multiple() {
-        let keys = StatsUtmKeys::new(&[StatsUtmKey::UtmSource, StatsUtmKey::UtmMedium]);
+        let keys = StatsUtmKeys(vec![StatsUtmKey::UtmSource, StatsUtmKey::UtmMedium]);
         assert_eq!(keys.to_string(), "utm_source,utm_medium");
     }
 
     #[test]
-    fn test_stats_utm_keys_all() {
-        let keys = StatsUtmKeys::new(&[
+    fn test_stats_utm_keys_all_explicit() {
+        let keys = StatsUtmKeys(vec![
             StatsUtmKey::UtmCampaign,
             StatsUtmKey::UtmSource,
             StatsUtmKey::UtmMedium,
@@ -154,9 +148,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "At least one UTM key must be provided")]
-    fn test_stats_utm_keys_empty() {
-        StatsUtmKeys::new(&[]);
+    fn test_stats_utm_keys_empty_defaults_to_all() {
+        let keys = StatsUtmKeys(vec![]);
+        assert_eq!(keys.to_string(), "utm_source,utm_medium,utm_campaign");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Follow-up to #1253. Changes `StatsUtmKeys` from a `String` newtype to a `Vec<StatsUtmKey>` newtype so callers work with typed keys instead of a pre-joined string. An empty vec now defaults to all UTM keys instead of panicking.

## Changes

- Change `StatsUtmKeys` inner type from `String` to `Vec<StatsUtmKey>`
- Remove `StatsUtmKeys::new` constructor in favor of direct construction
- Add `EnumIter` to `StatsUtmKey`; empty vec in `Display` falls back to all variants
- Add shared WP.com endpoint test helpers (`fixture_wp_com_api_url_resolver`, `validate_wp_com_rest_v1_1_endpoint`)
- Add endpoint-level unit tests for `stats_utm_endpoint`