### PR TITLE
Pin `wp-cli/restful` to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Support both Integer and String for `WPApiDetails.gmt_offset`](https://github.com/Automattic/wordpress-rs/pull/209)
+- Pin `wp-cli/restful` to v0.4.1 to fix Docker build (v0.4.2+ requires unreleased `wp-cli ^2.13`)
 
 ## [0.1]
 

--- a/wordpress.Dockerfile
+++ b/wordpress.Dockerfile
@@ -25,7 +25,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chown -R www-data:www-data /var/www/.wp-cli/
 
 # Run this command as root user since that's what the Docker will use when we run --http=http://localhost commands
-RUN wp --allow-root package install wp-cli/restful
+# Pin to v0.4.1 — v0.4.2+ requires wp-cli ^2.13 which is not yet released
+RUN wp --allow-root package install wp-cli/restful:0.4.1
 
 # Setup Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
v0.4.2+ requires `wp-cli ^2.13` which is not yet released, breaking the Docker build.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
