### PR TITLE
Add `Decimal2` type for precise 2-decimal-place values

### DIFF
--- a/wp_api/src/decimal2.rs
+++ b/wp_api/src/decimal2.rs
@@ -88,7 +88,14 @@ impl de::Visitor<'_> for Decimal2Visitor {
     type Value = Decimal2;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a number with at most 2 decimal places")
+        formatter.write_str("a number (or numeric string) with at most 2 decimal places")
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        let parsed: f64 = v
+            .parse()
+            .map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?;
+        self.visit_f64(parsed)
     }
 
     fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
@@ -141,6 +148,9 @@ mod tests {
     #[case(r#"{"value": 1.5}"#, 150)]
     #[case(r#"{"value": -3.25}"#, -325)]
     #[case(r#"{"value": 0.01}"#, 1)]
+    #[case(r#"{"value": "19.99"}"#, 1999)]
+    #[case(r#"{"value": "11"}"#, 1100)]
+    #[case(r#"{"value": "0.5"}"#, 50)]
     fn test_deserialize(#[case] json: &str, #[case] expected_hundredths: i64) {
         let wrapper: Wrapper = serde_json::from_str(json).expect("should deserialize");
         assert_eq!(wrapper.value.hundredths(), expected_hundredths);
@@ -150,7 +160,9 @@ mod tests {
     #[case(r#"{"value": 8.635}"#)]
     #[case(r#"{"value": 1.999}"#)]
     #[case(r#"{"value": 0.001}"#)]
-    fn test_deserialize_rejects_more_than_two_decimals(#[case] json: &str) {
+    #[case(r#"{"value": "8.635"}"#)]
+    #[case(r#"{"value": "abc"}"#)]
+    fn test_deserialize_rejects_invalid_values(#[case] json: &str) {
         let result: Result<Wrapper, _> = serde_json::from_str(json);
         assert!(
             result.is_err(),

--- a/wp_api/src/decimal2.rs
+++ b/wp_api/src/decimal2.rs
@@ -1,0 +1,182 @@
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Unexpected},
+};
+use std::fmt;
+
+uniffi::custom_type!(Decimal2, i64, {
+    lower: |decimal| decimal.hundredths(),
+    try_lift: |hundredths| Ok(Decimal2::from_hundredths(hundredths)),
+});
+
+/// A decimal number with at most 2 fractional digits, stored as an integer
+/// count of hundredths to avoid floating-point precision issues.
+///
+/// Deserialization rejects values with more than 2 decimal places rather
+/// than silently rounding.
+///
+/// ## Examples
+///
+/// - `11` → `Decimal2 { hundredths: 1100 }`
+/// - `8.63` → `Decimal2 { hundredths: 863 }`
+/// - `8.635` → deserialization error
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Decimal2 {
+    hundredths: i64,
+}
+
+impl Decimal2 {
+    /// Creates a `Decimal2` from a count of hundredths (e.g. `863` → `8.63`).
+    pub fn from_hundredths(hundredths: i64) -> Self {
+        Self { hundredths }
+    }
+
+    /// Returns the value expressed in hundredths (e.g. `8.63` → `863`).
+    pub fn hundredths(&self) -> i64 {
+        self.hundredths
+    }
+
+    /// Returns the whole part of the value (e.g. `8.63` → `8`, `-3.25` → `-3`).
+    pub fn whole_part(&self) -> i64 {
+        self.hundredths / 100
+    }
+
+    /// Returns the fractional part as a non-negative count of hundredths
+    /// (e.g. `8.63` → `63`, `-3.25` → `25`).
+    pub fn fractional_hundredths(&self) -> i64 {
+        (self.hundredths % 100).abs()
+    }
+}
+
+impl fmt::Display for Decimal2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let whole = self.whole_part();
+        let frac = self.fractional_hundredths();
+        if self.hundredths < 0 && whole == 0 {
+            write!(f, "-0.{frac:02}")
+        } else {
+            write!(f, "{whole}.{frac:02}")
+        }
+    }
+}
+
+impl Serialize for Decimal2 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let whole = self.whole_part();
+        let frac = self.fractional_hundredths();
+        if frac == 0 {
+            serializer.serialize_i64(whole)
+        } else {
+            // Reconstruct the f64 for JSON numeric output.
+            // Safe because values with at most 2 decimal places are exactly
+            // representable as f64 for any realistic magnitude.
+            let value = self.hundredths as f64 / 100.0;
+            serializer.serialize_f64(value)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Decimal2 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(Decimal2Visitor)
+    }
+}
+
+struct Decimal2Visitor;
+
+impl de::Visitor<'_> for Decimal2Visitor {
+    type Value = Decimal2;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a number with at most 2 decimal places")
+    }
+
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        let hundredths =
+            i64::try_from(v).map_err(|_| E::invalid_value(Unexpected::Unsigned(v), &self))?;
+        Ok(Decimal2 {
+            hundredths: hundredths * 100,
+        })
+    }
+
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        Ok(Decimal2 {
+            hundredths: v * 100,
+        })
+    }
+
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        let scaled = v * 100.0;
+        let rounded = scaled.round();
+        if (scaled - rounded).abs() > 1e-6 {
+            return Err(E::invalid_value(
+                Unexpected::Float(v),
+                &"a number with at most 2 decimal places",
+            ));
+        }
+        Ok(Decimal2 {
+            hundredths: rounded as i64,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct Wrapper {
+        value: Decimal2,
+    }
+
+    #[rstest]
+    #[case(r#"{"value": 11}"#, 1100)]
+    #[case(r#"{"value": 0}"#, 0)]
+    #[case(r#"{"value": 8.63}"#, 863)]
+    #[case(r#"{"value": 18.0}"#, 1800)]
+    #[case(r#"{"value": 1.5}"#, 150)]
+    #[case(r#"{"value": -3.25}"#, -325)]
+    #[case(r#"{"value": 0.01}"#, 1)]
+    fn test_deserialize(#[case] json: &str, #[case] expected_hundredths: i64) {
+        let wrapper: Wrapper = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(wrapper.value.hundredths(), expected_hundredths);
+    }
+
+    #[rstest]
+    #[case(r#"{"value": 8.635}"#)]
+    #[case(r#"{"value": 1.999}"#)]
+    #[case(r#"{"value": 0.001}"#)]
+    fn test_deserialize_rejects_more_than_two_decimals(#[case] json: &str) {
+        let result: Result<Wrapper, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "should reject value with more than 2 decimal places"
+        );
+    }
+
+    #[rstest]
+    #[case(1100, "11.00")]
+    #[case(863, "8.63")]
+    #[case(0, "0.00")]
+    #[case(-325, "-3.25")]
+    #[case(-5, "-0.05")]
+    fn test_display(#[case] hundredths: i64, #[case] expected: &str) {
+        let d = Decimal2 { hundredths };
+        assert_eq!(d.to_string(), expected);
+    }
+
+    #[rstest]
+    #[case(1100, "1100")]
+    #[case(863, "8.63")]
+    #[case(0, "0")]
+    #[case(1800, "1800")]
+    #[case(150, "1.5")]
+    fn test_serialize_roundtrip(#[case] hundredths: i64, #[case] _label: &str) {
+        let original = Decimal2 { hundredths };
+        let json = serde_json::to_string(&original).expect("should serialize");
+        let restored: Decimal2 = serde_json::from_str(&json).expect("should deserialize back");
+        assert_eq!(original, restored);
+    }
+}

