### PR TITLE
Add wp.com `GET /me/transactions/supported-countries` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com `POST /me/shopping-cart` endpoint for creating shopping carts with domain and plan products
 - WordPress.com `GET /sites/<site_id>/domains` endpoint for fetching all domains associated with a site
 - WordPress.com REST API implementation checklist (`WPCOM_REST_API_CHECKLIST.md`)
+- WordPress.com `GET /me/transactions/supported-countries` endpoint for listing countries supported in payment transactions
 
 ### Changed
 

--- a/WPCOM_REST_API_CHECKLIST.md
+++ b/WPCOM_REST_API_CHECKLIST.md
@@ -388,7 +388,7 @@ investigate the relevant code before making decisions based on this document.
 - [x] `POST /rest/v1.1/me/shopping-cart/$site` — create shopping cart (with site)
 - [x] `POST /rest/v1.1/me/shopping-cart/no-site` — create shopping cart (no site)
 - [ ] `POST /rest/v1.1/me/transactions` — redeem cart using credits
-- [ ] `GET /rest/v1.1/me/transactions/supported-countries` — supported countries
+- [x] `GET /rest/v1.1/me/transactions/supported-countries` — supported countries
 
 ## Verticals
 

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -528,9 +528,27 @@ impl std::fmt::Display for DomainName {
 impl_as_query_value_for_new_type!(CountryCode);
 uniffi::custom_newtype!(CountryCode, String);
 /// ISO 3166-1 alpha-2 country code (e.g. `"US"`, `"CA"`, `"GB"`).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+///
+/// Rejects empty strings during deserialization — an empty code is not
+/// a valid country.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CountryCode(pub String);
+
+impl<'de> serde::Deserialize<'de> for CountryCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.is_empty() {
+            return Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"a non-empty country code",
+            ));
+        }
+        Ok(Self(s))
+    }
+}
 
 impl std::fmt::Display for CountryCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/wp_api/src/wp_com/endpoint/me_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/me_endpoint.rs
@@ -1,3 +1,4 @@
+use crate::wp_com::domains::SupportedCountries;
 use crate::wp_com::me::WPComUserInfo;
 use crate::{
     request::endpoint::{AsNamespace, DerivedRequest},
@@ -9,10 +10,43 @@ use wp_derive_request_builder::WpDerivedRequest;
 enum MeRequest {
     #[get(url = "/me", output = WPComUserInfo)]
     Get,
+    #[get(url = "/me/transactions/supported-countries", output = SupportedCountries)]
+    TransactionsSupportedCountries,
 }
 
 impl DerivedRequest for MeRequest {
     fn namespace(&self) -> impl AsNamespace {
         WpComNamespace::RestV1_1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request::endpoint::ApiUrlResolver,
+        wp_com::endpoint::tests::{
+            fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
+        },
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[fixture]
+    fn endpoint(fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>) -> MeRequestEndpoint {
+        MeRequestEndpoint::new(fixture_wp_com_api_url_resolver)
+    }
+
+    #[rstest]
+    fn get(endpoint: MeRequestEndpoint) {
+        validate_wp_com_rest_v1_1_endpoint(endpoint.get(), "/me");
+    }
+
+    #[rstest]
+    fn transactions_supported_countries(endpoint: MeRequestEndpoint) {
+        validate_wp_com_rest_v1_1_endpoint(
+            endpoint.transactions_supported_countries(),
+            "/me/transactions/supported-countries",
+        );
     }
 }

--- a/wp_com_e2e/src/me_tests.rs
+++ b/wp_com_e2e/src/me_tests.rs
@@ -42,5 +42,36 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
         }));
     }
 
+    trials.push(Trial::test("me::transactions_supported_countries", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let response = ctx
+                    .client
+                    .me()
+                    .transactions_supported_countries()
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data;
+
+                if response.all.is_empty() {
+                    return Err("expected non-empty countries list".into());
+                }
+
+                // No separator entries should leak through.
+                let has_separator = response
+                    .featured
+                    .iter()
+                    .chain(response.all.iter())
+                    .any(|c| c.code.0.is_empty());
+                if has_separator {
+                    return Err("separator entry should be filtered out".into());
+                }
+
+                Ok(())
+            })
+        }
+    }));
+
     trials
 }


### PR DESCRIPTION
## Description

Adds the `GET /rest/v1.1/me/transactions/supported-countries/` endpoint for listing countries supported in payment transactions. Used by the domain registration flow to populate the country picker.

Reuses the existing `SupportedCountries` type since the API returns the same shape as `/domains/supported-countries/`.

## Changes

- New `TransactionsSupportedCountries` variant on `MeRequest` enum
- Reject empty strings in `CountryCode` deserialization. The transactions endpoint returns separator entries with enough fields to satisfy `SupportedCountry` deserialization, causing them to leak through the `Divider` filter. An empty string is not a valid ISO 3166-1 alpha-2 code — rejecting it during deserialization makes the separator naturally fall through to the `Divider` variant in the untagged enum.
- Endpoint URL tests
- E2e test validating response structure and separator filtering

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
