### PR TITLE
Enforce CHANGELOG updates on PRs

### DIFF
--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Only enforce on PR builds — the check is about *new* entries being added
+# alongside the change that ships them.
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  echo "Not a PR build — skipping changelog check"
+  exit 0
+fi
+
+# Dependabot-authored dependency bumps don't map to user-facing changelog entries.
+if [[ "${BUILDKITE_BRANCH:-}" == dependabot/* ]]; then
+  echo "Dependabot branch — skipping changelog check"
+  exit 0
+fi
+
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-trunk}"
+
+echo "--- :git: Fetching origin/${BASE_BRANCH}"
+git fetch --no-tags origin "$BASE_BRANCH"
+
+if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx "CHANGELOG.md"; then
+  echo "CHANGELOG.md was updated"
+  # If a prior run posted a failure comment, clean it up so a green run
+  # leaves no residue. No-ops if the comment doesn't exist.
+  comment_on_pr --id changelog-check --if-exist delete "" || true
+  exit 0
+fi
+
+FAILURE_MESSAGE=$(cat <<'EOF'
+:warning: **`CHANGELOG.md` was not updated in this PR.**
+
+Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.md` describing the change for our users. The format follows [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) — use one of:
+
+- `### Added` — for new features
+- `### Changed` — for changes in existing functionality (prefix `**BREAKING:**` if breaking)
+- `### Deprecated` — for soon-to-be-removed features
+- `### Removed` — for now-removed features
+- `### Fixed` — for any bug fixes
+- `### Security` — for vulnerability fixes
+
+If the change genuinely has no user-visible impact (e.g. CI-only tweaks, internal refactors), add a short entry under `### Changed` noting that.
+EOF
+)
+
+echo "" >&2
+echo "$FAILURE_MESSAGE" >&2
+echo "" >&2
+
+comment_on_pr --id changelog-check "$FAILURE_MESSAGE"
+
+exit 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,6 +52,9 @@ steps:
         command: |
           echo "--- :rust: Validate localization files"
           make validate-localizations
+      - label: ":memo: Validate Changelog"
+        command: .buildkite/commands/validate-changelog.sh
+        plugins: [$CI_TOOLKIT]
 
   #
   # Swift Group

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@
 ## Test plan
 
 [Add test plan here]
+
+## Changelog
+
+- [ ] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,39 @@
-## Trunk
+# Changelog
 
-### Breaking Changes
+All notable changes to this project will be documented in this file.
 
-- [Condense error variants into WpError](https://github.com/Automattic/wordpress-rs/pull/230)
-- [Contextual filtering](https://github.com/Automattic/wordpress-rs/pull/176)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### New Features
+## [Unreleased]
+
+### Added
 
 - [Post Types](https://developer.wordpress.org/rest-api/reference/post-types/) endpoint
 - [Site Settings](https://developer.wordpress.org/rest-api/reference/settings/) endpoint
 - [Wp Site Health Tests](https://developer.wordpress.org/rest-api/reference/wp-site-health-tests/) endpoint
-
-### Bug Fixes
-
-- [Support both Integer and String for `WPApiDetails.gmt_offset`](https://github.com/Automattic/wordpress-rs/pull/209)
-
-### Internal Changes
-
 - `WpDerivedRequest` now supports plain `get` requests
 - `WpDerivedRequest` now supports `additional_query_pairs`
 
-## 0.1
+### Changed
 
-This first release includes the following for the Kotlin, Rust & Swift platforms:
+- **BREAKING:** [Condense error variants into `WpError`](https://github.com/Automattic/wordpress-rs/pull/230)
+- **BREAKING:** [Contextual filtering](https://github.com/Automattic/wordpress-rs/pull/176)
+- Reformat `CHANGELOG.md` to follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and enforce changelog updates on PRs via a Buildkite check that also surfaces the failure as a GitHub PR comment (using the shared `comment_on_pr` helper from `a8c-ci-toolkit`)
+
+### Fixed
+
+- [Support both Integer and String for `WPApiDetails.gmt_offset`](https://github.com/Automattic/wordpress-rs/pull/209)
+
+## [0.1]
+
+Initial release with support for Kotlin, Rust, and Swift platforms.
+
+### Added
+
 - Authentication using Application Passwords
 - [Application Passwords](https://developer.wordpress.org/rest-api/reference/application-passwords/) endpoint
 - [Users](https://developer.wordpress.org/rest-api/reference/users/) endpoint
 - [Plugins](https://developer.wordpress.org/rest-api/reference/plugins/) endpoint
-
-It also includes all of the underlying infrastructure for this – including:
-- `wp_contextual` – A proc macro that generates `Edit`, `Embed` & `View` contextual types from given Sparse type
-- `wp_derive_request_builder` – A proc macro that generates endpoint, request builder and request executor types
+- `wp_contextual` – a proc macro that generates `Edit`, `Embed` & `View` contextual types from a given Sparse type
+- `wp_derive_request_builder` – a proc macro that generates endpoint, request builder, and request executor types


### PR DESCRIPTION
## Description

We have a `CHANGELOG.md`, but nobody updates it. This PR reformats it to follow [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) and adds a Buildkite check that fails PR builds when `CHANGELOG.md` has no diff against the base branch. On failure the check posts a comment to the PR via the shared `comment_on_pr` helper from `a8c-ci-toolkit`; on a subsequent green run the comment is deleted so PRs aren't left with stale noise. The check short-circuits on `dependabot/*` branches since dependency bumps don't map to user-facing changelog entries.

<img width="891" height="442" alt="Screenshot 2026-04-24 at 9 55 31 AM" src="https://github.com/user-attachments/assets/9f2c8b32-de24-44b9-8ce1-8efca392e103" />

## Changes

- Add `.buildkite/commands/validate-changelog.sh`. Fails on PR builds when `CHANGELOG.md` has no diff against the base branch. No-ops on non-PR builds and on `dependabot/*` branches.
- Add a `:memo: Validate Changelog` step to the Rust group in `.buildkite/pipeline.yml` (uses `[$CI_TOOLKIT]` so `comment_on_pr` is on `PATH`).
- Add a Changelog checklist item to `.github/PULL_REQUEST_TEMPLATE.md` pointing at the Keep a Changelog categories.
- Rewrite `CHANGELOG.md` to the Keep a Changelog 1.0.0 layout — header + spec link, `## [Unreleased]`, entries remapped to `Added` / `Changed` / `Fixed`, breaking changes prefixed with `**BREAKING:**`.

## Test plan

- [x] Confirmed end-to-end against this PR: failing run posts the comment, passing run deletes it (see screenshot).

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.