### PR TITLE
Change `DerivedRequest::namespace()` to an instance method

### DIFF
--- a/wp_api/src/jetpack/endpoint/connection_endpoint.rs
+++ b/wp_api/src/jetpack/endpoint/connection_endpoint.rs
@@ -19,7 +19,7 @@ enum ConnectionRequest {
 }
 
 impl DerivedRequest for ConnectionRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         JetpackNamespace {}
     }
 }

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -90,7 +90,7 @@ pub trait DerivedRequest {
         Vec::new()
     }
 
-    fn namespace() -> impl AsNamespace;
+    fn namespace(&self) -> impl AsNamespace;
 }
 
 pub trait AsNamespace: Send + Sync {

--- a/wp_api/src/request/endpoint/api_root_endpoint.rs
+++ b/wp_api/src/request/endpoint/api_root_endpoint.rs
@@ -10,7 +10,7 @@ enum ApiRootRequest {
 }
 
 impl DerivedRequest for ApiRootRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::None
     }
 }

--- a/wp_api/src/request/endpoint/application_passwords_endpoint.rs
+++ b/wp_api/src/request/endpoint/application_passwords_endpoint.rs
@@ -35,7 +35,7 @@ enum ApplicationPasswordsRequest {
 }
 
 impl DerivedRequest for ApplicationPasswordsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -27,7 +27,7 @@ impl DerivedRequest for CommentsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -28,7 +28,7 @@ impl DerivedRequest for MediaRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/menu_locations_endpoint.rs
+++ b/wp_api/src/request/endpoint/menu_locations_endpoint.rs
@@ -11,7 +11,7 @@ enum MenuLocationsRequest {
 }
 
 impl DerivedRequest for MenuLocationsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/nav_menu_item_autosaves_endpoint.rs
+++ b/wp_api/src/request/endpoint/nav_menu_item_autosaves_endpoint.rs
@@ -14,7 +14,7 @@ enum NavMenuItemAutosavesRequest {
 }
 
 impl DerivedRequest for NavMenuItemAutosavesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/nav_menu_items_endpoint.rs
+++ b/wp_api/src/request/endpoint/nav_menu_items_endpoint.rs
@@ -26,7 +26,7 @@ impl DerivedRequest for NavMenuItemsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/nav_menus_endpoint.rs
+++ b/wp_api/src/request/endpoint/nav_menus_endpoint.rs
@@ -24,7 +24,7 @@ impl DerivedRequest for NavMenusRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/navigation_autosaves_endpoint.rs
+++ b/wp_api/src/request/endpoint/navigation_autosaves_endpoint.rs
@@ -13,7 +13,7 @@ enum NavigationAutosavesRequest {
 }
 
 impl DerivedRequest for NavigationAutosavesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/navigation_revisions_endpoint.rs
+++ b/wp_api/src/request/endpoint/navigation_revisions_endpoint.rs
@@ -16,7 +16,7 @@ enum NavigationRevisionsRequest {
 }
 
 impl DerivedRequest for NavigationRevisionsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 

--- a/wp_api/src/request/endpoint/navigations_endpoint.rs
+++ b/wp_api/src/request/endpoint/navigations_endpoint.rs
@@ -29,7 +29,7 @@ impl DerivedRequest for NavigationsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/request/endpoint/plugins_endpoint.rs
@@ -18,7 +18,7 @@ enum PluginsRequest {
 }
 
 impl DerivedRequest for PluginsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/post_autosaves_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_autosaves_endpoint.rs
@@ -16,7 +16,7 @@ enum AutosavesRequest {
 }
 
 impl DerivedRequest for AutosavesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/post_revisions_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_revisions_endpoint.rs
@@ -17,7 +17,7 @@ enum PostRevisionsRequest {
 }
 
 impl DerivedRequest for PostRevisionsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 

--- a/wp_api/src/request/endpoint/post_statuses_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_statuses_endpoint.rs
@@ -11,7 +11,7 @@ enum PostStatusesRequest {
 }
 
 impl DerivedRequest for PostStatusesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/post_types_endpoint.rs
