### PR TITLE
Support encrypted log IDs when replying to unified conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live membership updates on `MediaMetadataCollectionWithEditContext`, so cached media lists reflect items moving in or out of the filter without a full refresh
 - WordPress.com `/domains/{name}/is-available` endpoint for checking domain availability, pricing, and transfer status
 - WordPress.com `/all-domains` endpoint for listing all domains across a user's sites
-- WordPress.com `/mobile-support/unified-conversations` endpoints for listing, fetching, and replying to unified support conversations, with attachment uploads supported when replying
+- WordPress.com `/mobile-support/unified-conversations` endpoints for listing, fetching, and replying to unified support conversations, with attachment uploads and encrypted log IDs supported when replying
 
 ### Changed
 

--- a/wp_api/src/wp_com/unified_conversations.rs
+++ b/wp_api/src/wp_com/unified_conversations.rs
@@ -55,6 +55,8 @@ pub struct UnifiedAttachment {
 #[derive(Debug, PartialEq, Eq, Serialize, uniffi::Record)]
 pub struct ReplyToUnifiedConversationParams {
     pub message: String,
+    #[uniffi(default = [])]
+    pub encrypted_log_ids: Vec<String>,
     #[serde(skip)]
     #[uniffi(default = [])]
     pub attachments: Vec<String>,


### PR DESCRIPTION
## Description

Mirrors `CreateSupportTicketParams.encrypted_log_ids` on the unified-conversations reply endpoint. Apps that have already uploaded logs to the encrypted logging service can pass the resulting IDs when replying to a unified conversation, so the server can correlate the logs with the conversation — the same flow already supported when creating a support ticket.

The IDs are opaque pass-through strings serialized into the reply body; no upload logic lives in this library.

## Changes

- Add an `encrypted_log_ids: Vec<String>` field to `ReplyToUnifiedConversationParams`, matching the `CreateSupportTicketParams` pattern (serialized as a regular field, `#[uniffi(default = [])]` so existing Swift/Kotlin callers stay source-compatible)
- Update the unified-conversations CHANGELOG entry to mention encrypted log ID support when replying

## Test plan

- `cargo test --lib -p wp_api` — 1733 passed
- `cargo fmt --all -- --check` — clean
- Existing unified-conversations deserialization and endpoint URL tests still pass

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)