### PR TITLE
Prototype: `WpDeriveParsedValue` proc macro generating `{Enum}Value` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `WpDeriveParsedValue` proc macro that generates `{Enum}Value` wrapper types for enums with fallback variants. The generated type is a `uniffi::Object` that pairs a parsed `Option<Enum>` with the raw API string, ensuring forward-compatible comparisons when new enum variants are added.
+
+### Changed
+
+- **BREAKING:** `PostStatus` fields in response and params types (`SparseAnyPost.status`, `PostCreateParams.status`, `PostUpdateParams.status`, `MediaCreateParams.status`, `MediaUpdateParams.status`) are now `Arc<PostStatusValue>` instead of `PostStatus`. Use `PostStatusValue.newFromRaw(string)` or `PostStatusValue.newFromValue(variant)` to construct, and `parsed()`, `raw()`, `matches()`, `matchesRaw()`, `matchesAny()` to inspect and compare values.
+
 ## [0.4.0] - 2026-05-29
 
 ### Added

--- a/wp_api/src/media.rs
+++ b/wp_api/src/media.rs
@@ -3,7 +3,7 @@ use crate::{
     date::WpGmtDateTime,
     impl_as_query_value_from_to_string,
     posts::{
-        PostCommentStatus, PostId, PostPingStatus, PostStatus, WpApiParamPostsOrderBy,
+        PostCommentStatus, PostId, PostPingStatus, PostStatusValue, WpApiParamPostsOrderBy,
         WpApiParamPostsSearchColumn,
     },
     request::{MultipartFormFile, RequiresMultipartForm},
@@ -203,7 +203,7 @@ pub struct MediaUpdateParams {
     /// One of: publish, future, draft, pending, private
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<PostStatus>,
+    pub status: Option<Arc<PostStatusValue>>,
     /// The title for the post.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -270,7 +270,7 @@ pub struct MediaCreateParams {
     /// One of: publish, future, draft, pending, private
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<PostStatus>,
+    pub status: Option<Arc<PostStatusValue>>,
     /// The title for the post.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -13,7 +13,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use wp_contextual::WpContextual;
-use wp_derive::WpDeriveParamsField;
+use wp_derive::{WpDeriveParamsField, WpDeriveParsedValue};
 
 #[derive(
     Debug,
@@ -604,6 +604,7 @@ pub struct PostFootnote {
     uniffi::Enum,
     strum_macros::EnumString,
     strum_macros::Display,
+    WpDeriveParsedValue,
 )]
 #[uniffi::export(Display)]
 #[serde(rename_all = "snake_case")]

--- a/wp_api/src/posts.rs
+++ b/wp_api/src/posts.rs
@@ -198,7 +198,7 @@ pub struct PostCreateParams {
     // One of: publish, future, draft, pending, private
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<PostStatus>,
+    pub status: Option<Arc<PostStatusValue>>,
     // A password to protect access to the content and excerpt.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -292,7 +292,7 @@ pub struct PostUpdateParams {
     // One of: publish, future, draft, pending, private
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<PostStatus>,
+    pub status: Option<Arc<PostStatusValue>>,
     // A password to protect access to the content and excerpt.
     #[uniffi(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -390,7 +390,7 @@ pub struct SparseAnyPost {
     #[WpContext(edit, embed, view)]
     pub slug: Option<String>,
     #[WpContext(edit, view)]
-    pub status: Option<PostStatus>,
+    pub status: Option<Arc<PostStatusValue>>,
     #[serde(rename = "type")]
     #[WpContext(edit, embed, view)]
     pub post_type: Option<String>,

--- a/wp_api_integration_tests/tests/test_media_mut.rs
+++ b/wp_api_integration_tests/tests/test_media_mut.rs
@@ -1,7 +1,8 @@
 use macro_helper::generate_update_test;
+use std::sync::Arc;
 use wp_api::{
     media::{MediaCreateParams, MediaUpdateParams},
-    posts::{PostCommentStatus, PostPingStatus, PostStatus},
+    posts::{PostCommentStatus, PostPingStatus, PostStatus, PostStatusValue},
 };
 use wp_api_integration_tests::prelude::*;
 
@@ -43,11 +44,31 @@ generate_update_test!(
 
 generate_update_test!(update_slug, slug, "new_slug".to_string());
 
-generate_update_test!(update_status_to_draft, status, PostStatus::Draft);
-generate_update_test!(update_status_to_future, status, PostStatus::Future);
-generate_update_test!(update_status_to_pending, status, PostStatus::Pending);
-generate_update_test!(update_status_to_private, status, PostStatus::Private);
-generate_update_test!(update_status_to_publish, status, PostStatus::Publish);
+generate_update_test!(
+    update_status_to_draft,
+    status,
+    Arc::new(PostStatusValue::from(PostStatus::Draft))
+);
+generate_update_test!(
+    update_status_to_future,
+    status,
+    Arc::new(PostStatusValue::from(PostStatus::Future))
+);
+generate_update_test!(
+    update_status_to_pending,
+    status,
+    Arc::new(PostStatusValue::from(PostStatus::Pending))
+);
+generate_update_test!(
+    update_status_to_private,
+    status,
+    Arc::new(PostStatusValue::from(PostStatus::Private))
+);
+generate_update_test!(
+    update_status_to_publish,
+    status,
+    Arc::new(PostStatusValue::from(PostStatus::Publish))
+);
 
 generate_update_test!(update_title, title, "new_title".to_string());
 

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -1,7 +1,8 @@
 use macro_helper::{generate_update_page_status_test, generate_update_test};
+use std::sync::Arc;
 use wp_api::posts::{
     AnyPostWithEditContext, PostCommentStatus, PostCreateParams, PostFootnote, PostMeta,
-    PostPingStatus, PostStatus, PostUpdateParams,
+    PostPingStatus, PostStatus, PostStatusValue, PostUpdateParams,
 };
 use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
 use wp_api_integration_tests::{PAGE_TEMPLATE_WITH_SIDEBAR, prelude::*};
@@ -379,13 +380,13 @@ generate_update_test!(
 async fn update_status_to_future() {
     test_update_page(
         &PostUpdateParams {
-            status: Some(PostStatus::Future),
+            status: Some(Arc::new(PostStatusValue::from(PostStatus::Future))),
             // Publish date has to be in the future
             date: Some("2026-09-09T12:00:00".to_string()),
             ..Default::default()
         },
         |updated_page, updated_page_from_wp_cli| {
-            assert_eq!(updated_page.status, PostStatus::Future);
+            assert!(updated_page.status.is_code(PostStatus::Future));
             assert_eq!(
                 updated_page_from_wp_cli.post_status,
                 PostStatus::Future.to_string()
@@ -463,11 +464,11 @@ mod macro_helper {
                 async fn [<update_page_status_to_ $status:lower>]() {
                     test_update_page(
                         &PostUpdateParams {
-                            status: Some(PostStatus::$status),
+                            status: Some(Arc::new(PostStatusValue::from(PostStatus::$status))),
                             ..Default::default()
                         },
                         |updated_page, updated_page_from_wp_cli| {
-                            assert_eq!(updated_page.status, PostStatus::$status);
+                            assert!(updated_page.status.is_code(PostStatus::$status));
                             assert_eq!(
                                 updated_page_from_wp_cli.post_status,
                                 PostStatus::$status.to_string()

--- a/wp_api_integration_tests/tests/test_pages_mut.rs
+++ b/wp_api_integration_tests/tests/test_pages_mut.rs
@@ -386,7 +386,7 @@ async fn update_status_to_future() {
             ..Default::default()
         },
         |updated_page, updated_page_from_wp_cli| {
-            assert!(updated_page.status.is_code(PostStatus::Future));
+            assert!(updated_page.status.matches(PostStatus::Future));
             assert_eq!(
                 updated_page_from_wp_cli.post_status,
                 PostStatus::Future.to_string()
@@ -468,7 +468,7 @@ mod macro_helper {
                             ..Default::default()
                         },
                         |updated_page, updated_page_from_wp_cli| {
-                            assert!(updated_page.status.is_code(PostStatus::$status));
+                            assert!(updated_page.status.matches(PostStatus::$status));
                             assert_eq!(
                                 updated_page_from_wp_cli.post_status,
                                 PostStatus::$status.to_string()

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -567,7 +567,7 @@ async fn update_status_to_future() {
             ..Default::default()
         },
         |updated_post, updated_post_from_wp_cli| {
-            assert!(updated_post.status.is_code(PostStatus::Future));
+            assert!(updated_post.status.matches(PostStatus::Future));
             assert_eq!(
                 updated_post_from_wp_cli.post_status,
                 PostStatus::Future.to_string()
@@ -658,7 +658,7 @@ mod macro_helper {
                             ..Default::default()
                         },
                         |updated_post, updated_post_from_wp_cli| {
-                            assert!(updated_post.status.is_code(PostStatus::$status));
+                            assert!(updated_post.status.matches(PostStatus::$status));
                             assert_eq!(
                                 updated_post_from_wp_cli.post_status,
                                 PostStatus::$status.to_string()

--- a/wp_api_integration_tests/tests/test_posts_mut.rs
+++ b/wp_api_integration_tests/tests/test_posts_mut.rs
@@ -2,9 +2,11 @@ use macro_helper::{
     generate_update_post_format_test, generate_update_post_status_test, generate_update_test,
 };
 use std::collections::HashMap;
+use std::sync::Arc;
 use wp_api::posts::{
     AnyPostWithEditContext, PostCommentStatus, PostCreateParams, PostFootnote, PostFormat,
-    PostListParams, PostMeta, PostPingStatus, PostRetrieveParams, PostStatus, PostUpdateParams,
+    PostListParams, PostMeta, PostPingStatus, PostRetrieveParams, PostStatus, PostStatusValue,
+    PostUpdateParams,
 };
 use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
 use wp_api::terms::TermId;
@@ -559,13 +561,13 @@ async fn update_tags() {
 async fn update_status_to_future() {
     test_update_post(
         &PostUpdateParams {
-            status: Some(PostStatus::Future),
+            status: Some(Arc::new(PostStatusValue::from(PostStatus::Future))),
             // Publish date has to be in the future
             date: Some("2026-09-09T12:00:00".to_string()),
             ..Default::default()
         },
         |updated_post, updated_post_from_wp_cli| {
-            assert_eq!(updated_post.status, PostStatus::Future);
+            assert!(updated_post.status.is_code(PostStatus::Future));
             assert_eq!(
                 updated_post_from_wp_cli.post_status,
                 PostStatus::Future.to_string()
@@ -652,11 +654,11 @@ mod macro_helper {
                 async fn [<update_post_status_to_ $status:lower>]() {
                     test_update_post(
                         &PostUpdateParams {
-                            status: Some(PostStatus::$status),
+                            status: Some(Arc::new(PostStatusValue::from(PostStatus::$status))),
                             ..Default::default()
                         },
                         |updated_post, updated_post_from_wp_cli| {
-                            assert_eq!(updated_post.status, PostStatus::$status);
+                            assert!(updated_post.status.is_code(PostStatus::$status));
                             assert_eq!(
                                 updated_post_from_wp_cli.post_status,
                                 PostStatus::$status.to_string()
@@ -725,7 +727,7 @@ async fn create_book_with_custom_taxonomy_terms() {
     )]));
     let params = PostCreateParams {
         title: Some("Integration Test Book".to_string()),
-        status: Some(PostStatus::Publish),
+        status: Some(Arc::new(PostStatusValue::from(PostStatus::Publish))),
         additional_fields: Some(additional),
         ..Default::default()
     };

--- a/wp_derive/src/lib.rs
+++ b/wp_derive/src/lib.rs
@@ -1,11 +1,17 @@
 use proc_macro::TokenStream;
 
 mod params_field;
+mod parsed_value;
 mod wp_deserialize;
 
 #[proc_macro_derive(WpDeserialize)]
 pub fn derive_wp_deserialize(input: TokenStream) -> TokenStream {
     wp_deserialize::derive(input)
+}
+
+#[proc_macro_derive(WpDeriveParsedValue, attributes(parsed_value))]
+pub fn derive_parsed_value(input: TokenStream) -> TokenStream {
+    parsed_value::derive(input)
 }
 
 #[proc_macro_derive(

--- a/wp_derive/src/parsed_value.rs
+++ b/wp_derive/src/parsed_value.rs
@@ -142,7 +142,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
 
             /// The parsed enum variant, or `None` if the raw string is unknown.
-            pub fn value(&self) -> Option<#enum_name> {
+            pub fn parsed(&self) -> Option<#enum_name> {
                 self.inner_value.clone()
             }
 
@@ -152,18 +152,18 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
 
             /// Check if this matches a known enum variant.
-            pub fn is_code(&self, code: #enum_name) -> bool {
-                self.inner_raw == Self::new_from_value(code).inner_raw
+            pub fn matches(&self, variant: #enum_name) -> bool {
+                self.inner_raw == Self::new_from_value(variant).inner_raw
             }
 
             /// Check if the raw string matches.
-            pub fn is_raw(&self, raw: String) -> bool {
+            pub fn matches_raw(&self, raw: String) -> bool {
                 self.inner_raw == raw
             }
 
             /// Check if this matches any of the given enum variants.
-            pub fn is_any_code(&self, codes: Vec<#enum_name>) -> bool {
-                codes.into_iter().any(|c| self.is_code(c))
+            pub fn matches_any(&self, variants: Vec<#enum_name>) -> bool {
+                variants.into_iter().any(|v| self.matches(v))
             }
         }
 

--- a/wp_derive/src/parsed_value.rs
+++ b/wp_derive/src/parsed_value.rs
@@ -113,6 +113,20 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
         }
 
+        impl crate::url_query::AsQueryValue for std::sync::Arc<#value_name> {
+            fn as_query_value(&self) -> impl AsRef<str> {
+                self.inner_raw.clone()
+            }
+        }
+
+        impl crate::OptionFromStr for std::sync::Arc<#value_name> {
+            type Err = std::convert::Infallible;
+
+            fn option_from_str(s: &str) -> Result<Option<Self>, Self::Err> {
+                Ok(Some(std::sync::Arc::new(#value_name::new_from_raw(s.to_string()))))
+            }
+        }
+
         #[uniffi::export]
         impl #value_name {
             /// Create from a raw API string. Resolves to the known enum variant if possible.

--- a/wp_derive/src/parsed_value.rs
+++ b/wp_derive/src/parsed_value.rs
@@ -1,0 +1,165 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, parse2};
+
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = TokenStream::from(input);
+    let derive_input: DeriveInput = parse2(input).expect("Failed to parse input");
+
+    let enum_name = &derive_input.ident;
+    let value_name = format_ident!("{}Value", enum_name);
+
+    // Check for #[parsed_value(resolution = "serde")] attribute to use serde-based resolution
+    // instead of strum's FromStr/Display. Default is strum.
+    let uses_serde = derive_input.attrs.iter().any(|attr| {
+        if !attr.path().is_ident("parsed_value") {
+            return false;
+        }
+        attr.parse_args::<syn::MetaNameValue>()
+            .map(|nv| {
+                nv.path.is_ident("resolution")
+                    && matches!(&nv.value, syn::Expr::Lit(lit) if matches!(&lit.lit, syn::Lit::Str(s) if s.value() == "serde"))
+            })
+            .unwrap_or(false)
+    });
+
+    let from_raw_body = if uses_serde {
+        quote! {
+            let value = serde_json::from_value::<#enum_name>(
+                serde_json::Value::String(raw.clone())
+            ).ok();
+            Self { inner_value: value, inner_raw: raw }
+        }
+    } else {
+        quote! {
+            use std::str::FromStr;
+            let value = #enum_name::from_str(&raw).ok();
+            // Filter out the Custom/fallback variant — if FromStr returns a Custom variant,
+            // that means it wasn't a known variant, so value should be None.
+            let value = value.filter(|v| v.to_string() == raw);
+            Self { inner_value: value, inner_raw: raw }
+        }
+    };
+
+    let from_value_body = if uses_serde {
+        // For serde-based enums, we can't easily get the string from a variant at runtime
+        // without serializing. We'll use serde_json for now.
+        quote! {
+            let raw = serde_json::to_value(&value)
+                .ok()
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .unwrap_or_default();
+            Self { inner_value: Some(value), inner_raw: raw }
+        }
+    } else {
+        quote! {
+            let raw = value.to_string();
+            Self { inner_value: Some(value), inner_raw: raw }
+        }
+    };
+
+    let output = quote! {
+        #[derive(Debug, Clone, uniffi::Object)]
+        #[uniffi::export(Eq, Hash)]
+        pub struct #value_name {
+            inner_value: Option<#enum_name>,
+            inner_raw: String,
+        }
+
+        impl PartialEq for #value_name {
+            fn eq(&self, other: &Self) -> bool {
+                self.inner_raw == other.inner_raw
+            }
+        }
+
+        impl Eq for #value_name {}
+
+        impl std::hash::Hash for #value_name {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.inner_raw.hash(state);
+            }
+        }
+
+        impl std::fmt::Display for #value_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.inner_raw)
+            }
+        }
+
+        impl std::str::FromStr for #value_name {
+            type Err = std::convert::Infallible;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self::new_from_raw(s.to_string()))
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for #value_name {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let raw = String::deserialize(deserializer)?;
+                Ok(Self::new_from_raw(raw))
+            }
+        }
+
+        impl serde::Serialize for #value_name {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.inner_raw.serialize(serializer)
+            }
+        }
+
+        impl From<#enum_name> for #value_name {
+            fn from(value: #enum_name) -> Self {
+                Self::new_from_value(value)
+            }
+        }
+
+        #[uniffi::export]
+        impl #value_name {
+            /// Create from a raw API string. Resolves to the known enum variant if possible.
+            #[uniffi::constructor]
+            pub fn new_from_raw(raw: String) -> Self {
+                #from_raw_body
+            }
+
+            /// Create from a known enum variant. Derives the raw string automatically.
+            #[uniffi::constructor]
+            pub fn new_from_value(value: #enum_name) -> Self {
+                #from_value_body
+            }
+
+            /// The parsed enum variant, or `None` if the raw string is unknown.
+            pub fn value(&self) -> Option<#enum_name> {
+                self.inner_value.clone()
+            }
+
+            /// The original raw string from the API.
+            pub fn raw(&self) -> String {
+                self.inner_raw.clone()
+            }
+
+            /// Check if this matches a known enum variant.
+            pub fn is_code(&self, code: #enum_name) -> bool {
+                self.inner_raw == Self::new_from_value(code).inner_raw
+            }
+
+            /// Check if the raw string matches.
+            pub fn is_raw(&self, raw: String) -> bool {
+                self.inner_raw == raw
+            }
+
+            /// Check if this matches any of the given enum variants.
+            pub fn is_any_code(&self, codes: Vec<#enum_name>) -> bool {
+                codes.into_iter().any(|c| self.is_code(c))
+            }
+        }
+
+        impl #value_name {
+            /// Access the inner enum value (for Rust-side pattern matching).
+            pub(crate) fn inner(&self) -> Option<&#enum_name> {
+                self.inner_value.as_ref()
+            }
+        }
+    };
+
+    output.into()
+}

--- a/wp_mobile/src/filters/post_list_filter.rs
+++ b/wp_mobile/src/filters/post_list_filter.rs
@@ -169,12 +169,12 @@ impl PostListFilter {
             if self.status.contains(&PostStatus::Any) {
                 // "any" excludes statuses with `exclude_from_search = true`.
                 // In WordPress core, `trash` and `auto-draft` have this flag set by default.
-                if post.status.is_code(PostStatus::Trash)
-                    || post.status.is_raw("auto-draft".to_string())
+                if post.status.matches(PostStatus::Trash)
+                    || post.status.matches_raw("auto-draft".to_string())
                 {
                     return false;
                 }
-            } else if !self.status.iter().any(|s| post.status.is_code(s.clone())) {
+            } else if !self.status.iter().any(|s| post.status.matches(s.clone())) {
                 return false;
             }
         }

--- a/wp_mobile/src/filters/post_list_filter.rs
+++ b/wp_mobile/src/filters/post_list_filter.rs
@@ -169,12 +169,12 @@ impl PostListFilter {
             if self.status.contains(&PostStatus::Any) {
                 // "any" excludes statuses with `exclude_from_search = true`.
                 // In WordPress core, `trash` and `auto-draft` have this flag set by default.
-                if post.status == PostStatus::Trash
-                    || post.status == PostStatus::Custom("auto-draft".to_string())
+                if post.status.is_code(PostStatus::Trash)
+                    || post.status.is_raw("auto-draft".to_string())
                 {
                     return false;
                 }
-            } else if !self.status.contains(&post.status) {
+            } else if !self.status.iter().any(|s| post.status.is_code(s.clone())) {
                 return false;
             }
         }

--- a/wp_mobile/src/service/mock_post_service.rs
+++ b/wp_mobile/src/service/mock_post_service.rs
@@ -11,7 +11,7 @@ use std::thread;
 use std::time::Duration;
 use wp_api::posts::{
     AnyPostWithEditContext, PostContentWithEditContext, PostGuidWithEditContext, PostId,
-    PostStatus, PostTitleWithEditContext,
+    PostStatus, PostStatusValue, PostTitleWithEditContext,
 };
 use wp_mobile_cache::{
     WpApiCache, context::EditContext, db_types::db_site::DbSite,
@@ -77,7 +77,9 @@ fn stress_test_batch_update(
                 // Randomize the post status
                 let mut rng = rand::rng();
                 let status_index = rng.random_range(0..STRESS_TEST_STATUS_VALUES.len());
-                post.status = STRESS_TEST_STATUS_VALUES[status_index].clone();
+                post.status = Arc::new(PostStatusValue::new_from_value(
+                    STRESS_TEST_STATUS_VALUES[status_index].clone(),
+                ));
 
                 repo.upsert(conn, db_site, &post)?;
             }
@@ -142,7 +144,7 @@ fn create_test_post(
         modified: "2025-01-01T00:00:00".to_string(),
         modified_gmt: "2025-01-01T00:00:00Z".parse().unwrap(),
         slug: slug.to_string(),
-        status: PostStatus::Publish,
+        status: Arc::new(PostStatusValue::new_from_value(PostStatus::Publish)),
         post_type: "post".to_string(),
         password: Some("".to_string()),
         permalink_template: None,

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1253,7 +1253,7 @@ mod tests {
             .expect("Post should exist");
 
         assert!(
-            retrieved.data.post.status.is_code(post_status),
+            retrieved.data.post.status.matches(post_status),
             "Post status mismatch"
         );
     }
@@ -1401,7 +1401,7 @@ mod tests {
                 .data
                 .post
                 .status
-                .is_code(wp_api::posts::PostStatus::Publish)
+                .matches(wp_api::posts::PostStatus::Publish)
         );
 
         // Filter by draft status
@@ -1419,7 +1419,7 @@ mod tests {
                 .data
                 .post
                 .status
-                .is_code(wp_api::posts::PostStatus::Draft)
+                .matches(wp_api::posts::PostStatus::Draft)
         );
 
         // No filter - returns all
@@ -1634,7 +1634,7 @@ mod tests {
             .expect("Post should exist after insert");
         assert_eq!(retrieved.data.row_id, entity_id.rowid);
         assert_eq!(retrieved.data.db_site_id, test_ctx.site.row_id);
-        assert!(retrieved.data.post.status.is_code(PostStatus::Draft));
+        assert!(retrieved.data.post.status.matches(PostStatus::Draft));
     }
 
     #[rstest]
@@ -1672,7 +1672,7 @@ mod tests {
             .select_by_post_id(&test_ctx.conn, &test_ctx.site, PostId(200))
             .expect("Failed to select post by post_id")
             .expect("Post should exist after update");
-        assert!(retrieved.data.post.status.is_code(PostStatus::Publish));
+        assert!(retrieved.data.post.status.matches(PostStatus::Publish));
         assert_eq!(retrieved.data.post.slug, "updated-slug");
 
         // Verify only one post exists with this ID

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -26,8 +26,8 @@ use wp_api::{
     posts::{
         AnyPostWithEditContext, AnyPostWithEmbedContext, AnyPostWithViewContext,
         PostContentWithEditContext, PostContentWithViewContext, PostGuidWithEditContext,
-        PostGuidWithViewContext, PostId, PostTitleWithEditContext, PostTitleWithEmbedContext,
-        PostTitleWithViewContext, SparsePostExcerpt,
+        PostGuidWithViewContext, PostId, PostStatusValue, PostTitleWithEditContext,
+        PostTitleWithEmbedContext, PostTitleWithViewContext, SparsePostExcerpt,
     },
     prelude::WpGmtDateTime,
     taxonomies::TaxonomyType,
@@ -472,7 +472,7 @@ impl PostContext for EditContext {
             modified: row.get_column(Modified)?,
             modified_gmt: parse_datetime(row, ModifiedGmt)?,
             slug: row.get_column(Slug)?,
-            status: parse_enum(row, Status)?,
+            status: Arc::new(parse_enum::<PostStatusValue, _>(row, Status)?),
             post_type: row.get_column(PostType)?,
             password: row.get_column(Password)?,
             permalink_template: row.get_column(PermalinkTemplate)?,
@@ -569,7 +569,7 @@ impl PostContext for ViewContext {
             modified: row.get_column(Modified)?,
             modified_gmt: parse_datetime(row, ModifiedGmt)?,
             slug: row.get_column(Slug)?,
-            status: parse_enum(row, Status)?,
+            status: Arc::new(parse_enum::<PostStatusValue, _>(row, Status)?),
             post_type: row.get_column(PostType)?,
             title: {
                 let title_rendered: Option<String> = row.get_column(TitleRendered)?;
@@ -1252,7 +1252,10 @@ mod tests {
             .expect("Failed to select post by entity_id")
             .expect("Post should exist");
 
-        assert_eq!(retrieved.data.post.status, post_status);
+        assert!(
+            retrieved.data.post.status.is_code(post_status),
+            "Post status mismatch"
+        );
     }
 
     #[rstest]

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -1396,9 +1396,12 @@ mod tests {
             )
             .unwrap();
         assert_eq!(published.len(), 1);
-        assert_eq!(
-            published[0].data.post.status,
-            wp_api::posts::PostStatus::Publish
+        assert!(
+            published[0]
+                .data
+                .post
+                .status
+                .is_code(wp_api::posts::PostStatus::Publish)
         );
 
         // Filter by draft status
@@ -1411,7 +1414,13 @@ mod tests {
             )
             .unwrap();
         assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].data.post.status, wp_api::posts::PostStatus::Draft);
+        assert!(
+            drafts[0]
+                .data
+                .post
+                .status
+                .is_code(wp_api::posts::PostStatus::Draft)
+        );
 
         // No filter - returns all
         let all = test_ctx
@@ -1625,7 +1634,7 @@ mod tests {
             .expect("Post should exist after insert");
         assert_eq!(retrieved.data.row_id, entity_id.rowid);
         assert_eq!(retrieved.data.db_site_id, test_ctx.site.row_id);
-        assert_eq!(retrieved.data.post.status, PostStatus::Draft);
+        assert!(retrieved.data.post.status.is_code(PostStatus::Draft));
     }
 
     #[rstest]
@@ -1663,7 +1672,7 @@ mod tests {
             .select_by_post_id(&test_ctx.conn, &test_ctx.site, PostId(200))
             .expect("Failed to select post by post_id")
             .expect("Post should exist after update");
-        assert_eq!(retrieved.data.post.status, PostStatus::Publish);
+        assert!(retrieved.data.post.status.is_code(PostStatus::Publish));
         assert_eq!(retrieved.data.post.slug, "updated-slug");
 
         // Verify only one post exists with this ID

--- a/wp_mobile_cache/src/test_fixtures/posts.rs
+++ b/wp_mobile_cache/src/test_fixtures/posts.rs
@@ -1,9 +1,10 @@
+use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 use wp_api::{
     media::MediaId,
     posts::{
         AnyPostWithEditContext, PostContentWithEditContext, PostFootnote, PostGuidWithEditContext,
-        PostId, PostMeta, PostStatus, PostTitleWithEditContext, SparsePostExcerpt,
+        PostId, PostMeta, PostStatus, PostStatusValue, PostTitleWithEditContext, SparsePostExcerpt,
     },
     terms::TermId,
     users::UserId,
@@ -106,7 +107,7 @@ impl PostBuilder {
 
     /// Set the post status.
     pub fn with_status(mut self, status: PostStatus) -> Self {
-        self.post.status = status;
+        self.post.status = Arc::new(PostStatusValue::from(status));
         self
     }
 
@@ -187,7 +188,7 @@ fn create_minimal_post() -> AnyPostWithEditContext {
         modified: "2024-01-01T00:00:00".to_string(),
         modified_gmt: "2024-01-01T00:00:00Z".parse().unwrap(),
         slug: "minimal-post".to_string(),
-        status: PostStatus::Publish,
+        status: Arc::new(PostStatusValue::from(PostStatus::Publish)),
         post_type: "post".to_string(),
         password: Some("".to_string()),
         permalink_template: None,
@@ -232,7 +233,7 @@ fn create_full_post() -> AnyPostWithEditContext {
         modified: "2024-01-16T14:20:00".to_string(),
         modified_gmt: "2024-01-16T14:20:00Z".parse().unwrap(),
         slug: "full-post".to_string(),
-        status: PostStatus::Draft,
+        status: Arc::new(PostStatusValue::from(PostStatus::Draft)),
         post_type: "post".to_string(),
         password: Some("secret".to_string()),
         permalink_template: Some("https://example.com/%postname%/".to_string()),
@@ -294,7 +295,7 @@ fn create_custom_post() -> AnyPostWithEditContext {
         modified: "2024-01-16T14:20:00".to_string(),
         modified_gmt: "2024-01-16T14:20:00Z".parse().unwrap(),
         slug: "1000".to_string(),
-        status: PostStatus::Draft,
+        status: Arc::new(PostStatusValue::from(PostStatus::Draft)),
         post_type: "jetpack-social-note".to_string(),
         password: None,
         permalink_template: None,

--- a/wp_mobile_integration_tests/tests/test_posts_mut.rs
+++ b/wp_mobile_integration_tests/tests/test_posts_mut.rs
@@ -1,5 +1,6 @@
+use std::sync::Arc;
 use wp_api::posts::{
-    PostCreateParams, PostId, PostStatus, PostUpdateParams, WpApiParamPostsOrderBy,
+    PostCreateParams, PostId, PostStatus, PostStatusValue, PostUpdateParams, WpApiParamPostsOrderBy,
 };
 use wp_api::prelude::*;
 use wp_api::request::endpoint::posts_endpoint::PostEndpointType;
@@ -44,7 +45,7 @@ async fn test_load_next_page_with_duplicate_items_all_fresh() {
         let params = PostCreateParams {
             title: Some(format!("Test Post {}", i)),
             date: Some(format!("{}{:02}T12:00:00", base_date, i)),
-            status: Some(PostStatus::Future),
+            status: Some(Arc::new(PostStatusValue::from(PostStatus::Future))),
             ..Default::default()
         };
         ctx.api
@@ -79,7 +80,7 @@ async fn test_load_next_page_with_duplicate_items_all_fresh() {
     let new_post_params = PostCreateParams {
         title: Some("New Post That Pushes One to Page 2".to_string()),
         date: Some(new_post_date),
-        status: Some(PostStatus::Future),
+        status: Some(Arc::new(PostStatusValue::from(PostStatus::Future))),
         ..Default::default()
     };
     ctx.api
@@ -157,7 +158,7 @@ async fn test_publish_draft_in_first_page_updates_collection() {
             &PostEndpointType::Posts,
             &PostId(published_id),
             &PostUpdateParams {
-                status: Some(PostStatus::Publish),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Publish))),
                 ..Default::default()
             },
         )
@@ -228,7 +229,7 @@ async fn test_publish_draft_in_second_page_updates_collection() {
             &PostEndpointType::Posts,
             &PostId(published_id),
             &PostUpdateParams {
-                status: Some(PostStatus::Publish),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Publish))),
                 ..Default::default()
             },
         )
@@ -288,7 +289,7 @@ async fn test_create_draft_inserts_into_draft_collection() {
             &PostEndpointType::Posts,
             &PostCreateParams {
                 title: Some("Integration Test Draft".to_string()),
-                status: Some(PostStatus::Draft),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Draft))),
                 ..Default::default()
             },
         )
@@ -391,7 +392,7 @@ async fn test_delete_permanently_removes_from_collection() {
             &PostEndpointType::Posts,
             &PostCreateParams {
                 title: Some("Post To Delete Permanently".to_string()),
-                status: Some(PostStatus::Draft),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Draft))),
                 ..Default::default()
             },
         )
@@ -404,7 +405,7 @@ async fn test_delete_permanently_removes_from_collection() {
         .trash_post(&PostEndpointType::Posts, &created.id)
         .await
         .expect("trash_post should succeed");
-    assert_eq!(trashed.status, PostStatus::Trash);
+    assert!(trashed.status.is_code(PostStatus::Trash));
 
     // Build a trash collection
     let filter = PostListFilter {
@@ -472,7 +473,7 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
             &PostEndpointType::Posts,
             &PostCreateParams {
                 title: Some("Post To Trash Then Load By ID".to_string()),
-                status: Some(PostStatus::Draft),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Draft))),
                 ..Default::default()
             },
         )
@@ -485,7 +486,7 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
         .trash_post(&PostEndpointType::Posts, &created.id)
         .await
         .expect("trash_post should succeed");
-    assert_eq!(trashed.status, PostStatus::Trash);
+    assert!(trashed.status.is_code(PostStatus::Trash));
 
     let result = ctx
         .service
@@ -503,9 +504,8 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
         .read_posts_by_ids_from_db(&[created.id.0])
         .expect("read_posts_by_ids_from_db should succeed");
     assert_eq!(cached_posts.len(), 1, "should have 1 cached post");
-    assert_eq!(
-        cached_posts[0].data.status,
-        PostStatus::Trash,
+    assert!(
+        cached_posts[0].data.status.is_code(PostStatus::Trash),
         "cached post should have Trash status"
     );
 
@@ -531,7 +531,7 @@ async fn test_load_posts_by_ids_includes_mixed_status_posts() {
             &PostEndpointType::Posts,
             &PostCreateParams {
                 title: Some("Draft Post For Mixed Status Test".to_string()),
-                status: Some(PostStatus::Draft),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Draft))),
                 ..Default::default()
             },
         )
@@ -545,7 +545,7 @@ async fn test_load_posts_by_ids_includes_mixed_status_posts() {
             &PostEndpointType::Posts,
             &PostCreateParams {
                 title: Some("Post To Trash For Mixed Status Test".to_string()),
-                status: Some(PostStatus::Draft),
+                status: Some(Arc::new(PostStatusValue::from(PostStatus::Draft))),
                 ..Default::default()
             },
         )
@@ -584,14 +584,12 @@ async fn test_load_posts_by_ids_includes_mixed_status_posts() {
         .find(|p| p.data.id == to_trash.id)
         .expect("trashed post should be in cache");
 
-    assert_eq!(
-        draft_post.data.status,
-        PostStatus::Draft,
+    assert!(
+        draft_post.data.status.is_code(PostStatus::Draft),
         "draft post should have Draft status"
     );
-    assert_eq!(
-        trashed_post.data.status,
-        PostStatus::Trash,
+    assert!(
+        trashed_post.data.status.is_code(PostStatus::Trash),
         "trashed post should have Trash status"
     );
 

--- a/wp_mobile_integration_tests/tests/test_posts_mut.rs
+++ b/wp_mobile_integration_tests/tests/test_posts_mut.rs
@@ -405,7 +405,7 @@ async fn test_delete_permanently_removes_from_collection() {
         .trash_post(&PostEndpointType::Posts, &created.id)
         .await
         .expect("trash_post should succeed");
-    assert!(trashed.status.is_code(PostStatus::Trash));
+    assert!(trashed.status.matches(PostStatus::Trash));
 
     // Build a trash collection
     let filter = PostListFilter {
@@ -486,7 +486,7 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
         .trash_post(&PostEndpointType::Posts, &created.id)
         .await
         .expect("trash_post should succeed");
-    assert!(trashed.status.is_code(PostStatus::Trash));
+    assert!(trashed.status.matches(PostStatus::Trash));
 
     let result = ctx
         .service
@@ -505,7 +505,7 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
         .expect("read_posts_by_ids_from_db should succeed");
     assert_eq!(cached_posts.len(), 1, "should have 1 cached post");
     assert!(
-        cached_posts[0].data.status.is_code(PostStatus::Trash),
+        cached_posts[0].data.status.matches(PostStatus::Trash),
         "cached post should have Trash status"
     );
 
@@ -585,11 +585,11 @@ async fn test_load_posts_by_ids_includes_mixed_status_posts() {
         .expect("trashed post should be in cache");
 
     assert!(
-        draft_post.data.status.is_code(PostStatus::Draft),
+        draft_post.data.status.matches(PostStatus::Draft),
         "draft post should have Draft status"
     );
     assert!(
-        trashed_post.data.status.is_code(PostStatus::Trash),
+        trashed_post.data.status.matches(PostStatus::Trash),
         "trashed post should have Trash status"
     );
 


### PR DESCRIPTION
## Description

Adds a derive macro that generates a `uniffi::Object` wrapper type for enums with fallback variants. Applied to `PostStatus` as proof of concept.

Generated `PostStatusValue`:
- `uniffi::Object` with controlled construction (no inconsistent state)
- Constructors: `new_from_raw(String)`, `new_from_value(PostStatus)`
- Accessors: `value() -> Option<PostStatus>`, `raw() -> String`
- Comparison: `is_code()`, `is_raw()`, `is_any_code()`
- Trait impls: `Display`, `FromStr`, `Serialize`, `Deserialize`, `Eq`, `Hash`
- Equality normalizes through the raw string

Supports both strum-based (default) and serde-based resolution via `#[parsed_value(resolution = "serde")]` attribute.


## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
