### PR TITLE
Add `/domains/{name}/is-available/` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MediaService.update_media` for editing media items
 - Sort/ordering predicates on `MediaListFilter`
 - Live membership updates on `MediaMetadataCollectionWithEditContext`, so cached media lists reflect items moving in or out of the filter without a full refresh
+- WordPress.com `/domains/{name}/is-available` endpoint for checking domain availability, pricing, and transfer status
 
 ### Changed
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -151,6 +151,80 @@ pub struct DomainPolicyNotice {
     pub message: String,
 }
 
+/// Response from `GET /domains/{name}/is-available/` (v1.3).
+///
+/// Reports whether a domain name is available for registration or
+/// mapping, along with pricing and product details when applicable.
+///
+/// The set of fields present varies by `status`: available domains
+/// include full pricing, transferrable domains include partial
+/// pricing, and blacklisted/restricted domains have only the core
+/// fields.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainAvailability {
+    /// The domain name that was checked.
+    pub domain_name: String,
+    /// The TLD portion of the domain (e.g. `"com"`, `"io"`, `"dev"`).
+    pub tld: String,
+    /// Availability status (e.g. `"available"`, `"transferrable"`,
+    /// `"blacklisted_domain"`, `"tld_not_supported"`,
+    /// `"restricted_domain"`,
+    /// `"recent_registration_lock_not_transferrable"`).
+    pub status: String,
+    /// Whether the domain can be mapped to a WordPress.com site
+    /// (e.g. `"mappable"`, `"blacklisted_domain"`,
+    /// `"restricted_domain"`).
+    pub mappable: String,
+    /// Whether the domain supports WHOIS privacy protection.
+    #[serde(default)]
+    #[uniffi(default = false)]
+    pub supports_privacy: bool,
+    /// Provider of the root domain (e.g. `"unknown"`).
+    pub root_domain_provider: String,
+    /// WordPress.com product ID for purchasing this domain.
+    pub product_id: Option<u64>,
+    /// WordPress.com product slug (e.g. `"domain_reg"`,
+    /// `"domain_transfer"`, `"dotnet_domain"`).
+    pub product_slug: Option<String>,
+    /// Formatted registration cost (e.g. `"TL 426"`, `"$18.00"`).
+    pub cost: Option<String>,
+    /// Formatted renewal cost (e.g. `"TL 426"`).
+    pub renew_cost: Option<String>,
+    /// Raw numeric renewal price in `currency_code`.
+    pub renew_raw_price: Option<u64>,
+    /// Raw numeric registration price in `currency_code`.
+    pub raw_price: Option<u64>,
+    /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`).
+    pub currency_code: Option<String>,
+    /// Reasons the domain matched (e.g. `"exact-match"`,
+    /// `"tld-exact"`, `"tld-common"`).
+    pub match_reasons: Option<Vec<String>>,
+    /// The registry vendor (e.g. `"availability"`).
+    pub vendor: Option<String>,
+    /// Type of ownership verification required (e.g.
+    /// `"no_verification_required"`).
+    pub ownership_verification_type: Option<String>,
+    /// `true` if the TLD requires HSTS (e.g. `.dev`).
+    pub hsts_required: Option<bool>,
+    /// Policy notices attached to the domain (e.g. HSTS warnings).
+    #[serde(default)]
+    #[uniffi(default = [])]
+    pub policy_notices: Vec<DomainPolicyNotice>,
+}
+
+impl_as_query_value_for_new_type!(DomainName);
+uniffi::custom_newtype!(DomainName, String);
+/// A domain name (e.g. `"example.com"`, `"myblog.org"`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DomainName(pub String);
+
+impl std::fmt::Display for DomainName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl_as_query_value_for_new_type!(CountryCode);
 uniffi::custom_newtype!(CountryCode, String);
 /// ISO 3166-1 alpha-2 country code (e.g. `"US"`, `"CA"`, `"GB"`).
@@ -508,5 +582,142 @@ mod tests {
         };
         assert_eq!(only.domain_name, "testsite.home.blog");
         assert_eq!(only.vendor, "dotblogsubdomains");
