### PR TITLE
`/all-domains/` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort/ordering predicates on `MediaListFilter`
 - Live membership updates on `MediaMetadataCollectionWithEditContext`, so cached media lists reflect items moving in or out of the filter without a full refresh
 - WordPress.com `/domains/{name}/is-available` endpoint for checking domain availability, pricing, and transfer status
+- WordPress.com `/all-domains` endpoint for listing all domains across a user's sites
 
 ### Changed
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -1,4 +1,5 @@
 use crate::{
+    date::WpGmtDateTime,
     decimal2::Decimal2,
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
@@ -379,9 +380,8 @@ pub struct AllDomainItem {
     pub current_user_is_owner: bool,
     /// Whether the site only has a domain (no content).
     pub is_domain_only_site: bool,
-    /// Expiry date as a string (e.g. `"2026-03-24 00:00:00"`), or `null`
-    /// if the domain has no expiry.
-    pub expiry: Option<String>,
+    /// Expiry date of the domain, or `None` if it has no expiry.
+    pub expiry: Option<WpGmtDateTime>,
     /// Whether the domain has expired.
     pub expired: bool,
     /// Whether this is the primary domain for the site.
@@ -420,8 +420,6 @@ pub enum DomainSubtypeId {
     DomainRegistration,
     /// Domain transfer in progress.
     DomainTransfer,
-    /// Redirect-only domain.
-    SiteRedirect,
     /// A subtype not covered by the known variants.
     #[serde(untagged)]
     Other(String),
@@ -448,12 +446,22 @@ pub struct DomainListItemStatus {
 pub enum DomainListItemStatusId {
     /// Domain is active and working.
     Active,
+    /// Domain setup is in progress.
+    InProgress,
     /// Domain is expiring soon.
     ExpiringSoon,
     /// Domain has expired.
     Expired,
+    /// Domain is pending renewal.
+    PendingRenewal,
+    /// Domain registration is pending.
+    PendingRegistration,
     /// Domain transfer is in progress.
     PendingTransfer,
+    /// Domain transfer has completed.
+    TransferCompleted,
+    /// Domain transfer encountered an error.
+    TransferError,
     /// Domain connection has an error.
     ConnectionError,
     /// A status not covered by the known variants.

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -435,9 +435,25 @@ pub struct DomainListItemStatus {
     /// Status severity type.
     #[serde(rename = "type")]
     pub status_type: DomainListItemStatusType,
-    /// Optional call-to-action identifier (e.g. `"view_domain"`,
-    /// `"view_purchase"`, `"view_domain_setup"`, `"view_transfer_setup"`).
-    pub cta: Option<String>,
+    /// Call-to-action for the user, if any action is needed.
+    pub cta: Option<DomainStatusCta>,
+}
+
+/// Call-to-action for a domain status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainStatusCta {
+    /// View the domain settings.
+    ViewDomain,
+    /// View the purchase/subscription.
+    ViewPurchase,
+    /// View the domain connection setup.
+    ViewDomainSetup,
+    /// View the domain transfer setup.
+    ViewTransferSetup,
+    /// A CTA not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
 }
 
 /// Status identifier for a domain in the all-domains list.
@@ -691,7 +707,10 @@ mod tests {
             expiring.domain_status.status_type,
             DomainListItemStatusType::Warning
         );
-        assert_eq!(expiring.domain_status.cta.as_deref(), Some("view_purchase"));
+        assert_eq!(
+            expiring.domain_status.cta,
+            Some(DomainStatusCta::ViewPurchase)
+        );
         assert!(expiring.is_domain_only_site);
         assert_eq!(expiring.tags, vec!["domain_only"]);
 
@@ -710,8 +729,8 @@ mod tests {
             DomainListItemStatusId::PendingTransfer
         );
         assert_eq!(
-            transfer.domain_status.cta.as_deref(),
-            Some("view_transfer_setup")
+            transfer.domain_status.cta,
+            Some(DomainStatusCta::ViewTransferSetup)
         );
         assert!(!transfer.can_set_as_primary);
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -2,7 +2,10 @@ use crate::{
     decimal2::Decimal2,
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::{CurrencyCode, WpComSiteId, products::ProductId, segments::SegmentId},
+    wp_com::{
+        CurrencyCode, WpComSiteId, products::ProductId, segments::SegmentId,
+        subscribers::SubscriptionId,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -336,6 +339,143 @@ pub struct DomainTransferInfo {
     pub transferrability: Option<DomainTransferrability>,
 }
 
+/// Optional query parameters for `GET /all-domains/` (v1.2).
+#[derive(Debug, Default, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct AllDomainsParams {
+    /// Filter domains by garden name.
+    #[uniffi(default = None)]
+    pub garden: Option<String>,
+}
+
+impl AppendUrlQueryPairs for AllDomainsParams {
+    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
+        query_pairs_mut.append_option_query_value_pair("garden", self.garden.as_ref());
+    }
+}
+
+/// Response from `GET /all-domains/` (v1.2).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct AllDomainsResponse {
+    /// List of domains across all sites for the authenticated user.
+    pub domains: Vec<AllDomainItem>,
+}
+
+/// A domain item returned by `GET /all-domains/` (v1.2).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct AllDomainItem {
+    /// The domain name (e.g. `"example.com"`).
+    pub domain: DomainName,
+    /// Domain subtype indicating how the domain is associated with the site.
+    pub subtype: DomainSubtype,
+    /// The site ID this domain belongs to.
+    pub blog_id: WpComSiteId,
+    /// The site name.
+    pub blog_name: String,
+    /// The site slug used in URLs.
+    pub site_slug: String,
+    /// Whether the domain is configured for automatic renewal.
+    pub auto_renewing: bool,
+    /// Whether the current authenticated user owns this domain.
+    pub current_user_is_owner: bool,
+    /// Whether the site only has a domain (no content).
+    pub is_domain_only_site: bool,
+    /// Expiry date as a string (e.g. `"2026-03-24 00:00:00"`), or `null`
+    /// if the domain has no expiry.
+    pub expiry: Option<String>,
+    /// Whether the domain has expired.
+    pub expired: bool,
+    /// Whether this is the primary domain for the site.
+    pub primary_domain: bool,
+    /// Whether this domain can be set as the site's primary domain.
+    pub can_set_as_primary: bool,
+    /// Resolved status of the domain.
+    pub domain_status: DomainListItemStatus,
+    /// Subscription ID for the domain purchase, if any.
+    pub subscription_id: Option<SubscriptionId>,
+    /// Tags describing domain characteristics
+    /// (e.g. `"domain_only"`, `"wpcom_staging"`, `"hundred_year_domain"`).
+    #[serde(default)]
+    #[uniffi(default = [])]
+    pub tags: Vec<String>,
+}
+
+/// Domain subtype indicating how the domain is associated with the site.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainSubtype {
+    /// Subtype identifier.
+    pub id: DomainSubtypeId,
+    /// Localized human-readable label.
+    pub label: String,
+}
+
+/// How a domain is associated with a WordPress.com site.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainSubtypeId {
+    /// Free WordPress.com address (e.g. `"mysite.wordpress.com"`).
+    DefaultAddress,
+    /// External domain connected/mapped to the site.
+    DomainConnection,
+    /// Domain registered through WordPress.com.
+    DomainRegistration,
+    /// Domain transfer in progress.
+    DomainTransfer,
+    /// Redirect-only domain.
+    SiteRedirect,
+    /// A subtype not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
+/// Resolved status of a domain in `GET /all-domains/` (v1.2).
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct DomainListItemStatus {
+    /// Status identifier.
+    pub id: DomainListItemStatusId,
+    /// Localized human-readable status label.
+    pub label: String,
+    /// Status severity type.
+    #[serde(rename = "type")]
+    pub status_type: DomainListItemStatusType,
+    /// Optional call-to-action identifier (e.g. `"view_domain"`,
+    /// `"view_purchase"`, `"view_domain_setup"`, `"view_transfer_setup"`).
+    pub cta: Option<String>,
+}
+
+/// Status identifier for a domain in the all-domains list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainListItemStatusId {
+    /// Domain is active and working.
+    Active,
+    /// Domain is expiring soon.
+    ExpiringSoon,
+    /// Domain has expired.
+    Expired,
+    /// Domain transfer is in progress.
+    PendingTransfer,
+    /// Domain connection has an error.
+    ConnectionError,
+    /// A status not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
+/// Severity type for a domain list item status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainListItemStatusType {
+    /// Everything is working normally.
+    Success,
+    /// Attention may be needed soon.
+    Warning,
+    /// Action is required.
+    Error,
+    /// A status type not covered by the known variants.
+    #[serde(untagged)]
+    Other(String),
+}
+
 impl_as_query_value_for_new_type!(DomainName);
 uniffi::custom_newtype!(DomainName, String);
 /// A domain name (e.g. `"example.com"`, `"myblog.org"`).
