### PR TITLE
Add domain suggestions and segments endpoints

### DIFF
--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -1,0 +1,303 @@
+use crate::{
+    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
+    wp_com::segments::SegmentId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct DomainSuggestionsParams {
+    /// The search term used to generate domain suggestions.
+    pub query: String,
+    /// The maximum number of suggestions to return.
+    #[uniffi(default = None)]
+    pub quantity: Option<u32>,
+    /// Restrict suggestions to the given TLDs (e.g. `["com", "net"]`).
+    ///
+    /// Must be serialized as PHP-style array parameters
+    /// (`tlds[]=com&tlds[]=net`). The API's PHP backend silently ignores
+    /// CSV (`tlds=com,net`) and honors only the last value when repeated
+    /// pairs (`tlds=com&tlds=net`) are used.
+    #[uniffi(default = None)]
+    pub tlds: Option<Vec<String>>,
+    /// Restrict suggestions to a specific vendor (e.g. `"dot"`).
+    #[uniffi(default = None)]
+    pub vendor: Option<String>,
+    /// If `true`, only return WordPress.com subdomain suggestions.
+    #[uniffi(default = None)]
+    pub only_wordpressdotcom: Option<bool>,
+    /// If `true`, include WordPress.com subdomain suggestions alongside
+    /// the regular domain suggestions.
+    #[uniffi(default = None)]
+    pub include_wordpressdotcom: Option<bool>,
+    /// If `true`, include `*.home.blog` subdomain suggestions.
+    #[uniffi(default = None)]
+    pub include_dotblogsubdomain: Option<bool>,
+    /// Segment identifier used by the API to tailor suggestions.
+    ///
+    /// Fetch available segments via the `/wpcom/v2/segments` endpoint.
+    /// Note: sending a valid `segment_id` pivots results toward free
+    /// `*.wordpress.com` subdomains (and curated themed `.blog`
+    /// subdomains for the Blog segment).
+    #[uniffi(default = None)]
+    pub segment_id: Option<SegmentId>,
+}
+
+impl AppendUrlQueryPairs for DomainSuggestionsParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_query_value_pair("query", &self.query)
+            .append_option_query_value_pair("quantity", self.quantity.as_ref())
+            .append_option_query_value_pair("vendor", self.vendor.as_ref())
+            .append_option_query_value_pair(
+                "only_wordpressdotcom",
+                self.only_wordpressdotcom.as_ref(),
+            )
+            .append_option_query_value_pair(
+                "include_wordpressdotcom",
+                self.include_wordpressdotcom.as_ref(),
+            )
+            .append_option_query_value_pair(
+                "include_dotblogsubdomain",
+                self.include_dotblogsubdomain.as_ref(),
+            )
+            .append_option_query_value_pair("segment_id", self.segment_id.as_ref());
+        if let Some(tlds) = self.tlds.as_ref() {
+            tlds.iter().for_each(|tld| {
+                query_pairs_mut.append_pair("tlds[]", tld);
+            });
+        }
+    }
+}
+
+/// A domain suggestion returned by the WordPress.com suggestions API.
+///
+/// The API returns two structurally different shapes in the same array:
+/// free WordPress.com subdomains (minimal) and paid domain registrations
+/// (full pricing and registration details).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Enum)]
+#[serde(untagged)]
+pub enum DomainSuggestion {
+    /// A paid domain registration suggestion with full pricing and
+    /// registration details.
+    Paid(PaidDomainSuggestion),
+    /// A free WordPress.com subdomain suggestion.
+    Free(FreeDomainSuggestion),
+}
+
+/// A free WordPress.com subdomain suggestion (e.g. `"mysite.wordpress.com"`).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct FreeDomainSuggestion {
+    /// The suggested domain name (e.g. `"mysite.wordpress.com"`).
+    pub domain_name: String,
+    /// Display cost (typically `"Free"`).
+    pub cost: String,
+    /// Whether this suggestion is free.
+    pub is_free: bool,
+}
+
+/// A paid domain registration suggestion with full pricing details.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct PaidDomainSuggestion {
+    /// The suggested domain name (e.g. `"coolsite.com"`).
+    pub domain_name: String,
+    /// Relevance score of the suggestion in the range `[0.0, 1.0]`.
+    pub relevance: f64,
+    /// Whether the domain supports WHOIS privacy protection.
+    pub supports_privacy: bool,
+    /// The registry vendor (e.g. `"donuts"`, `"dotblogsubdomains"`).
+    pub vendor: String,
+    /// Reasons why this suggestion was selected (e.g. `"exact-match"`,
+    /// `"tld-common"`). Omitted by the API when there are no match reasons.
+    pub match_reasons: Option<Vec<String>>,
+    /// Maximum number of years the domain can be registered for.
+    pub max_reg_years: u32,
+    /// Whether the domain supports multi-year registrations.
+    pub multi_year_reg_allowed: bool,
+    /// WordPress.com product ID used to purchase this domain.
+    pub product_id: u64,
+    /// WordPress.com product slug used to purchase this domain.
+    pub product_slug: String,
+    /// Formatted registration cost (e.g. `"$18.00"`).
+    pub cost: String,
+    /// Formatted renewal cost (e.g. `"$18.00"`).
+    pub renew_cost: String,
+    /// Raw numeric renewal price in `currency_code`.
+    pub renew_raw_price: f64,
+    /// Raw numeric registration price in `currency_code`.
+    pub raw_price: f64,
+    /// ISO 4217 currency code for `raw_price`/`renew_raw_price` (e.g. `"USD"`).
+    pub currency_code: String,
+    /// Promotional sale price in `currency_code`, if the domain is on sale.
+    pub sale_cost: Option<f64>,
+    /// `true` if the TLD requires HSTS (e.g. `.dev`).
+    pub hsts_required: Option<bool>,
+    /// Policy notices attached to the suggestion (e.g. HSTS warnings).
+    pub policy_notices: Option<Vec<DomainPolicyNotice>>,
+}
+
+/// A policy notice attached to a domain suggestion (e.g. an HSTS warning).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainPolicyNotice {
+    /// The notice type identifier (e.g. `"hsts"`).
+    #[serde(rename = "type")]
+    pub notice_type: String,
+    /// Short human-readable label for the notice.
+    pub label: String,
+    /// Full human-readable message describing the notice.
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    #[case("tests/wpcom/domains/suggestions/basic-query.json", 5)]
+    #[case("tests/wpcom/domains/suggestions/larger-quantity.json", 20)]
+    #[case("tests/wpcom/domains/suggestions/only-wordpressdotcom.json", 5)]
+    #[case("tests/wpcom/domains/suggestions/include-wordpressdotcom.json", 5)]
+    #[case("tests/wpcom/domains/suggestions/specific-tlds.json", 5)]
+    #[case("tests/wpcom/domains/suggestions/dot-vendor.json", 1)]
+    #[case("tests/wpcom/domains/suggestions/photography-niche.json", 5)]
+    #[case("tests/wpcom/domains/suggestions/obscure-query.json", 5)]
+    fn test_domain_suggestions_deserialization(
+        #[case] json_file_path: &str,
+        #[case] expected_len: usize,
+    ) {
+        let file = File::open(json_file_path).expect("Failed to open file");
+        let suggestions: Vec<DomainSuggestion> =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(suggestions.len(), expected_len);
+    }
+
+    #[test]
+    fn test_domain_suggestions_deserialization_basic_query_details() {
+        let file = File::open("tests/wpcom/domains/suggestions/basic-query.json")
+            .expect("Failed to open file");
+        let suggestions: Vec<DomainSuggestion> =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let first = match suggestions
+            .first()
+            .expect("expected at least one suggestion")
+        {
+            DomainSuggestion::Paid(paid) => paid,
+            DomainSuggestion::Free(_) => panic!("expected Paid variant for first suggestion"),
+        };
+        assert_eq!(first.domain_name, "brightspace.com");
+        assert_eq!(first.relevance, 1.0);
+        assert!(first.supports_privacy);
+        assert_eq!(first.vendor, "donuts");
+        assert_eq!(
+            first.match_reasons.as_deref(),
+            Some(["tld-common".to_string()].as_slice())
+        );
+        assert_eq!(first.max_reg_years, 10);
+        assert!(first.multi_year_reg_allowed);
+        assert_eq!(first.product_id, 6);
+        assert_eq!(first.product_slug, "domain_reg");
+        assert_eq!(first.cost, "$18.00");
+        assert_eq!(first.renew_cost, "$18.00");
+        assert_eq!(first.renew_raw_price, 18.0);
+        assert_eq!(first.raw_price, 18.0);
+        assert_eq!(first.currency_code, "USD");
+        assert_eq!(first.sale_cost, None);
+        assert_eq!(first.hsts_required, None);
+        assert!(first.policy_notices.is_none());
+
+        // `freshpage.art` has no `match_reasons` field in the JSON.
+        let freshpage_art = suggestions
+            .iter()
+            .find_map(|s| match s {
+                DomainSuggestion::Paid(p) if p.domain_name == "freshpage.art" => Some(p),
+                _ => None,
+            })
+            .expect("freshpage.art missing");
+        assert!(freshpage_art.match_reasons.is_none());
+        assert_eq!(freshpage_art.sale_cost, Some(1.64));
+
+        // `testsite.dev` has hsts_required and policy_notices populated.
+        let testsite_dev = suggestions
+            .iter()
+            .find_map(|s| match s {
+                DomainSuggestion::Paid(p) if p.domain_name == "testsite.dev" => Some(p),
+                _ => None,
+            })
+            .expect("testsite.dev missing");
+        assert_eq!(testsite_dev.hsts_required, Some(true));
+        let notices = testsite_dev
+            .policy_notices
+            .as_ref()
+            .expect("policy_notices missing");
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0].notice_type, "hsts");
+        assert_eq!(notices[0].label, "HSTS required");
+        assert!(notices[0].message.contains("SSL certificate"));
+    }
+
+    #[test]
+    fn test_domain_suggestions_deserialization_only_free() {
+        let file = File::open("tests/wpcom/domains/suggestions/only-wordpressdotcom.json")
+            .expect("Failed to open file");
+        let suggestions: Vec<DomainSuggestion> =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(suggestions.len(), 5);
+        for suggestion in &suggestions {
+            match suggestion {
+                DomainSuggestion::Free(free) => {
+                    assert!(free.domain_name.ends_with(".wordpress.com"));
+                    assert_eq!(free.cost, "Free");
+                    assert!(free.is_free);
+                }
+                DomainSuggestion::Paid(_) => {
+                    panic!("expected only Free variants in only-wordpressdotcom fixture")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_domain_suggestions_deserialization_mixed() {
+        let file = File::open("tests/wpcom/domains/suggestions/include-wordpressdotcom.json")
+            .expect("Failed to open file");
+        let suggestions: Vec<DomainSuggestion> =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(suggestions.len(), 5);
+
+        let free = match &suggestions[0] {
+            DomainSuggestion::Free(f) => f,
+            DomainSuggestion::Paid(_) => panic!("expected Free variant for first suggestion"),
+        };
+        assert!(free.domain_name.ends_with(".wordpress.com"));
+        assert!(free.is_free);
+
+        for suggestion in &suggestions[1..] {
+            assert!(
+                matches!(suggestion, DomainSuggestion::Paid(_)),
+                "expected Paid variants after the first suggestion"
+            );
+        }
+    }
+
+    #[test]
+    fn test_domain_suggestions_deserialization_dot_vendor() {
+        let file = File::open("tests/wpcom/domains/suggestions/dot-vendor.json")
+            .expect("Failed to open file");
+        let suggestions: Vec<DomainSuggestion> =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(suggestions.len(), 1);
+        let only = match &suggestions[0] {
+            DomainSuggestion::Paid(p) => p,
+            DomainSuggestion::Free(_) => panic!("expected Paid variant for dot-vendor fixture"),
+        };
+        assert_eq!(only.domain_name, "testsite.home.blog");
+        assert_eq!(only.vendor, "dotblogsubdomains");
+    }
+}

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -132,7 +132,9 @@ pub struct PaidDomainSuggestion {
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
     pub hsts_required: Option<bool>,
     /// Policy notices attached to the suggestion (e.g. HSTS warnings).
-    pub policy_notices: Option<Vec<DomainPolicyNotice>>,
+    #[serde(default)]
+    #[uniffi(default = [])]
+    pub policy_notices: Vec<DomainPolicyNotice>,
 }
 
 /// A policy notice attached to a domain suggestion (e.g. an HSTS warning).
@@ -207,7 +209,7 @@ mod tests {
         assert_eq!(first.currency_code, "USD");
         assert_eq!(first.sale_cost, None);
         assert_eq!(first.hsts_required, None);
-        assert!(first.policy_notices.is_none());
+        assert!(first.policy_notices.is_empty());
 
         // `freshpage.art` has no `match_reasons` field in the JSON.
         let freshpage_art = suggestions
@@ -229,14 +231,14 @@ mod tests {
             })
             .expect("testsite.dev missing");
         assert_eq!(testsite_dev.hsts_required, Some(true));
-        let notices = testsite_dev
-            .policy_notices
-            .as_ref()
-            .expect("policy_notices missing");
-        assert_eq!(notices.len(), 1);
-        assert_eq!(notices[0].notice_type, "hsts");
-        assert_eq!(notices[0].label, "HSTS required");
-        assert!(notices[0].message.contains("SSL certificate"));
+        assert_eq!(testsite_dev.policy_notices.len(), 1);
+        assert_eq!(testsite_dev.policy_notices[0].notice_type, "hsts");
+        assert_eq!(testsite_dev.policy_notices[0].label, "HSTS required");
+        assert!(
+            testsite_dev.policy_notices[0]
+                .message
+                .contains("SSL certificate")
+        );
     }
 
     #[test]

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -6,12 +6,14 @@ use crate::{
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
+pub mod domains_endpoint;
 pub mod extensions;
 pub mod followers_endpoint;
 pub mod jetpack_connection_endpoint;
 pub mod languages_endpoint;
 pub mod me_endpoint;
 pub mod oauth2;
+pub mod segments_endpoint;
 pub mod sites_endpoint;
 pub mod stats_city_views_endpoint;
 pub mod stats_clicks_endpoint;
@@ -145,6 +147,10 @@ pub(crate) mod tests {
 
     pub fn validate_wp_com_rest_v1_1_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
         validate_endpoint(WpComNamespace::RestV1_1, endpoint_url, path);
+    }
+
+    pub fn validate_wp_com_v2_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
+        validate_endpoint(WpComNamespace::V2, endpoint_url, path);
     }
 
     fn validate_endpoint(namespace: WpComNamespace, endpoint_url: ApiEndpointUrl, path: &str) {

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -1,0 +1,100 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{
+        WpComNamespace,
+        domains::{DomainSuggestion, DomainSuggestionsParams},
+    },
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum DomainsRequest {
+    #[get(url = "/domains/suggestions", params = &DomainSuggestionsParams, output = Vec<DomainSuggestion>)]
+    Suggestions,
+}
+
+impl DerivedRequest for DomainsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::RestV1_1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request::endpoint::ApiUrlResolver,
+        wp_com::{
+            endpoint::tests::{
+                fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
+            },
+            segments::SegmentId,
+        },
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    #[case::minimal(
+        base_domain_suggestions_params(),
+        "/domains/suggestions?query=coolsite&quantity=5"
+    )]
+    #[case::with_tlds(
+        DomainSuggestionsParams {
+            tlds: Some(vec!["com".to_string(), "net".to_string(), "org".to_string()]),
+            ..base_domain_suggestions_params()
+        },
+        "/domains/suggestions?query=coolsite&quantity=5&tlds%5B%5D=com&tlds%5B%5D=net&tlds%5B%5D=org"
+    )]
+    #[case::only_wordpressdotcom(
+        DomainSuggestionsParams { only_wordpressdotcom: Some(true), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&only_wordpressdotcom=true"
+    )]
+    #[case::include_wordpressdotcom(
+        DomainSuggestionsParams { include_wordpressdotcom: Some(true), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&include_wordpressdotcom=true"
+    )]
+    #[case::vendor(
+        DomainSuggestionsParams { vendor: Some("dot".to_string()), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&vendor=dot"
+    )]
+    #[case::include_dotblogsubdomain(
+        DomainSuggestionsParams { include_dotblogsubdomain: Some(true), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&include_dotblogsubdomain=true"
+    )]
+    #[case::include_dotblogsubdomain_false(
+        DomainSuggestionsParams { include_dotblogsubdomain: Some(false), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&include_dotblogsubdomain=false"
+    )]
+    #[case::segment_id(
+        DomainSuggestionsParams { segment_id: Some(SegmentId(2)), ..base_domain_suggestions_params() },
+        "/domains/suggestions?query=coolsite&quantity=5&segment_id=2"
+    )]
+    fn suggestions(
+        endpoint: DomainsRequestEndpoint,
+        #[case] params: DomainSuggestionsParams,
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_com_rest_v1_1_endpoint(endpoint.suggestions(&params), expected_path);
+    }
+
+    fn base_domain_suggestions_params() -> DomainSuggestionsParams {
+        DomainSuggestionsParams {
+            query: "coolsite".to_string(),
+            quantity: Some(5),
+            tlds: None,
+            vendor: None,
+            only_wordpressdotcom: None,
+            include_wordpressdotcom: None,
+            include_dotblogsubdomain: None,
+            segment_id: None,
+        }
+    }
+
+    #[fixture]
+    fn endpoint(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> DomainsRequestEndpoint {
+        DomainsRequestEndpoint::new(fixture_wp_com_api_url_resolver)
+    }
+}

