### PR TITLE
Group dependabot Ruby updates with daily cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Replace `u8`, `u16` types with `u32` across struct fields, function parameters, return types, and enum reprs as a defensive measure against an [Android ART AOT compiler bug](https://github.com/jkmassel/uniffi-armv7-aot-checksum-bug) that mishandles small integer JNI return values on ARM32 ([#1339](https://github.com/Automattic/wordpress-rs/issues/1339))
 - `MediaService.delete_media_permanently` now updates live media collections in place, so deletes appear without a refresh round-trip
 - **Internal:** Buildkite step on trunk pushes that prunes `pr-build/<n>` branches whose PR is closed, sweeping orphans accumulated since `publish_pr_xcframework` started creating them.
+- **Internal:** Group Dependabot Ruby minor/patch updates and cap open bundler PRs at 5.
 
 ## [0.3.0] - 2026-05-18
 


### PR DESCRIPTION
## Description

Updates Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

## Changes

- Add `groups: ruby-minor-and-patch` to the existing bundler block so minor and patch Ruby updates are batched into one PR.
- Add `open-pull-requests-limit: 5` to cap the number of open bundler PRs.

The cargo, swift, and gradle ecosystems are untouched.

## Test plan

Dependabot config is consumed by GitHub, not the repo's CI. Verified with `yq . .github/dependabot.yml` (parses), and `git diff` shows only the bundler block changed.

## Changelog

- [x] Added an `**Internal:**` entry under `## [Unreleased]` -> `### Changed`.

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.