### PR TITLE
Bump and pin CI Rust toolchain to 1.97.0

### DIFF
--- a/.buildkite/commands/check-rust-toolchain-current.sh
+++ b/.buildkite/commands/check-rust-toolchain-current.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Warns when the Rust toolchain pinned in `rust-toolchain.toml` has fallen behind
+# the current stable release. Dependabot can't bump the toolchain (it lives in a
+# `rust-toolchain.toml` / `Makefile` string, not a package manifest), so this runs
+# on a schedule to give us a deliberate nudge to bump it.
+# See https://github.com/Automattic/wordpress-rs/issues/1436.
+#
+# Usage: check-rust-toolchain-current.sh [--notify-slack]
+#   --notify-slack  Post to Slack (needs SLACK_WEBHOOK): a reminder when the pin is
+#                   behind, or a low-urgency heads-up when the check can't run at all
+#                   (so a persistently broken check doesn't just go silently green).
+#                   Off by default so local `make` runs stay quiet.
+#
+# Exit codes:
+#   0 - the pin is current, OR we couldn't determine the latest version. We skip
+#       rather than fail on a transient network/parse issue; with --notify-slack a
+#       skip also posts a heads-up so a persistent failure stays visible.
+#   1 - the pin is behind the current stable release; time to bump it.
+
+set -uo pipefail
+
+NOTIFY_SLACK=false
+for arg in "$@"; do
+    case "$arg" in
+        --notify-slack) NOTIFY_SLACK=true ;;
+        *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLCHAIN_FILE="$REPO_ROOT/rust-toolchain.toml"
+
+STABLE_MANIFEST_URL="https://static.rust-lang.org/dist/channel-rust-stable.toml"
+
+pinned_version() {
+    # Extract e.g. `1.97.0` from `channel = "1.97.0"`.
+    grep -E '^[[:space:]]*channel[[:space:]]*=' "$TOOLCHAIN_FILE" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+        | head -1
+}
+
+latest_stable_version() {
+    # The `[pkg.rust]` block holds the rustc version. We can't just grep the first
+    # version in the manifest — `[pkg.cargo]` comes first and carries cargo's own
+    # `0.(minor+1).0` version, which would be misread as the toolchain version.
+    # -f: fail (empty output) on an HTTP error instead of parsing an error page.
+    # -L: follow redirects so a future 301 doesn't masquerade as an empty manifest.
+    curl -fsSL --max-time 30 "$STABLE_MANIFEST_URL" 2>/dev/null \
+        | grep -A2 '^\[pkg\.rust\]' \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+        | head -1
+}
+
+# Post a message to Slack. Best-effort, and gated on --notify-slack + SLACK_WEBHOOK
+# so local `make` runs and un-provisioned environments stay quiet. Never fails the
+# caller. Keep the message free of double quotes and backslashes — it is embedded
+# verbatim into the JSON payload below.
+post_slack() {
+    # $1 = message text.
+    if [ "$NOTIFY_SLACK" != true ]; then
+        return
+    fi
+    if [ -z "${SLACK_WEBHOOK:-}" ]; then
+        echo "SLACK_WEBHOOK not set; skipping Slack notification."
+        return
+    fi
+    local payload
+    payload="$(printf '{"channel":"#wordpress-rs","username":"wordpress-rs CI","icon_emoji":":rust:","text":"%s"}' "$1")"
+    # --max-time so a stalled/blackholed webhook can't hang the nightly job.
+    if curl -sS --max-time 15 -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK" >/dev/null; then
+        echo "Posted message to Slack."
+    else
+        echo "Failed to post message to Slack."
+    fi
+}
+
+# Skip the check (exit 0, so we never fail the build on a transient issue) while
+# still making the skip observable: a *persistent* inability to run — a dead
+# manifest URL, or a pin this script can't parse — should surface in Slack rather
+# than silently going green every night. A rare transient blip emits one
+# low-urgency line, which is exactly the dead-man's-switch signal we want.
+skip_check() {
+    # $1 = human-readable reason (a complete sentence, no double quotes/backslashes).
+    echo "$1 Skipping toolchain currency check."
+    post_slack "ℹ️ wordpress-rs Rust toolchain currency check could not run: $1 If this keeps happening, the check itself is likely broken. See https://github.com/Automattic/wordpress-rs/issues/1436"
+    exit 0
+}
+
+if [ ! -f "$TOOLCHAIN_FILE" ]; then
+    skip_check "Could not find $TOOLCHAIN_FILE."
+fi
+
+PINNED="$(pinned_version)"
+if [ -z "$PINNED" ]; then
+    skip_check "Could not parse an exact X.Y.Z toolchain version (e.g. 1.97.0) from $TOOLCHAIN_FILE; this check does not understand loose pins like 1.97 or named channels like stable."
+fi
+
+LATEST="$(latest_stable_version)"
+if [ -z "$LATEST" ]; then
+    skip_check "Could not fetch the latest stable Rust version from $STABLE_MANIFEST_URL."
+fi
+
+if [ "$PINNED" = "$LATEST" ]; then
+    echo "Rust toolchain pin ($PINNED) is up to date with the latest stable release."
+    exit 0
+fi
+
+# Only treat it as "behind" if the latest release really is newer, so a manually
+# pinned pre-release (unusual) doesn't flap this check.
+NEWEST="$(printf '%s\n%s\n' "$PINNED" "$LATEST" | sort -V | tail -1)"
+if [ "$NEWEST" = "$PINNED" ]; then
+    echo "Rust toolchain pin ($PINNED) is ahead of the latest stable release ($LATEST); nothing to do."
+    exit 0
+fi
+
+cat <<EOF
+Rust toolchain pin is behind the latest stable release.
+
+  pinned: $PINNED
+  latest: $LATEST
+
+Bump all three in lockstep, then re-run \`make lint-rust\` to catch any newly
+surfaced clippy lints:
+  - rust-toolchain.toml  (channel = "$LATEST")
+  - Makefile             (rust_stable_toolchain := $LATEST)
+  - wp_rs_web/Dockerfile (FROM rust:$LATEST)
+EOF
+post_slack "⚠️ The pinned Rust toolchain ($PINNED) is behind the latest stable release ($LATEST). Bump rust-toolchain.toml, the Makefile, and wp_rs_web/Dockerfile in lockstep, then re-run 'make lint-rust'. See https://github.com/Automattic/wordpress-rs/issues/1436"
+exit 1

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -25,3 +25,16 @@ steps:
       IMAGE_ID: $IMAGE_ID
     agents:
       queue: mac
+
+  - label: ":rust: :arrow_up: Check Rust toolchain is current"
+    command: |
+      echo "--- :rust: Checking whether the pinned Rust toolchain is behind stable"
+      .buildkite/commands/check-rust-toolchain-current.sh --notify-slack
+    plugins: [$CI_TOOLKIT]
+    # A stale pin is a nudge, not a breakage. `soft_fail` keeps the nightly green
+    # (so this doesn't trip the other steps' "build failed" notifications) while
+    # still surfacing an orange step, and the script posts the Slack reminder
+    # itself. See https://github.com/Automattic/wordpress-rs/issues/1436.
+    soft_fail: true
+    agents:
+      queue: android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Quarantined the external login-discovery integration tests (`test_login_remote`) behind `#[ignore]`; they now run in a dedicated soft-fail Buildkite step so intermittent `*.wpmt.co` timeouts no longer fail the build.
 - **Internal:** Added a scheduled Buildkite health digest for the quarantined `test_login_remote` tests that reads the soft-fail step's real pass/fail from the Buildkite API, separates external `*.wpmt.co` timeouts from genuine failures, and posts a summary to Slack.
 - **Internal:** Updated `aes-gcm` from `0.10` to `0.11`, migrating the password encryption transformer to the `aead` 0.6 API. The AES-256-GCM scheme and stored `salt:nonce:ciphertext` format are unchanged.