+    }
+
+    #[rstest]
+    #[case::available(
+        "tests/wpcom/domains/is_available/available.json",
+        "freshsite2025.com",
+        "com",
+        "available",
+        "mappable",
+        true
+    )]
+    #[case::blacklisted(
+        "tests/wpcom/domains/is_available/not-available.json",
+        "example.com",
+        "com",
+        "blacklisted_domain",
+        "blacklisted_domain",
+        true
+    )]
+    #[case::transferrable(
+        "tests/wpcom/domains/is_available/transferrable.json",
+        "taken-domain.io",
+        "io",
+        "transferrable",
+        "mappable",
+        true
+    )]
+    #[case::tld_not_supported(
+        "tests/wpcom/domains/is_available/tld-not-supported.json",
+        "mysite.ai",
+        "ai",
+        "tld_not_supported",
+        "mappable",
+        false
+    )]
+    #[case::hsts_required(
+        "tests/wpcom/domains/is_available/hsts-required.json",
+        "myproject.dev",
+        "dev",
+        "recent_registration_lock_not_transferrable",
+        "mappable",
+        false
+    )]
+    fn test_domain_availability_deserialization(
+        #[case] json_file_path: &str,
+        #[case] expected_domain: &str,
+        #[case] expected_tld: &str,
+        #[case] expected_status: &str,
+        #[case] expected_mappable: &str,
+        #[case] expected_privacy: bool,
+    ) {
+        let file = File::open(json_file_path).expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.domain_name, expected_domain);
+        assert_eq!(availability.tld, expected_tld);
+        assert_eq!(availability.status, expected_status);
+        assert_eq!(availability.mappable, expected_mappable);
+        assert_eq!(availability.supports_privacy, expected_privacy);
+    }
+
+    #[test]
+    fn test_domain_availability_available_details() {
+        let file = File::open("tests/wpcom/domains/is_available/available.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.product_id, Some(6));
+        assert_eq!(availability.product_slug.as_deref(), Some("domain_reg"));
+        assert_eq!(availability.cost.as_deref(), Some("$18.00"));
+        assert_eq!(availability.renew_cost.as_deref(), Some("$18.00"));
+        assert_eq!(availability.raw_price, Some(1800));
+        assert_eq!(availability.renew_raw_price, Some(1800));
+        assert_eq!(availability.currency_code.as_deref(), Some("USD"));
+        assert_eq!(
+            availability.match_reasons.as_deref(),
+            Some(
+                ["exact-match", "tld-exact", "tld-common"]
+                    .map(String::from)
+                    .as_slice()
+            )
+        );
+        assert_eq!(availability.vendor.as_deref(), Some("availability"));
+        assert_eq!(
+            availability.ownership_verification_type.as_deref(),
+            Some("no_verification_required")
+        );
+    }
+
+    #[test]
+    fn test_domain_availability_blacklisted_has_no_pricing() {
+        let file = File::open("tests/wpcom/domains/is_available/not-available.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.product_id, None);
+        assert_eq!(availability.product_slug, None);
+        assert_eq!(availability.cost, None);
+        assert_eq!(availability.raw_price, None);
+        assert_eq!(availability.currency_code, None);
+        assert_eq!(availability.match_reasons, None);
+        assert!(availability.policy_notices.is_empty());
+    }
+
+    #[test]
+    fn test_domain_availability_transferrable_partial_pricing() {
+        let file = File::open("tests/wpcom/domains/is_available/transferrable.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.product_id, Some(1337));
+        assert_eq!(
+            availability.product_slug.as_deref(),
+            Some("domain_transfer")
+        );
+        assert_eq!(availability.cost.as_deref(), Some("$48.00"));
+        assert_eq!(availability.raw_price, Some(4800));
+        // Transferrable domains don't include renewal pricing.
+        assert_eq!(availability.renew_cost, None);
+        assert_eq!(availability.renew_raw_price, None);
+    }
+
+    #[test]
+    fn test_domain_availability_hsts_policy_notices() {
+        let file = File::open("tests/wpcom/domains/is_available/hsts-required.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.hsts_required, Some(true));
+        assert_eq!(availability.policy_notices.len(), 1);
+        assert_eq!(availability.policy_notices[0].notice_type, "hsts");
+        assert_eq!(availability.policy_notices[0].label, "HSTS required");
+        assert!(
+            availability.policy_notices[0]
+                .message
+                .contains("SSL certificate")
+        );
     }
 }

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -201,6 +201,29 @@ pub enum DomainAvailabilityStatus {
     Other(String),
 }
 
+/// Whether a domain can be mapped to a WordPress.com site.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainMappableStatus {
+    /// Domain can be mapped.
+    Mappable,
+    /// Domain is blacklisted and cannot be mapped.
+    BlacklistedDomain,
+    /// Domain is already mapped to another site.
+    MappedDomain,
+    /// Domain format is invalid.
+    InvalidDomain,
+    /// TLD is invalid.
+    InvalidTld,
+    /// Domain is restricted and cannot be mapped.
+    RestrictedDomain,
+    /// Domain has a pending transfer.
+    TransferPending,
+    /// A status not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
 /// Response from `GET /domains/{name}/is-available/` (v1.3).
 ///
 /// Reports whether a domain name is available for registration or
@@ -217,9 +240,8 @@ pub struct DomainAvailability {
     pub tld: String,
     /// Availability status.
     pub status: DomainAvailabilityStatus,
-    /// Whether the domain can be mapped to a WordPress.com site
-    /// (e.g. `"mappable"`, `"blacklisted_domain"`).
-    pub mappable: String,
+    /// Whether the domain can be mapped to a WordPress.com site.
+    pub mappable: DomainMappableStatus,
     /// Whether the domain supports WHOIS privacy protection.
     #[serde(default)]
     #[uniffi(default = false)]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -248,45 +248,20 @@ pub struct DomainAvailability {
     pub supports_privacy: bool,
     /// Provider of the root domain (`"wpcom"` or `"unknown"`).
     pub root_domain_provider: String,
-    // -- Product/pricing fields (conditional on status) --
-    /// WordPress.com product ID for purchasing this domain.
-    pub product_id: Option<ProductId>,
-    /// WordPress.com product slug (e.g. `"domain_reg"`,
-    /// `"domain_transfer"`).
-    pub product_slug: Option<String>,
-    /// Formatted registration/transfer cost (e.g. `"$18.00"`).
-    pub cost: Option<String>,
-    /// Formatted renewal cost.
-    pub renew_cost: Option<String>,
-    /// Raw numeric renewal price in `currency_code`.
-    pub renew_raw_price: Option<Decimal2>,
-    /// Raw numeric registration/transfer price in `currency_code`.
-    pub raw_price: Option<Decimal2>,
-    /// ISO 4217 currency code.
-    pub currency_code: Option<CurrencyCode>,
-    /// Discounted sale price when a coupon applies.
-    pub sale_cost: Option<Decimal2>,
-    /// `true` if a premium domain exceeds the price limit.
-    pub is_price_limit_exceeded: Option<bool>,
-    // -- Match/vendor fields (available domains only) --
-    /// Reasons the domain matched (e.g. `"exact-match"`,
-    /// `"tld-exact"`, `"tld-common"`).
-    pub match_reasons: Option<Vec<String>>,
-    /// The registry vendor (e.g. `"availability"`).
-    pub vendor: Option<String>,
-    /// `true` for status `"available_premium"`.
-    pub is_supported_premium_domain: Option<bool>,
-    // -- Mapping/transfer fields --
+    /// Product and pricing details. Present for available and
+    /// transferrable domains, absent for unavailable domains.
+    #[serde(flatten)]
+    pub pricing: Option<DomainPricing>,
+    /// Match and vendor info. Present for available domains.
+    #[serde(flatten)]
+    pub match_info: Option<DomainMatchInfo>,
+    /// Transfer and mapping details. Present when the domain is
+    /// already registered or mapped by the same user on another site.
+    #[serde(flatten)]
+    pub transfer_info: Option<DomainTransferInfo>,
     /// Type of ownership verification required (e.g.
     /// `"no_verification_required"`).
     pub ownership_verification_type: Option<String>,
-    /// Transfer status for mapped domains (e.g. `"transferrable"`,
-    /// `"recent_registration_lock_not_transferrable"`).
-    pub transferrability: Option<String>,
-    /// Primary domain of the other site where this domain is
-    /// registered or mapped (same user, different site).
-    pub other_site_domain: Option<String>,
-    // -- TLD-specific fields --
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
     pub hsts_required: Option<bool>,
     /// `true` if the `.gay` TLD policy notice is required.
@@ -297,9 +272,56 @@ pub struct DomainAvailability {
     #[serde(default)]
     #[uniffi(default = [])]
     pub policy_notices: Vec<DomainPolicyNotice>,
-    // -- Maintenance --
     /// When domain registration or TLD is in maintenance, the end time.
     pub maintenance_end_time: Option<String>,
+}
+
+/// Product and pricing details for an available or transferrable domain.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainPricing {
+    /// WordPress.com product ID for purchasing this domain.
+    pub product_id: ProductId,
+    /// WordPress.com product slug (e.g. `"domain_reg"`,
+    /// `"domain_transfer"`).
+    pub product_slug: String,
+    /// Formatted registration/transfer cost (e.g. `"$18.00"`).
+    pub cost: String,
+    /// Raw numeric registration/transfer price in `currency_code`.
+    pub raw_price: Decimal2,
+    /// ISO 4217 currency code.
+    pub currency_code: CurrencyCode,
+    /// Formatted renewal cost. Not present for transfer-only domains.
+    pub renew_cost: Option<String>,
+    /// Raw numeric renewal price in `currency_code`.
+    pub renew_raw_price: Option<Decimal2>,
+    /// Discounted sale price when a coupon applies.
+    pub sale_cost: Option<Decimal2>,
+    /// `true` if a premium domain exceeds the price limit.
+    pub is_price_limit_exceeded: Option<bool>,
+    /// `true` for supported premium domains.
+    pub is_supported_premium_domain: Option<bool>,
+}
+
+/// Match and vendor information for an available domain.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainMatchInfo {
+    /// Reasons the domain matched (e.g. `"exact-match"`,
+    /// `"tld-exact"`, `"tld-common"`).
+    pub match_reasons: Vec<String>,
+    /// The registry vendor (e.g. `"availability"`).
+    pub vendor: String,
+}
+
+/// Transfer and mapping details for a domain registered or mapped
+/// by the same user on another site.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainTransferInfo {
+    /// Primary domain of the other site where this domain is
+    /// registered or mapped.
+    pub other_site_domain: String,
+    /// Transfer status (e.g. `"transferrable"`,
+    /// `"recent_registration_lock_not_transferrable"`).
+    pub transferrability: Option<String>,
 }
 
 impl_as_query_value_for_new_type!(DomainName);
@@ -755,31 +777,32 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.product_id, Some(ProductId(6)));
-        assert_eq!(availability.product_slug.as_deref(), Some("domain_reg"));
-        assert_eq!(availability.cost.as_deref(), Some("$18.00"));
-        assert_eq!(availability.renew_cost.as_deref(), Some("$18.00"));
+
+        let pricing = availability
+            .pricing
+            .as_ref()
+            .expect("available domain should have pricing");
+        assert_eq!(pricing.product_id, ProductId(6));
+        assert_eq!(pricing.product_slug, "domain_reg");
+        assert_eq!(pricing.cost, "$18.00");
+        assert_eq!(pricing.raw_price, Decimal2::from_hundredths(1800));
+        assert_eq!(pricing.currency_code, CurrencyCode("USD".to_string()));
+        assert_eq!(pricing.renew_cost.as_deref(), Some("$18.00"));
         assert_eq!(
-            availability.raw_price,
+            pricing.renew_raw_price,
             Some(Decimal2::from_hundredths(1800))
         );
+
+        let match_info = availability
+            .match_info
+            .as_ref()
+            .expect("available domain should have match info");
         assert_eq!(
-            availability.renew_raw_price,
-            Some(Decimal2::from_hundredths(1800))
+            match_info.match_reasons,
+            ["exact-match", "tld-exact", "tld-common"].map(String::from)
         );
-        assert_eq!(
-            availability.currency_code,
-            Some(CurrencyCode("USD".to_string()))
-        );
-        assert_eq!(
-            availability.match_reasons.as_deref(),
-            Some(
-                ["exact-match", "tld-exact", "tld-common"]
-                    .map(String::from)
-                    .as_slice()
-            )
-        );
-        assert_eq!(availability.vendor.as_deref(), Some("availability"));
+        assert_eq!(match_info.vendor, "availability");
+
         assert_eq!(
             availability.ownership_verification_type.as_deref(),
             Some("no_verification_required")
@@ -792,12 +815,8 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert!(availability.product_id.is_none());
-        assert!(availability.product_slug.is_none());
-        assert!(availability.cost.is_none());
-        assert!(availability.raw_price.is_none());
-        assert!(availability.currency_code.is_none());
-        assert!(availability.match_reasons.is_none());
+        assert!(availability.pricing.is_none());
+        assert!(availability.match_info.is_none());
         assert!(availability.policy_notices.is_empty());
     }
 
@@ -807,19 +826,18 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.product_id, Some(ProductId(1337)));
-        assert_eq!(
-            availability.product_slug.as_deref(),
-            Some("domain_transfer")
-        );
-        assert_eq!(availability.cost.as_deref(), Some("$48.00"));
-        assert_eq!(
-            availability.raw_price,
-            Some(Decimal2::from_hundredths(4800))
-        );
+
+        let pricing = availability
+            .pricing
+            .as_ref()
+            .expect("transferrable domain should have pricing");
+        assert_eq!(pricing.product_id, ProductId(1337));
+        assert_eq!(pricing.product_slug, "domain_transfer");
+        assert_eq!(pricing.cost, "$48.00");
+        assert_eq!(pricing.raw_price, Decimal2::from_hundredths(4800));
         // Transferrable domains don't include renewal pricing.
-        assert!(availability.renew_cost.is_none());
-        assert!(availability.renew_raw_price.is_none());
+        assert!(pricing.renew_cost.is_none());
+        assert!(pricing.renew_raw_price.is_none());
     }
 
     #[test]
@@ -828,12 +846,14 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.is_supported_premium_domain, Some(true));
-        assert_eq!(availability.is_price_limit_exceeded, Some(false));
-        assert_eq!(
-            availability.raw_price,
-            Some(Decimal2::from_hundredths(500000))
-        );
+
+        let pricing = availability
+            .pricing
+            .as_ref()
+            .expect("premium domain should have pricing");
+        assert_eq!(pricing.is_supported_premium_domain, Some(true));
+        assert_eq!(pricing.is_price_limit_exceeded, Some(false));
+        assert_eq!(pricing.raw_price, Decimal2::from_hundredths(500000));
     }
 
     #[test]
