### PR TITLE
[Tooling] Add remote login test-suite health digest

### DIFF
--- a/.buildkite/report-remote-login-integration-test-suite-health.yml
+++ b/.buildkite/report-remote-login-integration-test-suite-health.yml
@@ -1,11 +1,8 @@
-# Scheduled health digest for the quarantined remote login-discovery integration tests.
-#
-# The schedule that runs this pipeline is managed externally (Terraform), not from
-# this repo.
-#
-# The report itself is the `report_remote_login_integration_test_suite_health`
-# Fastlane lane (see `fastlane/Fastfile`). It is pure Ruby (Buildkite API + Slack
-# webhook), so it runs on the Linux `android` queue — no Xcode/mac VM needed.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Runs the health digest for the quarantined remote login-discovery integration tests.
+# Meant to run on a schedule configured on the Buildkite end.
 steps:
   - label: ":rust: :mag: Remote Login Integration Test Suite Health"
     command: |

--- a/.buildkite/report-remote-login-integration-test-suite-health.yml
+++ b/.buildkite/report-remote-login-integration-test-suite-health.yml
@@ -1,0 +1,16 @@
+# Scheduled health digest for the quarantined remote login-discovery integration tests.
+#
+# The schedule that runs this pipeline is managed externally (Terraform), not from
+# this repo.
+#
+# The report itself is the `report_remote_login_integration_test_suite_health`
+# Fastlane lane (see `fastlane/Fastfile`). It is pure Ruby (Buildkite API + Slack
+# webhook), so it runs on the Linux `android` queue — no Xcode/mac VM needed.
+steps:
+  - label: ":rust: :mag: Remote Login Integration Test Suite Health"
+    command: |
+      install_gems
+      bundle exec fastlane report_remote_login_integration_test_suite_health
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.
 - **Internal:** Added a `buildkite-triage` Claude skill for pulling failing tests from a Buildkite build via the Buildkite MCP.
 - **Internal:** Quarantined the external login-discovery integration tests (`test_login_remote`) behind `#[ignore]`; they now run in a dedicated soft-fail Buildkite step so intermittent `*.wpmt.co` timeouts no longer fail the build.
+- **Internal:** Added a scheduled Buildkite health digest for the quarantined `test_login_remote` tests that reads the soft-fail step's real pass/fail from the Buildkite API, separates external `*.wpmt.co` timeouts from genuine failures, and posts a summary to Slack.
 
 ## [0.5.0] - 2026-06-18
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'buildkit', '~> 1.6'
 gem 'fastlane', '~> 2.237'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.10'
 gem 'fluent-tools', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  buildkit (~> 1.6)
   faraday (~> 1.10)
   fastlane (~> 2.237)
   fastlane-plugin-wpmreleasetoolkit (~> 14.10)

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,10 @@ test-rust-integration-remote-login:
 	@# Help: Run the flaky external login-discovery tests (ignored in the main suite; hit real *.wpmt.co sites).
 	$(rust_docker_run) cargo test --package wp_api_integration_tests --test test_login_remote -- --ignored --nocapture
 
+report-remote-login-integration-test-suite-health:
+	@# Help: Post the remote login integration-test-suite health digest to Slack (needs BUILDKITE_TOKEN + SLACK_WEBHOOK).
+	bundle exec fastlane report_remote_login_integration_test_suite_health
+
 test-kotlin-integration:
 	@# Help: Run Kotlin integration tests in test server.
 	docker exec -i wordpress /bin/bash < ./scripts/run-kotlin-integration-tests.sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -516,21 +516,20 @@ lane :report_remote_login_integration_test_suite_health do
   require 'net/http'
   require 'json'
 
-  api_token = ENV['BUILDKITE_TOKEN'] || ENV['BUILDKITE_API_TOKEN'] ||
-              UI.user_error!('Set BUILDKITE_TOKEN (with the read_builds scope) to run this lane.')
+  api_token = get_required_env!('BUILDKITE_TOKEN')
   slack_webhook = get_required_env!('SLACK_WEBHOOK')
   days = Integer(ENV.fetch('REPORT_DAYS', '7'))
 
   org = 'automattic'