--- a/wp_api/src/decimal2.rs
+++ b/wp_api/src/decimal2.rs
@@ -92,17 +92,19 @@ impl de::Visitor<'_> for Decimal2Visitor {
     }
 
     fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
-        let hundredths =
+        let signed =
             i64::try_from(v).map_err(|_| E::invalid_value(Unexpected::Unsigned(v), &self))?;
-        Ok(Decimal2 {
-            hundredths: hundredths * 100,
-        })
+        let hundredths = signed
+            .checked_mul(100)
+            .ok_or_else(|| E::invalid_value(Unexpected::Unsigned(v), &self))?;
+        Ok(Decimal2 { hundredths })
     }
 
     fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
-        Ok(Decimal2 {
-            hundredths: v * 100,
-        })
+        let hundredths = v
+            .checked_mul(100)
+            .ok_or_else(|| E::invalid_value(Unexpected::Signed(v), &self))?;
+        Ok(Decimal2 { hundredths })
     }
 
     fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {

--- a/wp_api/src/decimal2.rs
+++ b/wp_api/src/decimal2.rs
@@ -182,12 +182,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case(1100, "1100")]
-    #[case(863, "8.63")]
-    #[case(0, "0")]
-    #[case(1800, "1800")]
-    #[case(150, "1.5")]
-    fn test_serialize_roundtrip(#[case] hundredths: i64, #[case] _label: &str) {
+    #[case(1100)]
+    #[case(863)]
+    #[case(0)]
+    #[case(1800)]
+    #[case(150)]
+    fn test_serialize_roundtrip(#[case] hundredths: i64) {
         let original = Decimal2 { hundredths };
         let json = serde_json::to_string(&original).expect("should serialize");
         let restored: Decimal2 = serde_json::from_str(&json).expect("should deserialize back");

--- a/wp_api/src/lib.rs
+++ b/wp_api/src/lib.rs
@@ -15,6 +15,7 @@ pub mod application_passwords;
 pub mod auth;
 pub mod comments;
 pub mod date;
+pub mod decimal2;
 pub mod login;
 pub mod media;
 pub mod menu_locations;

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -1,4 +1,5 @@
 use crate::{
+    decimal2::Decimal2,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
     wp_com::segments::SegmentId,
 };
@@ -122,13 +123,13 @@ pub struct PaidDomainSuggestion {
     /// Formatted renewal cost (e.g. `"$18.00"`).
     pub renew_cost: String,
     /// Raw numeric renewal price in `currency_code`.
-    pub renew_raw_price: f64,
+    pub renew_raw_price: Decimal2,
     /// Raw numeric registration price in `currency_code`.
-    pub raw_price: f64,
+    pub raw_price: Decimal2,
     /// ISO 4217 currency code for `raw_price`/`renew_raw_price` (e.g. `"USD"`).
     pub currency_code: String,
     /// Promotional sale price in `currency_code`, if the domain is on sale.
-    pub sale_cost: Option<f64>,
+    pub sale_cost: Option<Decimal2>,
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
     pub hsts_required: Option<bool>,
     /// Policy notices attached to the suggestion (e.g. HSTS warnings).
@@ -204,8 +205,8 @@ mod tests {
         assert_eq!(first.product_slug, "domain_reg");
         assert_eq!(first.cost, "$18.00");
         assert_eq!(first.renew_cost, "$18.00");
-        assert_eq!(first.renew_raw_price, 18.0);
-        assert_eq!(first.raw_price, 18.0);
+        assert_eq!(first.renew_raw_price.hundredths(), 1800);
+        assert_eq!(first.raw_price.hundredths(), 1800);
         assert_eq!(first.currency_code, "USD");
         assert_eq!(first.sale_cost, None);
         assert_eq!(first.hsts_required, None);
@@ -220,7 +221,7 @@ mod tests {
             })
             .expect("freshpage.art missing");
         assert!(freshpage_art.match_reasons.is_none());
-        assert_eq!(freshpage_art.sale_cost, Some(1.64));
+        assert_eq!(freshpage_art.sale_cost.map(|d| d.hundredths()), Some(164));
 
         // `testsite.dev` has hsts_required and policy_notices populated.
         let testsite_dev = suggestions


### PR DESCRIPTION
Replaces f64 for monetary fields (`raw_price`, `renew_raw_price`, `sale_cost`) in domain suggestions to avoid floating-point precision issues.