@@ -842,15 +862,17 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let transfer_info = availability
+            .transfer_info
+            .as_ref()
+            .expect("mapped-same-user should have transfer info");
+        assert_eq!(transfer_info.other_site_domain, "myothersite.wordpress.com");
         assert_eq!(
-            availability.other_site_domain.as_deref(),
-            Some("myothersite.wordpress.com")
-        );
-        assert_eq!(
-            availability.transferrability.as_deref(),
+            transfer_info.transferrability.as_deref(),
             Some("transferrable")
         );
-        assert!(availability.product_id.is_none());
+        assert!(availability.pricing.is_none());
     }
 
     #[test]
@@ -859,14 +881,13 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(
-            availability.sale_cost,
-            Some(Decimal2::from_hundredths(1000))
-        );
-        assert_eq!(
-            availability.raw_price,
-            Some(Decimal2::from_hundredths(2500))
-        );
+
+        let pricing = availability
+            .pricing
+            .as_ref()
+            .expect("sale domain should have pricing");
+        assert_eq!(pricing.sale_cost, Some(Decimal2::from_hundredths(1000)));
+        assert_eq!(pricing.raw_price, Decimal2::from_hundredths(2500));
     }
 
     #[test]
@@ -893,7 +914,7 @@ mod tests {
             availability.maintenance_end_time.as_deref(),
             Some("2026-05-01 12:00:00")
         );
-        assert!(availability.product_id.is_none());
+        assert!(availability.pricing.is_none());
     }
 
     #[test]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -725,8 +725,8 @@ mod tests {
     )]
     #[case::sale_coupon(
         "tests/wpcom/domains/is_available/sale-coupon.json",
-        "newsite.info",
-        "info",
+        "freshblog2025.online",
+        "online",
         "available",
         "mappable",
         true
@@ -738,6 +738,14 @@ mod tests {
         "tld_in_maintenance",
         "mappable",
         false
+    )]
+    #[case::dot_gay_notice(
+        "tests/wpcom/domains/is_available/dot-gay-notice.json",
+        "testsite2025.gay",
+        "gay",
+        "mappable",
+        "mappable",
+        true
     )]
     fn test_domain_availability_deserialization(
         #[case] json_file_path: &str,
@@ -852,8 +860,22 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.sale_cost, Some(Decimal2::from_hundredths(700)));
-        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(2000)));
+        assert_eq!(availability.sale_cost, Some(Decimal2::from_hundredths(1000)));
+        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(2500)));
+    }
+
+    #[test]
+    fn test_domain_availability_dot_gay_notice() {
+        let file = File::open("tests/wpcom/domains/is_available/dot-gay-notice.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.is_dot_gay_notice_required, Some(true));
+        assert_eq!(availability.policy_notices.len(), 1);
+        assert_eq!(
+            availability.policy_notices[0].notice_type,
+            "gay_accept_requirements"
+        );
     }
 
     #[test]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -182,62 +182,20 @@ pub enum DomainAvailabilityStatus {
     Available,
     /// Premium domain available at a higher price.
     AvailablePremium,
-    /// Available but reserved.
-    AvailableReserved,
-    /// Available but not registrable by current user.
-    AvailableButNotRegistrable,
     /// Domain can be transferred in.
     Transferrable,
     /// Premium domain can be transferred in.
     TransferrablePremium,
-    /// Registered on the same site being checked.
-    RegisteredOnSameSite,
-    /// Registered by the same user on a different site.
+    /// Already registered by the same user on a different site.
     RegisteredOnOtherSiteSameUser,
-    /// Registered by a different user.
-    RegisteredDomain,
-    /// Mapped to same site, can still be registered.
-    MappedToSameSiteRegistrable,
-    /// Mapped to same site, can be transferred.
-    MappedToSameSiteTransferrable,
-    /// Mapped to same site, cannot be transferred.
-    MappedToSameSiteNotTransferrable,
-    /// Mapped to another site by the same user, registrable.
-    MappedToOtherSiteSameUserRegistrable,
-    /// Mapped to another site by the same user.
+    /// Already mapped to another site by the same user.
     MappedToOtherSiteSameUser,
-    /// Mapped by a different user.
-    MappedDomain,
-    /// Transfer in progress by the same user.
-    TransferPendingSameUser,
-    /// Transfer in progress by a different user.
-    TransferPending,
-    /// Domain in redemption period.
-    InRedemption,
     /// TLD is not supported for registration.
     TldNotSupported,
     /// TLD is currently in maintenance.
     TldInMaintenance,
-    /// Domain registration is temporarily disabled.
-    DomainRegistrationUnavailable,
-    /// 60-day transfer lock active.
-    RecentRegistrationLockNotTransferrable,
-    /// EPP status prevents transfer.
-    ServerTransferProhibitedNotTransferrable,
     /// Domain is blacklisted.
     BlacklistedDomain,
-    /// Domain is restricted.
-    RestrictedDomain,
-    /// WordPress.com managed subdomain (.blog, .link, etc.).
-    DotblogSubdomain,
-    /// 100-year domain vendor but TLD not supported.
-    HundredYearDomainTldRestriction,
-    /// CNAME conflict prevents mapping.
-    ConflictingCnameExists,
-    /// Domain can be mapped (mappable-only status).
-    Mappable,
-    /// Unknown status.
-    Unknown,
     /// A status not covered by the known variants.
     #[serde(untagged)]
     Other(String),
@@ -722,7 +680,7 @@ mod tests {
     #[case::hsts_required(
         "tests/wpcom/domains/is_available/hsts-required.json",
         "myproject.dev",
-        DomainAvailabilityStatus::RecentRegistrationLockNotTransferrable,
+        DomainAvailabilityStatus::Other("recent_registration_lock_not_transferrable".to_string()),
         false
     )]
     #[case::available_premium(
@@ -752,7 +710,7 @@ mod tests {
     #[case::dot_gay_notice(
         "tests/wpcom/domains/is_available/dot-gay-notice.json",
         "testsite2025.gay",
-        DomainAvailabilityStatus::Mappable,
+        DomainAvailabilityStatus::Other("mappable".to_string()),
         true
     )]
     fn test_domain_availability_deserialization(

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -2,7 +2,7 @@ use crate::{
     decimal2::Decimal2,
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::segments::SegmentId,
+    wp_com::{WpComSiteId, segments::SegmentId},
 };
 use serde::{Deserialize, Serialize};
 
@@ -149,6 +149,29 @@ pub struct DomainPolicyNotice {
     pub label: String,
     /// Full human-readable message describing the notice.
     pub message: String,
+}
+
+/// Optional query parameters for `GET /domains/{name}/is-available/`.
+#[derive(Debug, Default, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct DomainAvailabilityParams {
+    /// Site ID to check domain availability against.
+    #[uniffi(default = None)]
+    pub blog_id: Option<WpComSiteId>,
+    /// Whether this is a pre-check before adding to cart.
+    #[uniffi(default = None)]
+    pub is_cart_pre_check: Option<bool>,
+    /// Vendor for the availability check (e.g. `"100-year-domains"`).
+    #[uniffi(default = None)]
+    pub vendor: Option<String>,
+}
+
+impl AppendUrlQueryPairs for DomainAvailabilityParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut
+            .append_option_query_value_pair("blog_id", self.blog_id.as_ref())
+            .append_option_query_value_pair("is_cart_pre_check", self.is_cart_pre_check.as_ref())
+            .append_option_query_value_pair("vendor", self.vendor.as_ref());
+    }
 }
 
 /// Response from `GET /domains/{name}/is-available/` (v1.3).

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -312,6 +312,19 @@ pub struct DomainMatchInfo {
     pub vendor: String,
 }
 
+/// Transfer status of a domain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainTransferrability {
+    /// Domain can be transferred in.
+    Transferrable,
+    /// Premium domain can be transferred in.
+    TransferrablePremium,
+    /// A status not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
 /// Transfer and mapping details for a domain registered or mapped
 /// by the same user on another site.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
@@ -319,9 +332,8 @@ pub struct DomainTransferInfo {
     /// Primary domain of the other site where this domain is
     /// registered or mapped.
     pub other_site_domain: String,
-    /// Transfer status (e.g. `"transferrable"`,
-    /// `"recent_registration_lock_not_transferrable"`).
-    pub transferrability: Option<String>,
+    /// Transfer status of this domain.
+    pub transferrability: Option<DomainTransferrability>,
 }
 
 impl_as_query_value_for_new_type!(DomainName);
@@ -869,8 +881,8 @@ mod tests {
             .expect("mapped-same-user should have transfer info");
         assert_eq!(transfer_info.other_site_domain, "myothersite.wordpress.com");
         assert_eq!(
-            transfer_info.transferrability.as_deref(),
-            Some("transferrable")
+            transfer_info.transferrability,
+            Some(DomainTransferrability::Transferrable)
         );
         assert!(availability.pricing.is_none());
     }

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -775,7 +775,10 @@ mod tests {
         assert_eq!(availability.product_slug.as_deref(), Some("domain_reg"));
         assert_eq!(availability.cost.as_deref(), Some("$18.00"));
         assert_eq!(availability.renew_cost.as_deref(), Some("$18.00"));
-        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(1800)));
+        assert_eq!(
+            availability.raw_price,
+            Some(Decimal2::from_hundredths(1800))
+        );
         assert_eq!(
             availability.renew_raw_price,
             Some(Decimal2::from_hundredths(1800))
@@ -823,7 +826,10 @@ mod tests {
             Some("domain_transfer")
         );
         assert_eq!(availability.cost.as_deref(), Some("$48.00"));
-        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(4800)));
+        assert_eq!(
+            availability.raw_price,
+            Some(Decimal2::from_hundredths(4800))
+        );
         // Transferrable domains don't include renewal pricing.
         assert!(availability.renew_cost.is_none());
         assert!(availability.renew_raw_price.is_none());