+++ b/wp_api/src/request/endpoint/post_types_endpoint.rs
@@ -11,7 +11,7 @@ enum PostTypesRequest {
 }
 
 impl DerivedRequest for PostTypesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/posts_endpoint.rs
+++ b/wp_api/src/request/endpoint/posts_endpoint.rs
@@ -47,7 +47,7 @@ impl DerivedRequest for PostsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/search_endpoint.rs
+++ b/wp_api/src/request/endpoint/search_endpoint.rs
@@ -8,7 +8,7 @@ enum SearchRequest {
 }
 
 impl DerivedRequest for SearchRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/site_settings_endpoint.rs
+++ b/wp_api/src/request/endpoint/site_settings_endpoint.rs
@@ -10,7 +10,7 @@ enum SiteSettingsRequest {
 }
 
 impl DerivedRequest for SiteSettingsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/taxonomies_endpoint.rs
+++ b/wp_api/src/request/endpoint/taxonomies_endpoint.rs
@@ -11,7 +11,7 @@ enum TaxonomiesRequest {
 }
 
 impl DerivedRequest for TaxonomiesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/templates_endpoint.rs
+++ b/wp_api/src/request/endpoint/templates_endpoint.rs
@@ -27,7 +27,7 @@ impl DerivedRequest for TemplatesRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/terms_endpoint.rs
+++ b/wp_api/src/request/endpoint/terms_endpoint.rs
@@ -46,7 +46,7 @@ impl DerivedRequest for TermsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/themes_endpoint.rs
+++ b/wp_api/src/request/endpoint/themes_endpoint.rs
@@ -11,7 +11,7 @@ enum ThemesRequest {
 }
 
 impl DerivedRequest for ThemesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/users_endpoint.rs
+++ b/wp_api/src/request/endpoint/users_endpoint.rs
@@ -26,7 +26,7 @@ enum UsersRequest {
 }
 
 impl DerivedRequest for UsersRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/widget_types_endpoint.rs
+++ b/wp_api/src/request/endpoint/widget_types_endpoint.rs
@@ -11,7 +11,7 @@ enum WidgetTypesRequest {
 }
 
 impl DerivedRequest for WidgetTypesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/widgets_endpoint.rs
+++ b/wp_api/src/request/endpoint/widgets_endpoint.rs
@@ -24,7 +24,7 @@ impl DerivedRequest for WidgetsRequest {
         }
     }
 
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpV2
     }
 }

--- a/wp_api/src/request/endpoint/wp_block_editor_endpoint.rs
+++ b/wp_api/src/request/endpoint/wp_block_editor_endpoint.rs
@@ -9,7 +9,7 @@ enum WpBlockEditorRequest {
 }
 
 impl DerivedRequest for WpBlockEditorRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpBlockEditorV1
     }
 }

--- a/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
+++ b/wp_api/src/request/endpoint/wp_site_health_tests_endpoint.rs
@@ -27,7 +27,7 @@ enum WpSiteHealthTestsRequest {
 }
 
 impl DerivedRequest for WpSiteHealthTestsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpNamespace::WpSiteHealthV1
     }
 }

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -14,7 +14,7 @@ enum DomainsRequest {
 }
 
 impl DerivedRequest for DomainsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/followers_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/followers_endpoint.rs
@@ -16,7 +16,7 @@ enum FollowersRequest {
 }
 
 impl DerivedRequest for FollowersRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/jetpack_connection_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/jetpack_connection_endpoint.rs
@@ -14,7 +14,7 @@ enum JetpackConnectionRequest {
 }
 
 impl DerivedRequest for JetpackConnectionRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/languages_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/languages_endpoint.rs
@@ -12,7 +12,7 @@ enum LanguagesRequest {
 }
 
 impl DerivedRequest for LanguagesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/me_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/me_endpoint.rs
@@ -12,7 +12,7 @@ enum MeRequest {
 }
 
 impl DerivedRequest for MeRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/oauth2.rs
