### PR TITLE
Add start_date and stat_fields support to stats/visits endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- WordPress.com `GET /sites/<site_id>/stats/visits` now supports the `start_date` and `stat_fields` query parameters. `StatsVisitsParams` gained a `start_date: Option<String>` field and a `stat_fields: Option<StatsVisitsFields>` field (a type-safe comma-separated list of the new `StatsVisitsField` enum: `Views`, `Visitors`, `Likes`, `Reblogs`, `Comments`, `Posts`).
+- WordPress.com `GET /sites/<site_id>/stats/visits` now supports the `start_date` and `stat_fields` query parameters. `StatsVisitsParams` gained a `start_date: Option<String>` field and a `stat_fields: Vec<StatsVisitsField>` field, where `StatsVisitsField` is a new enum (`Views`, `Visitors`, `Likes`, `Reblogs`, `Comments`, `Posts`). An empty `stat_fields` omits the parameter, letting the API return its default set of fields.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- WordPress.com `GET /sites/<site_id>/stats/visits` now supports the `start_date` and `stat_fields` query parameters. `StatsVisitsParams` gained a `start_date: Option<String>` field and a `stat_fields: Option<StatsVisitsFields>` field (a type-safe comma-separated list of the new `StatsVisitsField` enum: `Views`, `Visitors`, `Likes`, `Reblogs`, `Comments`, `Posts`).
+
 ### Changed
 
 - Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -106,7 +106,12 @@ impl AppendUrlQueryPairs for StatsVisitsParams {
             .append_option_query_value_pair("quantity", self.quantity.as_ref())
             .append_option_query_value_pair("date", self.end_date.as_ref())
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
-            .append_option_query_value_pair("stat_fields", self.stat_fields.as_ref())
+            .append_option_query_value_pair(
+                "stat_fields",
+                self.stat_fields
+                    .as_ref()
+                    .filter(|fields| !fields.0.is_empty()),
+            )
             .append_option_query_value_pair("locale", self.locale.as_ref());
     }
 }

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -340,6 +340,30 @@ mod tests {
     }
 
     #[test]