@@ -483,6 +623,94 @@ mod tests {
 
     use super::*;
     use rstest::*;
+
+    #[rstest]
+    #[case("tests/wpcom/domains/all_domains/basic.json", 3)]
+    #[case("tests/wpcom/domains/all_domains/mixed-statuses.json", 4)]
+    fn test_all_domains_deserialization(#[case] json_file_path: &str, #[case] expected_len: usize) {
+        let file = File::open(json_file_path).expect("Failed to open file");
+        let response: AllDomainsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert_eq!(response.domains.len(), expected_len);
+    }
+
+    #[test]
+    fn test_all_domains_basic_details() {
+        let file =
+            File::open("tests/wpcom/domains/all_domains/basic.json").expect("Failed to open file");
+        let response: AllDomainsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let first = &response.domains[0];
+        assert_eq!(first.domain.0, "fake-blog-123.wordpress.com");
+        assert_eq!(first.subtype.id, DomainSubtypeId::DefaultAddress);
+        assert_eq!(first.blog_id, WpComSiteId(11111));
+        assert_eq!(first.blog_name, "Fake Blog 123");
+        assert!(!first.auto_renewing);
+        assert!(first.expiry.is_none());
+        assert!(!first.expired);
+        assert!(first.primary_domain);
+        assert!(first.subscription_id.is_none());
+        assert!(first.tags.is_empty());
+        assert_eq!(first.domain_status.id, DomainListItemStatusId::Active);
+        assert_eq!(
+            first.domain_status.status_type,
+            DomainListItemStatusType::Success
+        );
+        assert!(first.domain_status.cta.is_none());
+
+        // Empty blog_name is a real edge case from the API.
+        let empty_name = &response.domains[1];
+        assert_eq!(empty_name.blog_name, "");
+
+        let staging = &response.domains[2];
+        assert_eq!(staging.tags, vec!["wpcom_staging"]);
+    }
+
+    #[test]
+    fn test_all_domains_mixed_statuses() {
+        let file = File::open("tests/wpcom/domains/all_domains/mixed-statuses.json")
+            .expect("Failed to open file");
+        let response: AllDomainsResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+
+        let expiring = &response.domains[0];
+        assert_eq!(
+            expiring.domain_status.id,
+            DomainListItemStatusId::ExpiringSoon
+        );
+        assert_eq!(
+            expiring.domain_status.status_type,
+            DomainListItemStatusType::Warning
+        );
+        assert_eq!(expiring.domain_status.cta.as_deref(), Some("view_purchase"));
+        assert!(expiring.is_domain_only_site);
+        assert_eq!(expiring.tags, vec!["domain_only"]);
+
+        let expired = &response.domains[1];
+        assert_eq!(expired.domain_status.id, DomainListItemStatusId::Expired);
+        assert_eq!(
+            expired.domain_status.status_type,
+            DomainListItemStatusType::Error
+        );
+        assert!(expired.expired);
+
+        let transfer = &response.domains[2];
+        assert_eq!(transfer.subtype.id, DomainSubtypeId::DomainTransfer);
+        assert_eq!(
+            transfer.domain_status.id,
+            DomainListItemStatusId::PendingTransfer
+        );
+        assert_eq!(
+            transfer.domain_status.cta.as_deref(),
+            Some("view_transfer_setup")
+        );
+        assert!(!transfer.can_set_as_primary);
+
+        let century = &response.domains[3];
+        assert_eq!(century.tags, vec!["hundred_year_domain"]);
+        assert!(century.auto_renewing);
+    }
 
     #[rstest]
     #[case("tests/wpcom/domains/suggestions/basic-query.json", 5)]

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -4,7 +4,7 @@ use crate::{
     impl_as_query_value_for_new_type,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
     wp_com::{
-        CurrencyCode, WpComSiteId, products::ProductId, segments::SegmentId,
+        CurrencyCode, WpComSiteId, products::ProductId, segments::SegmentId, sites::WpComSiteSlug,
         subscribers::SubscriptionId,
     },
 };
@@ -373,7 +373,7 @@ pub struct AllDomainItem {
     /// The site name.
     pub blog_name: String,
     /// The site slug used in URLs.
-    pub site_slug: String,
+    pub site_slug: WpComSiteSlug,
     /// Whether the domain is configured for automatic renewal.
     pub auto_renewing: bool,
     /// Whether the current authenticated user owns this domain.

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -169,6 +169,10 @@ pub(crate) mod tests {
         validate_endpoint(WpComNamespace::RestV1_1, endpoint_url, path);
     }
 
+    pub fn validate_wp_com_rest_v1_2_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
+        validate_endpoint(WpComNamespace::RestV1_2, endpoint_url, path);
+    }
+
     pub fn validate_wp_com_rest_v1_3_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {
         validate_endpoint(WpComNamespace::RestV1_3, endpoint_url, path);
     }

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -3,8 +3,9 @@ use crate::{
     wp_com::{
         WpComNamespace,
         domains::{
-            CountryCode, DomainAvailability, DomainAvailabilityParams, DomainName,
-            DomainSuggestion, DomainSuggestionsParams, SupportedCountries, SupportedState,
+            AllDomainsParams, AllDomainsResponse, CountryCode, DomainAvailability,
+            DomainAvailabilityParams, DomainName, DomainSuggestion, DomainSuggestionsParams,
+            SupportedCountries, SupportedState,
         },
     },
 };
@@ -20,12 +21,15 @@ enum DomainsRequest {
     SupportedStates,
     #[get(url = "/domains/<domain_name>/is-available", params = &DomainAvailabilityParams, output = DomainAvailability)]
     IsAvailable,
+    #[get(url = "/all-domains", params = &AllDomainsParams, output = AllDomainsResponse)]
+    AllDomains,
 }
 
 impl DerivedRequest for DomainsRequest {
     fn namespace(&self) -> impl AsNamespace {
         match self {
             Self::IsAvailable => WpComNamespace::RestV1_3,
+            Self::AllDomains => WpComNamespace::RestV1_2,
             _ => WpComNamespace::RestV1_1,
         }
     }
@@ -38,10 +42,10 @@ mod tests {
         request::endpoint::ApiUrlResolver,
         wp_com::{
             WpComSiteId,
-            domains::{CountryCode, DomainAvailabilityParams, DomainName},
+            domains::{AllDomainsParams, CountryCode, DomainAvailabilityParams, DomainName},
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
-                validate_wp_com_rest_v1_3_endpoint,
+                validate_wp_com_rest_v1_2_endpoint, validate_wp_com_rest_v1_3_endpoint,
             },
             segments::SegmentId,
         },
@@ -139,6 +143,24 @@ mod tests {
                 },
             ),
             "/domains/test.com/is-available?blog_id=12345&is_cart_pre_check=true&vendor=100-year-domains",
+        );
+    }
+
+    #[rstest]
+    fn all_domains(endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_2_endpoint(
+            endpoint.all_domains(&AllDomainsParams::default()),
+            "/all-domains?",
+        );
+    }
+
+    #[rstest]
+    fn all_domains_with_garden(endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_2_endpoint(
+            endpoint.all_domains(&AllDomainsParams {
+                garden: Some("starter".to_string()),
+            }),
+            "/all-domains?garden=starter",
         );
     }
 