+++ b/wp_api/src/wp_com/endpoint/oauth2.rs
@@ -27,7 +27,7 @@ enum Oauth2Request {
 }
 
 impl DerivedRequest for Oauth2Request {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::Oauth2
     }
 }

--- a/wp_api/src/wp_com/endpoint/segments_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/segments_endpoint.rs
@@ -11,7 +11,7 @@ enum SegmentsRequest {
 }
 
 impl DerivedRequest for SegmentsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/sites_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/sites_endpoint.rs
@@ -19,7 +19,7 @@ enum SitesRequest {
 }
 
 impl DerivedRequest for SitesRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_2
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_city_views_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_city_views_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsCityViewsRequest {
 }
 
 impl DerivedRequest for StatsCityViewsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_clicks_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_clicks_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsClicksRequest {
 }
 
 impl DerivedRequest for StatsClicksRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_country_views_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_country_views_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsCountryViewsRequest {
 }
 
 impl DerivedRequest for StatsCountryViewsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_devices_browser_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_devices_browser_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsDevicesBrowserRequest {
 }
 
 impl DerivedRequest for StatsDevicesBrowserRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_devices_platform_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_devices_platform_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsDevicesPlatformRequest {
 }
 
 impl DerivedRequest for StatsDevicesPlatformRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_devices_screensize_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_devices_screensize_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsDevicesScreensizeRequest {
 }
 
 impl DerivedRequest for StatsDevicesScreensizeRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_emails_summary_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_emails_summary_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsEmailsSummaryRequest {
 }
 
 impl DerivedRequest for StatsEmailsSummaryRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_file_downloads_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_file_downloads_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsFileDownloadsRequest {
 }
 
 impl DerivedRequest for StatsFileDownloadsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_insights_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_insights_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsInsightsRequest {
 }
 
 impl DerivedRequest for StatsInsightsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_referrers_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_referrers_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsReferrersRequest {
 }
 
 impl DerivedRequest for StatsReferrersRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_region_views_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_region_views_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsRegionViewsRequest {
 }
 
 impl DerivedRequest for StatsRegionViewsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_search_terms_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_search_terms_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsSearchTermsRequest {
 }
 
 impl DerivedRequest for StatsSearchTermsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_subscribers_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_subscribers_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsSubscribersRequest {
 }
 
 impl DerivedRequest for StatsSubscribersRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_summary_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_summary_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsSummaryRequest {
 }
 
 impl DerivedRequest for StatsSummaryRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_tags_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_tags_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsTagsRequest {
 }
 
 impl DerivedRequest for StatsTagsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_top_authors_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_top_authors_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsTopAuthorsRequest {
 }
 
 impl DerivedRequest for StatsTopAuthorsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_top_posts_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_top_posts_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsTopPostsRequest {
 }
 
 impl DerivedRequest for StatsTopPostsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_utm_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsUtmRequest {
 }
 
 impl DerivedRequest for StatsUtmRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_video_plays_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_video_plays_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsVideoPlaysRequest {
 }
 
 impl DerivedRequest for StatsVideoPlaysRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/stats_visits_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_visits_endpoint.rs
@@ -14,7 +14,7 @@ enum StatsVisitsRequest {
 }
 
 impl DerivedRequest for StatsVisitsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
     }
 }

--- a/wp_api/src/wp_com/endpoint/subscribers_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/subscribers_endpoint.rs
@@ -33,7 +33,7 @@ enum SubscribersRequest {
 }
 
 impl DerivedRequest for SubscribersRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/support_bots_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/support_bots_endpoint.rs
@@ -30,7 +30,7 @@ enum SupportBotsRequest {
 }
 
 impl DerivedRequest for SupportBotsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/support_eligibility_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/support_eligibility_endpoint.rs
@@ -12,7 +12,7 @@ enum SupportEligibilityRequest {
 }
 
 impl DerivedRequest for SupportEligibilityRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_api/src/wp_com/endpoint/support_tickets_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/support_tickets_endpoint.rs
