### PR TITLE
Support attachments when replying to unified conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live membership updates on `MediaMetadataCollectionWithEditContext`, so cached media lists reflect items moving in or out of the filter without a full refresh
 - WordPress.com `/domains/{name}/is-available` endpoint for checking domain availability, pricing, and transfer status
 - WordPress.com `/all-domains` endpoint for listing all domains across a user's sites
-- WordPress.com `/mobile-support/unified-conversations` endpoints for listing, fetching, and replying to unified support conversations
+- WordPress.com `/mobile-support/unified-conversations` endpoints for listing, fetching, and replying to unified support conversations, with attachment uploads supported when replying
 
 ### Changed
 

--- a/wp_api/src/wp_com/endpoint/unified_conversations_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/unified_conversations_endpoint.rs
@@ -17,7 +17,7 @@ enum UnifiedConversationsRequest {
     GetUnifiedConversationList,
     #[get(url = "/mobile-support/unified-conversations/<conversation_id>", output = UnifiedConversation)]
     GetUnifiedConversation,
-    #[post(url = "/mobile-support/unified-conversations/<conversation_id>", params = &ReplyToUnifiedConversationParams, output = UnifiedConversation)]
+    #[post(url = "/mobile-support/unified-conversations/<conversation_id>", params = &ReplyToUnifiedConversationParams, output = UnifiedConversation, multipart = true)]
     ReplyToUnifiedConversation,
 }
 

--- a/wp_api/src/wp_com/unified_conversations.rs
+++ b/wp_api/src/wp_com/unified_conversations.rs
@@ -2,7 +2,12 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{JsonValue, date::WpGmtDateTime, wp_com::support_tickets::ConversationId};
+use crate::{
+    JsonValue,
+    date::WpGmtDateTime,
+    request::{MultipartFormFile, RequiresMultipartForm},
+    wp_com::support_tickets::ConversationId,
+};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct UnifiedConversationSummary {
@@ -50,6 +55,28 @@ pub struct UnifiedAttachment {
 #[derive(Debug, PartialEq, Eq, Serialize, uniffi::Record)]
 pub struct ReplyToUnifiedConversationParams {
     pub message: String,
+    #[serde(skip)]
+    #[uniffi(default = [])]
+    pub attachments: Vec<String>,
+}
+
+impl RequiresMultipartForm for ReplyToUnifiedConversationParams {
+    fn multipart_form_files(&self) -> HashMap<String, MultipartFormFile> {
+        self.attachments
+            .iter()
+            .enumerate()
+            .map(|(i, file_path)| {
+                (
+                    format!("attachment_{i}"),
+                    MultipartFormFile {
+                        file_path: file_path.clone(),
+                        mime_type: None,
+                        file_name: None,
+                    },
+                )
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Enables attachment uploads when replying to a unified support conversation. Previously, the unified conversations reply endpoint only accepted a plain-text `message`, while the older support-tickets reply endpoint already supported attachments. This brings the unified endpoint to parity using the exact same multipart machinery.

## Changes

- Added an `attachments: Vec<String>` field to `ReplyToUnifiedConversationParams` (defaults to empty, skipped during JSON serialization).
- Implemented `RequiresMultipartForm` for `ReplyToUnifiedConversationParams`, mapping each attachment path to an `attachment_N` file part — mirroring `AddMessageToSupportConversationParams`.
- Marked the `ReplyToUnifiedConversation` endpoint as `multipart = true` so the request builder sends `multipart/form-data` instead of JSON.

Endpoint (unchanged URL): `POST /wpcom/v2/mobile-support/unified-conversations/<conversation_id>`

## Test plan

- `cargo build -p wp_api` and `cargo clippy -p wp_api --all-features` pass with no warnings.
- `cargo test -p wp_api --lib unified_conversations` passes (existing endpoint URL + deserialization tests).
- ⚠️ Server-side caveat: this only makes the client *send* multipart attachments. Confirm the WordPress.com `unified-conversations/<id>` reply route actually accepts `attachment_N` file parts; otherwise uploaded files will be ignored by the backend.

## Changelog

- [ ] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
