### PR TITLE
Capture custom entries in site settings via additional_fields

### DIFF
--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_json_value_from_float() {
-        assert_eq!(JsonValue::from(&serde_json::json!(3.14)), JsonValue::Float(3.14));
+        assert_eq!(JsonValue::from(&serde_json::json!(2.5)), JsonValue::Float(2.5));
     }
 
     #[test]

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -132,6 +132,27 @@ pub enum JsonValue {
     Object(HashMap<String, JsonValue>),
 }
 
+impl From<&Value> for JsonValue {
+    fn from(value: &Value) -> Self {
+        match value {
+            Value::Null => JsonValue::Null,
+            Value::Bool(b) => JsonValue::Bool(*b),
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    JsonValue::Int(i)
+                } else {
+                    JsonValue::Float(n.as_f64().unwrap_or(0.0))
+                }
+            }
+            Value::String(s) => JsonValue::String(s.clone()),
+            Value::Array(arr) => JsonValue::Array(arr.iter().map(JsonValue::from).collect()),
+            Value::Object(obj) => {
+                JsonValue::Object(obj.iter().map(|(k, v)| (k.clone(), JsonValue::from(v))).collect())
+            }
+        }
+    }
+}
+
 /// Similar to `JsonValue`, but exported as a Uniffi object.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, uniffi::Object)]
 #[uniffi::export(Eq, Hash)]
@@ -152,6 +173,20 @@ impl AnyJson {
                 .collect(),
             _ => vec![],
         }
+    }
+
+    /// Returns the keys present in this JSON object, or an empty vec if not an object.
+    pub fn keys(&self) -> Vec<String> {
+        match &self.raw {
+            Value::Object(map) => map.keys().cloned().collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Returns the value for a given key as a `JsonValue`, or `None` if the key
+    /// doesn't exist or this isn't an object.
+    pub fn value_for_key(&self, key: &str) -> Option<JsonValue> {
+        self.raw.get(key).map(JsonValue::from)
     }
 
     /// Creates an AnyJson from a map of keys to term ID arrays.

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -390,4 +390,71 @@ mod tests {
         assert_eq!(person.name, "Alice");
         assert_eq!(person.other_fields.raw, serde_json::json!({}));
     }
+
+    #[test]
+    fn test_json_value_from_null() {
+        assert_eq!(JsonValue::from(&serde_json::json!(null)), JsonValue::Null);
+    }
+
+    #[test]
+    fn test_json_value_from_bool() {
+        assert_eq!(JsonValue::from(&serde_json::json!(true)), JsonValue::Bool(true));
+        assert_eq!(JsonValue::from(&serde_json::json!(false)), JsonValue::Bool(false));
+    }
+
+    #[test]
+    fn test_json_value_from_positive_int() {
+        assert_eq!(JsonValue::from(&serde_json::json!(42)), JsonValue::Int(42));
+    }
+
+    #[test]
+    fn test_json_value_from_negative_int() {
+        assert_eq!(JsonValue::from(&serde_json::json!(-7)), JsonValue::Int(-7));
+    }
+
+    #[test]
+    fn test_json_value_from_large_u64() {
+        // u64::MAX doesn't fit in i64, so it falls through to the u64 → f64 path
+        let val = serde_json::json!(u64::MAX);
+        assert_eq!(JsonValue::from(&val), JsonValue::Float(u64::MAX as f64));
+    }
+
+    #[test]
+    fn test_json_value_from_float() {
+        assert_eq!(JsonValue::from(&serde_json::json!(3.14)), JsonValue::Float(3.14));
+    }
+
+    #[test]
+    fn test_json_value_from_string() {
+        assert_eq!(
+            JsonValue::from(&serde_json::json!("hello")),
+            JsonValue::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_json_value_from_array() {
+        assert_eq!(
+            JsonValue::from(&serde_json::json!([1, "two", null])),
+            JsonValue::Array(vec![
+                JsonValue::Int(1),
+                JsonValue::String("two".to_string()),
+                JsonValue::Null,
+            ])
+        );
+    }
+
+    #[test]
+    fn test_json_value_from_nested_object() {
+        assert_eq!(
+            JsonValue::from(&serde_json::json!({"a": {"b": [1, 2]}})),
+            JsonValue::Object(HashMap::from([(
+                "a".to_string(),
+                JsonValue::Object(HashMap::from([(
+                    "b".to_string(),
+                    JsonValue::Array(vec![JsonValue::Int(1), JsonValue::Int(2)])
+                )]))
+            )]))
+        );
+    }
 }

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -140,8 +140,16 @@ impl From<&Value> for JsonValue {
             Value::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     JsonValue::Int(i)
+                } else if let Some(u) = n.as_u64() {
+                    // u64 values that don't fit in i64 (> i64::MAX) — store as
+                    // float, accepting precision loss beyond 2^53. WordPress
+                    // APIs don't produce values in this range.
+                    JsonValue::Float(u as f64)
                 } else {
-                    JsonValue::Float(n.as_f64().unwrap_or(0.0))
+                    // Must be a float — as_f64() only returns None for
+                    // out-of-range values which serde_json won't parse without
+                    // the arbitrary_precision feature.
+                    JsonValue::Float(n.as_f64().expect("unexpected unrepresentable JSON number"))
                 }
             }
             Value::String(s) => JsonValue::String(s.clone()),

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -154,9 +154,11 @@ impl From<&Value> for JsonValue {
             }
             Value::String(s) => JsonValue::String(s.clone()),
             Value::Array(arr) => JsonValue::Array(arr.iter().map(JsonValue::from).collect()),
-            Value::Object(obj) => {
-                JsonValue::Object(obj.iter().map(|(k, v)| (k.clone(), JsonValue::from(v))).collect())
-            }
+            Value::Object(obj) => JsonValue::Object(
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), JsonValue::from(v)))
+                    .collect(),
+            ),
         }
     }
 }