--- a/wp_api/tests/wpcom/domains/all_domains/basic.json
+++ b/wp_api/tests/wpcom/domains/all_domains/basic.json
@@ -1,0 +1,78 @@
+{
+  "domains": [
+    {
+      "domain": "fake-blog-123.wordpress.com",
+      "subtype": {
+        "id": "default_address",
+        "label": "Included site address"
+      },
+      "blog_id": 11111,
+      "blog_name": "Fake Blog 123",
+      "site_slug": "fake-blog-123.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": false,
+      "is_domain_only_site": false,
+      "expiry": null,
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "active",
+        "label": "Active",
+        "type": "success"
+      },
+      "subscription_id": null,
+      "tags": []
+    },
+    {
+      "domain": "fake-empty-name.wordpress.com",
+      "subtype": {
+        "id": "default_address",
+        "label": "Included site address"
+      },
+      "blog_id": 22222,
+      "blog_name": "",
+      "site_slug": "fake-empty-name.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": false,
+      "is_domain_only_site": false,
+      "expiry": null,
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "active",
+        "label": "Active",
+        "type": "success"
+      },
+      "subscription_id": null,
+      "tags": []
+    },
+    {
+      "domain": "fake-staging-site.wpcomstaging.com",
+      "subtype": {
+        "id": "default_address",
+        "label": "Included site address"
+      },
+      "blog_id": 33333,
+      "blog_name": "Site Title",
+      "site_slug": "fake-staging-site.wpcomstaging.com",
+      "auto_renewing": false,
+      "current_user_is_owner": false,
+      "is_domain_only_site": false,
+      "expiry": null,
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "active",
+        "label": "Active",
+        "type": "success"
+      },
+      "subscription_id": null,
+      "tags": [
+        "wpcom_staging"
+      ]
+    }
+  ]
+}

