### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-05
+
 ### Added
 
 - [Post Types](https://developer.wordpress.org/rest-api/reference/post-types/) endpoint


### PR DESCRIPTION
## Description

Version bump for the 0.2.0 release. Per `Documentation/RELEASING.md`, this PR only edits `CHANGELOG.md`: it renames the existing `## [Unreleased]` section to `## [0.2.0] - 2026-05-05` and adds a fresh empty `## [Unreleased]` section above it.

## Changes

- Rename `## [Unreleased]` → `## [0.2.0] - 2026-05-05` in `CHANGELOG.md`
- Add a new empty `## [Unreleased]` section above the new version header

## Test plan

- [ ] Verify the diff only touches `CHANGELOG.md`
- [ ] Verify the new `[0.2.0]` header uses today's UTC date and strict semver
- [ ] After merge, trigger a Buildkite build on `trunk` with `NEW_VERSION=0.2.0`

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.