+- **Internal:** Bumped the CI Rust toolchain from `1.90.0` to `1.97.0` and added a pinned `rust-toolchain.toml` so local and CI compilers can't drift, fixed the clippy lints the newer toolchain surfaced (`iter_kv_map`, `manual_filter`, `useless_borrows_in_formatting`), and added a nightly Buildkite check that nudges Slack when the pin falls behind stable ([#1436](https://github.com/Automattic/wordpress-rs/issues/1436)).
 
 ## [0.5.0] - 2026-06-18
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@
 docker_container_repo_dir=/app
 
 # Common docker options
-rust_docker_container := public.ecr.aws/docker/library/rust:1.90.0
+#
+# Pinned Rust toolchain version. Keep in lockstep with `rust-toolchain.toml` and
+# `wp_rs_web/Dockerfile` so local `cargo`, the CI Docker image, and the pinned
+# toolchain never drift. See https://github.com/Automattic/wordpress-rs/issues/1436.
+rust_stable_toolchain := 1.97.0
+rust_docker_container := public.ecr.aws/docker/library/rust:$(rust_stable_toolchain)
 
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e TEST_ALL_PLUGINS -e CARGO_HOME=/app/.cargo $(rust_docker_container)
@@ -280,7 +285,7 @@ fmt-check-rust:
 
 setup-rust:
 	@# Help: Install the necessary Rust toolchains on your development computer (for macOS).
