### PR TITLE
Fix WpComApiClient crash when refreshing authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a typo in a public doc comment (`maintainance` → `maintenance`)
+- Fixed a crash when using an invalid token in `WpComApiClient`
 
 ### Changed
 

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -67,6 +67,20 @@ pub enum WpApiError {
     },
 }
 
+impl WpApiError {
+    pub fn status_code(&self) -> Option<u32> {
+        match self {
+            WpApiError::InvalidHttpStatusCode { status_code, .. }
+            | WpApiError::UnknownError { status_code, .. }
+            | WpApiError::WpError { status_code, .. } => Some(*status_code),
+            WpApiError::RequestExecutionFailed { status_code, .. } => *status_code,
+            WpApiError::MediaFileNotFound { .. }
+            | WpApiError::ResponseParsingError { .. }
+            | WpApiError::SiteUrlParsingError { .. } => None,
+        }
+    }
+}
+
 impl MaybeWpError for WpApiError {
     fn wp_error_code(&self) -> Option<&WpErrorCode> {
         match self {

--- a/wp_api/src/auth.rs
+++ b/wp_api/src/auth.rs
@@ -86,6 +86,13 @@ impl ModifiableAuthenticationProvider {
             .expect("If the lock is poisoned, there isn't much we can do")
             .insert_header(headers)
     }
+
+    fn current_auth(&self) -> WpAuthentication {
+        self.auth
+            .read()
+            .expect("If the lock is poisoned, there isn't much we can do")
+            .clone()
+    }
 }
 
 #[derive(uniffi::Object)]
@@ -286,6 +293,17 @@ impl WpAuthenticationProvider {
 }
 
 impl WpAuthenticationProvider {
+    /// The credential currently in use, so callers can tell which authentication
+    /// scheme a request was made with (e.g. an application password versus a
+    /// bearer token).
+    pub(crate) fn current_auth(&self) -> WpAuthentication {
+        match self {
+            WpAuthenticationProvider::StaticAuthenticationProvider { auth } => auth.clone(),
+            WpAuthenticationProvider::DynamicAuthenticationProvider { inner } => inner.auth(),
+            WpAuthenticationProvider::Modifiable { inner } => inner.current_auth(),
+        }
+    }
+
     pub fn insert_header(&self, headers: &mut HeaderMap) {
         match self {
             WpAuthenticationProvider::StaticAuthenticationProvider { auth } => {

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -1,7 +1,7 @@
 use self::endpoint::WpEndpointUrl;
 use crate::{
     api_error::{ParsedRequestError, RequestExecutionError, WpApiError, WpErrorCode},
-    auth::WpAuthenticationProvider,
+    auth::{WpAuthentication, WpAuthenticationProvider},
     url_query::{FromUrlQueryPairs, UrlQueryPairsMap},
 };
 use base64::Engine;
@@ -944,7 +944,21 @@ pub async fn fetch_authentication_state(
     request_executor: Arc<dyn RequestExecutor>,
     api_url_resolver: Arc<dyn ApiUrlResolver>,
     authentication_provider: Arc<WpAuthenticationProvider>,
-) -> Result<AuthenticationState, WpApiError> {
+) -> Result<Option<AuthenticationState>, WpApiError> {
+    // The introspection request below validates the application password used on
+    // the current request, so it is only meaningful when the request actually
+    // authenticates with one (HTTP Basic). For any other scheme (e.g. a bearer
+    // token on WordPress.com) there is no application password to introspect, so
+    // there is no authentication state to report (`Ok(None)`). This also avoids
+    // resolving the `/wp/v2` namespace on resolvers that don't serve it (e.g.
+    // `WpComApiClientInternalUrlResolver`), which would panic.
+    if !matches!(
+        authentication_provider.current_auth(),
+        WpAuthentication::AuthorizationHeader { .. }
+    ) {
+        return Ok(None);
+    }
+
     let request =
         ApplicationPasswordsRequestBuilder::new(api_url_resolver, authentication_provider)
             .retrieve_current_with_edit_context()
@@ -955,14 +969,14 @@ pub async fn fetch_authentication_state(
         WpApiError,
     > = response.parse();
     match parsed_res {
-        Ok(_) => Ok(AuthenticationState::Authenticated),
+        Ok(_) => Ok(Some(AuthenticationState::Authenticated)),
         Err(wp_api_error) => {
             if let WpApiError::WpError {
                 error_code: WpErrorCode::Unauthorized,
                 ..
             } = wp_api_error
             {
-                Ok(AuthenticationState::Unauthorized)
+                Ok(Some(AuthenticationState::Unauthorized))
             } else {
                 Err(wp_api_error)
             }

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -154,6 +154,18 @@ pub fn wp_com_client() -> WpComApiClient {
     })
 }
 
+pub fn wp_com_client_with_invalid_token() -> WpComApiClient {
+    WpComApiClient::new(WpApiClientDelegate {
+        auth_provider: WpAuthenticationProvider::static_with_auth(WpAuthentication::Bearer {
+            token: "invalid_token".to_string(),
+        })
+        .into(),
+        request_executor: Arc::new(ReqwestRequestExecutor::default()),
+        middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
+        app_notifier: Arc::new(EmptyAppNotifier),
+    })
+}
+
 pub fn api_client_backed_by_wp_com(site_id: String) -> WpApiClient {
     WpApiClient::new(
         Arc::new(WpComDotOrgApiUrlResolver::new(

--- a/wp_api_integration_tests/tests/test_wp_com_immut.rs
+++ b/wp_api_integration_tests/tests/test_wp_com_immut.rs
@@ -1,0 +1,31 @@
+use serial_test::parallel;
+use wp_api_integration_tests::wp_com_client_with_invalid_token;
+
+#[tokio::test]
+#[parallel]
+async fn use_invalid_token_get_me() {
+    let client = wp_com_client_with_invalid_token();
+    let result = client.me().get().await;
+    let err = result.unwrap_err();
+    let status_code = err.status_code().unwrap();
+    assert!(
+        (400..500).contains(&status_code),
+        "Expected status code in 4xx range, got: {status_code}"
+    );
+}
+
+#[tokio::test]
+#[parallel]
+async fn use_invalid_token_get_support_conversation_list() {
+    let client = wp_com_client_with_invalid_token();
+    let result = client
+        .support_tickets()
+        .get_support_conversation_list()
+        .await;
+    let err = result.unwrap_err();
+    let status_code = err.status_code().unwrap();
+    assert!(
+        (400..500).contains(&status_code),
+        "Expected status code in 4xx range, got: {status_code}"
+    );
+}

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -95,7 +95,7 @@ fn generate_async_request_executor(
                         let response = #perform_call;
                         let response_status_code = response.status_code;
                         let parsed_response = response.parse();
-                        let unauthorized = parsed_response.is_unauthorized_error().unwrap_or_default() || (response_status_code == 401 && self.fetch_authentication_state().await.map(|auth_state| auth_state.is_unauthorized()).unwrap_or_default());
+                        let unauthorized = parsed_response.is_unauthorized_error().unwrap_or_default() || (response_status_code == 401 && self.fetch_authentication_state().await.map(|auth_state| auth_state.map_or(true, |auth_state| auth_state.is_unauthorized())).unwrap_or_default());
 
                         Ok((parsed_response, unauthorized, request_url))
                     };
@@ -240,7 +240,7 @@ fn generate_async_request_executor(
         impl #generated_request_executor_ident {
             #(#exported_functions)*
 
-            pub async fn fetch_authentication_state(&self) -> Result<#crate_ident::request::AuthenticationState, #error_type> {
+            pub async fn fetch_authentication_state(&self) -> Result<Option<#crate_ident::request::AuthenticationState>, #error_type> {
                 #crate_ident::request::fetch_authentication_state(self.delegate.request_executor.clone(), self.api_url_resolver.clone(), self.delegate.auth_provider.clone()).await
             }
 


### PR DESCRIPTION
Alternative to https://github.com/Automattic/wordpress-rs/pull/1127

This PR solves the same problem, with a different approach: instead of checking if the `/wp/v2` namespace can be "resolved", this PR checks if the authentication method is using an application password. Since the `fetch_authentication_state`'s implementation is verifying the application password is still valid, it makes more sense to early exit the function unless an application password is used.