--- a/wp_api/tests/wpcom/domains/all_domains/mixed-statuses.json
+++ b/wp_api/tests/wpcom/domains/all_domains/mixed-statuses.json
@@ -1,0 +1,103 @@
+{
+  "domains": [
+    {
+      "domain": "expiring-soon.com",
+      "subtype": {
+        "id": "domain_registration",
+        "label": "Domain name registration"
+      },
+      "blog_id": 11111,
+      "blog_name": "Expiring Site",
+      "site_slug": "expiring.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": true,
+      "expiry": "2026-05-01 00:00:00",
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "expiring_soon",
+        "label": "Expiring soon",
+        "type": "warning",
+        "cta": "view_purchase"
+      },
+      "subscription_id": 22222,
+      "tags": ["domain_only"]
+    },
+    {
+      "domain": "old-domain.net",
+      "subtype": {
+        "id": "domain_registration",
+        "label": "Domain name registration"
+      },
+      "blog_id": 33333,
+      "blog_name": "Expired Site",
+      "site_slug": "expired.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": "2025-01-15 00:00:00",
+      "expired": true,
+      "primary_domain": false,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "expired",
+        "label": "Expired",
+        "type": "error",
+        "cta": "view_purchase"
+      },
+      "subscription_id": 44444,
+      "tags": []
+    },
+    {
+      "domain": "transferring.org",
+      "subtype": {
+        "id": "domain_transfer",
+        "label": "Domain name transfer"
+      },
+      "blog_id": 55555,
+      "blog_name": "Transfer Site",
+      "site_slug": "transfer.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": null,
+      "expired": false,
+      "primary_domain": false,
+      "can_set_as_primary": false,
+      "domain_status": {
+        "id": "pending_transfer",
+        "label": "Transfer in progress",
+        "type": "success",
+        "cta": "view_transfer_setup"
+      },
+      "subscription_id": 66666,
+      "tags": []
+    },
+    {
+      "domain": "century.blog",
+      "subtype": {
+        "id": "domain_registration",
+        "label": "Domain name registration"
+      },
+      "blog_id": 77777,
+      "blog_name": "100 Year Site",
+      "site_slug": "century.wordpress.com",
+      "auto_renewing": true,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": "2125-06-15 00:00:00",
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "active",
+        "label": "Active",
+        "type": "success"
+      },
+      "subscription_id": 88888,
+      "tags": ["hundred_year_domain"]
+    }
+  ]
+}

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -177,8 +177,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     }
                 }
 
