### PR TITLE
[Tooling] Secure Claude workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,21 +12,41 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
+      # issue_comment payloads identify PR comments, but do not include the PR
+      # head repo. Query the PR before allowing Claude to run on fork PRs.
+      - name: Check PR origin
+        id: pr-origin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${ISSUE_NUMBER}" --jq '.head.repo.full_name' 2>/dev/null || true)"
+
+          if [ "$head_repo" = "$REPOSITORY" ]; then
+            echo "is_internal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping Claude for external PR from ${head_repo:-unknown}."
+          fi
+
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        if: steps.pr-origin.outputs.is_internal == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: PR Review with Progress Tracking
+        if: steps.pr-origin.outputs.is_internal == 'true'
         uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55 # v1.0.154
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number }}
 
             Perform a comprehensive code review with the following focus areas:
 
@@ -56,7 +76,6 @@ jobs:
                - Check API documentation accuracy
 
             Provide detailed feedback using inline comments for specific issues.
-            Use top-level comments for general observations or praise.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
+      id-token: write # Required by claude-code-action for GitHub App token exchange.
     steps:
       # issue_comment payloads identify PR comments, but do not include the PR
       # head repo. Query the PR before allowing Claude to run on fork PRs.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       # issue_comment payloads identify PR comments, but do not include the PR
       # head repo. Query the PR before allowing Claude to run on fork PRs.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,7 +23,11 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${ISSUE_NUMBER}" --jq '.head.repo.full_name' 2>/dev/null || true)"
+          if ! head_repo="$(gh api "repos/${REPOSITORY}/pulls/${ISSUE_NUMBER}" --jq '.head.repo.full_name')"; then
+            echo "Unable to determine PR head repository for #${ISSUE_NUMBER}; skipping Claude."
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "$head_repo" = "$REPOSITORY" ]; then
             echo "is_internal=true" >> "$GITHUB_OUTPUT"
@@ -37,6 +41,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: PR Review with Progress Tracking
         if: steps.pr-origin.outputs.is_internal == 'true'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,14 +5,20 @@ on:
     types: [created]
 
 jobs:
-  review-with-tracking:
+  check-pr-origin:
     if: |
-      github.event.issue.pull_request && contains(github.event.comment.body, '@claude')
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
-      id-token: write # Required by claude-code-action for GitHub App token exchange.
+      pull-requests: read
+    outputs:
+      is_internal: ${{ steps.pr-origin.outputs.is_internal }}
     steps:
       # issue_comment payloads identify PR comments, but do not include the PR
       # head repo. Query the PR before allowing Claude to run on fork PRs.
@@ -37,15 +43,23 @@ jobs:
             echo "Skipping Claude for external PR from ${head_repo:-unknown}."
           fi
 
+
+  review-with-tracking:
+    needs: check-pr-origin
+    if: needs.check-pr-origin.outputs.is_internal == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # Required by claude-code-action for GitHub App token exchange.
+    steps:
       - name: Checkout repository
-        if: steps.pr-origin.outputs.is_internal == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: PR Review with Progress Tracking
-        if: steps.pr-origin.outputs.is_internal == 'true'
         uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55 # v1.0.154
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.
+
 ## [0.5.0] - 2026-06-18
 
 ### Added


### PR DESCRIPTION
## Summary
- Allow `@claude` review comments only from trusted commenters and skip Claude workflows on fork/external PRs before checkout or Claude execution.
- Pin mutable action references and preserve the Claude action's required OIDC permission for GitHub App token exchange.
- Keep review feedback inline-only where the workflow does not grant issue-comment permissions.


