### PR TITLE
[TEST] verify changelog CI failure + PR comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** [Condense error variants into `WpError`](https://github.com/Automattic/wordpress-rs/pull/230)
 - **BREAKING:** [Contextual filtering](https://github.com/Automattic/wordpress-rs/pull/176)
 - Reformat `CHANGELOG.md` to follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and enforce changelog updates on PRs via a Buildkite check that also surfaces the failure as a GitHub PR comment
+- Test entry, added to verify the changelog check deletes its own failure comment on a subsequent green run
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > This project is under heavy development and shouldn't be considered production-ready yet. We're happy to hear any feedback you might have, but we're not yet ready to accept significant code contributions from others. We look forward to engaging with the community on this project in early 2025.
 
-A cross-platform implementation of the [WordPress REST API](https://developer.wordpress.org/rest-api/) written in Rust, with bindings for Kotlin, Swift, and more.
+A cross-platform implementation of the [WordPress REST API](https://developer.wordpress.org/rest-api/) written in Rust, with bindings for Kotlin, Swift, and more platforms.
 
 ## Prerequisites
 


### PR DESCRIPTION
Throwaway PR that targets \`jkmassel/changelog-ci\` as its base so the diff contains only a trivial README tweak and omits \`CHANGELOG.md\` on purpose. Goal: exercise the failing path of \`.buildkite/commands/validate-changelog.sh\` end-to-end and confirm the PR comment posts.

Will be closed once verified.