### PR TITLE
Add wp.com `POST /sites/<site_id>/domains/primary` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
+- WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 
 ### Changed
 

--- a/WPCOM_REST_API_CHECKLIST.md
+++ b/WPCOM_REST_API_CHECKLIST.md
@@ -106,7 +106,7 @@ investigate the relevant code before making decisions based on this document.
 - [x] `GET /rest/v1.1/domains/supported-countries/` — supported countries
 - [x] `GET /rest/v1.1/domains/supported-states/$country/` — states for country
 - [x] `GET /rest/v1.1/sites/$site/domains/` — site domains
-- [ ] `POST /rest/v1.1/sites/$site/domains/primary/` — set primary domain
+- [x] `POST /rest/v1.1/sites/$site/domains/primary/` — set primary domain
 - [x] `GET /rest/v1.3/domains/$domain/is-available/` — check domain availability
 
 ## Geo

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -1000,6 +1000,20 @@ pub struct SiteDomain {
     pub whois_update_unmodifiable_fields: Option<Vec<String>>,
 }
 
+/// Request body for `POST /rest/v1.1/sites/{siteId}/domains/primary/`.
+#[derive(Debug, Clone, Serialize, uniffi::Record)]
+pub struct SetPrimaryDomainParams {
+    /// The domain name to set as the site's primary domain.
+    pub domain: DomainName,
+}
+
+/// Response from `POST /rest/v1.1/sites/{siteId}/domains/primary/`.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct SetPrimaryDomainResponse {
+    /// Whether the primary domain was set successfully.
+    pub success: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs::File;

--- a/wp_api/src/wp_com/domains.rs
+++ b/wp_api/src/wp_com/domains.rs
@@ -1801,4 +1801,13 @@ mod tests {
         );
         assert!(transfer.ssl_status.is_none());
     }
+
+    #[test]
+    fn test_set_primary_domain_response_deserialization() {
+        let file = File::open("tests/wpcom/domains/set_primary/success.json")
+            .expect("Failed to open file");
+        let response: SetPrimaryDomainResponse =
+            serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert!(response.success);
+    }
 }

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -5,7 +5,8 @@ use crate::{
         domains::{
             AllDomainsParams, AllDomainsResponse, CountryCode, DomainAvailability,
             DomainAvailabilityParams, DomainName, DomainSuggestion, DomainSuggestionsParams,
-            SiteDomainsResponse, SupportedCountries, SupportedState,
+            SetPrimaryDomainParams, SetPrimaryDomainResponse, SiteDomainsResponse,
+            SupportedCountries, SupportedState,
         },
     },
 };
@@ -25,6 +26,8 @@ enum DomainsRequest {
     AllDomains,
     #[get(url = "/sites/<wp_com_site_id>/domains", output = SiteDomainsResponse)]
     SiteDomains,
+    #[post(url = "/sites/<wp_com_site_id>/domains/primary", params = &SetPrimaryDomainParams, output = SetPrimaryDomainResponse)]
+    SetPrimary,
 }
 
 impl DerivedRequest for DomainsRequest {
@@ -175,6 +178,17 @@ mod tests {
         #[case] expected_path: &str,
     ) {
         validate_wp_com_rest_v1_1_endpoint(endpoint.site_domains(&site_id), expected_path);
+    }
+
+    #[rstest]
+    #[case::numeric_id(WpComSiteId(12345), "/sites/12345/domains/primary")]
+    #[case::large_id(WpComSiteId(229889220), "/sites/229889220/domains/primary")]
+    fn set_primary(
+        endpoint: DomainsRequestEndpoint,
+        #[case] site_id: WpComSiteId,
+        #[case] expected_path: &str,
+    ) {
+        validate_wp_com_rest_v1_1_endpoint(endpoint.set_primary(&site_id), expected_path);
     }
 
     fn base_domain_suggestions_params() -> DomainSuggestionsParams {

--- a/wp_api/tests/wpcom/domains/set_primary/success.json
+++ b/wp_api/tests/wpcom/domains/set_primary/success.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/wp_com_e2e/src/domains_tests.rs
+++ b/wp_com_e2e/src/domains_tests.rs
@@ -3,7 +3,7 @@ use libtest_mimic::Trial;
 use std::sync::Arc;
 use wp_api::wp_com::domains::{
     AllDomainsParams, CountryCode, DomainAvailabilityParams, DomainAvailabilityStatus,
-    DomainListItemStatusType, DomainName, DomainSubtypeId, SiteDomainType,
+    DomainListItemStatusType, DomainName, DomainSubtypeId, SetPrimaryDomainParams, SiteDomainType,
 };
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
@@ -276,6 +276,51 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                             .into());
                         }
                     }
+                }
+
+                Ok(())
+            })
+        }
+    }));
+
+    // POST /sites/{siteId}/domains/primary/
+    //
+    // This endpoint mutates the site's primary domain, so the test reads the
+    // current primary and sets it again. This exercises the endpoint
+    // idempotently without changing the test site's effective primary domain.
+    trials.push(Trial::test("domains::set_primary", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let domains = ctx
+                    .client
+                    .domains()
+                    .site_domains(&site_id)
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data
+                    .domains;
+
+                let primary = match domains.iter().find(|d| d.primary_domain == Some(true)) {
+                    Some(domain) => domain,
+                    None => return Err("expected the test site to have a primary domain".into()),
+                };
+
+                let response = ctx
+                    .client
+                    .domains()
+                    .set_primary(
+                        &site_id,
+                        &SetPrimaryDomainParams {
+                            domain: primary.domain.clone(),
+                        },
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?
+                    .data;
+
+                if !response.success {
+                    return Err("expected set_primary to report success".into());
                 }
 
                 Ok(())


### PR DESCRIPTION
## Description

Adds the `POST /rest/v1.1/sites/<site_id>/domains/primary/` endpoint for setting a site's primary domain. The request body carries a single `domain` field, and the response is `{ "success": bool }`. Used after a successful domain registration to designate the newly registered domain as the site's primary.

## Changes

- New `SetPrimaryDomainParams` (request body, single `domain: DomainName` field) and `SetPrimaryDomainResponse` (`success: bool`) types in `domains.rs`
- New `SetPrimary` `POST` variant on the `DomainsRequest` enum, served from the `RestV1.1` namespace
- Idempotent `domains::set_primary` e2e test: reads the site's current primary domain via `site_domains` and sets it again, so the endpoint is exercised against the live test site without changing its effective primary domain

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