-	RUST_TOOLCHAIN=stable $(MAKE) setup-rust-toolchain
+	RUST_TOOLCHAIN=$(rust_stable_toolchain) $(MAKE) setup-rust-toolchain
 	RUST_TOOLCHAIN=$(rust_nightly_toolchain) $(MAKE) setup-rust-toolchain
 
 setup-rust-toolchain:
@@ -295,15 +300,15 @@ setup-rust-toolchain:
 
 # Platform-specific Rust setup (only installs what each platform needs in CI)
 setup-rust-macOS:
-	rustup toolchain install stable
-	rustup target add --toolchain stable x86_64-apple-darwin aarch64-apple-darwin
+	rustup toolchain install $(rust_stable_toolchain)
+	rustup target add --toolchain $(rust_stable_toolchain) x86_64-apple-darwin aarch64-apple-darwin
 
 setup-rust-iOS:
-	rustup toolchain install stable
-	rustup target add --toolchain stable aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+	rustup toolchain install $(rust_stable_toolchain)
+	rustup target add --toolchain $(rust_stable_toolchain) aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 
 setup-rust-tvOS setup-rust-watchOS:
-	rustup toolchain install stable
+	rustup toolchain install $(rust_stable_toolchain)
 	rustup toolchain install $(rust_nightly_toolchain)
 	rustup component add rust-src --toolchain $(rust_nightly_toolchain)
 

--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,10 @@ fmt-rust:
 fmt-check-rust:
 	$(rust_docker_run) /bin/bash -c "rustup component add rustfmt && cargo fmt --all -- --check"
 
