### PR TITLE
Default media upload progress total to the file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.
+
 ## [0.5.0] - 2026-06-18
 
 ### Added

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -280,9 +280,11 @@ extension Progress {
     func setTotalUnitCountToFileSizeIfUnset(filePath: String) throws {
         guard totalUnitCount == 0 else { return }
         let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
-        if let size = attributes[.size] as? NSNumber {
-            totalUnitCount = size.int64Value
-        }
+        let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        // A zero-byte file (or an unreadable size) would leave the total at 0 and trip
+        // `fulfill`'s precondition. Use 1 as a placeholder so the request proceeds and the
+        // caller gets the server's "file is empty" error instead of a crash.
+        totalUnitCount = max(size, 1)
     }
 }
 

--- a/native/swift/Sources/wordpress-api/WordPressAPI.swift
+++ b/native/swift/Sources/wordpress-api/WordPressAPI.swift
@@ -255,7 +255,8 @@ public final class WordPressAPI: Sendable {
         params: MediaCreateParams,
         fulfilling progress: Progress
     ) async throws -> MediaRequestCreateResponse {
-        try await fulfill(progress: progress) { [media] in
+        try progress.setTotalUnitCountToFileSizeIfUnset(filePath: params.filePath)
+        return try await fulfill(progress: progress) { [media] in
             try await media.createCancellation(params: params, context: $0)
         }
     }
@@ -268,6 +269,22 @@ public final class WordPressAPI: Sendable {
 }
 
 #if PROGRESS_REPORTING_ENABLED
+
+extension Progress {
+    /// Defaults an unset total (0) to the byte size of the file at `filePath`.
+    ///
+    /// Media upload callers otherwise have to stat the file themselves just to satisfy
+    /// `fulfill`'s requirement that the total be greater than zero. A missing or unreadable
+    /// file throws rather than leaving the total unset, so the failure surfaces here instead
+    /// of as a confusing zero-total upload.
+    func setTotalUnitCountToFileSizeIfUnset(filePath: String) throws {
+        guard totalUnitCount == 0 else { return }
+        let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
+        if let size = attributes[.size] as? NSNumber {
+            totalUnitCount = size.int64Value
+        }
+    }
+}
 
 extension SafeRequestExecutor {
     func fulfill<R: Sendable>(

--- a/native/swift/Sources/wordpress-api/WpService+Extensions.swift
+++ b/native/swift/Sources/wordpress-api/WpService+Extensions.swift
@@ -10,6 +10,7 @@ extension WpService {
         params: MediaCreateParams,
         fulfilling progress: Progress
     ) async throws -> MediaWithEditContext {
+        try progress.setTotalUnitCountToFileSizeIfUnset(filePath: params.filePath)
         if let executor = requestExecutor() as? SafeRequestExecutor {
             return try await executor.fulfill(progress: progress) { [service = media()] context in
                 try await service.createMedia(params: params, context: context)

--- a/native/swift/Tests/integration-tests/MediaTests.swift
+++ b/native/swift/Tests/integration-tests/MediaTests.swift
@@ -38,7 +38,9 @@ struct MediaTests {
     #if os(macOS)
     @Test
     func uploadProgress() async throws {
-        let progress = Progress.discreteProgress(totalUnitCount: 100)
+        // Use a bare `Progress` (total of 0) to verify `uploadMedia` defaults the total
+        // to the upload file's size; otherwise `fractionCompleted` could never reach 1.
+        let progress = Progress()
         #expect(progress.fractionCompleted == 0)
 
         let file = try #require(Bundle.module.url(forResource: "test-data/test_media.jpg", withExtension: nil))


### PR DESCRIPTION
When the progress passed to uploadMedia has a total of zero, default it to the byte size of the file being uploaded.