@@ -837,7 +843,10 @@ mod tests {
             serde_json::from_reader(file).expect("Unable to parse JSON");
         assert_eq!(availability.is_supported_premium_domain, Some(true));
         assert_eq!(availability.is_price_limit_exceeded, Some(false));
-        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(500000)));
+        assert_eq!(
+            availability.raw_price,
+            Some(Decimal2::from_hundredths(500000))
+        );
     }
 
     #[test]
@@ -850,7 +859,10 @@ mod tests {
             availability.other_site_domain.as_deref(),
             Some("myothersite.wordpress.com")
         );
-        assert_eq!(availability.transferrability.as_deref(), Some("transferrable"));
+        assert_eq!(
+            availability.transferrability.as_deref(),
+            Some("transferrable")
+        );
         assert!(availability.product_id.is_none());
     }
 
@@ -860,8 +872,14 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.sale_cost, Some(Decimal2::from_hundredths(1000)));
-        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(2500)));
+        assert_eq!(
+            availability.sale_cost,
+            Some(Decimal2::from_hundredths(1000))
+        );
+        assert_eq!(
+            availability.raw_price,
+            Some(Decimal2::from_hundredths(2500))
+        );
     }
 
     #[test]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -272,8 +272,8 @@ pub struct DomainAvailability {
     #[serde(default)]
     #[uniffi(default = [])]
     pub policy_notices: Vec<DomainPolicyNotice>,
-    /// When domain registration or TLD is in maintenance, the end time.
-    pub maintenance_end_time: Option<String>,
+    /// Unix timestamp of when maintenance ends for this domain or TLD.
+    pub maintenance_end_time: Option<u64>,
 }
 
 /// Product and pricing details for an available or transferrable domain.
@@ -910,10 +910,7 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(
-            availability.maintenance_end_time.as_deref(),
-            Some("2026-05-01 12:00:00")
-        );
+        assert_eq!(availability.maintenance_end_time, Some(1777651200));
         assert!(availability.pricing.is_none());
     }
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -2,7 +2,7 @@ use crate::{
     decimal2::Decimal2,
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::{CurrencyCode, WpComSiteId, segments::SegmentId},
+    wp_com::{CurrencyCode, WpComSiteId, products::ProductId, segments::SegmentId},
 };
 use serde::{Deserialize, Serialize};
 
@@ -116,7 +116,7 @@ pub struct PaidDomainSuggestion {
     /// Whether the domain supports multi-year registrations.
     pub multi_year_reg_allowed: bool,
     /// WordPress.com product ID used to purchase this domain.
-    pub product_id: u64,
+    pub product_id: ProductId,
     /// WordPress.com product slug used to purchase this domain.
     pub product_slug: String,
     /// Formatted registration cost (e.g. `"$18.00"`).
@@ -228,7 +228,7 @@ pub struct DomainAvailability {
     pub root_domain_provider: String,
     // -- Product/pricing fields (conditional on status) --
     /// WordPress.com product ID for purchasing this domain.
-    pub product_id: Option<u64>,
+    pub product_id: Option<ProductId>,
     /// WordPress.com product slug (e.g. `"domain_reg"`,
     /// `"domain_transfer"`).
     pub product_slug: Option<String>,
@@ -472,7 +472,7 @@ mod tests {
         );
         assert_eq!(first.max_reg_years, 10);
         assert!(first.multi_year_reg_allowed);
-        assert_eq!(first.product_id, 6);
+        assert_eq!(first.product_id, ProductId(6));
         assert_eq!(first.product_slug, "domain_reg");
         assert_eq!(first.cost, "$18.00");
         assert_eq!(first.renew_cost, "$18.00");
@@ -733,7 +733,7 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.product_id, Some(6));
+        assert_eq!(availability.product_id, Some(ProductId(6)));
         assert_eq!(availability.product_slug.as_deref(), Some("domain_reg"));
         assert_eq!(availability.cost.as_deref(), Some("$18.00"));
         assert_eq!(availability.renew_cost.as_deref(), Some("$18.00"));
@@ -785,7 +785,7 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.product_id, Some(1337));
+        assert_eq!(availability.product_id, Some(ProductId(1337)));
         assert_eq!(
             availability.product_slug.as_deref(),
             Some("domain_transfer")

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -174,6 +174,75 @@ impl AppendUrlQueryPairs for DomainAvailabilityParams {
     }
 }
 
+/// Availability status for a domain checked via `GET /domains/{name}/is-available/`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainAvailabilityStatus {
+    /// Domain is available for registration.
+    Available,
+    /// Premium domain available at a higher price.
+    AvailablePremium,
+    /// Available but reserved.
+    AvailableReserved,
+    /// Available but not registrable by current user.
+    AvailableButNotRegistrable,
+    /// Domain can be transferred in.
+    Transferrable,
+    /// Premium domain can be transferred in.
+    TransferrablePremium,
+    /// Registered on the same site being checked.
+    RegisteredOnSameSite,
+    /// Registered by the same user on a different site.
+    RegisteredOnOtherSiteSameUser,
+    /// Registered by a different user.
+    RegisteredDomain,
+    /// Mapped to same site, can still be registered.
+    MappedToSameSiteRegistrable,
+    /// Mapped to same site, can be transferred.
+    MappedToSameSiteTransferrable,
+    /// Mapped to same site, cannot be transferred.
+    MappedToSameSiteNotTransferrable,
+    /// Mapped to another site by the same user, registrable.
+    MappedToOtherSiteSameUserRegistrable,
+    /// Mapped to another site by the same user.
+    MappedToOtherSiteSameUser,
+    /// Mapped by a different user.
+    MappedDomain,
+    /// Transfer in progress by the same user.
+    TransferPendingSameUser,
+    /// Transfer in progress by a different user.
+    TransferPending,
+    /// Domain in redemption period.
+    InRedemption,
+    /// TLD is not supported for registration.
+    TldNotSupported,
+    /// TLD is currently in maintenance.
+    TldInMaintenance,
+    /// Domain registration is temporarily disabled.
+    DomainRegistrationUnavailable,
+    /// 60-day transfer lock active.
+    RecentRegistrationLockNotTransferrable,
+    /// EPP status prevents transfer.
+    ServerTransferProhibitedNotTransferrable,
+    /// Domain is blacklisted.
+    BlacklistedDomain,
+    /// Domain is restricted.
+    RestrictedDomain,
+    /// WordPress.com managed subdomain (.blog, .link, etc.).
+    DotblogSubdomain,
+    /// 100-year domain vendor but TLD not supported.
+    HundredYearDomainTldRestriction,
+    /// CNAME conflict prevents mapping.
+    ConflictingCnameExists,
+    /// Domain can be mapped (mappable-only status).
+    Mappable,
+    /// Unknown status.
+    Unknown,
+    /// A status not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
 /// Response from `GET /domains/{name}/is-available/` (v1.3).
 ///
 /// Reports whether a domain name is available for registration or
