### PR TITLE
Add injectable request error logging to Kotlin clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com REST API implementation checklist (`WPCOM_REST_API_CHECKLIST.md`)
 - WordPress.com `GET /me/transactions/supported-countries` endpoint for listing countries supported in payment transactions
 - WordPress.com `GET /me/domain-contact-information` endpoint for fetching WHOIS/domain contact details
+- Kotlin: `WpRequestResult.toLogErrorString()` returns a concise, log-only description of a failed request (or `null` on success) for diagnostics
 
 ### Changed
 
+- Kotlin: `WpComApiClient`, `WpApiClient`, and `JetpackApiClient` `request(...)` now log failed requests via `System.err` (which surfaces in logcat) by default; pass `logErrors = false` to opt out
 - **BREAKING:** `AllDomainItem.expiry` changed from `Option<WpGmtDateTime>` to `Option<WpDateString>`. The `/all-domains` endpoint returns date-only values (`"YYYY-MM-DD"`), which failed to deserialize as a datetime; callers now receive the raw `"YYYY-MM-DD"` string instead of a timestamp.
 - **BREAKING:** `product_slug` and `billing_product_slug` fields on `Product`, `PaidDomainSuggestion`, `DomainPricing`, `WPComPlan`, and `WPComProduct` changed from `String` to `ProductSlug`. Callers that match on or construct these values will need to wrap/unwrap with `ProductSlug(...)`.
 - Publish releases automatically on version-bump in the changelog file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com `GET /me/transactions/supported-countries` endpoint for listing countries supported in payment transactions
 - WordPress.com `GET /me/domain-contact-information` endpoint for fetching WHOIS/domain contact details
 - Kotlin: `WpRequestResult.toLogErrorString()` returns a concise, log-only description of a failed request (or `null` on success) for diagnostics
+- Kotlin: `WpComApiClient`, `WpApiClient`, and `JetpackApiClient` accept an optional `errorLogger: RequestErrorLogger` constructor parameter. When provided, failed requests are reported to it via `toLogErrorString()`, letting callers route errors to their own logger or crash reporter. No logging happens when no logger is configured.
 
 ### Changed
-
-- Kotlin: `WpComApiClient`, `WpApiClient`, and `JetpackApiClient` `request(...)` now log failed requests via `System.err` (which surfaces in logcat) by default; pass `logErrors = false` to opt out
 - **BREAKING:** `AllDomainItem.expiry` changed from `Option<WpGmtDateTime>` to `Option<WpDateString>`. The `/all-domains` endpoint returns date-only values (`"YYYY-MM-DD"`), which failed to deserialize as a datetime; callers now receive the raw `"YYYY-MM-DD"` string instead of a timestamp.
 - **BREAKING:** `product_slug` and `billing_product_slug` fields on `Product`, `PaidDomainSuggestion`, `DomainPricing`, `WPComPlan`, and `WPComProduct` changed from `String` to `ProductSlug`. Callers that match on or construct these values will need to wrap/unwrap with `ProductSlug(...)`.
 - Publish releases automatically on version-bump in the changelog file

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
@@ -2,18 +2,6 @@ package rs.wordpress.api.kotlin
 
 import uniffi.wp_api.WpApiException
 
