### PR TITLE
Replace `rust-android-gradle` with `cargo-ndk`

### DIFF
--- a/.buildkite/build-android-rust-target.sh
+++ b/.buildkite/build-android-rust-target.sh
@@ -23,6 +23,9 @@ esac
 # Only install the single target needed — no Apple targets or nightly toolchain
 rustup target add "$RUST_TARGET"
 
+echo "--- :package: Installing cargo-ndk"
+cargo install cargo-ndk --locked
+
 # This is a temporary step until we implement a more graceful way to handle missing credentials
 printf "site_url\nadmin_username\nadmin_password\nadmin_password_uuid\nsubscriber_username\nsubscriber_password\nsubscriber_password_uuid\n" > test_credentials
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 
+### Changed
+
+- **Internal:** Build the Android JNI libraries with `cargo-ndk` instead of the `rust-android-gradle` Gradle plugin.
+
 ## [0.6.0] - 2026-07-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,7 @@ setup-rust-android-targets:
 		i686-linux-android \
 		armv7-linux-androideabi \
 		aarch64-linux-android
+	cargo install cargo-ndk --locked
 
 run-wp-cli-command:
 	@docker exec wordpress /bin/bash -c "wp --allow-root $(ARGS)"

--- a/native/kotlin/api/android/build.gradle.kts
+++ b/native/kotlin/api/android/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
-    id("org.mozilla.rust-android-gradle.rust-android")
     id("com.automattic.android.publish-to-s3")
 }
 
