### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-25
+
 ### Added
 
 - `MediaService.create_media` for uploading media, with a Swift `WpService.uploadMedia` wrapper that streams upload progress


### PR DESCRIPTION
Promotes the `Unreleased` section to `0.4.0` so the latest Android fix (`u8`/`u16` → `u32` widening for [#1339](https://github.com/Automattic/wordpress-rs/issues/1339)) ships along with the rest of the queued changes.

Per [`Documentation/RELEASING.md`](Documentation/RELEASING.md), this is the version-bump PR. After merge, trigger the release from Buildkite with `NEW_VERSION=0.4.0`.

## Why `0.4.0`

Two `**BREAKING**` entries since `0.3.0`:

- `DomainListItemStatusType` gained `Alert` / `Neutral` / `Premium` variants — affects exhaustive `match`/`when` arms
- `u8` / `u16` → `u32` widening across field, parameter, return, and enum-repr boundaries

## Test plan

- [ ] CHANGELOG diff matches the pattern from [#1346](https://github.com/Automattic/wordpress-rs/pull/1346) (Release 0.3.0) and [#1318](https://github.com/Automattic/wordpress-rs/pull/1318) (Release 0.2.0): new `## [0.4.0] - 2026-05-25` header inserted directly under `## [Unreleased]`
- [ ] `Release` label applied