+    fn test_stats_visits_params_serialization_with_empty_stat_fields() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits")
+                .expect("Failed to parse url");
+
+        let params = StatsVisitsParams {
+            unit: Some(StatsVisitsUnit::Day),
+            quantity: Some(7),
+            end_date: None,
+            start_date: None,
+            stat_fields: Some(StatsVisitsFields(vec![])),
+            locale: None,
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=day&quantity=7"
+        );
+    }
+
+    #[test]
     fn test_stats_visits_fields_display() {
         assert_eq!(
             StatsVisitsFields(vec![

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -60,20 +60,7 @@ pub enum StatsVisitsField {
     Posts,
 }
 
-uniffi::custom_newtype!(StatsVisitsFields, Vec<StatsVisitsField>);
-/// The stat fields to include in the stats visits response.
-/// An empty vec results in the API returning its default set of fields.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatsVisitsFields(pub Vec<StatsVisitsField>);
-
-impl std::fmt::Display for StatsVisitsFields {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let joined: Vec<_> = self.0.iter().map(|field| field.to_string()).collect();
-        write!(f, "{}", joined.join(","))
-    }
-}
-
-impl_as_query_value_from_to_string!(StatsVisitsFields);
+impl_as_query_value_from_to_string!(StatsVisitsField);
 
 /// Parameters for the stats visits endpoint.
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
@@ -91,9 +78,9 @@ pub struct StatsVisitsParams {
     #[uniffi(default = None)]
     pub start_date: Option<String>,
     /// The specific stat fields to include in the response.
-    /// When `None`, the API returns its default set of fields.
-    #[uniffi(default = None)]
-    pub stat_fields: Option<StatsVisitsFields>,
+    /// When empty, the API returns its default set of fields.
+    #[uniffi(default = [])]
+    pub stat_fields: Vec<StatsVisitsField>,
     /// The locale for the response.
     #[uniffi(default = None)]
     pub locale: Option<WPComLanguage>,
@@ -106,12 +93,7 @@ impl AppendUrlQueryPairs for StatsVisitsParams {
             .append_option_query_value_pair("quantity", self.quantity.as_ref())
             .append_option_query_value_pair("date", self.end_date.as_ref())
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
-            .append_option_query_value_pair(
-                "stat_fields",
-                self.stat_fields
-                    .as_ref()
-                    .filter(|fields| !fields.0.is_empty()),
-            )
+            .append_vec_query_value_pair("stat_fields", self.stat_fields.as_ref())
             .append_option_query_value_pair("locale", self.locale.as_ref());
     }
 }
@@ -280,7 +262,7 @@ mod tests {
             quantity: Some(24),
             end_date: Some("2025-01-15".to_string()),
             start_date: None,
-            stat_fields: None,
+            stat_fields: vec![],
             locale: Some(WPComLanguage::English),
         };
 
@@ -304,7 +286,7 @@ mod tests {
             quantity: Some(7),
             end_date: None,
             start_date: None,
-            stat_fields: None,
+            stat_fields: vec![],
             locale: None,
         };
 
@@ -328,10 +310,7 @@ mod tests {
             quantity: Some(12),
             end_date: Some("2026-07-13".to_string()),
             start_date: Some("2025-08-01".to_string()),
-            stat_fields: Some(StatsVisitsFields(vec![
-                StatsVisitsField::Views,
-                StatsVisitsField::Visitors,
-            ])),
+            stat_fields: vec![StatsVisitsField::Views, StatsVisitsField::Visitors],
             locale: None,
         };
 
@@ -355,7 +334,7 @@ mod tests {
             quantity: Some(7),
             end_date: None,
             start_date: None,
-            stat_fields: Some(StatsVisitsFields(vec![])),
+            stat_fields: vec![],
             locale: None,
         };
 
@@ -366,25 +345,6 @@ mod tests {
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=day&quantity=7"
         );
-    }
-
-    #[test]
-    fn test_stats_visits_fields_display() {
-        assert_eq!(
-            StatsVisitsFields(vec![
-                StatsVisitsField::Views,
-                StatsVisitsField::Visitors,
-                StatsVisitsField::Likes,
-                StatsVisitsField::Comments,
-            ])
-            .to_string(),
-            "views,visitors,likes,comments"
-        );
-        assert_eq!(
-            StatsVisitsFields(vec![StatsVisitsField::Views]).to_string(),
-            "views"
-        );
-        assert_eq!(StatsVisitsFields(vec![]).to_string(), "");
     }
 
     #[rstest]

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -34,6 +34,47 @@ pub enum StatsVisitsUnit {
 
 impl_as_query_value_from_to_string!(StatsVisitsUnit);
 
+/// A stat field that can be requested from the stats visits endpoint.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum StatsVisitsField {
+    Views,
+    Visitors,
+    Likes,
+    Reblogs,
+    Comments,
+    Posts,
+}
+
+uniffi::custom_newtype!(StatsVisitsFields, Vec<StatsVisitsField>);
+/// The stat fields to include in the stats visits response.
+/// An empty vec results in the API returning its default set of fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatsVisitsFields(pub Vec<StatsVisitsField>);
+
+impl std::fmt::Display for StatsVisitsFields {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let joined: Vec<_> = self.0.iter().map(|field| field.to_string()).collect();
+        write!(f, "{}", joined.join(","))
+    }
+}
+
+impl_as_query_value_from_to_string!(StatsVisitsFields);
+
 /// Parameters for the stats visits endpoint.
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
 pub struct StatsVisitsParams {
@@ -46,6 +87,13 @@ pub struct StatsVisitsParams {
     /// The end date to query stats for (format: YYYY-MM-DD).
     #[uniffi(default = None)]
     pub end_date: Option<String>,
+    /// The start date to query stats for (format: YYYY-MM-DD).
+    #[uniffi(default = None)]
+    pub start_date: Option<String>,
+    /// The specific stat fields to include in the response.
+    /// When `None`, the API returns its default set of fields.
+    #[uniffi(default = None)]
+    pub stat_fields: Option<StatsVisitsFields>,
     /// The locale for the response.
     #[uniffi(default = None)]
     pub locale: Option<WPComLanguage>,
@@ -57,6 +105,8 @@ impl AppendUrlQueryPairs for StatsVisitsParams {
             .append_option_query_value_pair("unit", self.unit.as_ref())
             .append_option_query_value_pair("quantity", self.quantity.as_ref())
             .append_option_query_value_pair("date", self.end_date.as_ref())
+            .append_option_query_value_pair("start_date", self.start_date.as_ref())
+            .append_option_query_value_pair("stat_fields", self.stat_fields.as_ref())
             .append_option_query_value_pair("locale", self.locale.as_ref());
     }
 }
@@ -224,6 +274,8 @@ mod tests {
             unit: Some(StatsVisitsUnit::Hour),
             quantity: Some(24),
             end_date: Some("2025-01-15".to_string()),
+            start_date: None,
+            stat_fields: None,
             locale: Some(WPComLanguage::English),
         };
 
@@ -246,6 +298,8 @@ mod tests {
             unit: Some(StatsVisitsUnit::Day),
             quantity: Some(7),
             end_date: None,
+            start_date: None,
+            stat_fields: None,
             locale: None,
         };
 
@@ -256,6 +310,52 @@ mod tests {
             query_pairs.finish().as_str(),
             "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=day&quantity=7"
         );
+    }
+
+    #[test]
+    fn test_stats_visits_params_serialization_with_start_date_and_stat_fields() {
+        let mut url =
+            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits")
+                .expect("Failed to parse url");
+
+        let params = StatsVisitsParams {
+            unit: Some(StatsVisitsUnit::Month),
+            quantity: Some(12),
+            end_date: Some("2026-07-13".to_string()),
+            start_date: Some("2025-08-01".to_string()),
+            stat_fields: Some(StatsVisitsFields(vec![
+                StatsVisitsField::Views,
+                StatsVisitsField::Visitors,
+            ])),
+            locale: None,
+        };
+
+        let mut query_pairs = url.query_pairs_mut();
+        params.append_query_pairs(&mut query_pairs);
+
+        assert_eq!(
+            query_pairs.finish().as_str(),
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=month&quantity=12&date=2026-07-13&start_date=2025-08-01&stat_fields=views%2Cvisitors"
+        );
+    }
+
+    #[test]
+    fn test_stats_visits_fields_display() {
+        assert_eq!(
+            StatsVisitsFields(vec![
+                StatsVisitsField::Views,
+                StatsVisitsField::Visitors,
+                StatsVisitsField::Likes,
+                StatsVisitsField::Comments,
+            ])
+            .to_string(),
+            "views,visitors,likes,comments"
+        );
+        assert_eq!(
+            StatsVisitsFields(vec![StatsVisitsField::Views]).to_string(),
+            "views"
+        );
+        assert_eq!(StatsVisitsFields(vec![]).to_string(), "");
     }
 
     #[rstest]


### PR DESCRIPTION
## Description

The WordPress.com `GET /sites/<site_id>/stats/visits` endpoint accepts `start_date` and `stat_fields` query parameters, but `StatsVisitsParams` did not expose them — so calls like `.../stats/visits?unit=month&date=2026-07-13&start_date=2025-08-01&quantity=12&stat_fields=views,visitors` could not be fully expressed. This PR adds support for both.

## Changes

- Added `start_date: Option<String>` to `StatsVisitsParams` (format `YYYY-MM-DD`), following the pattern already used in `stats_utm.rs`.
- Added `stat_fields: Option<StatsVisitsFields>` to `StatsVisitsParams`. When `None`, the API returns its default set of fields.
- Added a `StatsVisitsField` enum (`Views`, `Visitors`, `Likes`, `Reblogs`, `Comments`, `Posts`) and a `StatsVisitsFields(Vec<StatsVisitsField>)` newtype whose `Display` joins values with commas, exposed to bindings via `uniffi::custom_newtype!` (mirrors the existing `StatsUtmKeys` pattern).
- Wired both parameters into `AppendUrlQueryPairs::append_query_pairs`.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)