### PR TITLE
Add `SiteRedirect` variant to `DomainSubtypeId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Add `Alert`, `Neutral`, and `Premium` variants to `DomainListItemStatusType`. Values that previously deserialized as `Other(String)` will now match their own variants, which may affect exhaustive `match`/`when` expressions.
+- **BREAKING:** Add `SiteRedirect` variant to `DomainSubtypeId` for redirect domains. Previously deserialized as `Other("site_redirect")`.
 - **BREAKING:** Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
 - `MediaService.delete_media_permanently` now updates live media collections in place, so deletes appear without a refresh round-trip
 - **Internal:** Buildkite step on trunk pushes that prunes `pr-build/<n>` branches whose PR is closed, sweeping orphans accumulated since `publish_pr_xcframework` started creating them.

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -420,6 +420,8 @@ pub enum DomainSubtypeId {
     DomainRegistration,
     /// Domain transfer in progress.
     DomainTransfer,
+    /// Site redirect to another URL.
+    SiteRedirect,
     /// A subtype not covered by the known variants.
     #[serde(untagged)]
     Other(String),
@@ -655,7 +657,7 @@ mod tests {
     use rstest::*;
 
     #[rstest]
-    #[case("tests/wpcom/domains/all_domains/basic.json", 3)]
+    #[case("tests/wpcom/domains/all_domains/basic.json", 4)]
     #[case("tests/wpcom/domains/all_domains/mixed-statuses.json", 7)]
     fn test_all_domains_deserialization(#[case] json_file_path: &str, #[case] expected_len: usize) {
         let file = File::open(json_file_path).expect("Failed to open file");
@@ -695,6 +697,10 @@ mod tests {
 
         let staging = &response.domains[2];
         assert_eq!(staging.tags, vec!["wpcom_staging"]);
+
+        let redirect = &response.domains[3];
+        assert_eq!(redirect.subtype.id, DomainSubtypeId::SiteRedirect);
+        assert_eq!(redirect.subtype.label, "Site redirect");
     }
 
     #[test]

--- a/wp_api/tests/wpcom/domains/all_domains/basic.json
+++ b/wp_api/tests/wpcom/domains/all_domains/basic.json
@@ -73,6 +73,30 @@
       "tags": [
         "wpcom_staging"
       ]
+    },
+    {
+      "domain": "old-domain.com",
+      "subtype": {
+        "id": "site_redirect",
+        "label": "Site redirect"
+      },
+      "blog_id": 44444,
+      "blog_name": "Redirect Target",
+      "site_slug": "redirect-target.wordpress.com",
+      "auto_renewing": false,
+      "current_user_is_owner": true,
+      "is_domain_only_site": false,
+      "expiry": "2027-01-01 00:00:00",
+      "expired": false,
+      "primary_domain": false,
+      "can_set_as_primary": false,
+      "domain_status": {
+        "id": "active",
+        "label": "Active",
+        "type": "success"
+      },
+      "subscription_id": 55555,
+      "tags": []
     }
   ]
 }


### PR DESCRIPTION
## Description

The WordPress.com backend uses `site_redirect` as the subtype ID for redirect domains. Previously this deserialized as `Other("site_redirect")`.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
