### PR TITLE
Add `Alert`, `Neutral`, and `Premium` variants to `DomainListItemStatusType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Add `Alert`, `Neutral`, and `Premium` variants to `DomainListItemStatusType`. Values that previously deserialized as `Other(String)` will now match their own variants, which may affect exhaustive `match`/`when` expressions.
 - **BREAKING:** Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
 - `MediaService.delete_media_permanently` now updates live media collections in place, so deletes appear without a refresh round-trip
 - **Internal:** Buildkite step on trunk pushes that prunes `pr-build/<n>` branches whose PR is closed, sweeping orphans accumulated since `publish_pr_xcframework` started creating them.

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -495,6 +495,12 @@ pub enum DomainListItemStatusType {
     Warning,
     /// Action is required.
     Error,
+    /// Domain mapping not pointing correctly.
+    Alert,
+    /// Domain is parked (domain-only site with no active status).
+    Neutral,
+    /// Premium domain.
+    Premium,
     /// A status type not covered by the known variants.
     #[serde(untagged)]
     Other(String),
@@ -650,7 +656,7 @@ mod tests {
 
     #[rstest]
     #[case("tests/wpcom/domains/all_domains/basic.json", 3)]
-    #[case("tests/wpcom/domains/all_domains/mixed-statuses.json", 4)]
+    #[case("tests/wpcom/domains/all_domains/mixed-statuses.json", 7)]
     fn test_all_domains_deserialization(#[case] json_file_path: &str, #[case] expected_len: usize) {
         let file = File::open(json_file_path).expect("Failed to open file");
         let response: AllDomainsResponse =
@@ -737,6 +743,29 @@ mod tests {
         let century = &response.domains[3];
         assert_eq!(century.tags, vec!["hundred_year_domain"]);
         assert!(century.auto_renewing);
+
+        let mapped = &response.domains[4];
+        assert_eq!(
+            mapped.domain_status.status_type,
+            DomainListItemStatusType::Alert
+        );
+        assert_eq!(
+            mapped.domain_status.cta,
+            Some(DomainStatusCta::ViewDomainSetup)
+        );
+
+        let parked = &response.domains[5];
+        assert_eq!(
+            parked.domain_status.status_type,
+            DomainListItemStatusType::Neutral
+        );
+        assert!(parked.is_domain_only_site);
+
+        let premium = &response.domains[6];
+        assert_eq!(
+            premium.domain_status.status_type,
+            DomainListItemStatusType::Premium
+        );
     }
 
     #[rstest]

--- a/wp_api/tests/wpcom/domains/all_domains/mixed-statuses.json
+++ b/wp_api/tests/wpcom/domains/all_domains/mixed-statuses.json
@@ -98,6 +98,79 @@
       },
       "subscription_id": 88888,
       "tags": ["hundred_year_domain"]
+    },
+    {
+      "domain": "mapped-wrong.example.com",
+      "subtype": {
+        "id": "domain_mapping",
+        "label": "Domain mapping"
+      },
+      "blog_id": 99999,
+      "blog_name": "Mapped Site",
+      "site_slug": "mapped.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": null,
+      "expired": false,
+      "primary_domain": false,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "not_pointing_correctly",
+        "label": "Not pointing correctly",
+        "type": "alert",
+        "cta": "view_domain_setup"
+      },
+      "subscription_id": null,
+      "tags": []
+    },
+    {
+      "domain": "parked-domain.com",
+      "subtype": {
+        "id": "domain_registration",
+        "label": "Domain name registration"
+      },
+      "blog_id": 10101,
+      "blog_name": "",
+      "site_slug": "parked.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": true,
+      "expiry": "2027-03-01 00:00:00",
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "parked",
+        "label": "Parked",
+        "type": "neutral"
+      },
+      "subscription_id": 20202,
+      "tags": ["domain_only"]
+    },
+    {
+      "domain": "fancy-name.luxury",
+      "subtype": {
+        "id": "domain_registration",
+        "label": "Domain name registration"
+      },
+      "blog_id": 30303,
+      "blog_name": "Premium Site",
+      "site_slug": "premium.wordpress.com",
+      "auto_renewing": true,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": "2027-08-01 00:00:00",
+      "expired": false,
+      "primary_domain": true,
+      "can_set_as_primary": true,
+      "domain_status": {
+        "id": "premium",
+        "label": "Premium",
+        "type": "premium"
+      },
+      "subscription_id": 40404,
+      "tags": []
     }
   ]
 }

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -191,7 +191,10 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     match &domain.domain_status.status_type {
                         DomainListItemStatusType::Success
                         | DomainListItemStatusType::Warning
-                        | DomainListItemStatusType::Error => {}
+                        | DomainListItemStatusType::Error
+                        | DomainListItemStatusType::Alert
+                        | DomainListItemStatusType::Neutral
+                        | DomainListItemStatusType::Premium => {}
                         DomainListItemStatusType::Other(s) => {
                             return Err(format!(
                                 "unexpected status type '{}' for domain '{}'",


### PR DESCRIPTION
## Description

The WordPress.com backend returns these `status_type` values from `Domain_Status_Resolver` but they were falling into `Other(String)`:
- `alert` — domain mapping not pointing correctly
- `neutral` — domain is parked (domain-only site)
- `premium` — premium domain

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