@@ -182,23 +251,14 @@ impl AppendUrlQueryPairs for DomainAvailabilityParams {
 /// The set of fields present varies by `status`: available domains
 /// include full pricing, transferrable domains include partial
 /// pricing, and unavailable domains have only the core fields.
-///
-/// Common `status` values: `"available"`, `"available_premium"`,
-/// `"transferrable"`, `"transferrable_premium"`,
-/// `"tld_not_supported"`, `"tld_in_maintenance"`,
-/// `"blacklisted_domain"`, `"mapped_domain"`,
-/// `"registered_domain"`, `"registered_on_other_site_same_user"`,
-/// `"mapped_to_other_site_same_user"`,
-/// `"recent_registration_lock_not_transferrable"`,
-/// `"dotblog_subdomain"`, `"unknown"`.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct DomainAvailability {
     /// The domain name that was checked.
     pub domain_name: String,
     /// The TLD portion of the domain (e.g. `"com"`, `"io"`, `"dev"`).
     pub tld: String,
-    /// Availability status — see struct-level docs for known values.
-    pub status: String,
+    /// Availability status.
+    pub status: DomainAvailabilityStatus,
     /// Whether the domain can be mapped to a WordPress.com site
     /// (e.g. `"mappable"`, `"blacklisted_domain"`).
     pub mappable: String,
@@ -219,22 +279,14 @@ pub struct DomainAvailability {
     /// Formatted renewal cost.
     pub renew_cost: Option<String>,
     /// Raw numeric renewal price in `currency_code`.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub renew_raw_price: Option<Decimal2>,
     /// Raw numeric registration/transfer price in `currency_code`.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub raw_price: Option<Decimal2>,
     /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`).
     pub currency_code: Option<String>,
     /// Discounted sale price when a coupon applies.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub sale_cost: Option<Decimal2>,
     /// `true` if a premium domain exceeds the price limit.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub is_price_limit_exceeded: Option<bool>,
     // -- Match/vendor fields (available domains only) --
     /// Reasons the domain matched (e.g. `"exact-match"`,
@@ -243,8 +295,6 @@ pub struct DomainAvailability {
     /// The registry vendor (e.g. `"availability"`).
     pub vendor: Option<String>,
     /// `true` for status `"available_premium"`.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub is_supported_premium_domain: Option<bool>,
     // -- Mapping/transfer fields --
     /// Type of ownership verification required (e.g.
@@ -260,12 +310,8 @@ pub struct DomainAvailability {
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
     pub hsts_required: Option<bool>,
     /// `true` if the `.gay` TLD policy notice is required.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub is_dot_gay_notice_required: Option<bool>,
     /// `true` if premium domain transfers are unsupported for this TLD.
-    #[serde(default)]
-    #[uniffi(default = None)]
     pub cannot_transfer_due_to_unsupported_premium_tld: Option<bool>,
     /// Policy notices attached to the domain (e.g. HSTS warnings).
     #[serde(default)]
@@ -274,24 +320,6 @@ pub struct DomainAvailability {
     // -- Maintenance --
     /// When domain registration or TLD is in maintenance, the end time.
     pub maintenance_end_time: Option<String>,
-    /// TMCH (Trademark Claims) notice info as a raw JSON string,
-    /// if applicable. Complex XML-derived structure that varies by TLD.
-    #[serde(
-        default,
-        deserialize_with = "crate::wp_com::domains::deserialize_json_value_as_string",
-        skip_serializing_if = "Option::is_none"
-    )]
-    #[uniffi(default = None)]
-    pub trademark_claims_notice_info: Option<String>,
-}
-
-/// Deserializes an arbitrary JSON value into its stringified form.
-fn deserialize_json_value_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value: Option<serde_json::Value> = Option::deserialize(deserializer)?;
-    Ok(value.map(|v| v.to_string()))
 }
 
 impl_as_query_value_for_new_type!(DomainName);
@@ -670,98 +698,74 @@ mod tests {
     #[case::available(
         "tests/wpcom/domains/is_available/available.json",
         "freshsite2025.com",
-        "com",
-        "available",
-        "mappable",
+        DomainAvailabilityStatus::Available,
         true
     )]
     #[case::blacklisted(
         "tests/wpcom/domains/is_available/not-available.json",
         "example.com",
-        "com",
-        "blacklisted_domain",
-        "blacklisted_domain",
+        DomainAvailabilityStatus::BlacklistedDomain,
         true
     )]
     #[case::transferrable(
         "tests/wpcom/domains/is_available/transferrable.json",
         "taken-domain.io",
-        "io",
-        "transferrable",
-        "mappable",
+        DomainAvailabilityStatus::Transferrable,
         true
     )]
     #[case::tld_not_supported(
         "tests/wpcom/domains/is_available/tld-not-supported.json",
         "mysite.ai",
-        "ai",
-        "tld_not_supported",
-        "mappable",
+        DomainAvailabilityStatus::TldNotSupported,
         false
     )]
     #[case::hsts_required(
         "tests/wpcom/domains/is_available/hsts-required.json",
         "myproject.dev",
-        "dev",
-        "recent_registration_lock_not_transferrable",
-        "mappable",
+        DomainAvailabilityStatus::RecentRegistrationLockNotTransferrable,
         false
     )]
     #[case::available_premium(
         "tests/wpcom/domains/is_available/available-premium.json",
         "luxury.com",
-        "com",
-        "available_premium",
-        "mappable",
+        DomainAvailabilityStatus::AvailablePremium,
         true
     )]
     #[case::mapped_same_user(
         "tests/wpcom/domains/is_available/mapped-same-user.json",
         "myblog.com",
-        "com",
-        "mapped_to_other_site_same_user",
-        "mappable",
+        DomainAvailabilityStatus::MappedToOtherSiteSameUser,
         true
     )]
     #[case::sale_coupon(
         "tests/wpcom/domains/is_available/sale-coupon.json",
         "freshblog2025.online",
-        "online",
-        "available",
-        "mappable",
+        DomainAvailabilityStatus::Available,
         true
     )]
     #[case::maintenance(
         "tests/wpcom/domains/is_available/maintenance.json",
         "mysite.example",
-        "example",
-        "tld_in_maintenance",
-        "mappable",
+        DomainAvailabilityStatus::TldInMaintenance,
         false
     )]
     #[case::dot_gay_notice(
         "tests/wpcom/domains/is_available/dot-gay-notice.json",
         "testsite2025.gay",
-        "gay",
-        "mappable",
-        "mappable",
+        DomainAvailabilityStatus::Mappable,
         true
     )]
     fn test_domain_availability_deserialization(
         #[case] json_file_path: &str,
         #[case] expected_domain: &str,
-        #[case] expected_tld: &str,
-        #[case] expected_status: &str,
-        #[case] expected_mappable: &str,
+        #[case] expected_status: DomainAvailabilityStatus,
         #[case] expected_privacy: bool,
     ) {
         let file = File::open(json_file_path).expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
         assert_eq!(availability.domain_name, expected_domain);
-        assert_eq!(availability.tld, expected_tld);
         assert_eq!(availability.status, expected_status);
-        assert_eq!(availability.mappable, expected_mappable);
         assert_eq!(availability.supports_privacy, expected_privacy);
     }
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -158,62 +158,117 @@ pub struct DomainPolicyNotice {
 ///
 /// The set of fields present varies by `status`: available domains
 /// include full pricing, transferrable domains include partial
-/// pricing, and blacklisted/restricted domains have only the core
-/// fields.
+/// pricing, and unavailable domains have only the core fields.
+///
+/// Common `status` values: `"available"`, `"available_premium"`,
+/// `"transferrable"`, `"transferrable_premium"`,
+/// `"tld_not_supported"`, `"tld_in_maintenance"`,
+/// `"blacklisted_domain"`, `"mapped_domain"`,
+/// `"registered_domain"`, `"registered_on_other_site_same_user"`,
+/// `"mapped_to_other_site_same_user"`,
+/// `"recent_registration_lock_not_transferrable"`,
+/// `"dotblog_subdomain"`, `"unknown"`.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct DomainAvailability {
     /// The domain name that was checked.
     pub domain_name: String,
     /// The TLD portion of the domain (e.g. `"com"`, `"io"`, `"dev"`).
     pub tld: String,
-    /// Availability status (e.g. `"available"`, `"transferrable"`,
-    /// `"blacklisted_domain"`, `"tld_not_supported"`,
-    /// `"restricted_domain"`,
-    /// `"recent_registration_lock_not_transferrable"`).
+    /// Availability status — see struct-level docs for known values.
     pub status: String,
     /// Whether the domain can be mapped to a WordPress.com site
-    /// (e.g. `"mappable"`, `"blacklisted_domain"`,
-    /// `"restricted_domain"`).
+    /// (e.g. `"mappable"`, `"blacklisted_domain"`).
     pub mappable: String,
     /// Whether the domain supports WHOIS privacy protection.
     #[serde(default)]
     #[uniffi(default = false)]
     pub supports_privacy: bool,
-    /// Provider of the root domain (e.g. `"unknown"`).
+    /// Provider of the root domain (`"wpcom"` or `"unknown"`).
     pub root_domain_provider: String,
+    // -- Product/pricing fields (conditional on status) --
     /// WordPress.com product ID for purchasing this domain.
     pub product_id: Option<u64>,
     /// WordPress.com product slug (e.g. `"domain_reg"`,
-    /// `"domain_transfer"`, `"dotnet_domain"`).
+    /// `"domain_transfer"`).
     pub product_slug: Option<String>,
-    /// Formatted registration cost (e.g. `"TL 426"`, `"$18.00"`).
+    /// Formatted registration/transfer cost (e.g. `"$18.00"`).
     pub cost: Option<String>,
-    /// Formatted renewal cost (e.g. `"TL 426"`).
+    /// Formatted renewal cost.
     pub renew_cost: Option<String>,
     /// Raw numeric renewal price in `currency_code`.
     #[serde(default)]
     #[uniffi(default = None)]
     pub renew_raw_price: Option<Decimal2>,
-    /// Raw numeric registration price in `currency_code`.
+    /// Raw numeric registration/transfer price in `currency_code`.
     #[serde(default)]
     #[uniffi(default = None)]
     pub raw_price: Option<Decimal2>,
     /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`).
     pub currency_code: Option<String>,
+    /// Discounted sale price when a coupon applies.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub sale_cost: Option<Decimal2>,
+    /// `true` if a premium domain exceeds the price limit.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub is_price_limit_exceeded: Option<bool>,
+    // -- Match/vendor fields (available domains only) --
     /// Reasons the domain matched (e.g. `"exact-match"`,
     /// `"tld-exact"`, `"tld-common"`).
     pub match_reasons: Option<Vec<String>>,
     /// The registry vendor (e.g. `"availability"`).
     pub vendor: Option<String>,
+    /// `true` for status `"available_premium"`.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub is_supported_premium_domain: Option<bool>,
+    // -- Mapping/transfer fields --
     /// Type of ownership verification required (e.g.
     /// `"no_verification_required"`).
     pub ownership_verification_type: Option<String>,
+    /// Transfer status for mapped domains (e.g. `"transferrable"`,
+    /// `"recent_registration_lock_not_transferrable"`).
+    pub transferrability: Option<String>,
+    /// Primary domain of the other site where this domain is
+    /// registered or mapped (same user, different site).
+    pub other_site_domain: Option<String>,
+    // -- TLD-specific fields --
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
     pub hsts_required: Option<bool>,
+    /// `true` if the `.gay` TLD policy notice is required.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub is_dot_gay_notice_required: Option<bool>,
+    /// `true` if premium domain transfers are unsupported for this TLD.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub cannot_transfer_due_to_unsupported_premium_tld: Option<bool>,
     /// Policy notices attached to the domain (e.g. HSTS warnings).
     #[serde(default)]
     #[uniffi(default = [])]
     pub policy_notices: Vec<DomainPolicyNotice>,
+    // -- Maintenance --
+    /// When domain registration or TLD is in maintenance, the end time.
+    pub maintenance_end_time: Option<String>,
+    /// TMCH (Trademark Claims) notice info as a raw JSON string,
+    /// if applicable. Complex XML-derived structure that varies by TLD.
+    #[serde(
+        default,
+        deserialize_with = "crate::wp_com::domains::deserialize_json_value_as_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[uniffi(default = None)]
+    pub trademark_claims_notice_info: Option<String>,
+}
+
+/// Deserializes an arbitrary JSON value into its stringified form.
+fn deserialize_json_value_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    Ok(value.map(|v| v.to_string()))
 }
 
 impl_as_query_value_for_new_type!(DomainName);
