### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,24 @@ updates:
       ruby-minor-and-patch:
         update-types: [minor, patch]
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 1
 
       - name: PR Review with Progress Tracking
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -19,20 +19,20 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
       with:
         platforms: linux/amd64,linux/arm64
         file: ./wp_rs_web/Dockerfile

--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Configure cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Setup pages
         id: pages
         uses: actions/configure-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `product_slug` and `billing_product_slug` fields on `Product`, `PaidDomainSuggestion`, `DomainPricing`, `WPComPlan`, and `WPComProduct` changed from `String` to `ProductSlug`. Callers that match on or construct these values will need to wrap/unwrap with `ProductSlug(...)`.
 - Publish releases automatically on version-bump in the changelog file
 - **Internal:** Route Dependabot Ruby dependency reviews through `CODEOWNERS` instead of the retired `reviewers` key.
+- Pinned third-party GitHub Actions to commit SHA to mitigate supply-chain vulnerabilities
 
 ### Fixed
 


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 7
- Repo-level unpinned usage count from the trunk recheck: 7
- Dependabot GitHub Actions coverage: appended (.github/dependabot.yml)


Known label limitations:
- `dtolnay/rust-toolchain` keeps `# stable` because no more specific same-major tag was found.
- `Swatinem/rust-cache` keeps `# v2` because the existing `v2` ref resolves to this commit; specific `v2.x` tags point to different commits.

Verification commands:

```bash
# anthropics/claude-code-action # v1.0.140 -> fbda2eb1bdc90d319b8d853f5deb53bca199a7c1
gh api repos/anthropics/claude-code-action/commits/v1.0.140 --jq '.sha'
# expected: fbda2eb1bdc90d319b8d853f5deb53bca199a7c1

# docker/build-push-action # v6.19.2 -> 10e90e3645eae34f1e60eeb005ba3a3d33f178e8
gh api repos/docker/build-push-action/commits/v6.19.2 --jq '.sha'
# expected: 10e90e3645eae34f1e60eeb005ba3a3d33f178e8

# docker/login-action # v3.7.0 -> c94ce9fb468520275223c153574b00df6fe4bcc9
gh api repos/docker/login-action/commits/v3.7.0 --jq '.sha'
# expected: c94ce9fb468520275223c153574b00df6fe4bcc9

# docker/setup-buildx-action # v3.12.0 -> 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
gh api repos/docker/setup-buildx-action/commits/v3.12.0 --jq '.sha'
# expected: 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

# docker/setup-qemu-action # v3.7.0 -> c7c53464625b32c7a7e944ae62b3e17d2b600130
gh api repos/docker/setup-qemu-action/commits/v3.7.0 --jq '.sha'
# expected: c7c53464625b32c7a7e944ae62b3e17d2b600130

# dtolnay/rust-toolchain # stable -> 29eef336d9b2848a0b548edc03f92a220660cdb8
gh api repos/dtolnay/rust-toolchain/commits/stable --jq '.sha'
# expected: 29eef336d9b2848a0b548edc03f92a220660cdb8

# Swatinem/rust-cache # v2 -> e18b497796c12c097a38f9edb9d0641fb99eee32
gh api repos/Swatinem/rust-cache/commits/v2 --jq '.sha'
# expected: e18b497796c12c097a38f9edb9d0641fb99eee32
```