-  pipeline = 'wordpress-rs'
+  pipeline = PROJECT_NAME
   slack_channel = '#wordpress-rs'
   step_label = 'Remote Login Discovery' # substring of the soft-fail step's label
   investigate_cap = 3
   timeout_signature = /HttpTimeoutError|timed out/
   created_from = (Time.now.utc - (days * 86_400)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
-  # The step is soft-fail, so its failures never reach GitHub. Read each run's real
-  # exit_status from the Buildkite API instead. Builds come back newest-first.
+  # Read each run's real exit_status from the Buildkite API for accuracy.
+  # Builds come back newest-first.
   client = Buildkit.new(token: api_token)
   client.auto_paginate = true
   runs = client.pipeline_builds(org, pipeline, created_from: created_from, per_page: 100).flat_map do |build|
@@ -560,7 +559,7 @@ lane :report_remote_login_integration_test_suite_health do
   total = runs.size
   passed = runs.count { |run| run[:exit_status].zero? }
 
-  # --- Compose the Slack digest ---
+  # Compose the Slack digest.
   section = ->(text) { { type: 'section', text: { type: 'mrkdwn', text: text } } }
   header = "*Remote Login Discovery — Integration Test Suite Health*  ·  last #{days} days"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -510,6 +510,91 @@ lane :set_up_signing_release do |readonly: true|
   set_up_certificate_in_keychain(type: 'appstore', readonly: readonly)
 end
 
+desc 'Post a Slack health digest for the quarantined remote login-discovery integration tests'
+lane :report_remote_login_integration_test_suite_health do
+  require 'buildkit'
+  require 'net/http'
+  require 'json'
+
+  api_token = ENV['BUILDKITE_TOKEN'] || ENV['BUILDKITE_API_TOKEN'] ||
+              UI.user_error!('Set BUILDKITE_TOKEN (with the read_builds scope) to run this lane.')
+  slack_webhook = get_required_env!('SLACK_WEBHOOK')
+  days = Integer(ENV.fetch('REPORT_DAYS', '7'))
+
+  org = 'automattic'
+  pipeline = 'wordpress-rs'
+  slack_channel = '#wordpress-rs'
+  step_label = 'Remote Login Discovery' # substring of the soft-fail step's label
+  investigate_cap = 3
+  timeout_signature = /HttpTimeoutError|timed out/
+  created_from = (Time.now.utc - (days * 86_400)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+  # The step is soft-fail, so its failures never reach GitHub. Read each run's real
+  # exit_status from the Buildkite API instead. Builds come back newest-first.
+  client = Buildkit.new(token: api_token)
+  client.auto_paginate = true
+  runs = client.pipeline_builds(org, pipeline, created_from: created_from, per_page: 100).flat_map do |build|
+    Array(build.jobs).filter_map do |job|
+      next unless job.respond_to?(:name) && job.name.to_s.include?(step_label)
+      next if job.respond_to?(:retried) && job.retried
+      next if !job.respond_to?(:exit_status) || job.exit_status.nil?
+
+      { build: build.number, url: build.web_url, job_id: job.id, exit_status: job.exit_status }
+    end
+  end
+
+  # Bucket each failed run: timeouts are expected/flaky; anything else is worth investigating.
+  timeouts = 0
+  other = []
+  runs.reject { |run| run[:exit_status].zero? }.each do |run|
+    log = client.job_log(org, pipeline, run[:build], run[:job_id])
+    content = log.respond_to?(:content) ? log.content.to_s : ''
+    if content.match?(timeout_signature)
+      timeouts += 1
+    else
+      failed = content.scan(/(login_spec_[a-z0-9_]+) \.\.\. FAILED/).flatten.uniq
+      other << { build: run[:build], url: run[:url], test: failed.empty? ? 'unknown' : failed.join(', ') }
+    end
+  end
+
+  total = runs.size
+  passed = runs.count { |run| run[:exit_status].zero? }
+
+  # --- Compose the Slack digest ---
+  section = ->(text) { { type: 'section', text: { type: 'mrkdwn', text: text } } }
+  header = "*Remote Login Discovery — Integration Test Suite Health*  ·  last #{days} days"
+
+  blocks =
+    if total.zero?
+      [section.call("#{header}\nThe step did not run in this window.")]
+    else
+      pct = ->(count) { (count * 100.0 / total).round }
+      table = [
+        format('%-13s %3d%%  (%d/%d)', 'Pass rate', pct.call(passed), passed, total),
+        format('%-13s %3d%%  (%d/%d)', 'Timeout Error', pct.call(timeouts), timeouts, total),
+        format('%-13s %3d%%  (%d/%d)', 'Other Errors', pct.call(other.size), other.size, total)
+      ].join("\n")
+      digest = [section.call("#{header}\n```\n#{table}\n```")]
+      if other.any?
+        capped = other.size > investigate_cap ? " (showing #{investigate_cap})" : ''
+        listed = other.first(investigate_cap).map { |o| "• <#{o[:url]}|#{o[:build]}> · `#{o[:test]}`" }
+        digest << section.call(":warning: *#{other.size} failures need investigating#{capped}:*\n#{listed.join("\n")}")
+      end
+      digest
+    end
+
+  payload = {
+    channel: slack_channel,
+    username: 'wordpress-rs CI',
+    icon_emoji: ':mag:',
+    attachments: [{ color: other.empty? ? 'good' : 'danger', blocks: blocks }]
+  }
+  response = Net::HTTP.post(URI.parse(slack_webhook), payload.to_json, 'Content-Type' => 'application/json')
+  UI.user_error!("Slack returned #{response.code}: #{response.body}") unless response.is_a?(Net::HTTPSuccess)
+
+  UI.success("Posted digest: #{total} runs, #{timeouts} timeout, #{other.size} other.")
+end
+
 # Utils
 
 XCFRAMEWORK_COMMENT_MARKER = '<!-- wordpress-rs-xcframework-build -->'


### PR DESCRIPTION
## Description

Adds a scheduled Buildkite pipeline plus a Fastlane lane (`report_remote_login_integration_test_suite_health`) that post a weekly Slack digest of the quarantined `test_login_remote` step: pass rate and timeout-vs-other error counts, read from the Buildkite API with failing runs linked for investigation.


## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