@@ -629,6 +684,38 @@ mod tests {
         "mappable",
         false
     )]
+    #[case::available_premium(
+        "tests/wpcom/domains/is_available/available-premium.json",
+        "luxury.com",
+        "com",
+        "available_premium",
+        "mappable",
+        true
+    )]
+    #[case::mapped_same_user(
+        "tests/wpcom/domains/is_available/mapped-same-user.json",
+        "myblog.com",
+        "com",
+        "mapped_to_other_site_same_user",
+        "mappable",
+        true
+    )]
+    #[case::sale_coupon(
+        "tests/wpcom/domains/is_available/sale-coupon.json",
+        "newsite.info",
+        "info",
+        "available",
+        "mappable",
+        true
+    )]
+    #[case::maintenance(
+        "tests/wpcom/domains/is_available/maintenance.json",
+        "mysite.example",
+        "example",
+        "tld_in_maintenance",
+        "mappable",
+        false
+    )]
     fn test_domain_availability_deserialization(
         #[case] json_file_path: &str,
         #[case] expected_domain: &str,
@@ -709,6 +796,54 @@ mod tests {
         // Transferrable domains don't include renewal pricing.
         assert!(availability.renew_cost.is_none());
         assert!(availability.renew_raw_price.is_none());
+    }
+
+    #[test]
+    fn test_domain_availability_premium_fields() {
+        let file = File::open("tests/wpcom/domains/is_available/available-premium.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.is_supported_premium_domain, Some(true));
+        assert_eq!(availability.is_price_limit_exceeded, Some(false));
+        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(500000)));
+    }
+
+    #[test]
+    fn test_domain_availability_mapped_same_user() {
+        let file = File::open("tests/wpcom/domains/is_available/mapped-same-user.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(
+            availability.other_site_domain.as_deref(),
+            Some("myothersite.wordpress.com")
+        );
+        assert_eq!(availability.transferrability.as_deref(), Some("transferrable"));
+        assert!(availability.product_id.is_none());
+    }
+
+    #[test]
+    fn test_domain_availability_sale_coupon() {
+        let file = File::open("tests/wpcom/domains/is_available/sale-coupon.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(availability.sale_cost, Some(Decimal2::from_hundredths(700)));
+        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(2000)));
+    }
+
+    #[test]
+    fn test_domain_availability_maintenance() {
+        let file = File::open("tests/wpcom/domains/is_available/maintenance.json")
+            .expect("Failed to open file");
+        let availability: DomainAvailability =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(
+            availability.maintenance_end_time.as_deref(),
+            Some("2026-05-01 12:00:00")
+        );
+        assert!(availability.product_id.is_none());
     }
 
     #[test]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -2,7 +2,7 @@ use crate::{
     decimal2::Decimal2,
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::{WpComSiteId, segments::SegmentId},
+    wp_com::{CurrencyCode, WpComSiteId, segments::SegmentId},
 };
 use serde::{Deserialize, Serialize};
 
