### PR TITLE
Clean up `pr-build/*` branches for closed PRs on trunk pushes

### DIFF
--- a/.buildkite/cleanup-pr-build-branches.sh
+++ b/.buildkite/cleanup-pr-build-branches.sh
@@ -12,75 +12,82 @@ if [[ "${BUILDKITE_BRANCH:-}" != "trunk" ]]; then
 fi
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-  echo "GITHUB_TOKEN not set, cannot query PR state" >&2
+  echo "GITHUB_TOKEN not set, cannot reach GitHub API" >&2
   exit 1
 fi
 
-GITHUB_REPO="automattic/wordpress-rs"
+API="https://api.github.com/repos/automattic/wordpress-rs"
 
-echo '--- :robot_face: Use bot for Git operations'
-source use-bot-for-git
-
-echo "--- :mag: Listing pr-build/* branches on origin"
-mapfile -t branches < <(
-  git ls-remote --heads origin 'refs/heads/pr-build/*' \
-    | awk '{print $2}' \
-    | sed 's|^refs/heads/||'
-)
-
-echo "Found ${#branches[@]} pr-build branches"
-
-if [[ ${#branches[@]} -eq 0 ]]; then
-  exit 0
-fi
-
-echo "--- :github: Checking PR state for each branch"
-to_delete=()
-for branch in "${branches[@]}"; do
-  pr_number="${branch#pr-build/}"
-  if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
-    echo "Skipping $branch (unexpected suffix)"
-    continue
-  fi
-
+# Calls the GitHub API. Sets GH_STATUS and GH_BODY globals.
+gh_request() {
+  local response
   response=$(
     curl --silent --show-error \
+      --request "$1" \
       --write-out $'\n%{http_code}' \
       --header "Authorization: Bearer ${GITHUB_TOKEN}" \
       --header "Accept: application/vnd.github+json" \
       --header "X-GitHub-Api-Version: 2022-11-28" \
-      "https://api.github.com/repos/${GITHUB_REPO}/pulls/${pr_number}"
+      "${API}$2"
   )
-  http_code=$(printf '%s' "$response" | tail -n1)
-  body=$(printf '%s' "$response" | sed '$d')
+  GH_STATUS=$(printf '%s' "$response" | tail -n1)
+  GH_BODY=$(printf '%s' "$response" | sed '$d')
+}
 
-  if [[ "$http_code" != "200" ]]; then
-    echo "Skipping $branch (HTTP $http_code from GitHub)"
+echo "--- :mag: Listing pr-build/* branches via GitHub API"
+branches=()
+page=1
+while :; do
+  gh_request GET "/branches?per_page=100&page=${page}"
+  if [[ "$GH_STATUS" != "200" ]]; then
+    echo "Failed to list branches (HTTP $GH_STATUS): $GH_BODY" >&2
+    exit 1
+  fi
+
+  count=$(printf '%s' "$GH_BODY" | jq 'length')
+  [[ "$count" -eq 0 ]] && break
+
+  mapfile -t page_branches < <(
+    printf '%s' "$GH_BODY" | jq -r '.[].name | select(test("^pr-build/[0-9]+$"))'
+  )
+  branches+=("${page_branches[@]}")
+
+  [[ "$count" -lt 100 ]] && break
+  page=$((page + 1))
+done
+
+echo "Found ${#branches[@]} pr-build branches"
+[[ ${#branches[@]} -eq 0 ]] && exit 0
+
+echo "--- :github: Checking PR state and deleting closed-PR branches"
+deleted=0
+kept=0
+skipped=0
+for branch in "${branches[@]}"; do
+  pr_number="${branch#pr-build/}"
+
+  gh_request GET "/pulls/${pr_number}"
+  if [[ "$GH_STATUS" != "200" ]]; then
+    echo "Skipping $branch (HTTP $GH_STATUS from /pulls/${pr_number})"
+    skipped=$((skipped + 1))
     continue
   fi
 
-  state=$(printf '%s' "$body" | jq -r '.state')
-
-  if [[ "$state" == "closed" ]]; then
-    echo "Marking $branch for deletion (PR #$pr_number is closed)"
-    to_delete+=("$branch")
-  else
+  state=$(printf '%s' "$GH_BODY" | jq -r '.state')
+  if [[ "$state" != "closed" ]]; then
     echo "Keeping $branch (PR #$pr_number is $state)"
+    kept=$((kept + 1))
+    continue
+  fi
+
+  gh_request DELETE "/git/refs/heads/${branch}"
+  if [[ "$GH_STATUS" == "204" ]]; then
+    echo "Deleted $branch (PR #$pr_number was closed)"
+    deleted=$((deleted + 1))
+  else
+    echo "Failed to delete $branch (HTTP $GH_STATUS): $GH_BODY" >&2
+    skipped=$((skipped + 1))
   fi
 done
 
-if [[ ${#to_delete[@]} -eq 0 ]]; then
-  echo "No closed PR branches to delete"
-  exit 0
-fi
-
-echo "--- :wastebasket: Deleting ${#to_delete[@]} stale branches"
-chunk_size=50
-for ((i=0; i<${#to_delete[@]}; i+=chunk_size)); do
-  chunk=("${to_delete[@]:i:chunk_size}")
-  refspecs=()
-  for branch in "${chunk[@]}"; do
-    refspecs+=(":refs/heads/${branch}")
-  done
-  git push origin "${refspecs[@]}"
-done
+echo "--- :white_check_mark: Done: deleted=$deleted kept=$kept skipped=$skipped"

--- a/.buildkite/cleanup-pr-build-branches.sh
+++ b/.buildkite/cleanup-pr-build-branches.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Deletes `pr-build/<n>` branches whose PR is closed (merged or rejected).
+# Runs on trunk pushes so the just-merged PR's branch gets cleaned up
+# immediately, and any orphans accumulated from prior failures get swept too.
+
+if [[ "${BUILDKITE_BRANCH:-}" != "trunk" ]]; then
+  echo "Not a trunk build (branch=${BUILDKITE_BRANCH:-unset}), skipping"
+  exit 0
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN not set, cannot query PR state" >&2
+  exit 1
+fi
+
+GITHUB_REPO="automattic/wordpress-rs"
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo "--- :mag: Listing pr-build/* branches on origin"
+mapfile -t branches < <(
+  git ls-remote --heads origin 'refs/heads/pr-build/*' \
+    | awk '{print $2}' \
+    | sed 's|^refs/heads/||'
+)
+
+echo "Found ${#branches[@]} pr-build branches"
+
+if [[ ${#branches[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+echo "--- :github: Checking PR state for each branch"
+to_delete=()
+for branch in "${branches[@]}"; do
+  pr_number="${branch#pr-build/}"
+  if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+    echo "Skipping $branch (unexpected suffix)"
+    continue
+  fi
+
+  response=$(
+    curl --silent --show-error \
+      --write-out $'\n%{http_code}' \
+      --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/${GITHUB_REPO}/pulls/${pr_number}"
+  )
+  http_code=$(printf '%s' "$response" | tail -n1)
+  body=$(printf '%s' "$response" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "Skipping $branch (HTTP $http_code from GitHub)"
+    continue
+  fi
+
+  state=$(printf '%s' "$body" | jq -r '.state')
+
+  if [[ "$state" == "closed" ]]; then
+    echo "Marking $branch for deletion (PR #$pr_number is closed)"
+    to_delete+=("$branch")
+  else
+    echo "Keeping $branch (PR #$pr_number is $state)"
+  fi
+done
+
+if [[ ${#to_delete[@]} -eq 0 ]]; then
+  echo "No closed PR branches to delete"
+  exit 0
+fi
+
+echo "--- :wastebasket: Deleting ${#to_delete[@]} stale branches"
+chunk_size=50
+for ((i=0; i<${#to_delete[@]}; i+=chunk_size)); do
+  chunk=("${to_delete[@]:i:chunk_size}")
+  refspecs=()
+  for branch in "${chunk[@]}"; do
+    refspecs+=(":refs/heads/${branch}")
+  done
+  git push origin "${refspecs[@]}"
+done

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -342,6 +342,11 @@ steps:
         agents:
           queue: android
 
+  - label: ":wastebasket: Clean up `pr-build/*` branches for closed PRs"
+    command: .buildkite/cleanup-pr-build-branches.sh
+    plugins: [$CI_TOOLKIT]
+    if: build.branch == "trunk" && build.env("NEW_VERSION") == null
+
   - label: ":rocket: Publish Swift release $NEW_VERSION"
     command: .buildkite/release.sh $NEW_VERSION
     depends_on: swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `MediaService.delete_media_permanently` now updates live media collections in place, so deletes appear without a refresh round-trip
+- **Internal:** Buildkite step on trunk pushes that prunes `pr-build/<n>` branches whose PR is closed, sweeping orphans accumulated since `publish_pr_xcframework` started creating them.
 
 ## [0.3.0] - 2026-05-18
 


### PR DESCRIPTION
## Description

Each PR build creates a `pr-build/<PR#>` branch via `fastlane publish_pr_xcframework` so the iOS apps can pull the snapshot xcframework. Nothing prunes these afterwards, so they accumulate — there are 118 of them on origin today, most for long-merged PRs.

This adds a Buildkite step that runs on every trunk push, lists the `pr-build/*` refs, asks GitHub for each PR's state, and deletes the refs whose PR is `closed` (covers both merged and rejected — GitHub collapses them).

## Changes

- **`.buildkite/cleanup-pr-build-branches.sh`** (new): guards on `BUILDKITE_BRANCH == "trunk"`, sources `use-bot-for-git`, enumerates via `git ls-remote --heads origin 'refs/heads/pr-build/*'`, queries `GET /repos/automattic/wordpress-rs/pulls/<n>` with `GITHUB_TOKEN`, and deletes closed-PR refs with batched `git push origin :refs/heads/...` (chunks of 50). Skips on non-200 responses so we never delete a ref we couldn't verify.
- **`.buildkite/pipeline.yml`**: new top-level step gated to `build.branch == "trunk" && build.env("NEW_VERSION") == null` (skips release builds, matching the publish-trunk-xcframework gate). Default agent queue, like the other git+API helper steps (`validate-changelog.sh`).

## Test plan

- [ ] First trunk merge after this lands sweeps the ~118 existing orphans
- [ ] Subsequent trunk merges delete the just-merged PR's `pr-build/<n>` branch
- [ ] Step is skipped on PR builds and on release builds (`NEW_VERSION` set)
- [ ] Open-PR `pr-build/*` branches are left alone
- [ ] If GitHub returns non-200 for a PR (deleted, rate-limit, transient), the corresponding branch is preserved and the step continues

## Changelog

- [x] No `CHANGELOG.md` entry — CI-only change with no user-visible impact.