@@ -398,8 +400,14 @@ mod tests {
 
     #[test]
     fn test_json_value_from_bool() {
-        assert_eq!(JsonValue::from(&serde_json::json!(true)), JsonValue::Bool(true));
-        assert_eq!(JsonValue::from(&serde_json::json!(false)), JsonValue::Bool(false));
+        assert_eq!(
+            JsonValue::from(&serde_json::json!(true)),
+            JsonValue::Bool(true)
+        );
+        assert_eq!(
+            JsonValue::from(&serde_json::json!(false)),
+            JsonValue::Bool(false)
+        );
     }
 
     #[test]
@@ -421,7 +429,10 @@ mod tests {
 
     #[test]
     fn test_json_value_from_float() {
-        assert_eq!(JsonValue::from(&serde_json::json!(2.5)), JsonValue::Float(2.5));
+        assert_eq!(
+            JsonValue::from(&serde_json::json!(2.5)),
+            JsonValue::Float(2.5)
+        );
     }
 
     #[test]

--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -115,6 +115,8 @@ pub struct SparseSiteSettings {
     pub site_logo: Option<u64>,
     #[WpContext(edit, embed, view)]
     pub site_icon: Option<u64>,
+    // Read-only for now — captures extra keys from plugin responses (e.g. Jetpack).
+    // Writing custom settings back via SiteSettingsUpdateParams is a separate effort.
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]
     #[WpContextualOption]

--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -403,4 +403,37 @@ mod tests {
         let additional = settings.additional_fields.expect("additional_fields should be present");
         assert!(additional.keys().contains(&"Blogroll Recommendations".to_string()));
     }
+
+    // With no unknown fields, additional_fields is Some with an empty object
+    // (not None). Consumers should check keys().is_empty() rather than is_none().
+    #[test]
+    fn test_additional_fields_is_empty_when_no_custom_entries() {
+        let json = r#"{
+            "title": "Test Site",
+            "description": "",
+            "url": "https://example.com",
+            "email": "test@example.com",
+            "timezone": "",
+            "date_format": "F j, Y",
+            "time_format": "g:i a",
+            "start_of_week": 1,
+            "language": "en_US",
+            "use_smilies": true,
+            "default_category": 1,
+            "default_post_format": "standard",
+            "posts_per_page": 10,
+            "show_on_front": "posts",
+            "page_on_front": 0,
+            "page_for_posts": 0,
+            "default_ping_status": "open",
+            "default_comment_status": "open",
+            "site_logo": null,
+            "site_icon": 0
+        }"#;
+        let settings: SiteSettingsWithViewContext = serde_json::from_str(json).unwrap();
+        let additional = settings
+            .additional_fields
+            .expect("additional_fields should be Some even with no custom entries");
+        assert!(additional.keys().is_empty());
+    }
 }