@@ -127,8 +127,8 @@ pub struct PaidDomainSuggestion {
     pub renew_raw_price: Decimal2,
     /// Raw numeric registration price in `currency_code`.
     pub raw_price: Decimal2,
-    /// ISO 4217 currency code for `raw_price`/`renew_raw_price` (e.g. `"USD"`).
-    pub currency_code: String,
+    /// ISO 4217 currency code for `raw_price`/`renew_raw_price`.
+    pub currency_code: CurrencyCode,
     /// Promotional sale price in `currency_code`, if the domain is on sale.
     pub sale_cost: Option<Decimal2>,
     /// `true` if the TLD requires HSTS (e.g. `.dev`).
@@ -282,8 +282,8 @@ pub struct DomainAvailability {
     pub renew_raw_price: Option<Decimal2>,
     /// Raw numeric registration/transfer price in `currency_code`.
     pub raw_price: Option<Decimal2>,
-    /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`).
-    pub currency_code: Option<String>,
+    /// ISO 4217 currency code.
+    pub currency_code: Option<CurrencyCode>,
     /// Discounted sale price when a coupon applies.
     pub sale_cost: Option<Decimal2>,
     /// `true` if a premium domain exceeds the price limit.
@@ -520,7 +520,7 @@ mod tests {
         assert_eq!(first.renew_cost, "$18.00");
         assert_eq!(first.renew_raw_price.hundredths(), 1800);
         assert_eq!(first.raw_price.hundredths(), 1800);
-        assert_eq!(first.currency_code, "USD");
+        assert_eq!(first.currency_code, CurrencyCode("USD".to_string()));
         assert!(first.sale_cost.is_none());
         assert!(first.hsts_required.is_none());
         assert!(first.policy_notices.is_empty());
@@ -787,7 +787,10 @@ mod tests {
             availability.renew_raw_price,
             Some(Decimal2::from_hundredths(1800))
         );
-        assert_eq!(availability.currency_code.as_deref(), Some("USD"));
+        assert_eq!(
+            availability.currency_code,
+            Some(CurrencyCode("USD".to_string()))
+        );
         assert_eq!(
             availability.match_reasons.as_deref(),
             Some(

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -191,9 +191,13 @@ pub struct DomainAvailability {
     /// Formatted renewal cost (e.g. `"TL 426"`).
     pub renew_cost: Option<String>,
     /// Raw numeric renewal price in `currency_code`.
-    pub renew_raw_price: Option<u64>,
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub renew_raw_price: Option<Decimal2>,
     /// Raw numeric registration price in `currency_code`.
-    pub raw_price: Option<u64>,
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub raw_price: Option<Decimal2>,
     /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`).
     pub currency_code: Option<String>,
     /// Reasons the domain matched (e.g. `"exact-match"`,
@@ -411,8 +415,8 @@ mod tests {
         assert_eq!(first.renew_raw_price.hundredths(), 1800);
         assert_eq!(first.raw_price.hundredths(), 1800);
         assert_eq!(first.currency_code, "USD");
-        assert_eq!(first.sale_cost, None);
-        assert_eq!(first.hsts_required, None);
+        assert!(first.sale_cost.is_none());
+        assert!(first.hsts_required.is_none());
         assert!(first.policy_notices.is_empty());
 
         // `freshpage.art` has no `match_reasons` field in the JSON.
@@ -653,8 +657,11 @@ mod tests {
         assert_eq!(availability.product_slug.as_deref(), Some("domain_reg"));
         assert_eq!(availability.cost.as_deref(), Some("$18.00"));
         assert_eq!(availability.renew_cost.as_deref(), Some("$18.00"));
-        assert_eq!(availability.raw_price, Some(1800));
-        assert_eq!(availability.renew_raw_price, Some(1800));
+        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(1800)));
+        assert_eq!(
+            availability.renew_raw_price,
+            Some(Decimal2::from_hundredths(1800))
+        );
         assert_eq!(availability.currency_code.as_deref(), Some("USD"));
         assert_eq!(
             availability.match_reasons.as_deref(),
@@ -677,12 +684,12 @@ mod tests {
             .expect("Failed to open file");
         let availability: DomainAvailability =
             serde_json::from_reader(file).expect("Unable to parse JSON");
-        assert_eq!(availability.product_id, None);
-        assert_eq!(availability.product_slug, None);
-        assert_eq!(availability.cost, None);
-        assert_eq!(availability.raw_price, None);
-        assert_eq!(availability.currency_code, None);
-        assert_eq!(availability.match_reasons, None);
+        assert!(availability.product_id.is_none());
+        assert!(availability.product_slug.is_none());
+        assert!(availability.cost.is_none());
+        assert!(availability.raw_price.is_none());
+        assert!(availability.currency_code.is_none());
+        assert!(availability.match_reasons.is_none());
         assert!(availability.policy_notices.is_empty());
     }
 
@@ -698,10 +705,10 @@ mod tests {
             Some("domain_transfer")
         );
         assert_eq!(availability.cost.as_deref(), Some("$48.00"));
-        assert_eq!(availability.raw_price, Some(4800));
+        assert_eq!(availability.raw_price, Some(Decimal2::from_hundredths(4800)));
         // Transferrable domains don't include renewal pricing.
-        assert_eq!(availability.renew_cost, None);
-        assert_eq!(availability.renew_raw_price, None);
+        assert!(availability.renew_cost.is_none());
+        assert!(availability.renew_raw_price.is_none());
     }
 
     #[test]

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -169,6 +169,10 @@ pub(crate) mod tests {
         validate_endpoint(WpComNamespace::RestV1_1, endpoint_url, path);
     }
 
+    pub fn validate_wp_com_rest_v1_3_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
+        validate_endpoint(WpComNamespace::RestV1_3, endpoint_url, path);
+    }
+
     pub fn validate_wp_com_v2_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
         validate_endpoint(WpComNamespace::V2, endpoint_url, path);
     }

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -37,8 +37,8 @@ mod tests {
     use crate::{
         request::endpoint::ApiUrlResolver,
         wp_com::{
-            domains::{CountryCode, DomainAvailabilityParams, DomainName},
             WpComSiteId,
+            domains::{CountryCode, DomainAvailabilityParams, DomainName},
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
                 validate_wp_com_rest_v1_3_endpoint,

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -3,8 +3,8 @@ use crate::{
     wp_com::{
         WpComNamespace,
         domains::{
-            CountryCode, DomainSuggestion, DomainSuggestionsParams, SupportedCountries,
-            SupportedState,
+            CountryCode, DomainAvailability, DomainName, DomainSuggestion,
+            DomainSuggestionsParams, SupportedCountries, SupportedState,
         },
     },
 };
@@ -18,11 +18,16 @@ enum DomainsRequest {
     SupportedCountries,
     #[get(url = "/domains/supported-states/<country_code>", output = Vec<SupportedState>)]
     SupportedStates,
+    #[get(url = "/domains/<domain_name>/is-available", output = DomainAvailability)]
+    IsAvailable,
 }
 
 impl DerivedRequest for DomainsRequest {
     fn namespace(&self) -> impl AsNamespace {
-        WpComNamespace::RestV1_1
+        match self {
+            Self::IsAvailable => WpComNamespace::RestV1_3,
+            _ => WpComNamespace::RestV1_1,
+        }
     }
 }
 
@@ -32,9 +37,10 @@ mod tests {
     use crate::{
         request::endpoint::ApiUrlResolver,
         wp_com::{
-            domains::CountryCode,
+            domains::{CountryCode, DomainName},
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
+                validate_wp_com_rest_v1_3_endpoint,
             },
             segments::SegmentId,
         },
@@ -104,6 +110,17 @@ mod tests {
         #[case] expected_path: &str,
     ) {
         validate_wp_com_rest_v1_1_endpoint(endpoint.supported_states(&country_code), expected_path);
+    }
+
+    #[rstest]
+    #[case::com(DomainName("example.com".to_string()), "/domains/example.com/is-available")]
+    #[case::org(DomainName("myblog.org".to_string()), "/domains/myblog.org/is-available")]
+    fn is_available(
+        endpoint: DomainsRequestEndpoint,
+        #[case] domain_name: DomainName,
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_com_rest_v1_3_endpoint(endpoint.is_available(&domain_name), expected_path);
     }
 
     fn base_domain_suggestions_params() -> DomainSuggestionsParams {

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -3,8 +3,8 @@ use crate::{
     wp_com::{
         WpComNamespace,
         domains::{
-            CountryCode, DomainAvailability, DomainName, DomainSuggestion,
-            DomainSuggestionsParams, SupportedCountries, SupportedState,
+            CountryCode, DomainAvailability, DomainAvailabilityParams, DomainName,
+            DomainSuggestion, DomainSuggestionsParams, SupportedCountries, SupportedState,
         },
     },
 };
@@ -18,7 +18,7 @@ enum DomainsRequest {
     SupportedCountries,
     #[get(url = "/domains/supported-states/<country_code>", output = Vec<SupportedState>)]
     SupportedStates,
-    #[get(url = "/domains/<domain_name>/is-available", output = DomainAvailability)]
+    #[get(url = "/domains/<domain_name>/is-available", params = &DomainAvailabilityParams, output = DomainAvailability)]
     IsAvailable,
 }
 
@@ -37,7 +37,8 @@ mod tests {
     use crate::{
         request::endpoint::ApiUrlResolver,
         wp_com::{
-            domains::{CountryCode, DomainName},
+            domains::{CountryCode, DomainAvailabilityParams, DomainName},
+            WpComSiteId,
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
                 validate_wp_com_rest_v1_3_endpoint,
@@ -113,14 +114,32 @@ mod tests {
     }
 
     #[rstest]
-    #[case::com(DomainName("example.com".to_string()), "/domains/example.com/is-available")]
-    #[case::org(DomainName("myblog.org".to_string()), "/domains/myblog.org/is-available")]
+    #[case::com(DomainName("example.com".to_string()), "/domains/example.com/is-available?")]
+    #[case::org(DomainName("myblog.org".to_string()), "/domains/myblog.org/is-available?")]
     fn is_available(
         endpoint: DomainsRequestEndpoint,
         #[case] domain_name: DomainName,
         #[case] expected_path: &str,
     ) {
-        validate_wp_com_rest_v1_3_endpoint(endpoint.is_available(&domain_name), expected_path);
+        validate_wp_com_rest_v1_3_endpoint(
+            endpoint.is_available(&domain_name, &DomainAvailabilityParams::default()),
+            expected_path,
+        );
+    }
+
+    #[rstest]
+    fn is_available_with_params(endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_3_endpoint(
+            endpoint.is_available(
+                &DomainName("test.com".to_string()),
+                &DomainAvailabilityParams {
+                    blog_id: Some(WpComSiteId(12345)),
+                    is_cart_pre_check: Some(true),
+                    vendor: Some("100-year-domains".to_string()),
+                },
+            ),
+            "/domains/test.com/is-available?blog_id=12345&is_cart_pre_check=true&vendor=100-year-domains",
+        );
     }
 
     fn base_domain_suggestions_params() -> DomainSuggestionsParams {

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -90,6 +90,7 @@ pub(crate) enum WpComNamespace {
     Oauth2,
     RestV1_1,
     RestV1_2,
+    RestV1_3,
     V2,
 }
 
@@ -99,6 +100,7 @@ impl AsNamespace for WpComNamespace {
             WpComNamespace::Oauth2 => "/oauth2",
             WpComNamespace::RestV1_1 => "/rest/v1.1",
             WpComNamespace::RestV1_2 => "/rest/v1.2",
+            WpComNamespace::RestV1_3 => "/rest/v1.3",
             WpComNamespace::V2 => "/wpcom/v2",
         }
     }

--- a/wp_api/tests/wpcom/domains/is_available/available-premium.json
+++ b/wp_api/tests/wpcom/domains/is_available/available-premium.json
@@ -1,0 +1,20 @@
+{
+  "domain_name": "luxury.com",
+  "tld": "com",
+  "status": "available_premium",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "product_id": 6,
+  "product_slug": "domain_reg",
+  "cost": "$5,000.00",
+  "renew_cost": "$5,000.00",
+  "renew_raw_price": 5000,
+  "raw_price": 5000,
+  "currency_code": "USD",
+  "is_supported_premium_domain": true,
+  "is_price_limit_exceeded": false,
+  "match_reasons": ["exact-match", "tld-exact", "tld-common"],
+  "vendor": "availability",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_api/tests/wpcom/domains/is_available/available.json
+++ b/wp_api/tests/wpcom/domains/is_available/available.json
@@ -9,8 +9,8 @@
   "product_slug": "domain_reg",
   "cost": "$18.00",
   "renew_cost": "$18.00",
-  "renew_raw_price": 1800,
-  "raw_price": 1800,
+  "renew_raw_price": 18,
+  "raw_price": 18,
   "currency_code": "USD",
   "match_reasons": [
     "exact-match",

--- a/wp_api/tests/wpcom/domains/is_available/available.json
+++ b/wp_api/tests/wpcom/domains/is_available/available.json
@@ -1,0 +1,22 @@
+{
+  "domain_name": "freshsite2025.com",
+  "tld": "com",
+  "status": "available",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "product_id": 6,
+  "product_slug": "domain_reg",
+  "cost": "$18.00",
+  "renew_cost": "$18.00",
+  "renew_raw_price": 1800,
+  "raw_price": 1800,
+  "currency_code": "USD",
+  "match_reasons": [
+    "exact-match",
+    "tld-exact",
+    "tld-common"
+  ],
+  "vendor": "availability",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_api/tests/wpcom/domains/is_available/dot-gay-notice.json
+++ b/wp_api/tests/wpcom/domains/is_available/dot-gay-notice.json
@@ -1,0 +1,17 @@
+{
+  "domain_name": "testsite2025.gay",
+  "tld": "gay",
+  "status": "mappable",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "is_dot_gay_notice_required": true,
+  "ownership_verification_type": "no_verification_required",
+  "policy_notices": [
+    {
+      "type": "gay_accept_requirements",
+      "label": "Special requirements",
+      "message": "Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations."
+    }
+  ]
+}

--- a/wp_api/tests/wpcom/domains/is_available/hsts-required.json
+++ b/wp_api/tests/wpcom/domains/is_available/hsts-required.json
@@ -1,0 +1,22 @@
+{
+  "domain_name": "myproject.dev",
+  "tld": "dev",
+  "status": "recent_registration_lock_not_transferrable",
+  "mappable": "mappable",
+  "supports_privacy": false,
+  "root_domain_provider": "unknown",
+  "hsts_required": true,
+  "product_id": 1337,
+  "product_slug": "domain_transfer",
+  "cost": "$120.00",
+  "raw_price": 12000,
+  "currency_code": "USD",
+  "ownership_verification_type": "no_verification_required",
+  "policy_notices": [
+    {
+      "type": "hsts",
+      "label": "HSTS required",
+      "message": "All domains with this ending require an SSL certificate to host a website."
+    }
+  ]
+}

--- a/wp_api/tests/wpcom/domains/is_available/hsts-required.json
+++ b/wp_api/tests/wpcom/domains/is_available/hsts-required.json
@@ -9,7 +9,7 @@
   "product_id": 1337,
   "product_slug": "domain_transfer",
   "cost": "$120.00",
-  "raw_price": 12000,
+  "raw_price": 120,
   "currency_code": "USD",
   "ownership_verification_type": "no_verification_required",
   "policy_notices": [

--- a/wp_api/tests/wpcom/domains/is_available/maintenance.json
+++ b/wp_api/tests/wpcom/domains/is_available/maintenance.json
@@ -5,5 +5,5 @@
   "mappable": "mappable",
   "supports_privacy": false,
   "root_domain_provider": "unknown",
-  "maintenance_end_time": "2026-05-01 12:00:00"
+  "maintenance_end_time": 1777651200
 }

--- a/wp_api/tests/wpcom/domains/is_available/maintenance.json
+++ b/wp_api/tests/wpcom/domains/is_available/maintenance.json
@@ -1,0 +1,9 @@
+{
+  "domain_name": "mysite.example",
+  "tld": "example",
+  "status": "tld_in_maintenance",
+  "mappable": "mappable",
+  "supports_privacy": false,
+  "root_domain_provider": "unknown",
+  "maintenance_end_time": "2026-05-01 12:00:00"
+}

--- a/wp_api/tests/wpcom/domains/is_available/mapped-same-user.json
+++ b/wp_api/tests/wpcom/domains/is_available/mapped-same-user.json
@@ -1,0 +1,11 @@
+{
+  "domain_name": "myblog.com",
+  "tld": "com",
+  "status": "mapped_to_other_site_same_user",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "other_site_domain": "myothersite.wordpress.com",
+  "transferrability": "transferrable",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_api/tests/wpcom/domains/is_available/not-available.json
+++ b/wp_api/tests/wpcom/domains/is_available/not-available.json
@@ -1,0 +1,8 @@
+{
+  "domain_name": "example.com",
+  "tld": "com",
+  "status": "blacklisted_domain",
+  "mappable": "blacklisted_domain",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown"
+}

--- a/wp_api/tests/wpcom/domains/is_available/sale-coupon.json
+++ b/wp_api/tests/wpcom/domains/is_available/sale-coupon.json
@@ -1,0 +1,19 @@
+{
+  "domain_name": "newsite.info",
+  "tld": "info",
+  "status": "available",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "product_id": 18,
+  "product_slug": "dotinfo_domain",
+  "cost": "$20.00",
+  "renew_cost": "$20.00",
+  "renew_raw_price": 20,
+  "raw_price": 20,
+  "currency_code": "USD",
+  "sale_cost": 7.00,
+  "match_reasons": ["exact-match", "tld-exact"],
+  "vendor": "availability",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_api/tests/wpcom/domains/is_available/sale-coupon.json
+++ b/wp_api/tests/wpcom/domains/is_available/sale-coupon.json
@@ -1,19 +1,22 @@
 {
-  "domain_name": "newsite.info",
-  "tld": "info",
+  "domain_name": "freshblog2025.online",
+  "tld": "online",
   "status": "available",
   "mappable": "mappable",
   "supports_privacy": true,
   "root_domain_provider": "unknown",
-  "product_id": 18,
-  "product_slug": "dotinfo_domain",
-  "cost": "$20.00",
-  "renew_cost": "$20.00",
-  "renew_raw_price": 20,
-  "raw_price": 20,
+  "product_id": 271,
+  "product_slug": "dotonline_domain",
+  "cost": "$25.00",
+  "renew_cost": "$25.00",
+  "renew_raw_price": 25,
+  "raw_price": 25,
   "currency_code": "USD",
-  "sale_cost": 7.00,
-  "match_reasons": ["exact-match", "tld-exact"],
+  "sale_cost": 10.00,
+  "match_reasons": [
+    "exact-match",
+    "tld-exact"
+  ],
   "vendor": "availability",
   "ownership_verification_type": "no_verification_required"
 }

--- a/wp_api/tests/wpcom/domains/is_available/tld-not-supported.json
+++ b/wp_api/tests/wpcom/domains/is_available/tld-not-supported.json
@@ -1,0 +1,9 @@
+{
+  "domain_name": "mysite.ai",
+  "tld": "ai",
+  "status": "tld_not_supported",
+  "mappable": "mappable",
+  "supports_privacy": false,
+  "root_domain_provider": "unknown",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_api/tests/wpcom/domains/is_available/transferrable.json
+++ b/wp_api/tests/wpcom/domains/is_available/transferrable.json
@@ -8,7 +8,7 @@
   "product_id": 1337,
   "product_slug": "domain_transfer",
   "cost": "$48.00",
-  "raw_price": 4800,
+  "raw_price": 48,
   "currency_code": "USD",
   "ownership_verification_type": "no_verification_required"
 }

--- a/wp_api/tests/wpcom/domains/is_available/transferrable.json
+++ b/wp_api/tests/wpcom/domains/is_available/transferrable.json
@@ -1,0 +1,14 @@
+{
+  "domain_name": "taken-domain.io",
+  "tld": "io",
+  "status": "transferrable",
+  "mappable": "mappable",
+  "supports_privacy": true,
+  "root_domain_provider": "unknown",
+  "product_id": 1337,
+  "product_slug": "domain_transfer",
+  "cost": "$48.00",
+  "raw_price": 4800,
+  "currency_code": "USD",
+  "ownership_verification_type": "no_verification_required"
+}

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -1,7 +1,9 @@
 use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::domains::{CountryCode, DomainAvailabilityParams, DomainName};
+use wp_api::wp_com::domains::{
+    CountryCode, DomainAvailabilityParams, DomainAvailabilityStatus, DomainName,
+};
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     let mut trials = vec![];
@@ -106,7 +108,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     .into());
                 }
 
-                if availability.status == "available" {
+                if availability.status == DomainAvailabilityStatus::Available {
                     return Err("expected google.com to not be available".into());
                 }
 
@@ -130,9 +132,9 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     .map_err(|e| e.to_string())?
                     .data;
 
-                if availability.status != "available" {
+                if availability.status != DomainAvailabilityStatus::Available {
                     return Err(format!(
-                        "expected status 'available', got '{}'",
+                        "expected status Available, got {:?}",
                         availability.status
                     )
                     .into());

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -144,8 +144,8 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     return Err("expected .com domain to support privacy".into());
                 }
 
-                if availability.product_id.is_none() {
-                    return Err("expected product_id for available domain".into());
+                if availability.pricing.is_none() {
+                    return Err("expected pricing for available domain".into());
                 }
 
                 Ok(())

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -1,7 +1,7 @@
 use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::domains::{CountryCode, DomainName};
+use wp_api::wp_com::domains::{CountryCode, DomainAvailabilityParams, DomainName};
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     let mut trials = vec![];
@@ -90,7 +90,10 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                 let availability = ctx
                     .client
                     .domains()
-                    .is_available(&DomainName("google.com".to_string()))
+                    .is_available(
+                        &DomainName("google.com".to_string()),
+                        &DomainAvailabilityParams::default(),
+                    )
                     .await
                     .map_err(|e| e.to_string())?
                     .data;
@@ -119,9 +122,10 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                 let availability = ctx
                     .client
                     .domains()
-                    .is_available(&DomainName(
-                        "xyzzy-test-unlikely-taken-2025.com".to_string(),
-                    ))
+                    .is_available(
+                        &DomainName("xyzzy-test-unlikely-taken-2025.com".to_string()),
+                        &DomainAvailabilityParams::default(),
+                    )
                     .await
                     .map_err(|e| e.to_string())?
                     .data;

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -1,7 +1,7 @@
 use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::domains::CountryCode;
+use wp_api::wp_com::domains::{CountryCode, DomainName};
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     let mut trials = vec![];
@@ -76,6 +76,70 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                         states.len()
                     )
                     .into());
+                }
+
+                Ok(())
+            })
+        }
+    }));
+
+    trials.push(Trial::test("domains::is_available_taken", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let availability = ctx
+                    .client
+                    .domains()
+                    .is_available(&DomainName("google.com".to_string()))
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data;
+
+                if availability.domain_name != "google.com" {
+                    return Err(format!(
+                        "expected domain_name 'google.com', got '{}'",
+                        availability.domain_name
+                    )
+                    .into());
+                }
+
+                if availability.status == "available" {
+                    return Err("expected google.com to not be available".into());
+                }
+
+                Ok(())
+            })
+        }
+    }));
+
+    trials.push(Trial::test("domains::is_available_likely_available", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let availability = ctx
+                    .client
+                    .domains()
+                    .is_available(&DomainName(
+                        "xyzzy-test-unlikely-taken-2025.com".to_string(),
+                    ))
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data;
+
+                if availability.status != "available" {
+                    return Err(format!(
+                        "expected status 'available', got '{}'",
+                        availability.status
+                    )
+                    .into());
+                }
+
+                if !availability.supports_privacy {
+                    return Err("expected .com domain to support privacy".into());
+                }
+
+                if availability.product_id.is_none() {
+                    return Err("expected product_id for available domain".into());
                 }
 
                 Ok(())


### PR DESCRIPTION
Add the WordPress.com `GET /rest/v1.3/domains/{name}/is-available` endpoint for checking domain availability, pricing, and transfer status.

## Changes

- Add `RestV1_3` namespace variant and `DomainName` newtype
- Add `DomainAvailability` response type with conditional inner structs:
  - `DomainPricing` (product/pricing fields, present for available and transferrable domains)
  - `DomainMatchInfo` (match reasons and vendor, present for available domains)
  - `DomainTransferInfo` (transfer/mapping details for same-user cross-site scenarios)
- Add enums with `Other(String)` fallback: `DomainAvailabilityStatus`, `DomainMappableStatus`, `DomainTransferrability`
- Add `CurrencyCode` (ISO 4217) and `ProductId` newtypes
- Add `DomainAvailabilityParams` for optional query parameters (`blog_id`, `is_cart_pre_check`, `vendor`)
- Add 10 anonymized test fixtures covering all response shapes (available, premium, transferrable, blacklisted, maintenance, HSTS, .gay notice, sale coupon, mapped-same-user, TLD not supported)
- Add e2e tests for domain availability checks

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
