### PR TITLE
Fix typo in a doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a typo in a public doc comment (`maintainance` → `maintenance`)
+
 ## [0.4.0] - 2026-05-29
 
 ### Added

--- a/wp_contextual/src/lib.rs
+++ b/wp_contextual/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! This is a much better solution, because we have strongly typed values. However, that's a lot
 //! of code just for 2 types with only 2 fields. Furthermore, it's very difficult to tell which
-//! fields are available for each `context` and has a higher maintainance cost.
+//! fields are available for each `context` and has a higher maintenance cost.
 //!
 //! In order to address this, we have [`WpContextual`] derive macro. Let's start from simple, and
 //! build up to the example:


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments and documentation — no behaviour change. Code identifiers and user-facing strings are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/doc-only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