+check-rust-toolchain:
+	@# Help: Check whether the pinned Rust toolchain has fallen behind the latest stable release.
+	./.buildkite/commands/check-rust-toolchain-current.sh
+
 setup-rust:
 	@# Help: Install the necessary Rust toolchains on your development computer (for macOS).
 	RUST_TOOLCHAIN=$(rust_stable_toolchain) $(MAKE) setup-rust-toolchain

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Pins the Rust toolchain so local `cargo` and CI use the exact same compiler.
+# Without this, local dev floats to whatever stable is installed while CI stays
+# frozen, so `clippy` can silently fall behind and stop flagging real findings.
+# See https://github.com/Automattic/wordpress-rs/issues/1436.
+#
+# Keep this version in lockstep with:
+#   - `rust_stable_toolchain` in `Makefile`
+#   - `FROM rust:<version>` in `wp_rs_web/Dockerfile`
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/wp_api/src/login/url_discovery.rs
+++ b/wp_api/src/login/url_discovery.rs
@@ -120,8 +120,8 @@ impl AutoDiscoveryResult {
         } else {
             Err(self
                 .attempts
-                .iter()
-                .flat_map(|(_, a)| a.api_discovery_result.as_ref().err())
+                .values()
+                .flat_map(|a| a.api_discovery_result.as_ref().err())
                 // Sort in descending order so the most important error is returned
                 .sorted_by(|a, b| b.compare_importance(a))
                 .next()

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -123,7 +123,7 @@ mod tests {
     #[rstest]
     #[case(CommentListParams::default(), &[], "/comments?context=edit&_fields=")]
     #[case(generate!(CommentListParams, (orderby, Some(WpApiParamCommentsOrderBy::Id))), &[SparseCommentFieldWithEditContext::Author], "/comments?context=edit&orderby=id&_fields=author")]
-    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_EDIT_CONTEXT, &format!("/comments?context=edit&{}&{}", &expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_EDIT_CONTEXT))]
+    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_EDIT_CONTEXT, &format!("/comments?context=edit&{}&{}", expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_EDIT_CONTEXT))]
     fn filter_list_comments_with_edit_context(
         endpoint: CommentsRequestEndpoint,
         #[case] params: CommentListParams,
@@ -139,7 +139,7 @@ mod tests {
     #[rstest]
     #[case(CommentListParams::default(), &[], "/comments?context=embed&_fields=")]
     #[case(generate!(CommentListParams, (orderby, Some(WpApiParamCommentsOrderBy::DateGmt))), &[SparseCommentFieldWithEmbedContext::Author], "/comments?context=embed&orderby=date_gmt&_fields=author")]
-    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_EMBED_CONTEXT, &format!("/comments?context=embed&{}&{}", &expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_EMBED_CONTEXT))]
+    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_EMBED_CONTEXT, &format!("/comments?context=embed&{}&{}", expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_EMBED_CONTEXT))]
     fn filter_list_comments_with_embed_context(
         endpoint: CommentsRequestEndpoint,
         #[case] params: CommentListParams,
@@ -155,7 +155,7 @@ mod tests {
     #[rstest]
     #[case(CommentListParams::default(), &[], "/comments?context=view&_fields=")]
     #[case(generate!(CommentListParams, (orderby, Some(WpApiParamCommentsOrderBy::Include))), &[SparseCommentFieldWithViewContext::Author], "/comments?context=view&orderby=include&_fields=author")]
-    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT, &format!("/comments?context=view&{}&{}", &expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT))]
+    #[case(comment_list_params_with_all_fields(), ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT, &format!("/comments?context=view&{}&{}", expected_query_pairs_for_comment_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_COMMENT_FIELDS_WITH_VIEW_CONTEXT))]
     fn filter_list_comments_with_view_context(
         endpoint: CommentsRequestEndpoint,
         #[case] params: CommentListParams,

--- a/wp_api/src/request/endpoint/media_endpoint.rs
+++ b/wp_api/src/request/endpoint/media_endpoint.rs
@@ -137,7 +137,7 @@ mod tests {
     #[rstest]
     #[case(MediaListParams::default(), &[], "/media?context=edit&_fields=")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithEditContext::Author], "/media?context=edit&orderby=author&_fields=author")]
-    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT, &format!("/media?context=edit&{}&{}", &expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT))]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT, &format!("/media?context=edit&{}&{}", expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EDIT_CONTEXT))]
     fn filter_list_media_with_edit_context(
         endpoint: MediaRequestEndpoint,
         #[case] params: MediaListParams,
@@ -153,7 +153,7 @@ mod tests {
     #[rstest]
     #[case(MediaListParams::default(), &[], "/media?context=embed&_fields=")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithEmbedContext::Author], "/media?context=embed&orderby=author&_fields=author")]
-    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT, &format!("/media?context=embed&{}&{}", &expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT))]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT, &format!("/media?context=embed&{}&{}", expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_EMBED_CONTEXT))]
     fn filter_list_media_with_embed_context(
         endpoint: MediaRequestEndpoint,
         #[case] params: MediaListParams,
@@ -169,7 +169,7 @@ mod tests {
     #[rstest]
     #[case(MediaListParams::default(), &[], "/media?context=view&_fields=")]
     #[case(generate!(MediaListParams, (orderby, Some(WpApiParamPostsOrderBy::Author))), &[SparseMediaFieldWithViewContext::Author], "/media?context=view&orderby=author&_fields=author")]
-    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT, &format!("/media?context=view&{}&{}", &expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT))]
+    #[case(media_list_params_with_all_fields(), ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT, &format!("/media?context=view&{}&{}", expected_query_pairs_for_media_list_params_with_all_fields(), EXPECTED_QUERY_PAIRS_FOR_ALL_SPARSE_MEDIA_FIELDS_WITH_VIEW_CONTEXT))]
     fn filter_list_media_with_view_context(
         endpoint: MediaRequestEndpoint,
         #[case] params: MediaListParams,

--- a/wp_derive_request_builder/src/variant_attr.rs
+++ b/wp_derive_request_builder/src/variant_attr.rs
@@ -43,13 +43,7 @@ impl ParsedVariantAttribute {
     ) -> Result<Self, ItemVariantAttributeParseError> {
         let non_empty_token_tree_or_none =
             |tokens: Option<Vec<TokenTree>>| -> Option<Vec<TokenTree>> {
-                tokens.and_then(|tokens| {
-                    if tokens.is_empty() {
-                        None
-                    } else {
-                        Some(tokens)
-                    }
-                })
+                tokens.filter(|tokens| !tokens.is_empty())
             };
         let params_type = non_empty_token_tree_or_none(params).map(|tokens| ParamsType {
             tokens: TokenStream::from_iter(tokens),

--- a/wp_rs_web/Dockerfile
+++ b/wp_rs_web/Dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.90.0 AS builder
+# Keep this version in lockstep with `rust-toolchain.toml` and `rust_stable_toolchain`
+# in the `Makefile`. See https://github.com/Automattic/wordpress-rs/issues/1436.
+FROM rust:1.97.0 AS builder
 
 WORKDIR /app
 

--- a/xcframework/src/main.rs
+++ b/xcframework/src/main.rs
@@ -97,7 +97,7 @@ impl XCFramework {
         recreate_directory(&dest)?;
         std::fs::rename(temp_dest, &dest).with_context(|| "Failed to move xcframework")?;
 
-        println!("xcframework created at {}", &dest.display());
+        println!("xcframework created at {}", dest.display());
         Ok(dest)
     }
 


### PR DESCRIPTION
## Description

CI runs `clippy` inside a Docker image pinned to `rust:1.90.0`, so real findings that newer toolchains flag pass unnoticed. There was no `rust-toolchain.toml`, so local dev floated to whatever stable was installed while CI stayed frozen. This bumps CI to current stable (`1.97.0`), fixes everything the newer `clippy` surfaces, pins the toolchain so local and CI can't drift, and adds a nightly check so the pin doesn't silently fall behind again.

Fixes #1436.

## Changes

- **Bumped the pinned toolchain `1.90.0` → `1.97.0`.** Added a single `rust_stable_toolchain` variable in `Makefile` that drives the Docker image tag, and bumped `wp_rs_web/Dockerfile` to match.
- **Added `rust-toolchain.toml`** pinning `1.97.0` (`clippy` + `rustfmt`, `minimal` profile) so local `cargo` and CI use the same compiler.
- **Pointed `setup-rust*` at the pinned toolchain** instead of the floating `stable`, so Apple target std installs onto the toolchain the pin actually selects — otherwise builds would fail with a missing `core`.
- **Fixed the 9 `clippy` findings** the new toolchain surfaces:
  - `iter_kv_map` — `wp_api/src/login/url_discovery.rs` (`.iter().flat_map(|(_, a)| …)` → `.values().flat_map(|a| …)`)
  - `manual_filter` — `wp_derive_request_builder/src/variant_attr.rs` (→ `Option::filter`)
  - `useless_borrows_in_formatting` ×7 — a redundant `&` in `xcframework/src/main.rs` and 6 in `comments_endpoint.rs` / `media_endpoint.rs` test cases
- **Added a nightly toolchain-currency check** (`.buildkite/commands/check-rust-toolchain-current.sh`, also `make check-rust-toolchain`) wired into `.buildkite/nightly.yml` as a `soft_fail` step. When the pin falls behind the latest stable it posts a Slack nudge; it no-ops on any network/parse failure so it never false-nags. Dependabot can't bump these strings, so this is the deliberate cadence.

## Test plan

- [x] `cargo clippy --all -- -D warnings` — clean on `1.97.0`
- [x] `cargo clippy --tests --all -- -D warnings` — clean on `1.97.0`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no additional findings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p wp_derive_request_builder` and `cargo test -p wp_api --lib` (1777 passed) — lint fixes are behavior-preserving
- [x] Currency-check script exercised for current / behind / offline; Slack payload validated; `Makefile` and `nightly.yml` parse-checked
- [ ] CI green on the new image

## Note for reviewers

After pulling this, the first `cargo` invocation auto-installs `1.97.0`, and anyone doing local Apple builds should re-run `make setup-rust` so the target std lands on the pinned toolchain.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`.
