### PR TITLE
Replace small integer types (`u8`, `u16`) with `u32` as defensive measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
+- **BREAKING:** Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
 
 ## [0.3.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
+
 ## [0.3.0] - 2026-05-18
 
 ### Added

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -197,7 +197,7 @@ class WpRequestExecutor @JvmOverloads constructor(
             return call.execute().use { response ->
                 WpNetworkResponse(
                     body = response.body.bytes(),
-                    statusCode = response.code.toUShort(),
+                    statusCode = response.code.toUInt(),
                     responseHeaderMap = WpNetworkHeaderMap.fromMultiMap(response.headers.toMultimap()),
                     requestUrl = requestUrl,
                     requestMethod = requestMethod,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -10,20 +10,20 @@ sealed class WpRequestResult<T> {
     data class WpError<T>(
         val errorCode: WpErrorCode,
         val errorMessage: String,
-        val statusCode: UShort,
+        val statusCode: UInt,
         val response: String,
         val requestUrl: String,
         val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class InvalidHttpStatusCode<T>(
-        val statusCode: UShort,
+        val statusCode: UInt,
         val requestUrl: String,
         val requestMethod: RequestMethod,
     ) : WpRequestResult<T>()
 
     data class RequestExecutionFailed<T>(
-        val statusCode: UShort?,
+        val statusCode: UInt?,
         val redirects: List<WpRedirect>?,
         val reason: RequestExecutionErrorReason,
         val requestUrl: String,
@@ -46,7 +46,7 @@ sealed class WpRequestResult<T> {
     ) : WpRequestResult<T>()
 
     data class UnknownError<T>(
-        val statusCode: UShort,
+        val statusCode: UInt,
         val response: String,
         val requestUrl: String,
         val requestMethod: RequestMethod,

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -19,7 +19,7 @@ extension WpNetworkResponse {
 
         self = WpNetworkResponse(
             body: data,
-            statusCode: UInt16(response.statusCode),
+            statusCode: UInt32(response.statusCode),
             responseHeaderMap: try WpNetworkHeaderMap.fromMap(hashMap: response.httpHeaders),
             requestUrl: request.url(),
             requestMethod: request.method(),

--- a/native/swift/Sources/wordpress-api/WPComLanguage+Extensions.swift
+++ b/native/swift/Sources/wordpress-api/WPComLanguage+Extensions.swift
@@ -87,7 +87,7 @@ public extension WpComLanguage {
         self = selfValue
     }
 
-    init(id: UInt16) {
+    init(id: UInt32) {
         guard let selfValue = wpComLanguageFromId(id: id) else {
             preconditionFailure("Invalid WP.com Language ID: \(id)")
         }

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -119,7 +119,7 @@ extension WpNetworkResponse {
         )
     }
 
-    static func jsonResponse(named name: String, statusCode: UInt16 = 200) throws -> WpNetworkResponse {
+    static func jsonResponse(named name: String, statusCode: UInt32 = 200) throws -> WpNetworkResponse {
 
         guard
             let resourceUrl = Bundle

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -28,12 +28,12 @@ pub trait MaybeWpError {
 #[derive(Debug, PartialEq, Eq, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]
 pub enum WpApiError {
     InvalidHttpStatusCode {
-        status_code: u16,
+        status_code: u32,
         request_url: String,
         request_method: RequestMethod,
     },
     RequestExecutionFailed {
-        status_code: Option<u16>,
+        status_code: Option<u32>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
         request_url: String,
@@ -52,7 +52,7 @@ pub enum WpApiError {
         reason: String,
     },
     UnknownError {
-        status_code: u16,
+        status_code: u32,
         response: String,
         request_url: String,
         request_method: RequestMethod,
@@ -60,7 +60,7 @@ pub enum WpApiError {
     WpError {
         error_code: WpErrorCode,
         error_message: String,
-        status_code: u16,
+        status_code: u32,
         response: String,
         request_url: String,
         request_method: RequestMethod,
@@ -143,7 +143,7 @@ impl ParsedRequestError for WpApiError {
                 });
             }
 
-            match http::StatusCode::from_u16(response.status_code) {
+            match http::StatusCode::from_u16(response.status_code as u16) {
                 Ok(status) => {
                     if status.is_client_error() || status.is_server_error() {
                         Some(Self::UnknownError {
@@ -587,7 +587,7 @@ impl WpErrorCode {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]
 pub enum RequestExecutionError {
     RequestExecutionFailed {
-        status_code: Option<u16>,
+        status_code: Option<u32>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
         request_url: String,

--- a/wp_api/src/login/nonce.rs
+++ b/wp_api/src/login/nonce.rs
@@ -170,7 +170,7 @@ impl WpRestNonceRetrieval {
 #[derive(Debug, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]
 pub enum NonceRetrievalError {
     AlreadyLoggedIn { username: String },
-    UnexpectedResponse { status_code: u16, body: String },
+    UnexpectedResponse { status_code: u32, body: String },
     ApiError { error: WpApiError },
 }
 

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -407,7 +407,7 @@ impl AutoDiscoveryAttemptFailure {
     /// to how how much progress was made into api discovery before this failure happened.
     ///
     /// The numbers are for comparison only and otherwise meaningless.
-    pub(in crate::login::url_discovery) fn importance(&self) -> usize {
+    pub(in crate::login::url_discovery) fn importance(&self) -> u32 {
         let parse_site_url_multipler = 1;
         let find_api_root_failure_multipler = 10;
         let fetch_and_parse_api_root_failure_multiplier = 1000;
@@ -416,13 +416,13 @@ impl AutoDiscoveryAttemptFailure {
             AutoDiscoveryAttemptFailure::FindApiRoot {
                 find_api_root_failure,
                 ..
-            } => find_api_root_failure_multipler * find_api_root_failure.importance().get(),
+            } => find_api_root_failure_multipler * find_api_root_failure.importance().get() as u32,
             AutoDiscoveryAttemptFailure::FetchAndParseApiRoot {
                 fetch_and_parse_api_root_failure,
                 ..
             } => {
                 fetch_and_parse_api_root_failure_multiplier
-                    * fetch_and_parse_api_root_failure.importance().get()
+                    * fetch_and_parse_api_root_failure.importance().get() as u32
             }
         }
     }
@@ -503,7 +503,7 @@ pub enum FetchAndParseApiRootFailure {
     WpError {
         error_code: WpErrorCode,
         error_message: String,
-        status_code: u16,
+        status_code: u32,
     },
     ApplicationPasswordsNotSupported {
         api_details: Arc<WpApiDetails>,
@@ -703,7 +703,7 @@ pub(crate) fn construct_attempts(input_site_url: String) -> Vec<AutoDiscoveryAtt
 #[derive(Debug, thiserror::Error, uniffi::Error, WpDeriveLocalizable)]
 pub enum FetchApiDetailsError {
     RequestExecutionFailed {
-        status_code: Option<u16>,
+        status_code: Option<u32>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
     },

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -490,8 +490,8 @@ pub struct AudioMediaDetails {
     pub data_format: Option<String>,
     pub codec: Option<String>,
     pub sample_rate: Option<u32>,
-    pub channels: Option<u8>,
-    pub bits_per_sample: Option<u8>,
+    pub channels: Option<u32>,
+    pub bits_per_sample: Option<u32>,
     pub lossless: Option<bool>,
     #[serde(rename = "channelmode")]
     pub channel_mode: Option<String>,

--- a/wp_api/src/middleware.rs
+++ b/wp_api/src/middleware.rs
@@ -169,14 +169,14 @@ where
 
 #[derive(Debug, uniffi::Object)]
 pub struct RetryAfterMiddleware {
-    max_retries: u8,
+    max_retries: u32,
     max_retry_wait_seconds: u64,
 }
 
 #[uniffi::export]
 impl RetryAfterMiddleware {
     #[uniffi::constructor]
-    pub fn new(max_retries: u8, max_retry_wait_seconds: u64) -> Self {
+    pub fn new(max_retries: u32, max_retry_wait_seconds: u64) -> Self {
         println!("Creating retry middleware");
         Self {
             max_retries,
@@ -401,7 +401,7 @@ mod tests {
                     request_executor,
                     WpNetworkResponse {
                         body: vec![],
-                        status_code: initial_response_status_code,
+                        status_code: initial_response_status_code as u32,
                         response_header_map: Arc::new(WpNetworkHeaderMap::default()),
                         request_url: WpEndpointUrl("http://example.com".to_string()),
                         request_method: RequestMethod::GET,
@@ -496,7 +496,7 @@ mod tests {
         }
 
         async fn execute_retry_after_middleware(
-            max_retries: u8,
+            max_retries: u32,
         ) -> Result<WpNetworkResponse, RequestExecutionError> {
             let foo_executor = FooExecutor {
                 first_request: AtomicBool::new(true),

--- a/wp_api/src/middleware.rs
+++ b/wp_api/src/middleware.rs
@@ -385,7 +385,7 @@ mod tests {
         async fn execute_api_discovery_authentication_middleware(
             request_executor: Arc<FooExecutor>,
             initial_request_has_authorization_header: bool,
-            initial_response_status_code: u16,
+            initial_response_status_code: u32,
         ) -> Result<WpNetworkResponse, RequestExecutionError> {
             let middleware =
                 ApiDiscoveryAuthenticationMiddleware::new("foo".to_string(), "bar".to_string());
@@ -401,7 +401,7 @@ mod tests {
                     request_executor,
                     WpNetworkResponse {
                         body: vec![],
-                        status_code: initial_response_status_code as u32,
+                        status_code: initial_response_status_code,
                         response_header_map: Arc::new(WpNetworkHeaderMap::default()),
                         request_url: WpEndpointUrl("http://example.com".to_string()),
                         request_method: RequestMethod::GET,

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -224,7 +224,7 @@ impl WpNetworkRequestBody {
 #[derive(uniffi::Object)]
 pub struct WpNetworkRequest {
     pub(crate) uuid: String,
-    pub(crate) retry_count: u8,
+    pub(crate) retry_count: u32,
     pub(crate) method: RequestMethod,
     pub(crate) url: WpEndpointUrl,
     pub(crate) header_map: Arc<WpNetworkHeaderMap>,
@@ -246,7 +246,7 @@ impl WpNetworkRequest {
     }
 
     /// How many times this request has this request been attempted?
-    pub fn retry_count(&self) -> u8 {
+    pub fn retry_count(&self) -> u32 {
         self.retry_count
     }
 
@@ -462,7 +462,7 @@ impl NetworkRequestAccessor for WpMultipartFormRequest {
 #[derive(uniffi::Record)]
 pub struct WpNetworkResponse {
     pub body: Vec<u8>,
-    pub status_code: u16,
+    pub status_code: u32,
     pub response_header_map: Arc<WpNetworkHeaderMap>,
     pub request_url: WpEndpointUrl,
     pub request_method: RequestMethod,

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -86,7 +86,7 @@ impl ReqwestRequestExecutor {
         let body = response.bytes().await?;
 
         Ok(WpNetworkResponse {
-            status_code: status.as_u16(),
+            status_code: status.as_u16() as u32,
             body: body.to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(response_header_map)),
             request_url: wp_request.url(),
@@ -165,7 +165,7 @@ impl RequestExecutor for ReqwestRequestExecutor {
 
         let header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
-            status_code: response.status().as_u16(),
+            status_code: response.status().as_u16() as u32,
             body: response.bytes().await.unwrap().to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
             request_url: upload_request.url(),
@@ -188,7 +188,7 @@ fn request_execution_error_from_reqwest(
     request_url: String,
     request_method: RequestMethod,
 ) -> RequestExecutionError {
-    let status_code = error.status().map(|s| s.as_u16());
+    let status_code = error.status().map(|s| s.as_u16() as u32);
     let reason = if error.is_timeout() {
         RequestExecutionErrorReason::HttpTimeoutError
     } else if let Some(tls_error) = error.as_tls_error() {

--- a/wp_api/src/unit_test_common.rs
+++ b/wp_api/src/unit_test_common.rs
@@ -43,7 +43,7 @@ pub fn unit_test_example_date_as_query_value(key: &str) -> String {
 }
 
 #[cfg(test)]
-pub fn wp_network_response_from_json(json: &str, status_code: u16) -> WpNetworkResponse {
+pub fn wp_network_response_from_json(json: &str, status_code: u32) -> WpNetworkResponse {
     WpNetworkResponse {
         body: json.into(),
         status_code,

--- a/wp_api/src/wordpress_org/client.rs
+++ b/wp_api/src/wordpress_org/client.rs
@@ -199,7 +199,7 @@ pub enum WordPressOrgApiClientError {
         reason: String,
     },
     RequestExecutionFailed {
-        status_code: Option<u16>,
+        status_code: Option<u32>,
         redirects: Option<Vec<WpRedirect>>,
         reason: RequestExecutionErrorReason,
     },
@@ -208,7 +208,7 @@ pub enum WordPressOrgApiClientError {
         response: String,
     },
     UnexpectedStatusCodeError {
-        status_code: u16,
+        status_code: u32,
         response: String,
     },
 }

--- a/wp_api/src/wp_com/language.rs
+++ b/wp_api/src/wp_com/language.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct WpComRemoteLanguage {
-    pub id: u16,
+    pub id: u32,
     pub localized: String,
     pub name: String,
-    pub popularity_rank: Option<u16>,
+    pub popularity_rank: Option<u32>,
 }
 
 pub type WpComRemoteLanguageMap = HashMap<String, WpComRemoteLanguage>;
@@ -33,7 +33,7 @@ impl AppendUrlQueryPairs for LanguagesGetParams {
 
 /// WordPress.com language codes with their IDs as discriminants
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, uniffi::Enum)]
-#[repr(u16)]
+#[repr(u32)]
 pub enum WPComLanguage {
     English = 1,
     Afrikaans = 2,
@@ -217,7 +217,7 @@ impl WPComLanguage {
 
     /// Returns the popularity rank if this is a popular language
     /// Returns None if the language is not marked as popular
-    pub fn popular_rank(&self) -> Option<u8> {
+    pub fn popular_rank(&self) -> Option<u32> {
         self.popular_rank_internal()
     }
 
@@ -227,14 +227,14 @@ impl WPComLanguage {
     }
 
     /// Returns the numeric language ID as used by WordPress.com
-    pub fn language_id(&self) -> u16 {
-        *self as u16
+    pub fn language_id(&self) -> u32 {
+        *self as u32
     }
 }
 
 /// Lookup a WPComLanguage by its numeric ID
 #[uniffi::export]
-pub fn wp_com_language_from_id(id: u16) -> Option<WPComLanguage> {
+pub fn wp_com_language_from_id(id: u32) -> Option<WPComLanguage> {
     WPComLanguage::from_id(id)
 }
 
@@ -258,12 +258,12 @@ pub fn wp_com_language_popular() -> Vec<WPComLanguage> {
 
 impl WPComLanguage {
     /// Lookup a language by its numeric ID (discriminant)
-    pub fn from_id(id: u16) -> Option<Self> {
+    pub fn from_id(id: u32) -> Option<Self> {
         Self::from_discriminant(id)
     }
 
     /// Lookup a language by its discriminant value
-    pub fn from_discriminant(id: u16) -> Option<Self> {
+    pub fn from_discriminant(id: u32) -> Option<Self> {
         match id {
             1 => Some(Self::English),
             2 => Some(Self::Afrikaans),
@@ -1198,7 +1198,7 @@ impl WPComLanguage {
 
     /// Returns the popularity rank if this is a popular language (internal method)
     /// Returns None if the language is not marked as popular
-    fn popular_rank_internal(&self) -> Option<u8> {
+    fn popular_rank_internal(&self) -> Option<u32> {
         match self {
             Self::English => Some(1),
             Self::Spanish => Some(2),

--- a/wp_api/src/wp_com/support_bots.rs
+++ b/wp_api/src/wp_com/support_bots.rs
@@ -192,7 +192,7 @@ pub struct CreateBotConversationFeedbackParams {
 }
 
 #[derive(Debug, PartialEq, Eq, uniffi::Enum, Serialize_repr, Deserialize_repr)]
-#[repr(u8)]
+#[repr(u32)]
 pub enum FeedbackRating {
     Positive = 1,
     Negative = 0,

--- a/wp_api_integration_tests/src/mock.rs
+++ b/wp_api_integration_tests/src/mock.rs
@@ -107,7 +107,7 @@ pub mod response_helpers {
         }
     }
 
-    pub fn empty_response(status_code: u16) -> WpNetworkResponse {
+    pub fn empty_response(status_code: u32) -> WpNetworkResponse {
         WpNetworkResponse {
             body: vec![],
             status_code,

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -241,7 +241,7 @@ impl RequestExecutor for MediaErrNetworking {
                 .send()
                 .await
                 .map_err(|e| RequestExecutionError::RequestExecutionFailed {
-                    status_code: e.status().map(|s| s.as_u16()),
+                    status_code: e.status().map(|s| s.as_u16() as u32),
                     redirects: None,
                     reason: RequestExecutionErrorReason::GenericError {
                         error_message: e.to_string(),
@@ -252,7 +252,7 @@ impl RequestExecutor for MediaErrNetworking {
 
         let header_map = std::mem::take(response.headers_mut());
         Ok(WpNetworkResponse {
-            status_code: response.status().as_u16(),
+            status_code: response.status().as_u16() as u32,
             body: response.bytes().await.unwrap().to_vec(),
             response_header_map: Arc::new(WpNetworkHeaderMap::new(header_map)),
             request_url: upload_request.url(),

--- a/wp_com_e2e/src/languages_tests.rs
+++ b/wp_com_e2e/src/languages_tests.rs
@@ -78,7 +78,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
 
                     // Verify popularity rank consistency
                     match (language.popular_rank(), remote_language.popularity_rank) {
-                        (Some(local), Some(remote)) if local != remote as u8 => {
+                        (Some(local), Some(remote)) if local != remote => {
                             return Err(format!(
                                 "Popularity rank mismatch for {}: expected {}, got {}",
                                 slug, remote, local

--- a/wp_mobile/src/collection/core.rs
+++ b/wp_mobile/src/collection/core.rs
@@ -238,7 +238,7 @@ impl MetadataCollectionCore {
         let Some(current_page) = current_page else {
             log::debug!("MetadataCollection: No pages loaded yet, need refresh first");
             return Ok(crate::sync::SyncResult::no_op(
-                self.items().map(|items| items.len()).unwrap_or(0),
+                self.items().map(|items| items.len() as u32).unwrap_or(0),
                 Some(true), // has_more_pages = true, but need refresh first
                 None,       // current_page = None (not loaded)
                 None,       // total_pages = None
@@ -249,7 +249,7 @@ impl MetadataCollectionCore {
         if total_pages.is_some_and(|total| current_page >= total) {
             log::debug!("MetadataCollection: Already at last page, nothing to load");
             return Ok(crate::sync::SyncResult::no_op(
-                self.items().map(|items| items.len()).unwrap_or(0),
+                self.items().map(|items| items.len() as u32).unwrap_or(0),
                 Some(false), // has_more_pages = false (on last page)
                 Some(current_page),
                 total_pages,

--- a/wp_mobile/src/service/media.rs
+++ b/wp_mobile/src/service/media.rs
@@ -29,7 +29,7 @@ use wp_mobile_cache::{
 };
 
 /// Maximum number of media items to fetch in a single batch request
-const BATCH_FETCH_SIZE: usize = 100;
+const BATCH_FETCH_SIZE: u32 = 100;
 
 /// Core WordPress attachment statuses. Used by `load_media_by_ids` as the
 /// baseline for hydration requests; the caller's filter statuses are unioned
@@ -48,15 +48,15 @@ pub struct LoadByIdsResult {
     /// Entity IDs of successfully loaded media
     pub entity_ids: Vec<EntityId>,
     /// Number of media items that were requested but failed to load
-    pub failed_count: usize,
+    pub failed_count: u32,
 }
 
 /// Statistics from fetching missing and stale media.
 pub(crate) struct FetchStats {
     /// Number of media items that needed fetching (Missing or Stale state)
-    pub(crate) fetched_count: usize,
+    pub(crate) fetched_count: u32,
     /// Number of media items that failed to fetch
-    pub(crate) failed_count: usize,
+    pub(crate) failed_count: u32,
 }
 
 /// Service layer for media operations
@@ -311,7 +311,7 @@ impl MediaService {
         let total_items = self
             .metadata_service
             .get_entity_ids(key)
-            .map(|ids| ids.len())
+            .map(|ids| ids.len() as u32)
             .unwrap_or(0);
 
         let pagination = self.metadata_service.get_pagination(key).ok().flatten();
@@ -350,11 +350,11 @@ impl MediaService {
             .map(|m| MediaId(m.id))
             .collect();
 
-        let fetched_count = ids_to_fetch.len();
-        let mut failed_count = 0;
+        let fetched_count = ids_to_fetch.len() as u32;
+        let mut failed_count: u32 = 0;
 
         if !ids_to_fetch.is_empty() {
-            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE) {
+            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE as usize) {
                 match self.load_media_by_ids(chunk.to_vec(), &filter.status).await {
                     Ok(result) => {
                         failed_count += result.failed_count;
@@ -366,7 +366,7 @@ impl MediaService {
                             chunk,
                             e
                         );
-                        failed_count += chunk.len();
+                        failed_count += chunk.len() as u32;
                     }
                 }
             }
@@ -431,7 +431,7 @@ impl MediaService {
 
         let params = MediaListParams {
             include: media_ids,
-            per_page: Some(BATCH_FETCH_SIZE as u32),
+            per_page: Some(BATCH_FETCH_SIZE),
             status: statuses,
             ..Default::default()
         };
@@ -485,7 +485,7 @@ impl MediaService {
                     .filter(|id| !fetched_set.contains(id))
                     .copied()
                     .collect();
-                let failed_count = failed_ids.len();
+                let failed_count = failed_ids.len() as u32;
                 if !failed_ids.is_empty() {
                     EntityStateService::save_batch(
                         &self.cache,

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -518,7 +518,7 @@ impl PostService {
         let params = PostListParams {
             include: post_ids,
             // Ensure we get all requested posts regardless of default per_page
-            per_page: Some(BATCH_FETCH_SIZE as u32),
+            per_page: Some(BATCH_FETCH_SIZE),
             // Request all available post statuses as defined in the WordPress REST API.
             // Use "any" to match all post statuses (including custom ones), plus
             // "trash" which WordPress excludes from "any" because it has

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -35,7 +35,7 @@ use wp_mobile_cache::{
 };
 
 /// Maximum number of posts to fetch in a single batch request
-const BATCH_FETCH_SIZE: usize = 100;
+const BATCH_FETCH_SIZE: u32 = 100;
 
 // Internal types
 
@@ -44,15 +44,15 @@ pub struct LoadByIdsResult {
     /// Entity IDs of successfully loaded posts
     pub entity_ids: Vec<EntityId>,
     /// Number of posts that were requested but failed to load
-    pub failed_count: usize,
+    pub failed_count: u32,
 }
 
 /// Statistics from fetching missing and stale posts.
 pub(crate) struct FetchStats {
     /// Number of posts that needed fetching (Missing or Stale state)
-    pub(crate) fetched_count: usize,
+    pub(crate) fetched_count: u32,
     /// Number of posts that failed to fetch
-    pub(crate) failed_count: usize,
+    pub(crate) failed_count: u32,
 }
 
 /// Service layer for post operations
@@ -377,7 +377,7 @@ impl PostService {
         let total_items = self
             .metadata_service
             .get_entity_ids(key)
-            .map(|ids| ids.len())
+            .map(|ids| ids.len() as u32)
             .unwrap_or(0);
 
         // Get pagination info from DB
@@ -421,12 +421,12 @@ impl PostService {
             .map(|m| PostId(m.id))
             .collect();
 
-        let fetched_count = ids_to_fetch.len();
-        let mut failed_count = 0;
+        let fetched_count = ids_to_fetch.len() as u32;
+        let mut failed_count: u32 = 0;
 
         if !ids_to_fetch.is_empty() {
             // Batch into chunks
-            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE) {
+            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE as usize) {
                 match self.load_posts_by_ids(endpoint_type, chunk.to_vec()).await {
                     Ok(result) => {
                         // Accumulate failures reported by load_posts_by_ids
@@ -440,7 +440,7 @@ impl PostService {
                             e
                         );
                         // Network/DB error - all items in this chunk failed
-                        failed_count += chunk.len();
+                        failed_count += chunk.len() as u32;
                     }
                 }
             }
@@ -580,7 +580,7 @@ impl PostService {
                     .filter(|id| !fetched_set.contains(id))
                     .copied()
                     .collect();
-                let failed_count = failed_ids.len();
+                let failed_count = failed_ids.len() as u32;
                 if !failed_ids.is_empty() {
                     EntityStateService::save_batch(
                         &self.cache,

--- a/wp_mobile/src/sync/metadata_fetch_result.rs
+++ b/wp_mobile/src/sync/metadata_fetch_result.rs
@@ -42,8 +42,8 @@ impl MetadataFetchResult {
     }
 
     /// Returns the number of items in this page.
-    pub fn page_count(&self) -> usize {
-        self.metadata.len()
+    pub fn page_count(&self) -> u32 {
+        self.metadata.len() as u32
     }
 }
 

--- a/wp_mobile/src/sync/sync_result.rs
+++ b/wp_mobile/src/sync/sync_result.rs
@@ -31,9 +31,9 @@ pub struct SyncResult {
 
 impl SyncResult {
     pub fn new(
-        total_items: usize,
-        fetched_count: usize,
-        failed_count: usize,
+        total_items: u32,
+        fetched_count: u32,
+        failed_count: u32,
         has_more_pages: Option<bool>,
         current_page: Option<u32>,
         total_pages: Option<u32>,
@@ -50,13 +50,13 @@ impl SyncResult {
 
     /// Create a result indicating no sync was needed.
     pub fn no_op(
-        total_items: usize,
+        total_items: u32,
         has_more_pages: Option<bool>,
         current_page: Option<u32>,
         total_pages: Option<u32>,
     ) -> Self {
         Self {
-            total_items: total_items as u64,
+            total_items: total_items.into(),
             fetched_count: 0,
             failed_count: 0,
             has_more_pages,

--- a/wp_mobile/src/sync/sync_result.rs
+++ b/wp_mobile/src/sync/sync_result.rs
@@ -56,7 +56,7 @@ impl SyncResult {
         total_pages: Option<u32>,
     ) -> Self {
         Self {
-            total_items: total_items.into(),
+            total_items: total_items as u64,
             fetched_count: 0,
             failed_count: 0,
             has_more_pages,


### PR DESCRIPTION
[An 11-year-old bug in Android's ART AOT compiler for ARM32](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) causes incorrect sign-extension of `Short` (16-bit) JNI return values, which can lead to UniFFI checksum mismatches at runtime (#1339).

While the upstream fix is being pursued separately, this change defensively widens all small integer types (`u8`, `u16`) to `u32` across struct fields, function parameters, return types, and enum reprs — particularly those on or near the UniFFI surface. This eliminates the possibility of hitting the AOT sign-extension bug if any of these types are ever exposed through UniFFI bindings.

Byte data (`Vec<u8>`, `&[u8]`, `[u8; N]`) used for request bodies, cryptographic keys, and certificates is left unchanged. Internal `usize` usage tied to `rusqlite` APIs and array indexing is also unchanged, as these types don't cross the FFI boundary.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