--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -368,11 +368,15 @@ mod tests {
         assert!(keys.contains(&"Blogroll Recommendations".to_string()));
 
         assert_eq!(
-            settings.additional_fields.value_for_key("jetpack_search_color_theme"),
+            settings
+                .additional_fields
+                .value_for_key("jetpack_search_color_theme"),
             Some(crate::JsonValue::String("light".to_string()))
         );
         assert_eq!(
-            settings.additional_fields.value_for_key("jetpack_search_enable_sort"),
+            settings
+                .additional_fields
+                .value_for_key("jetpack_search_enable_sort"),
             Some(crate::JsonValue::Bool(true))
         );
         assert_eq!(
@@ -381,7 +385,12 @@ mod tests {
         );
         // Known fields should NOT leak into additional_fields
         assert!(settings.additional_fields.value_for_key("title").is_none());
-        assert!(settings.additional_fields.value_for_key("site_icon").is_none());
+        assert!(
+            settings
+                .additional_fields
+                .value_for_key("site_icon")
+                .is_none()
+        );
     }
 
     #[test]
@@ -389,7 +398,12 @@ mod tests {
         let settings: SiteSettingsWithEditContext =
             serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
         assert_eq!(settings.title, "Test Site");
-        assert!(settings.additional_fields.keys().contains(&"jetpack_search_highlight_color".to_string()));
+        assert!(
+            settings
+                .additional_fields
+                .keys()
+                .contains(&"jetpack_search_highlight_color".to_string())
+        );
     }
 
     #[test]
@@ -397,8 +411,14 @@ mod tests {
         let settings: SparseSiteSettings =
             serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
         assert_eq!(settings.title, Some("Test Site".to_string()));
-        let additional = settings.additional_fields.expect("additional_fields should be present");
-        assert!(additional.keys().contains(&"Blogroll Recommendations".to_string()));
+        let additional = settings
+            .additional_fields
+            .expect("additional_fields should be present");
+        assert!(
+            additional
+                .keys()
+                .contains(&"Blogroll Recommendations".to_string())
+        );
     }
 
     // With no unknown fields, additional_fields is an empty object.

--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -119,7 +119,6 @@ pub struct SparseSiteSettings {
     // Writing custom settings back via SiteSettingsUpdateParams is a separate effort.
     #[serde(flatten)]
     #[WpContext(edit, embed, view)]
-    #[WpContextualOption]
     #[WpContextualExcludeFromFields]
     pub additional_fields: Option<Arc<AnyJson>>,
 }
@@ -362,28 +361,27 @@ mod tests {
             Some(SiteSettingsPingStatus::Open)
         );
 
-        let additional = settings.additional_fields.expect("additional_fields should be present");
-        let keys = additional.keys();
+        let keys = settings.additional_fields.keys();
         assert!(keys.contains(&"jetpack_search_color_theme".to_string()));
         assert!(keys.contains(&"active_templates".to_string()));
         assert!(keys.contains(&"cookie_consent_template".to_string()));
         assert!(keys.contains(&"Blogroll Recommendations".to_string()));
 
         assert_eq!(
-            additional.value_for_key("jetpack_search_color_theme"),
+            settings.additional_fields.value_for_key("jetpack_search_color_theme"),
             Some(crate::JsonValue::String("light".to_string()))
         );
         assert_eq!(
-            additional.value_for_key("jetpack_search_enable_sort"),
+            settings.additional_fields.value_for_key("jetpack_search_enable_sort"),
             Some(crate::JsonValue::Bool(true))
         );
         assert_eq!(
-            additional.value_for_key("active_templates"),
+            settings.additional_fields.value_for_key("active_templates"),
             Some(crate::JsonValue::Null)
         );
         // Known fields should NOT leak into additional_fields
-        assert!(additional.value_for_key("title").is_none());
-        assert!(additional.value_for_key("site_icon").is_none());
+        assert!(settings.additional_fields.value_for_key("title").is_none());
+        assert!(settings.additional_fields.value_for_key("site_icon").is_none());
     }
 
     #[test]
