### PR TITLE
Request reviews from apps-infra-tooling on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,4 +33,6 @@ updates:
     groups:
       ruby-minor-and-patch:
         update-types: [minor, patch]
+    reviewers:
+      - "Automattic/apps-infra-tooling"
     open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MediaService.delete_media_permanently` now updates live media collections in place, so deletes appear without a refresh round-trip
 - **Internal:** Buildkite step on trunk pushes that prunes `pr-build/<n>` branches whose PR is closed, sweeping orphans accumulated since `publish_pr_xcframework` started creating them.
 - **Internal:** Group Dependabot Ruby minor/patch updates and cap open bundler PRs at 5.
+- **Internal:** Request reviews from the apps-infra-tooling team on Dependabot bundler PRs.
 
 ## [0.3.0] - 2026-05-18
 


### PR DESCRIPTION
Adds `@Automattic/apps-infra-tooling` so that we can review the tooling updates Dependabot makes without disturbing product dev teams.

---

Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.