--- a/wp_api/src/wp_com/endpoint/segments_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/segments_endpoint.rs
@@ -1,0 +1,40 @@
+use crate::{
+    request::endpoint::{AsNamespace, DerivedRequest},
+    wp_com::{WpComNamespace, segments::Segment},
+};
+use wp_derive_request_builder::WpDerivedRequest;
+
+#[derive(WpDerivedRequest)]
+enum SegmentsRequest {
+    #[get(url = "/segments", output = Vec<Segment>)]
+    List,
+}
+
+impl DerivedRequest for SegmentsRequest {
+    fn namespace() -> impl AsNamespace {
+        WpComNamespace::V2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request::endpoint::ApiUrlResolver,
+        wp_com::endpoint::tests::{fixture_wp_com_api_url_resolver, validate_wp_com_v2_endpoint},
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    fn list(endpoint: SegmentsRequestEndpoint) {
+        validate_wp_com_v2_endpoint(endpoint.list(), "/segments");
+    }
+
+    #[fixture]
+    fn endpoint(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> SegmentsRequestEndpoint {
+        SegmentsRequestEndpoint::new(fixture_wp_com_api_url_resolver)
+    }
+}

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -4,12 +4,14 @@ use serde::{Deserialize, Serialize};
 use std::{num::ParseIntError, str::FromStr, sync::Arc};
 
 pub mod client;
+pub mod domains;
 pub mod endpoint;
 pub mod followers;
 pub mod jetpack_connection;
 pub mod language;
 pub mod me;
 pub mod oauth2;
+pub mod segments;
 pub mod sites;
 pub mod stats_city_views;
 pub mod stats_clicks;

--- a/wp_api/src/wp_com/segments.rs
+++ b/wp_api/src/wp_com/segments.rs
@@ -1,0 +1,75 @@
+use crate::impl_as_query_value_for_new_type;
+use serde::{Deserialize, Serialize};
+
+impl_as_query_value_for_new_type!(SegmentId);
+uniffi::custom_newtype!(SegmentId, u64);
+/// Identifier of a WordPress.com content segment (e.g. "Blog", "Business").
+///
+/// The set of valid IDs is hand-curated on the server and is not a dense
+/// range — fetch `/wpcom/v2/segments` to discover the currently valid IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SegmentId(pub u64);
+
+/// A WordPress.com content segment returned from `/wpcom/v2/segments`.
+///
+/// Segments are curated verticals (e.g. "Blog", "Business") used by the
+/// site-creation and domain-suggestion flows to tailor recommendations.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct Segment {
+    /// Stable numeric identifier for the segment.
+    pub id: SegmentId,
+    /// Stable machine-readable slug (e.g. `"blog"`, `"business"`).
+    /// More robust for client-side feature detection than the numeric `id`.
+    pub slug: String,
+    /// Whether this segment is shown in mobile clients.
+    pub mobile: bool,
+    /// Human-readable segment title (e.g. `"Blog"`).
+    #[serde(rename = "segment_type_title")]
+    pub title: String,
+    /// Human-readable segment subtitle/description.
+    #[serde(rename = "segment_type_subtitle")]
+    pub subtitle: String,
+    /// Public CDN URL of the segment icon.
+    #[serde(rename = "icon_URL")]
+    pub icon_url: String,
+    /// Hex color string associated with the icon (e.g. `"#3d4145"`).
+    pub icon_color: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segments_deserialization_all() {
+        let file =
+            std::fs::File::open("tests/wpcom/segments/all.json").expect("Failed to open file");
+        let segments: Vec<Segment> = serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        assert_eq!(segments.len(), 5);
+
+        let blog = segments
+            .iter()
+            .find(|s| s.slug == "blog")
+            .expect("blog segment missing");
+        assert_eq!(blog.id, SegmentId(2));
+        assert!(blog.mobile);
+        assert_eq!(blog.title, "Blog");
+        assert_eq!(
+            blog.subtitle,
+            "Share and discuss ideas, updates, or creations."
+        );
+        assert_eq!(
+            blog.icon_url,
+            "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_blogger.png"
+        );
+        assert_eq!(blog.icon_color, "#3d4145");
+
+        let online_store = segments
+            .iter()
+            .find(|s| s.slug == "online-store")
+            .expect("online-store segment missing");
+        assert_eq!(online_store.id, SegmentId(3));
+        assert!(!online_store.mobile);
+    }
+}

--- a/wp_api/tests/wpcom/domains/suggestions/basic-query.json
+++ b/wp_api/tests/wpcom/domains/suggestions/basic-query.json
@@ -1,0 +1,101 @@
+[
+  {
+    "domain_name": "brightspace.com",
+    "relevance": 1,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 6,
+    "product_slug": "domain_reg",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "testsite.blog",
+    "relevance": 0.99,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "freshpage.art",
+    "relevance": 0.8,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 355,
+    "product_slug": "dotart_domain",
+    "cost": "$33.00",
+    "renew_cost": "$33.00",
+    "renew_raw_price": 33,
+    "raw_price": 33,
+    "currency_code": "USD",
+    "sale_cost": 1.64
+  },
+  {
+    "domain_name": "testsite.dev",
+    "relevance": 0.6,
+    "supports_privacy": false,
+    "vendor": "donuts",
+    "hsts_required": true,
+    "policy_notices": [
+      {
+        "type": "hsts",
+        "label": "HSTS required",
+        "message": "All domains with this ending require an SSL certificate to host a website."
+      }
+    ],
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 373,
+    "product_slug": "dotdev_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "test-web.org",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/dot-vendor.json
+++ b/wp_api/tests/wpcom/domains/suggestions/dot-vendor.json
@@ -1,0 +1,21 @@
+[
+  {
+    "domain_name": "testsite.home.blog",
+    "relevance": 1,
+    "supports_privacy": true,
+    "vendor": "dotblogsubdomains",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/include-wordpressdotcom.json
+++ b/wp_api/tests/wpcom/domains/suggestions/include-wordpressdotcom.json
@@ -1,0 +1,87 @@
+[
+  {
+    "domain_name": "testsite03.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  },
+  {
+    "domain_name": "brightspace.com",
+    "relevance": 1,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 6,
+    "product_slug": "domain_reg",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "testsite.blog",
+    "relevance": 0.99,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "freshpage.art",
+    "relevance": 0.8,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 355,
+    "product_slug": "dotart_domain",
+    "cost": "$33.00",
+    "renew_cost": "$33.00",
+    "renew_raw_price": 33,
+    "raw_price": 33,
+    "currency_code": "USD",
+    "sale_cost": 1.64
+  },
+  {
+    "domain_name": "testsite.dev",
+    "relevance": 0.6,
+    "supports_privacy": false,
+    "vendor": "donuts",
+    "hsts_required": true,
+    "policy_notices": [
+      {
+        "type": "hsts",
+        "label": "HSTS required",
+        "message": "All domains with this ending require an SSL certificate to host a website."
+      }
+    ],
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 373,
+    "product_slug": "dotdev_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD"
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/larger-quantity.json
+++ b/wp_api/tests/wpcom/domains/suggestions/larger-quantity.json
@@ -1,0 +1,393 @@
+[
+  {
+    "domain_name": "brightspace.com",
+    "relevance": 1,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 6,
+    "product_slug": "domain_reg",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "testsite.blog",
+    "relevance": 0.99,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "freshpage.art",
+    "relevance": 0.8,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 355,
+    "product_slug": "dotart_domain",
+    "cost": "$33.00",
+    "renew_cost": "$33.00",
+    "renew_raw_price": 33,
+    "raw_price": 33,
+    "currency_code": "USD",
+    "sale_cost": 1.64
+  },
+  {
+    "domain_name": "testsite.dev",
+    "relevance": 0.6,
+    "supports_privacy": false,
+    "vendor": "donuts",
+    "hsts_required": true,
+    "policy_notices": [
+      {
+        "type": "hsts",
+        "label": "HSTS required",
+        "message": "All domains with this ending require an SSL certificate to host a website."
+      }
+    ],
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 373,
+    "product_slug": "dotdev_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "test-web.org",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "test-site.store",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 274,
+    "product_slug": "dotstore_domain",
+    "cost": "$43.00",
+    "renew_cost": "$43.00",
+    "renew_raw_price": 43,
+    "raw_price": 43,
+    "currency_code": "USD",
+    "sale_cost": 1.3
+  },
+  {
+    "domain_name": "testsite.xyz",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 86,
+    "product_slug": "dotxyz_domain",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "testsite.design",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 358,
+    "product_slug": "dotdesign_domain",
+    "cost": "$65.00",
+    "renew_cost": "$65.00",
+    "renew_raw_price": 65,
+    "raw_price": 65,
+    "currency_code": "USD",
+    "sale_cost": 16.36
+  },
+  {
+    "domain_name": "test-site.online",
+    "relevance": 0.1,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 271,
+    "product_slug": "dotonline_domain",
+    "cost": "$27.00",
+    "renew_cost": "$27.00",
+    "renew_raw_price": 27,
+    "raw_price": 27,
+    "currency_code": "USD",
+    "sale_cost": 1.08
+  },
+  {
+    "domain_name": "testsite.tech",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 275,
+    "product_slug": "dottech_domain",
+    "cost": "$72.00",
+    "renew_cost": "$72.00",
+    "renew_raw_price": 72,
+    "raw_price": 72,
+    "currency_code": "USD",
+    "sale_cost": 14.45
+  },
+  {
+    "domain_name": "testsite.club",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 80,
+    "product_slug": "dotclub_domain",
+    "cost": "$24.00",
+    "renew_cost": "$24.00",
+    "renew_raw_price": 24,
+    "raw_price": 24,
+    "currency_code": "USD",
+    "sale_cost": 7.25
+  },
+  {
+    "domain_name": "testsites.site",
+    "relevance": 0.04,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 78,
+    "product_slug": "dotsite_domain",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD",
+    "sale_cost": 1.08
+  },
+  {
+    "domain_name": "test-site.dev",
+    "relevance": 0.15,
+    "supports_privacy": false,
+    "vendor": "donuts",
+    "hsts_required": true,
+    "policy_notices": [
+      {
+        "type": "hsts",
+        "label": "HSTS required",
+        "message": "All domains with this ending require an SSL certificate to host a website."
+      }
+    ],
+    "match_reasons": [
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 373,
+    "product_slug": "dotdev_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "test-site.design",
+    "relevance": 0.13,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 358,
+    "product_slug": "dotdesign_domain",
+    "cost": "$65.00",
+    "renew_cost": "$65.00",
+    "renew_raw_price": 65,
+    "raw_price": 65,
+    "currency_code": "USD",
+    "sale_cost": 16.36
+  },
+  {
+    "domain_name": "test-site.blog",
+    "relevance": 0.11,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "test-site.club",
+    "relevance": 0.09,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 80,
+    "product_slug": "dotclub_domain",
+    "cost": "$24.00",
+    "renew_cost": "$24.00",
+    "renew_raw_price": 24,
+    "raw_price": 24,
+    "currency_code": "USD",
+    "sale_cost": 7.25
+  },
+  {
+    "domain_name": "testweb.tech",
+    "relevance": 0.05,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 275,
+    "product_slug": "dottech_domain",
+    "cost": "$72.00",
+    "renew_cost": "$72.00",
+    "renew_raw_price": 72,
+    "raw_price": 72,
+    "currency_code": "USD",
+    "sale_cost": 14.45
+  },
+  {
+    "domain_name": "testweb.blog",
+    "relevance": 0.05,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "testsites.design",
+    "relevance": 0.04,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 358,
+    "product_slug": "dotdesign_domain",
+    "cost": "$65.00",
+    "renew_cost": "$65.00",
+    "renew_raw_price": 65,
+    "raw_price": 65,
+    "currency_code": "USD",
+    "sale_cost": 16.36
+  },
+  {
+    "domain_name": "testweb.club",
+    "relevance": 0.04,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 80,
+    "product_slug": "dotclub_domain",
+    "cost": "$24.00",
+    "renew_cost": "$24.00",
+    "renew_raw_price": 24,
+    "raw_price": 24,
+    "currency_code": "USD",
+    "sale_cost": 7.25
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/obscure-query.json
+++ b/wp_api/tests/wpcom/domains/suggestions/obscure-query.json
@@ -1,0 +1,106 @@
+[
+  {
+    "domain_name": "xyzxyzxyzabcabc.com",
+    "relevance": 1,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 6,
+    "product_slug": "domain_reg",
+    "cost": "$18.00",
+    "renew_cost": "$18.00",
+    "renew_raw_price": 18,
+    "raw_price": 18,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "xyzxyzxyzabcabc.blog",
+    "relevance": 0.99,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "xyzxyzxyzabcabc.art",
+    "relevance": 0.8,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 355,
+    "product_slug": "dotart_domain",
+    "cost": "$33.00",
+    "renew_cost": "$33.00",
+    "renew_raw_price": 33,
+    "raw_price": 33,
+    "currency_code": "USD",
+    "sale_cost": 1.64
+  },
+  {
+    "domain_name": "xyzxyzxyzabcabc.dev",
+    "relevance": 0.6,
+    "supports_privacy": false,
+    "vendor": "donuts",
+    "hsts_required": true,
+    "policy_notices": [
+      {
+        "type": "hsts",
+        "label": "HSTS required",
+        "message": "All domains with this ending require an SSL certificate to host a website."
+      }
+    ],
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 373,
+    "product_slug": "dotdev_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD"
+  },
+  {
+    "domain_name": "xyzxyzxyzabcabc.org",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/only-wordpressdotcom.json
+++ b/wp_api/tests/wpcom/domains/suggestions/only-wordpressdotcom.json
@@ -1,0 +1,27 @@
+[
+  {
+    "domain_name": "quietpage9.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  },
+  {
+    "domain_name": "brightspace9.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  },
+  {
+    "domain_name": "freshpage9.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  },
+  {
+    "domain_name": "freshweb9.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  },
+  {
+    "domain_name": "mytestweb9.wordpress.com",
+    "cost": "Free",
+    "is_free": true
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/photography-niche.json
+++ b/wp_api/tests/wpcom/domains/suggestions/photography-niche.json
@@ -1,0 +1,98 @@
+[
+  {
+    "domain_name": "traveljournalism.blog",
+    "relevance": 0.99,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 76,
+    "product_slug": "dotblog_domain",
+    "cost": "$20.00",
+    "renew_cost": "$20.00",
+    "renew_raw_price": 20,
+    "raw_price": 20,
+    "currency_code": "USD",
+    "sale_cost": 2.0
+  },
+  {
+    "domain_name": "newcooking.art",
+    "relevance": 0.8,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-similar"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 355,
+    "product_slug": "dotart_domain",
+    "cost": "$33.00",
+    "renew_cost": "$33.00",
+    "renew_raw_price": 33,
+    "raw_price": 33,
+    "currency_code": "USD",
+    "sale_cost": 1.64
+  },
+  {
+    "domain_name": "newcooking.org",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "cooking.design",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "exact-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 358,
+    "product_slug": "dotdesign_domain",
+    "cost": "$65.00",
+    "renew_cost": "$65.00",
+    "renew_raw_price": 65,
+    "raw_price": 65,
+    "currency_code": "USD",
+    "sale_cost": 16.36
+  },
+  {
+    "domain_name": "cookeries.club",
+    "relevance": 0.4,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "tld-similar"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 80,
+    "product_slug": "dotclub_domain",
+    "cost": "$24.00",
+    "renew_cost": "$24.00",
+    "renew_raw_price": 24,
+    "raw_price": 24,
+    "currency_code": "USD",
+    "sale_cost": 7.25
+  }
+]

--- a/wp_api/tests/wpcom/domains/suggestions/specific-tlds.json
+++ b/wp_api/tests/wpcom/domains/suggestions/specific-tlds.json
@@ -1,0 +1,98 @@
+[
+  {
+    "domain_name": "test-web.org",
+    "relevance": 0.98,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "freshpage.org",
+    "relevance": 0,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "brightspace.org",
+    "relevance": 0,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "quietpage.org",
+    "relevance": 0,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  },
+  {
+    "domain_name": "test-sites.org",
+    "relevance": 0,
+    "supports_privacy": true,
+    "vendor": "donuts",
+    "match_reasons": [
+      "tld-common",
+      "similar-match"
+    ],
+    "max_reg_years": 10,
+    "multi_year_reg_allowed": true,
+    "product_id": 5126,
+    "product_slug": "dotorg_domain",
+    "cost": "$11.00",
+    "renew_cost": "$11.00",
+    "renew_raw_price": 11,
+    "raw_price": 11,
+    "currency_code": "USD",
+    "sale_cost": 8.63
+  }
+]

--- a/wp_api/tests/wpcom/segments/all.json
+++ b/wp_api/tests/wpcom/segments/all.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 2,
+    "slug": "blog",
+    "mobile": true,
+    "segment_type_title": "Blog",
+    "segment_type_subtitle": "Share and discuss ideas, updates, or creations.",
+    "icon_URL": "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_blogger.png",
+    "icon_color": "#3d4145"
+  },
+  {
+    "id": 1,
+    "slug": "business",
+    "mobile": true,
+    "segment_type_title": "Business",
+    "segment_type_subtitle": "Promote products and services.",
+    "icon_URL": "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_business.png",
+    "icon_color": "#3d4145"
+  },
+  {
+    "id": 3,
+    "slug": "online-store",
+    "mobile": false,
+    "segment_type_title": "Online store",
+    "segment_type_subtitle": "Sell your collection of products online.",
+    "icon_URL": "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_store.png",
+    "icon_color": "#3d4145"
+  },
+  {
+    "id": 4,
+    "slug": "professional",
+    "mobile": true,
+    "segment_type_title": "Professional",
+    "segment_type_subtitle": "Showcase your portfolio, skills or work.",
+    "icon_URL": "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_professional.png",
+    "icon_color": "#3d4145"
+  },
+  {
+    "id": 6,
+    "slug": "blank-canvas",
+    "mobile": true,
+    "segment_type_title": "Blank Canvas",
+    "segment_type_subtitle": "Start with a blank site.",
+    "icon_URL": "https://s.wp.com/i/mobile_segmentation_icons/monochrome/ic_blank_canvas.png",
+    "icon_color": "#3d4145"
+  }
+]


### PR DESCRIPTION
Adds `GET /domains/suggestions` and `GET /wpcom/v2/segments` with their response types, a `SegmentId` newtype, and JSON fixture tests.

Note that `tlds` is serialized as a PHP-style array (`tlds[]=...`) since the API silently ignores CSV and honors only the last value for repeated pairs.