-private const val REQUEST_ERROR_LOG_TAG = "WpRequestError"
-
-/**
- * Logs a failed request via `System.err`, which is redirected to logcat on
- * Android (the same mechanism [DebugMiddleware] relies on). No-op on success
- * or when [enabled] is `false`.
- */
-internal fun WpRequestResult<*>.logErrorIfNeeded(enabled: Boolean) {
-    if (!enabled) return
-    toLogErrorString()?.let { System.err.println("$REQUEST_ERROR_LOG_TAG: $it") }
-}
-
 fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequestResult<T> =
     when (apiException) {
         is WpApiException.InvalidHttpStatusCode -> WpRequestResult.InvalidHttpStatusCode<T>(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/ApiClientHelpers.kt
@@ -2,6 +2,18 @@ package rs.wordpress.api.kotlin
 
 import uniffi.wp_api.WpApiException
 
+private const val REQUEST_ERROR_LOG_TAG = "WpRequestError"
+
+/**
+ * Logs a failed request via `System.err`, which is redirected to logcat on
+ * Android (the same mechanism [DebugMiddleware] relies on). No-op on success
+ * or when [enabled] is `false`.
+ */
+internal fun WpRequestResult<*>.logErrorIfNeeded(enabled: Boolean) {
+    if (!enabled) return
+    toLogErrorString()?.let { System.err.println("$REQUEST_ERROR_LOG_TAG: $it") }
+}
+
 fun <T> mapWpApiExceptionToWpRequestResult(apiException: WpApiException): WpRequestResult<T> =
     when (apiException) {
         is WpApiException.InvalidHttpStatusCode -> WpRequestResult.InvalidHttpStatusCode<T>(

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -21,20 +21,23 @@ class JetpackApiClient(
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val errorLogger: RequestErrorLogger? = null
 ) {
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,
         requestExecutor: RequestExecutor,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        errorLogger: RequestErrorLogger? = null
     ) : this(
         apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
         appNotifier,
-        dispatcher
+        dispatcher,
+        errorLogger
     )
 
     /**
@@ -47,13 +50,15 @@ class JetpackApiClient(
         interceptors: List<Interceptor>,
         networkAvailabilityProvider: NetworkAvailabilityProvider,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        errorLogger: RequestErrorLogger? = null
     ) : this(
         wpOrgSiteApiRootUrl,
         authProvider,
         requestExecutor = WpRequestExecutor(interceptors, networkAvailabilityProvider),
         appNotifier,
-        dispatcher
+        dispatcher,
+        errorLogger
     )
 
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
@@ -76,7 +81,6 @@ class JetpackApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
-        logErrors: Boolean = true,
         executeRequest: suspend (UniffiJetpackApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         val result = try {
@@ -84,7 +88,7 @@ class JetpackApiClient(
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult<T>(exception)
         }
-        result.logErrorIfNeeded(logErrors)
+        errorLogger?.let { logger -> result.toLogErrorString()?.let(logger::logError) }
         result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -44,6 +44,8 @@ class JetpackApiClient(
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpRequestExecutor] internally with the provided interceptors.
      */
+    // Trailing params are all optional config with defaults; the count is benign here.
+    @Suppress("LongParameterList")
     constructor(
         wpOrgSiteApiRootUrl: URL,
         authProvider: WpAuthenticationProvider,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/JetpackApiClient.kt
@@ -76,12 +76,15 @@ class JetpackApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
+        logErrors: Boolean = true,
         executeRequest: suspend (UniffiJetpackApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
-        try {
+        val result = try {
             WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
-            mapWpApiExceptionToWpRequestResult(exception)
+            mapWpApiExceptionToWpRequestResult<T>(exception)
         }
+        result.logErrorIfNeeded(logErrors)
+        result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestErrorLogger.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestErrorLogger.kt
@@ -1,0 +1,13 @@
+package rs.wordpress.api.kotlin
+
+/**
+ * Receives a concise, log-only description of a failed request (the value of
+ * [toLogErrorString]). Invoked only when a request fails — never on success.
+ *
+ * Implementations should forward the message to their platform logger or
+ * crash-reporting breadcrumbs. The message may contain raw response bodies and
+ * request URLs, so it must NEVER be surfaced to users.
+ */
+fun interface RequestErrorLogger {
+    fun logError(message: String)
+}

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -21,7 +21,8 @@ class WpApiClient @JvmOverloads constructor(
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val errorLogger: RequestErrorLogger? = null
 ) {
     @JvmOverloads
     constructor(
@@ -29,13 +30,15 @@ class WpApiClient @JvmOverloads constructor(
         authProvider: WpAuthenticationProvider,
         requestExecutor: RequestExecutor,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        errorLogger: RequestErrorLogger? = null
     ) : this(
         apiUrlResolver = WpOrgSiteApiUrlResolver(apiRootUrl = ParsedUrl.parse(wpOrgSiteApiRootUrl.toString())),
         authProvider,
         requestExecutor,
         appNotifier,
-        dispatcher
+        dispatcher,
+        errorLogger
     )
 
     /**
@@ -49,13 +52,15 @@ class WpApiClient @JvmOverloads constructor(
         interceptors: List<Interceptor>,
         networkAvailabilityProvider: NetworkAvailabilityProvider,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        errorLogger: RequestErrorLogger? = null
     ) : this(
         wpOrgSiteApiRootUrl,
         authProvider,
         requestExecutor = WpRequestExecutor(interceptors, networkAvailabilityProvider),
         appNotifier,
-        dispatcher
+        dispatcher,
+        errorLogger
     )
 
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
@@ -78,7 +83,6 @@ class WpApiClient @JvmOverloads constructor(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
-        logErrors: Boolean = true,
         executeRequest: suspend (UniffiWpApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         val result = try {
@@ -86,7 +90,7 @@ class WpApiClient @JvmOverloads constructor(
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult<T>(exception)
         }
-        result.logErrorIfNeeded(logErrors)
+        errorLogger?.let { logger -> result.toLogErrorString()?.let(logger::logError) }
         result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -78,12 +78,15 @@ class WpApiClient @JvmOverloads constructor(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
+        logErrors: Boolean = true,
         executeRequest: suspend (UniffiWpApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
-        try {
+        val result = try {
             WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
-            mapWpApiExceptionToWpRequestResult(exception)
+            mapWpApiExceptionToWpRequestResult<T>(exception)
         }
+        result.logErrorIfNeeded(logErrors)
+        result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpApiClient.kt
@@ -45,6 +45,8 @@ class WpApiClient @JvmOverloads constructor(
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpRequestExecutor] internally with the provided interceptors.
      */
+    // Trailing params are all optional config with defaults; the count is benign here.
+    @Suppress("LongParameterList")
     @JvmOverloads
     constructor(
         wpOrgSiteApiRootUrl: URL,

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -55,12 +55,15 @@ class WpComApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
+        logErrors: Boolean = true,
         executeRequest: suspend (UniffiWpComApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
-        try {
+        val result = try {
             WpRequestResult.Success(response = executeRequest(requestBuilder))
         } catch (exception: WpApiException) {
-            mapWpApiExceptionToWpRequestResult(exception)
+            mapWpApiExceptionToWpRequestResult<T>(exception)
         }
+        result.logErrorIfNeeded(logErrors)
+        result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -16,7 +16,8 @@ class WpComApiClient(
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val errorLogger: RequestErrorLogger? = null
 ) {
 
     /**
@@ -28,12 +29,14 @@ class WpComApiClient(
         interceptors: List<Interceptor>,
         networkAvailabilityProvider: NetworkAvailabilityProvider,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        errorLogger: RequestErrorLogger? = null
     ) : this(
         authProvider,
         requestExecutor = WpRequestExecutor(interceptors, networkAvailabilityProvider),
         appNotifier,
-        dispatcher
+        dispatcher,
+        errorLogger
     )
 
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
@@ -55,7 +58,6 @@ class WpComApiClient(
     //
     // It'll also help make sure any breaking changes to the API will end up as a compiler error.
     suspend fun <T> request(
-        logErrors: Boolean = true,
         executeRequest: suspend (UniffiWpComApiClient) -> T
     ): WpRequestResult<T> = withContext(dispatcher) {
         val result = try {
@@ -63,7 +65,7 @@ class WpComApiClient(
         } catch (exception: WpApiException) {
             mapWpApiExceptionToWpRequestResult<T>(exception)
         }
-        result.logErrorIfNeeded(logErrors)
+        errorLogger?.let { logger -> result.toLogErrorString()?.let(logger::logError) }
         result
     }
 }

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestResult.kt
@@ -58,3 +58,31 @@ sealed class WpRequestResult<T> {
             else -> null
         }
 }
+
+/**
+ * A concise description of a failed request for diagnostics, or `null` when the
+ * request succeeded.
+ *
+ * Intended for logs and crash reporting ONLY — it may include raw response
+ * bodies and request URLs. Never surface this to users; show a localized,
+ * user-facing message instead.
+ */
+fun WpRequestResult<*>.toLogErrorString(): String? = when (this) {
+    is WpRequestResult.Success -> null
+    is WpRequestResult.WpError ->
+        "WpError(code=$errorCode, status=$statusCode, message=$errorMessage, " +
+            "method=$requestMethod, url=$requestUrl)"
+    is WpRequestResult.InvalidHttpStatusCode ->
+        "InvalidHttpStatusCode(status=$statusCode, method=$requestMethod, url=$requestUrl)"
+    is WpRequestResult.RequestExecutionFailed ->
+        "RequestExecutionFailed(status=$statusCode, reason=$reason, " +
+            "method=$requestMethod, url=$requestUrl)"
+    is WpRequestResult.MediaFileNotFound -> "MediaFileNotFound(path=$filePath)"
+    is WpRequestResult.SiteUrlParsingError -> "SiteUrlParsingError(reason=$reason)"
+    is WpRequestResult.ResponseParsingError ->
+        "ResponseParsingError(reason=$reason, method=$requestMethod, " +
+            "url=$requestUrl, response=$response)"
+    is WpRequestResult.UnknownError ->
+        "UnknownError(status=$statusCode, method=$requestMethod, " +
+            "url=$requestUrl, response=$response)"
+}


### PR DESCRIPTION
## Description

Diagnosing a failed request previously meant each caller hand-rolling a description of the `WpRequestResult` error variant, and it was easy to drop useful fields (status code, error code, response body).

This adds a small, opt-in mechanism for routing failed requests to the caller's own logger or crash reporter, instead of any built-in sink.

## Changes

- Add `WpRequestResult.toLogErrorString()`: a concise, log-only description of a failed request (or `null` on success) covering every error variant, including the request method and URL. Documented as log/crash-reporting only — never for user display, as it may contain raw response bodies and URLs.
- Add a `RequestErrorLogger` functional interface — a single `logError(message: String)` sink that callers implement to forward messages to their platform logger or crash-reporting breadcrumbs.
- Add an optional `errorLogger: RequestErrorLogger? = null` constructor parameter to `WpComApiClient`, `WpApiClient`, and `JetpackApiClient`. When set, failed requests are reported to it via `toLogErrorString()`; when left unset, no logging occurs.
- Suppress `LongParameterList` on the interceptor convenience constructors: the new parameter pushes them to 7, but they are all optional config with defaults, so `errorLogger` is kept on every constructor for a consistent API rather than dropped asymmetrically.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
