### PR TITLE
Extend Apps Infra CODEOWNERS routing to CI and toolchain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,12 @@
 Gemfile*      @Automattic/apps-infra-tooling
 .ruby-version @Automattic/apps-infra-tooling
 .bundle/      @Automattic/apps-infra-tooling
+fastlane/     @Automattic/apps-infra-tooling
+
+# CI and automation
+.buildkite/           @Automattic/apps-infra-tooling
+.github/workflows/    @Automattic/apps-infra-tooling
+.github/dependabot.yml @Automattic/apps-infra-tooling
+
+# Toolchain and environment pins
+.java-version         @Automattic/apps-infra-tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `product_slug` and `billing_product_slug` fields on `Product`, `PaidDomainSuggestion`, `DomainPricing`, `WPComPlan`, and `WPComProduct` changed from `String` to `ProductSlug`. Callers that match on or construct these values will need to wrap/unwrap with `ProductSlug(...)`.
 - Publish releases automatically on version-bump in the changelog file
 - **Internal:** Route Dependabot Ruby dependency reviews through `CODEOWNERS` instead of the retired `reviewers` key.
+- **Internal:** Extend CODEOWNERS Ruby/Apps-Infra review routing to CI config and toolchain pins.
 - Pinned third-party GitHub Actions to commit SHA to mitigate supply-chain vulnerabilities
 
 ### Fixed


### PR DESCRIPTION
Extends the CODEOWNERS routing from #1370 beyond the Ruby dependency surface to the broader Apps Infra surface — CI config, automation, and toolchain pins — still routed to @Automattic/apps-infra-tooling. Only paths that exist in this repo are included. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

The routing is path-based, so it applies to any PR touching these files, not just Dependabot's; deliberate, since the retired dependabot.yml `reviewers` key has no source-scoped replacement.

---

Posted by Claude Code (Fable 5) on behalf of @mokagio.