-                // At least one domain should be a default_address
-                // (every WP.com account has a free .wordpress.com address).
+                // The test account should have at least one default_address
                 let has_default = response
                     .domains
                     .iter()

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -2,7 +2,8 @@ use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
 use wp_api::wp_com::domains::{
-    CountryCode, DomainAvailabilityParams, DomainAvailabilityStatus, DomainName,
+    AllDomainsParams, CountryCode, DomainAvailabilityParams, DomainAvailabilityStatus,
+    DomainListItemStatusType, DomainName, DomainSubtypeId,
 };
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
@@ -146,6 +147,60 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
 
                 if availability.pricing.is_none() {
                     return Err("expected pricing for available domain".into());
+                }
+
+                Ok(())
+            })
+        }
+    }));
+
+    trials.push(Trial::test("domains::all_domains", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let response = ctx
+                    .client
+                    .domains()
+                    .all_domains(&AllDomainsParams::default())
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data;
+
+                if response.domains.is_empty() {
+                    return Err("expected at least one domain".into());
+                }
+
+                // Every domain must have a non-empty domain name.
+                for domain in &response.domains {
+                    if domain.domain.0.is_empty() {
+                        return Err("expected non-empty domain name".into());
+                    }
+                }
+
+                // At least one domain should be a default_address
+                // (every WP.com account has a free .wordpress.com address).
+                let has_default = response
+                    .domains
+                    .iter()
+                    .any(|d| d.subtype.id == DomainSubtypeId::DefaultAddress);
+                if !has_default {
+                    return Err("expected at least one domain with subtype default_address".into());
+                }
+
+                // All status types should be known values.
+                for domain in &response.domains {
+                    match &domain.domain_status.status_type {
+                        DomainListItemStatusType::Success
+                        | DomainListItemStatusType::Warning
+                        | DomainListItemStatusType::Error => {}
+                        DomainListItemStatusType::Other(s) => {
+                            return Err(format!(
+                                "unexpected status type '{}' for domain '{}'",
+                                s, domain.domain.0
+                            )
+                            .into());
+                        }
+                    }
                 }
 
                 Ok(())


### PR DESCRIPTION
## Description

Add the WordPress.com `GET /rest/v1.2/all-domains/` endpoint for listing all domains across a user's sites.

## Changes

- Add `AllDomainsResponse` and `AllDomainItem` response types with typed inner structs:
  - `DomainSubtype` with `DomainSubtypeId` enum (`DefaultAddress`, `DomainConnection`, `DomainRegistration`, `DomainTransfer`)
  - `DomainListItemStatus` with `DomainListItemStatusId` enum (10 variants), `DomainListItemStatusType` enum, and `DomainStatusCta` enum
- Add `AllDomainsParams` for optional `garden` query parameter
- Use `WpGmtDateTime` for the `expiry` field

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