@@ -391,8 +389,7 @@ mod tests {
         let settings: SiteSettingsWithEditContext =
             serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
         assert_eq!(settings.title, "Test Site");
-        let additional = settings.additional_fields.expect("additional_fields should be present");
-        assert!(additional.keys().contains(&"jetpack_search_highlight_color".to_string()));
+        assert!(settings.additional_fields.keys().contains(&"jetpack_search_highlight_color".to_string()));
     }
 
     #[test]
@@ -404,8 +401,8 @@ mod tests {
         assert!(additional.keys().contains(&"Blogroll Recommendations".to_string()));
     }
 
-    // With no unknown fields, additional_fields is Some with an empty object
-    // (not None). Consumers should check keys().is_empty() rather than is_none().
+    // With no unknown fields, additional_fields is an empty object.
+    // Consumers should check keys().is_empty().
     #[test]
     fn test_additional_fields_is_empty_when_no_custom_entries() {
         let json = r#"{
@@ -431,9 +428,6 @@ mod tests {
             "site_icon": 0
         }"#;
         let settings: SiteSettingsWithViewContext = serde_json::from_str(json).unwrap();
-        let additional = settings
-            .additional_fields
-            .expect("additional_fields should be Some even with no custom entries");
-        assert!(additional.keys().is_empty());
+        assert!(settings.additional_fields.keys().is_empty());
     }
 }