@@ -23,7 +23,7 @@ enum SupportTicketsRequest {
 }
 
 impl DerivedRequest for SupportTicketsRequest {
-    fn namespace() -> impl AsNamespace {
+    fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::V2
     }
 }

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -339,8 +339,11 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
         let url_parts = variant.attr.url_parts.as_slice();
         let params_type = &variant.attr.params;
         let request_type = variant.attr.request_type;
-        let url_from_api_url_resolver =
-            fn_body_get_url_from_api_url_resolver(&parsed_enum.enum_ident, url_parts);
+        let url_from_api_url_resolver = fn_body_get_url_from_api_url_resolver(
+            &parsed_enum.enum_ident,
+            &variant.variant_ident,
+            url_parts,
+        );
         let query_pairs =
             fn_body_query_pairs(&config.crate_ident, params_type.as_ref(), request_type);
         let additional_query_pairs =

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -269,6 +269,7 @@ fn fn_arg_fields(context_and_filter_handler: &ContextAndFilterHandler) -> TokenS
 
 pub fn fn_body_get_url_from_api_url_resolver(
     enum_ident: &Ident,
+    variant_ident: &Ident,
     url_parts: &[UrlPart],
 ) -> TokenStream {
     let url_parts = url_parts
@@ -282,7 +283,7 @@ pub fn fn_body_get_url_from_api_url_resolver(
         })
         .collect::<Vec<TokenStream>>();
     quote! {
-        let mut url = std::sync::Arc::unwrap_or_clone(self.api_url_resolver.resolve( #enum_ident::namespace().namespace_value().to_string() , vec![#(#url_parts,)*])).inner;
+        let mut url = std::sync::Arc::unwrap_or_clone(self.api_url_resolver.resolve( #enum_ident::namespace(&#enum_ident::#variant_ident).namespace_value().to_string() , vec![#(#url_parts,)*])).inner;
     }
 }
 
@@ -1002,34 +1003,39 @@ mod tests {
     #[rstest]
     #[case(
         url_static_users(),
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [\"users\" . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [\"users\" . to_string () ,])) . inner ;"
     )]
     #[case(
         url_users_with_user_id(),
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () ,])) . inner ;"
     )]
     #[case(
         url_users_with_user_id(),
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () ,])) . inner ;"
     )]
     #[case(
         vec![UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string())],
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [user_id . to_string () , user_type . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [user_id . to_string () , user_type . to_string () ,])) . inner ;"
     )]
     #[case(
         vec![UrlPart::Static("users".to_string()), UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string()), ],
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () , user_type . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [\"users\" . to_string () , user_id . to_string () , user_type . to_string () ,])) . inner ;"
     )]
     #[case(
         vec![UrlPart::Static("users".to_string()), UrlPart::Static("me".to_string()), UrlPart::Dynamic("user_id".to_string()), UrlPart::Dynamic("user_type".to_string()), ],
-        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace () . namespace_value () . to_string () , vec ! [\"users\" . to_string () , \"me\" . to_string () , user_id . to_string () , user_type . to_string () ,])) . inner ;"
+        "let mut url = std :: sync :: Arc :: unwrap_or_clone (self . api_url_resolver . resolve (Foo :: namespace (& Foo :: Bar) . namespace_value () . to_string () , vec ! [\"users\" . to_string () , \"me\" . to_string () , user_id . to_string () , user_type . to_string () ,])) . inner ;"
     )]
     fn test_fn_body_get_url_from_api_root_url(
         #[case] url_parts: Vec<UrlPart>,
         #[case] expected_str: &str,
     ) {
         assert_eq!(
-            fn_body_get_url_from_api_url_resolver(&format_ident!("Foo"), &url_parts).to_string(),
+            fn_body_get_url_from_api_url_resolver(
+                &format_ident!("Foo"),
+                &format_ident!("Bar"),
+                &url_parts
+            )
+            .to_string(),
             expected_str
         );
     }


### PR DESCRIPTION
Allow individual `enum` variants to return different API namespaces by taking `&self`, enabling endpoints like `/domains/{name}/is-available/` (v1.3) to coexist with v1.1 endpoints in the same request `enum`.