@@ -47,7 +46,10 @@ android {
     // file - at least for now.
     lint.baseline = file("${project.rootDir}/config/lint/baseline.xml")
 
-    sourceSets["androidTest"].jniLibs.srcDirs.plus("${layout.buildDirectory.get()}/rustJniLibs/android")
+    // The Rust `.so` files produced by the `cargoBuild` task (below) are written here; registering
+    // the directory as a jniLibs source set makes AGP package them into the AAR and the test APK.
+    sourceSets["main"].jniLibs.srcDir("${layout.buildDirectory.get()}/rustJniLibs/android")
+    sourceSets["androidTest"].jniLibs.srcDir("${layout.buildDirectory.get()}/rustJniLibs/android")
 }
 
 dependencies {
@@ -83,27 +85,69 @@ dependencies {
     testImplementation(libs.jna)
 }
 
-val cargoProjectRoot = rootProject.ext.get("cargoProjectRoot")!!
-val moduleName = rootProject.ext.get("rustPrimaryModule").toString()
-cargo {
-    cargoCommand = rootProject.ext.get("cargoBinaryPath").toString()
-    rustcCommand = rootProject.ext.get("rustcBinaryPath").toString()
-    module = "$cargoProjectRoot/$moduleName/"
-    libname = moduleName
-    profile = "release"
-    targets = if (project.hasProperty("cargoTarget")) {
-        listOf(project.property("cargoTarget").toString())
-    } else {
-        listOf("arm", "arm64", "x86", "x86_64")
-    }
-    targetDirectory = "$cargoProjectRoot/target"
-    exec = { spec: ExecSpec, _: com.nishtahir.Toolchain ->
-        // https://doc.rust-lang.org/rustc/command-line-arguments.html#-g-include-debug-information
-        spec.environment("RUSTFLAGS", "-g")
+// --- Rust native library build ---
+//
+// Cross-compiles the Rust crate for each Android ABI with `cargo ndk`, writing the resulting `.so`
+// files to `build/rustJniLibs/android/<abi>/` — registered as a jniLibs source directory above so
+// AGP packages them into the AAR.
+//
+// Requires the `cargo-ndk` cargo subcommand (`cargo install cargo-ndk`) and the NDK named by
+// `ndkVersion` above to be installed.
+val cargoProjectRoot = rootProject.ext.get("cargoProjectRoot").toString()
+val rustModule = rootProject.ext.get("rustPrimaryModule").toString()
+val rustJniLibsDir = layout.buildDirectory.dir("rustJniLibs/android")
+
+// Map the `-PcargoTarget` name passed for single-ABI builds (e.g. `arm64`) to the Android ABI
+// understood by `cargo ndk`. With no property set, all four ABIs are built.
+val gradleTargetToAbi = mapOf(
+    "arm" to "armeabi-v7a",
+    "arm64" to "arm64-v8a",
+    "x86" to "x86",
+    "x86_64" to "x86_64",
+)
+val cargoAbis: List<String> = project.findProperty("cargoTarget")?.let { property ->
+    val target = property.toString()
+    listOf(gradleTargetToAbi[target] ?: error("Unknown cargoTarget '$target'"))
+} ?: gradleTargetToAbi.values.toList()
+
+tasks.register<Exec>("cargoBuild") {
+    group = "rust"
+    description = "Cross-compiles the Rust native library for Android via cargo-ndk"
+
+    workingDir(cargoProjectRoot)
+
+    // Point cargo-ndk at the same NDK that AGP is configured to use.
+    environment("ANDROID_NDK_HOME", android.sdkDirectory.resolve("ndk/${android.ndkVersion}").absolutePath)
+    // Include debug information in the release build.
+    environment("RUSTFLAGS", "-g")
+
+    commandLine(
+        buildList {
+            add(rootProject.ext.get("cargoBinaryPath").toString())
+            add("ndk")
+            add("--output-dir"); add(rustJniLibsDir.get().asFile.absolutePath)
+            add("--platform"); add(libs.versions.android.minSdk.get())
+            cargoAbis.forEach { abi -> add("-t"); add(abi) }
+            add("build"); add("--release"); add("--package"); add(rustModule)
+        }
+    )
+
+    outputs.dir(rustJniLibsDir)
+
+    doLast {
+        // cargo-ndk copies every cdylib the build produces; keep only the primary library. `wp_api`
+        // also declares a `cdylib` crate type, but its code is statically linked into
+        // `libwp_mobile.so` — the single library the generated UniFFI bindings load — so its
+        // standalone `.so` is redundant weight in the AAR.
+        val keep = "lib$rustModule.so"
+        rustJniLibsDir.get().asFile.walkTopDown()
+            .filter { it.isFile && it.extension == "so" && it.name != keep }
+            .forEach { it.delete() }
     }
 }
+
 tasks.matching { it.name.matches("merge.*JniLibFolders".toRegex()) }.configureEach {
-    inputs.dir(File("${layout.buildDirectory.get()}/rustJniLibs/android"))
+    inputs.dir(rustJniLibsDir)
     dependsOn("cargoBuild")
 }
 

--- a/native/kotlin/api/kotlin/build.gradle.kts
+++ b/native/kotlin/api/kotlin/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    alias(libs.plugins.rustAndroid)
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.publishToS3)

--- a/native/kotlin/build.gradle.kts
+++ b/native/kotlin/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinSerialization) apply false
-    alias(libs.plugins.rustAndroid) apply false
     alias(libs.plugins.publishToS3) apply false
 
     alias(libs.plugins.detekt)

--- a/native/kotlin/gradle/libs.versions.toml
+++ b/native/kotlin/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ okHttp = "5.4.0"
 navigation = "2.9.8"
 navigationCompose = "2.9.2"
 publish-to-s3-plugin = "0.10.0"
-rust-android-plugin = "0.9.6"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -61,4 +60,3 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 publishToS3 = { id = "com.automattic.android.publish-to-s3", version.ref = "publish-to-s3-plugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-rustAndroid = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rust-android-plugin" }


### PR DESCRIPTION
## Description

Builds the Android JNI libraries with the `cargo-ndk` cargo subcommand instead of the `org.mozilla.rust-android-gradle` Gradle plugin. The plugin has no Android Gradle Plugin 9 support, which blocks upgrading AGP.

## Changes

- Remove the `rust-android-gradle` plugin from the version catalog and all modules (it was unused in `:api:kotlin`).
- Reimplement `:api:android:cargoBuild` as a Gradle `Exec` task that runs `cargo ndk`, keeping the task name, `-PcargoTarget` ABI names, and `build/rustJniLibs/android/<abi>/` output path.
- Prune all but `libwp_mobile.so` from the output, since `cargo-ndk` copies every cdylib the build produces.
- Install `cargo-ndk` in the Android target CI script.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`.