--- a/wp_api/src/site_settings.rs
+++ b/wp_api/src/site_settings.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use wp_contextual::WpContextual;
+
+use crate::AnyJson;
 
 #[derive(Debug, Default, Serialize, uniffi::Record)]
 pub struct SiteSettingsUpdateParams {
@@ -112,6 +115,11 @@ pub struct SparseSiteSettings {
     pub site_logo: Option<u64>,
     #[WpContext(edit, embed, view)]
     pub site_icon: Option<u64>,
+    #[serde(flatten)]
+    #[WpContext(edit, embed, view)]
+    #[WpContextualOption]
+    #[WpContextualExcludeFromFields]
+    pub additional_fields: Option<Arc<AnyJson>>,
 }
 
 #[derive(
@@ -298,5 +306,99 @@ mod tests {
         }"#;
         let settings: SparseSiteSettings = serde_json::from_str(json).unwrap();
         assert_eq!(settings.default_ping_status, None);
+    }
+
+    // Reproduces a real Jetpack site response where plugins add arbitrary
+    // custom entries to the settings object. Parsing must succeed and the
+    // extra entries must be captured in `additional_fields`.
+    const RESPONSE_WITH_CUSTOM_ENTRIES: &str = r##"{
+        "active_templates": null,
+        "title": "Test Site",
+        "description": "",
+        "url": "https://example.com",
+        "email": "test@example.com",
+        "timezone": "",
+        "date_format": "F j, Y",
+        "time_format": "g:i a",
+        "start_of_week": 1,
+        "language": "en_US",
+        "use_smilies": true,
+        "default_category": 1,
+        "default_post_format": "standard",
+        "posts_per_page": 10,
+        "show_on_front": "posts",
+        "page_on_front": 0,
+        "page_for_posts": 0,
+        "default_ping_status": "open",
+        "default_comment_status": "open",
+        "site_logo": null,
+        "site_icon": 0,
+        "jetpack_search_ai_prompt_override": "",
+        "jetpack_search_color_theme": "light",
+        "jetpack_search_result_format": "expanded",
+        "jetpack_search_default_sort": "relevance",
+        "jetpack_search_overlay_trigger": "submit",
+        "jetpack_search_excluded_post_types": "",
+        "jetpack_search_highlight_color": "#FFC",
+        "jetpack_search_enable_sort": true,
+        "jetpack_search_inf_scroll": true,
+        "jetpack_search_filtering_opens_overlay": true,
+        "jetpack_search_show_post_date": true,
+        "jetpack_search_show_product_price": true,
+        "jetpack_search_show_powered_by": true,
+        "cookie_consent_template": null,
+        "Blogroll Recommendations": null
+    }"##;
+
+    #[test]
+    fn test_parse_view_context_with_custom_entries() {
+        let settings: SiteSettingsWithViewContext =
+            serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
+        assert_eq!(settings.title, "Test Site");
+        assert_eq!(
+            settings.default_ping_status,
+            Some(SiteSettingsPingStatus::Open)
+        );
+
+        let additional = settings.additional_fields.expect("additional_fields should be present");
+        let keys = additional.keys();
+        assert!(keys.contains(&"jetpack_search_color_theme".to_string()));
+        assert!(keys.contains(&"active_templates".to_string()));
+        assert!(keys.contains(&"cookie_consent_template".to_string()));
+        assert!(keys.contains(&"Blogroll Recommendations".to_string()));
+
+        assert_eq!(
+            additional.value_for_key("jetpack_search_color_theme"),
+            Some(crate::JsonValue::String("light".to_string()))
+        );
+        assert_eq!(
+            additional.value_for_key("jetpack_search_enable_sort"),
+            Some(crate::JsonValue::Bool(true))
+        );
+        assert_eq!(
+            additional.value_for_key("active_templates"),
+            Some(crate::JsonValue::Null)
+        );
+        // Known fields should NOT leak into additional_fields
+        assert!(additional.value_for_key("title").is_none());
+        assert!(additional.value_for_key("site_icon").is_none());
+    }
+
+    #[test]
+    fn test_parse_edit_context_with_custom_entries() {
+        let settings: SiteSettingsWithEditContext =
+            serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
+        assert_eq!(settings.title, "Test Site");
+        let additional = settings.additional_fields.expect("additional_fields should be present");
+        assert!(additional.keys().contains(&"jetpack_search_highlight_color".to_string()));
+    }
+
+    #[test]
+    fn test_parse_sparse_with_custom_entries() {
+        let settings: SparseSiteSettings =
+            serde_json::from_str(RESPONSE_WITH_CUSTOM_ENTRIES).unwrap();
+        assert_eq!(settings.title, Some("Test Site".to_string()));
+        let additional = settings.additional_fields.expect("additional_fields should be present");
+        assert!(additional.keys().contains(&"Blogroll Recommendations".to_string()));
     }
 }


### PR DESCRIPTION
## Description

Real WordPress sites with plugins (e.g. Jetpack) return extra keys in `/wp/v2/settings` responses that aren't part of the core schema — things like `jetpack_search_*`, `active_templates`, `cookie_consent_template`, `Blogroll Recommendations`. Previously these were silently dropped during deserialization.

This is deliberately **read-only** — `SiteSettingsUpdateParams` does not gain an `additional_fields` member. Writing custom plugin settings back to the API is a separate effort we'll tackle when there's a concrete use case.

## Changes

- Add `additional_fields: Option<Arc<AnyJson>>` to `SparseSiteSettings` with `#[serde(flatten)]`, following the existing pattern in `SparsePost` and `SparseComment`
- Add general-purpose `keys()` and `value_for_key()` accessors to `AnyJson` (the existing `term_ids_for_key` is post-specific)
- Add `From<&serde_json::Value>` impl for `JsonValue` to support `value_for_key`
- Add unit tests parsing a real Jetpack site response with 15 custom entries across all three context types

## Test plan

- [x] `cargo test --lib` — all 1344 tests pass
- [x] `cargo clippy --tests --all-targets --all-features -- -D warnings` — clean