### PR TITLE
Add configurable default OkHttp timeouts to the Kotlin `DefaultHttpClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Kotlin: `WpHttpClient.DefaultHttpClient` now applies more forgiving default OkHttp timeouts (connect 15s, read 60s, write 60s) instead of relying on OkHttp's 10s per-operation defaults, preventing premature timeouts when fetching large or slow-to-render responses. The values are configurable via a new `HttpClientTimeouts` type, accepted by both `DefaultHttpClient` and the `WpRequestExecutor` convenience constructor so callers can override them without building an `OkHttpClient` by hand.
 - Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.
 - Self-hosted login and endpoint requests now work against sites with plain permalinks. Previously, the client path-extended the discovered `?rest_route=/` API root, producing URLs like `…/index.php/wp/v2/users/me?rest_route=/` that WordPress collapsed to the API index ([#1366](https://github.com/Automattic/wordpress-rs/issues/1366)).
 - **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpHttpClient.kt
@@ -3,14 +3,35 @@ package rs.wordpress.api.kotlin
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.internal.tls.OkHostnameVerifier
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSession
+
+/**
+ * Client-wide OkHttp timeouts applied by [WpHttpClient.DefaultHttpClient].
+ *
+ * OkHttp's built-in per-operation defaults are 10s, which is too short for slow sites or large
+ * responses. These defaults are more forgiving; override any of them by passing a custom instance
+ * to [WpHttpClient.DefaultHttpClient] or the [WpRequestExecutor] convenience constructor.
+ */
+data class HttpClientTimeouts(
+    val connectTimeoutSeconds: Long = DEFAULT_CONNECT_TIMEOUT_SECONDS,
+    val readTimeoutSeconds: Long = DEFAULT_READ_TIMEOUT_SECONDS,
+    val writeTimeoutSeconds: Long = DEFAULT_WRITE_TIMEOUT_SECONDS,
+) {
+    companion object {
+        const val DEFAULT_CONNECT_TIMEOUT_SECONDS = 15L
+        const val DEFAULT_READ_TIMEOUT_SECONDS = 60L
+        const val DEFAULT_WRITE_TIMEOUT_SECONDS = 60L
+    }
+}
 
 sealed class WpHttpClient {
     abstract fun getClient(): OkHttpClient
 
     class DefaultHttpClient(
-        private val interceptors: List<Interceptor>
+        private val interceptors: List<Interceptor>,
+        private val timeouts: HttpClientTimeouts = HttpClientTimeouts(),
     ) : WpHttpClient() {
         private var allowedHostnames: Map<String, List<String>> = emptyMap()
 
@@ -27,6 +48,9 @@ sealed class WpHttpClient {
             return OkHttpClient.Builder().apply {
                 this@DefaultHttpClient.interceptors.forEach { addInterceptor(it) }
                 hostnameVerifier(WpRequestExecutorHostnameVerifier(allowedHostnames))
+                connectTimeout(timeouts.connectTimeoutSeconds, TimeUnit.SECONDS)
+                readTimeout(timeouts.readTimeoutSeconds, TimeUnit.SECONDS)
+                writeTimeout(timeouts.writeTimeoutSeconds, TimeUnit.SECONDS)
             }.build()
         }
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -61,7 +61,9 @@ class WpRequestExecutor @JvmOverloads constructor(
 
     /**
      * Convenience constructor that accepts a list of OkHttp interceptors.
-     * Uses [WpHttpClient.DefaultHttpClient] internally with the provided interceptors.
+     * Uses [WpHttpClient.DefaultHttpClient] internally with the provided interceptors and
+     * [timeouts] (defaulting to [HttpClientTimeouts]'s more forgiving values), so callers can
+     * tune timeouts without building an [okhttp3.OkHttpClient] by hand.
      */
     @JvmOverloads
     constructor(
@@ -69,9 +71,10 @@ class WpRequestExecutor @JvmOverloads constructor(
         networkAvailabilityProvider: NetworkAvailabilityProvider,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         fileResolver: FileResolver = DefaultFileResolver(),
-        uploadListener: UploadListener? = null
+        uploadListener: UploadListener? = null,
+        timeouts: HttpClientTimeouts = HttpClientTimeouts(),
     ) : this(
-        httpClient = WpHttpClient.DefaultHttpClient(interceptors),
+        httpClient = WpHttpClient.DefaultHttpClient(interceptors, timeouts),
         networkAvailabilityProvider = networkAvailabilityProvider,
         dispatcher = dispatcher,
         fileResolver = fileResolver,


### PR DESCRIPTION
## Description

`DefaultHttpClient` relied on OkHttp's 10s per-operation defaults, which are too short for slow sites or large responses. Apply connect 15s / read 60s / write 60s as client-wide defaults, and make them configurable through a new `HttpClientTimeouts` type accepted by both `DefaultHttpClient` and the `WpRequestExecutor` convenience constructor, so callers can override timeouts without hand-building an `OkHttpClient`.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
