### PR TITLE
Adaptive batch size for fetching posts/media by ID (record only — not for merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Post metadata sync now retries fetching posts by ID with progressively smaller batch sizes (`100 → 20 → 5`) when a request times out, instead of failing the whole batch. This lets sites that can't render a large batch of posts within the request timeout still sync in smaller pieces.
+- Post and media metadata sync now retry fetching by ID with progressively smaller batch sizes (`100 → 20 → 5`) when a request times out, instead of failing the whole batch. This lets sites that can't render a large batch within the request timeout still sync in smaller pieces.
 - Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.
 - Self-hosted login and endpoint requests now work against sites with plain permalinks. Previously, the client path-extended the discovered `?rest_route=/` API root, producing URLs like `…/index.php/wp/v2/users/me?rest_route=/` that WordPress collapsed to the API index ([#1366](https://github.com/Automattic/wordpress-rs/issues/1366)).
 - **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Post metadata sync now retries fetching posts by ID with progressively smaller batch sizes (`100 → 20 → 5`) when a request times out, instead of failing the whole batch. This lets sites that can't render a large batch of posts within the request timeout still sync in smaller pieces.
 - Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.
 - Self-hosted login and endpoint requests now work against sites with plain permalinks. Previously, the client path-extended the discovered `?rest_route=/` API root, producing URLs like `…/index.php/wp/v2/users/me?rest_route=/` that WordPress collapsed to the API index ([#1366](https://github.com/Automattic/wordpress-rs/issues/1366)).
 - **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.

--- a/wp_mobile/src/collection/fetch_error.rs
+++ b/wp_mobile/src/collection/fetch_error.rs
@@ -1,4 +1,4 @@
-use wp_api::prelude::WpApiError;
+use wp_api::prelude::{RequestExecutionErrorReason, WpApiError};
 use wp_localization::{MessageBundle, WpMessages, WpSupportsLocalization};
 use wp_localization_macro::WpDeriveLocalizable;
 use wp_mobile_cache::SqliteDbError;
@@ -18,6 +18,19 @@ pub enum FetchError {
     /// A list refresh occurred while a load-more fetch was in-flight,
     /// making the paginated results stale.
     StaleLoadMore,
+}
+
+impl FetchError {
+    /// Whether this error is a request timeout, as opposed to any other failure.
+    pub fn is_timeout(&self) -> bool {
+        matches!(
+            self,
+            FetchError::Api(WpApiError::RequestExecutionFailed {
+                reason: RequestExecutionErrorReason::HttpTimeoutError,
+                ..
+            })
+        )
+    }
 }
 
 impl From<WpApiError> for FetchError {

--- a/wp_mobile/src/service/adaptive_batch.rs
+++ b/wp_mobile/src/service/adaptive_batch.rs
@@ -1,0 +1,198 @@
+use crate::collection::FetchError;
+use std::future::Future;
+
+/// Load items by ID, degrading the batch size on request timeouts.
+///
+/// `batch_sizes` lists the sizes to try, largest first (e.g. `[100, 20, 5]`).
+/// IDs are split into chunks of the current size and passed to `load_chunk`.
+/// When a chunk request times out (per [`FetchError::is_timeout`]) and a smaller
+/// size is available, that chunk is requeued at the next size down and retried.
+/// Items that still time out at the smallest size — or fail for any non-timeout
+/// reason — are counted as failed. This lets sites that can't render a large
+/// batch within the request timeout still sync in smaller pieces.
+///
+/// `load_chunk` performs the actual fetch for one chunk and returns the number
+/// of items in that chunk that failed to load (e.g. requested but not returned).
+/// It is responsible for any per-item state tracking, such as marking entities
+/// `Failed`. `entity_label` names the items in log messages (e.g. `"posts"`).
+///
+/// Returns the total number of items that failed to load.
+///
+/// ## State Access
+/// - None directly; all state is read/written by the caller's `load_chunk`.
+pub(crate) async fn load_with_adaptive_batching<Id, F, Fut>(
+    ids: &[Id],
+    batch_sizes: &[usize],
+    entity_label: &str,
+    load_chunk: F,
+) -> u32
+where
+    Id: Clone + std::fmt::Debug,
+    F: Fn(Vec<Id>) -> Fut,
+    Fut: Future<Output = Result<u32, FetchError>>,
+{
+    let mut failed_count: u32 = 0;
+    // Work items: a set of IDs plus the index into `batch_sizes` of the size to
+    // use for them. Used as a stack — a timed-out chunk is requeued at the next
+    // smaller size and retried before the remaining same-size chunks.
+    let mut pending: Vec<(Vec<Id>, usize)> = vec![(ids.to_vec(), 0)];
+
+    while let Some((batch_ids, size_index)) = pending.pop() {
+        let batch_size = batch_sizes[size_index];
+        for chunk in batch_ids.chunks(batch_size) {
+            match load_chunk(chunk.to_vec()).await {
+                Ok(chunk_failed_count) => failed_count += chunk_failed_count,
+                Err(e) => {
+                    if e.is_timeout() && size_index + 1 < batch_sizes.len() {
+                        log::debug!(
+                            "Fetching {} {} by ID timed out; retrying with batch size {}",
+                            chunk.len(),
+                            entity_label,
+                            batch_sizes[size_index + 1]
+                        );
+                        pending.push((chunk.to_vec(), size_index + 1));
+                    } else {
+                        log::warn!(
+                            "Failed to load {} {} (IDs: {:?}): {}",
+                            chunk.len(),
+                            entity_label,
+                            chunk,
+                            e
+                        );
+                        failed_count += chunk.len() as u32;
+                    }
+                }
+            }
+        }
+    }
+
+    failed_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use wp_api::prelude::{RequestExecutionErrorReason, RequestMethod, WpApiError};
+
+    const SIZES: &[usize] = &[100, 20, 5];
+
+    fn timeout_error() -> FetchError {
+        FetchError::Api(WpApiError::RequestExecutionFailed {
+            status_code: None,
+            redirects: None,
+            reason: RequestExecutionErrorReason::HttpTimeoutError,
+            request_url: "https://example.com".to_string(),
+            request_method: RequestMethod::GET,
+        })
+    }
+
+    fn non_timeout_error() -> FetchError {
+        FetchError::Database {
+            err_message: "boom".to_string(),
+        }
+    }
+
+    /// With no failures the largest batch size is used and nothing degrades.
+    #[tokio::test]
+    async fn uses_largest_size_and_returns_zero_when_all_succeed() {
+        let calls = RefCell::new(Vec::new());
+        let ids: Vec<i64> = (1..=250).collect();
+
+        let failed = load_with_adaptive_batching(&ids, SIZES, "posts", |chunk| {
+            calls.borrow_mut().push(chunk.len());
+            async move { Ok::<u32, FetchError>(0) }
+        })
+        .await;
+
+        assert_eq!(failed, 0);
+        assert_eq!(*calls.borrow(), vec![100, 100, 50]);
+    }
+
+    /// The per-chunk failed counts reported by `load_chunk` are summed.
+    #[tokio::test]
+    async fn accumulates_failed_counts_from_successful_loads() {
+        let ids: Vec<i64> = (1..=10).collect();
+
+        let failed = load_with_adaptive_batching(&ids, &[5], "posts", |_chunk| async move {
+            Ok::<u32, FetchError>(2)
+        })
+        .await;
+
+        // 10 ids / size 5 = 2 chunks, each reporting 2 failures.
+        assert_eq!(failed, 4);
+    }
+
+    /// A timeout degrades the batch size until the chunk is small enough to
+    /// succeed; every item loads with no failures.
+    #[tokio::test]
+    async fn degrades_batch_size_on_timeout() {
+        let calls = RefCell::new(Vec::new());
+        let ids: Vec<i64> = (1..=12).collect();
+
+        let failed = load_with_adaptive_batching(&ids, SIZES, "posts", |chunk| {
+            let len = chunk.len();
+            calls.borrow_mut().push(len);
+            async move { if len > 5 { Err(timeout_error()) } else { Ok(0) } }
+        })
+        .await;
+
+        assert_eq!(failed, 0);
+        // 12 @100 -> timeout, 12 @20 -> timeout, then [5, 5, 2] @5 all succeed.
+        assert_eq!(*calls.borrow(), vec![12, 12, 5, 5, 2]);
+    }
+
+    /// Non-timeout errors are counted as failed immediately, without retrying at
+    /// a smaller size.
+    #[tokio::test]
+    async fn non_timeout_errors_are_not_retried() {
+        let calls = RefCell::new(Vec::new());
+        let ids: Vec<i64> = (1..=12).collect();
+
+        let failed = load_with_adaptive_batching(&ids, SIZES, "posts", |chunk| {
+            calls.borrow_mut().push(chunk.len());
+            async move { Err::<u32, FetchError>(non_timeout_error()) }
+        })
+        .await;
+
+        assert_eq!(failed, 12);
+        assert_eq!(*calls.borrow(), vec![12]);
+    }
+
+    /// Items that keep timing out at the smallest size are counted as failed.
+    #[tokio::test]
+    async fn marks_failed_when_smallest_batch_still_times_out() {
+        let ids: Vec<i64> = (1..=12).collect();
+
+        let failed = load_with_adaptive_batching(&ids, SIZES, "posts", |_chunk| async move {
+            Err::<u32, FetchError>(timeout_error())
+        })
+        .await;
+
+        assert_eq!(failed, 12);
+    }
+
+    /// A single persistently-failing ID only charges its smallest-size chunk as
+    /// failed; the other chunks still load.
+    #[tokio::test]
+    async fn only_the_failing_chunk_is_charged_at_the_smallest_size() {
+        let ids: Vec<i64> = (1..=12).collect();
+
+        let failed = load_with_adaptive_batching(&ids, SIZES, "posts", |chunk| {
+            let len = chunk.len();
+            let has_poison = chunk.contains(&7);
+            async move {
+                if len > 5 || has_poison {
+                    Err(timeout_error())
+                } else {
+                    Ok(0)
+                }
+            }
+        })
+        .await;
+
+        // Degrades to size 5: [1..=5] ok, [6..=10] contains 7 -> timeout at the
+        // smallest size -> all 5 charged, [11, 12] ok.
+        assert_eq!(failed, 5);
+    }
+}

--- a/wp_mobile/src/service/media.rs
+++ b/wp_mobile/src/service/media.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     filters::MediaListFilter,
     service::{
+        adaptive_batch::load_with_adaptive_batching,
         entity_state_service::{EntityStateReader, EntityStateReaderImpl, EntityStateService},
         metadata::MetadataService,
     },
@@ -32,8 +33,12 @@ use wp_mobile_cache::{
     repository::{entity_state::EntityType, media::MediaRepository},
 };
 
-/// Maximum number of media items to fetch in a single batch request
-const BATCH_FETCH_SIZE: u32 = 100;
+/// Batch sizes to try when fetching media by ID, largest first. When a batch
+/// request times out, the failing batch is retried with the next (smaller)
+/// size; media still timing out at the smallest size are marked as failed. This
+/// lets sites that can't render a large batch within the request timeout still
+/// sync in smaller pieces.
+const BATCH_FETCH_SIZES: &[usize] = &[100, 20, 5];
 
 /// Core WordPress attachment statuses. Used by `load_media_by_ids` as the
 /// baseline for hydration requests; the caller's filter statuses are unioned
@@ -367,22 +372,17 @@ impl MediaService {
         let mut failed_count: u32 = 0;
 
         if !ids_to_fetch.is_empty() {
-            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE as usize) {
-                match self.load_media_by_ids(chunk.to_vec(), &filter.status).await {
-                    Ok(result) => {
-                        failed_count += result.failed_count;
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to load {} media item(s) (IDs: {:?}): {}",
-                            chunk.len(),
-                            chunk,
-                            e
-                        );
-                        failed_count += chunk.len() as u32;
-                    }
-                }
-            }
+            failed_count = load_with_adaptive_batching(
+                &ids_to_fetch,
+                BATCH_FETCH_SIZES,
+                "media items",
+                |chunk| async move {
+                    self.load_media_by_ids(chunk, &filter.status)
+                        .await
+                        .map(|result| result.failed_count)
+                },
+            )
+            .await;
         }
 
         FetchStats {
@@ -444,7 +444,9 @@ impl MediaService {
 
         let params = MediaListParams {
             include: media_ids,
-            per_page: Some(BATCH_FETCH_SIZE),
+            // Ensure we get all requested media regardless of default per_page.
+            // Every chunk is at most the largest fetch batch size.
+            per_page: Some(BATCH_FETCH_SIZES[0] as u32),
             status: statuses,
             ..Default::default()
         };

--- a/wp_mobile/src/service/mod.rs
+++ b/wp_mobile/src/service/mod.rs
@@ -7,6 +7,7 @@ use wp_api::prelude::{ApiUrlResolver, WpApiClient, WpApiClientDelegate};
 use wp_api::request::RequestExecutor;
 use wp_mobile_cache::{WpApiCache, db_types::db_site::DbSite};
 
+mod adaptive_batch;
 pub mod entity_state_service;
 pub mod media;
 pub mod metadata;

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     filters::{AnyPostFilter, PostListFilter},
     service::{
+        adaptive_batch::load_with_adaptive_batching,
         entity_state_service::{EntityStateReader, EntityStateReaderImpl, EntityStateService},
         metadata::MetadataService,
     },
@@ -429,64 +430,23 @@ impl PostService {
         let mut failed_count: u32 = 0;
 
         if !ids_to_fetch.is_empty() {
-            failed_count = self
-                .load_posts_with_adaptive_batching(endpoint_type, &ids_to_fetch)
-                .await;
+            failed_count = load_with_adaptive_batching(
+                &ids_to_fetch,
+                BATCH_FETCH_SIZES,
+                "posts",
+                |chunk| async move {
+                    self.load_posts_by_ids(endpoint_type, chunk)
+                        .await
+                        .map(|result| result.failed_count)
+                },
+            )
+            .await;
         }
 
         FetchStats {
             fetched_count,
             failed_count,
         }
-    }
-
-    /// Load posts by ID, degrading the batch size on request timeouts.
-    ///
-    /// Starts with the largest size in [`BATCH_FETCH_SIZES`]. When a batch
-    /// request times out, that batch is split into smaller sub-batches (the next
-    /// size down) and retried. Posts that still time out at the smallest size —
-    /// or fail for any non-timeout reason — are counted as failed (their
-    /// `Failed` state is set by [`Self::load_posts_by_ids`]).
-    ///
-    /// Returns the number of posts that failed to load.
-    async fn load_posts_with_adaptive_batching(
-        &self,
-        endpoint_type: &PostEndpointType,
-        ids: &[PostId],
-    ) -> u32 {
-        let mut failed_count: u32 = 0;
-        // Work items: a set of IDs plus the index into `BATCH_FETCH_SIZES`
-        // of the batch size to use for them.
-        let mut pending: Vec<(Vec<PostId>, usize)> = vec![(ids.to_vec(), 0)];
-
-        while let Some((batch_ids, size_index)) = pending.pop() {
-            let batch_size = BATCH_FETCH_SIZES[size_index];
-            for chunk in batch_ids.chunks(batch_size) {
-                match self.load_posts_by_ids(endpoint_type, chunk.to_vec()).await {
-                    Ok(result) => failed_count += result.failed_count,
-                    Err(e) => {
-                        if e.is_timeout() && size_index + 1 < BATCH_FETCH_SIZES.len() {
-                            log::debug!(
-                                "Fetching {} posts by ID timed out; retrying with batch size {}",
-                                chunk.len(),
-                                BATCH_FETCH_SIZES[size_index + 1]
-                            );
-                            pending.push((chunk.to_vec(), size_index + 1));
-                        } else {
-                            log::warn!(
-                                "Failed to load {} posts (IDs: {:?}): {}",
-                                chunk.len(),
-                                chunk,
-                                e
-                            );
-                            failed_count += chunk.len() as u32;
-                        }
-                    }
-                }
-            }
-        }
-
-        failed_count
     }
 
     /// Load posts by IDs from network to cache with state tracking.

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -34,8 +34,12 @@ use wp_mobile_cache::{
     repository::{entity_state::EntityType, posts::PostRepository},
 };
 
-/// Maximum number of posts to fetch in a single batch request
-const BATCH_FETCH_SIZE: u32 = 100;
+/// Batch sizes to try when fetching posts by ID, largest first. When a batch
+/// request times out, the failing batch is retried with the next (smaller)
+/// size; posts still timing out at the smallest size are marked as failed. This
+/// lets sites that can't render a large batch within the request timeout still
+/// sync in smaller pieces.
+const BATCH_FETCH_SIZES: &[usize] = &[100, 20, 5];
 
 // Internal types
 
@@ -425,31 +429,64 @@ impl PostService {
         let mut failed_count: u32 = 0;
 
         if !ids_to_fetch.is_empty() {
-            // Batch into chunks
-            for chunk in ids_to_fetch.chunks(BATCH_FETCH_SIZE as usize) {
-                match self.load_posts_by_ids(endpoint_type, chunk.to_vec()).await {
-                    Ok(result) => {
-                        // Accumulate failures reported by load_posts_by_ids
-                        failed_count += result.failed_count;
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to load {} posts (IDs: {:?}): {}",
-                            chunk.len(),
-                            chunk,
-                            e
-                        );
-                        // Network/DB error - all items in this chunk failed
-                        failed_count += chunk.len() as u32;
-                    }
-                }
-            }
+            failed_count = self
+                .load_posts_with_adaptive_batching(endpoint_type, &ids_to_fetch)
+                .await;
         }
 
         FetchStats {
             fetched_count,
             failed_count,
         }
+    }
+
+    /// Load posts by ID, degrading the batch size on request timeouts.
+    ///
+    /// Starts with the largest size in [`BATCH_FETCH_SIZES`]. When a batch
+    /// request times out, that batch is split into smaller sub-batches (the next
+    /// size down) and retried. Posts that still time out at the smallest size —
+    /// or fail for any non-timeout reason — are counted as failed (their
+    /// `Failed` state is set by [`Self::load_posts_by_ids`]).
+    ///
+    /// Returns the number of posts that failed to load.
+    async fn load_posts_with_adaptive_batching(
+        &self,
+        endpoint_type: &PostEndpointType,
+        ids: &[PostId],
+    ) -> u32 {
+        let mut failed_count: u32 = 0;
+        // Work items: a set of IDs plus the index into `BATCH_FETCH_SIZES`
+        // of the batch size to use for them.
+        let mut pending: Vec<(Vec<PostId>, usize)> = vec![(ids.to_vec(), 0)];
+
+        while let Some((batch_ids, size_index)) = pending.pop() {
+            let batch_size = BATCH_FETCH_SIZES[size_index];
+            for chunk in batch_ids.chunks(batch_size) {
+                match self.load_posts_by_ids(endpoint_type, chunk.to_vec()).await {
+                    Ok(result) => failed_count += result.failed_count,
+                    Err(e) => {
+                        if e.is_timeout() && size_index + 1 < BATCH_FETCH_SIZES.len() {
+                            log::debug!(
+                                "Fetching {} posts by ID timed out; retrying with batch size {}",
+                                chunk.len(),
+                                BATCH_FETCH_SIZES[size_index + 1]
+                            );
+                            pending.push((chunk.to_vec(), size_index + 1));
+                        } else {
+                            log::warn!(
+                                "Failed to load {} posts (IDs: {:?}): {}",
+                                chunk.len(),
+                                chunk,
+                                e
+                            );
+                            failed_count += chunk.len() as u32;
+                        }
+                    }
+                }
+            }
+        }
+
+        failed_count
     }
 
     /// Load posts by IDs from network to cache with state tracking.
@@ -517,8 +554,9 @@ impl PostService {
 
         let params = PostListParams {
             include: post_ids,
-            // Ensure we get all requested posts regardless of default per_page
-            per_page: Some(BATCH_FETCH_SIZE),
+            // Ensure we get all requested posts regardless of default per_page.
+            // Every chunk is at most the largest fetch batch size.
+            per_page: Some(BATCH_FETCH_SIZES[0] as u32),
             // Request all available post statuses as defined in the WordPress REST API.
             // Use "any" to match all post statuses (including custom ones), plus
             // "trash" which WordPress excludes from "any" because it has
@@ -1426,6 +1464,115 @@ mod tests {
         let cache = Arc::new(WpApiCache::try_from(conn).expect("Cache creation should succeed"));
         let db_site_arc = Arc::new(db_site);
         PostService::new(api_client, db_site_arc, cache)
+    }
+
+    /// Parse the `include=<ids>` post IDs from a fetch request URL.
+    fn included_ids(url: &str) -> Vec<i64> {
+        url.split("include=")
+            .nth(1)
+            .and_then(|s| s.split('&').next())
+            .map(|s| {
+                s.replace("%2C", ",")
+                    .split(',')
+                    .filter_map(|p| p.parse::<i64>().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Builds a `PostService` whose network times out for fetch requests of
+    /// more than 5 IDs and returns posts for 5 or fewer — simulating a site that
+    /// can only render a small batch within the request timeout.
+    fn service_with_small_batch_limit() -> PostService {
+        let mock_executor = Arc::new(MockExecutor::with_execute_fn(|request| {
+            let ids = included_ids(&request.url().0);
+            if ids.len() > 5 {
+                return Err(RequestExecutionError::RequestExecutionFailed {
+                    status_code: None,
+                    redirects: None,
+                    reason: RequestExecutionErrorReason::HttpTimeoutError,
+                    request_url: request.url().0,
+                    request_method: request.method(),
+                });
+            }
+            let posts: Vec<AnyPostWithEditContext> = ids
+                .iter()
+                .map(|&id| {
+                    PostBuilder::minimal()
+                        .with_id(id)
+                        .with_slug(&format!("post-{id}"))
+                        .build()
+                })
+                .collect();
+            Ok(WpNetworkResponse {
+                body: serde_json::to_vec(&posts).expect("serialize posts"),
+                status_code: 200,
+                response_header_map: Arc::new(WpNetworkHeaderMap::default()),
+                request_url: request.url(),
+                request_method: request.method(),
+                request_header_map: Arc::new(WpNetworkHeaderMap::default()),
+            })
+        }));
+
+        let api_root_url =
+            Arc::new(ParsedUrl::parse("https://test.local/wp-json").expect("Parse URL"));
+        let api_client = Arc::new(WpApiClient::new(
+            Arc::new(WpOrgSiteApiUrlResolver::new(api_root_url)),
+            WpApiClientDelegate {
+                auth_provider: Arc::new(WpAuthenticationProvider::none()),
+                request_executor: mock_executor,
+                middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
+                app_notifier: Arc::new(EmptyAppNotifier),
+            },
+        ));
+
+        let mut conn = Connection::open_in_memory().expect("Create in-memory database");
+        let mut migration_manager = MigrationManager::new(&conn).expect("Create migration manager");
+        migration_manager
+            .perform_migrations()
+            .expect("Migrations succeed");
+
+        let site_repo = SiteRepository;
+        let self_hosted_site = SelfHostedSite {
+            url: "https://test.local".to_string(),
+            api_root: "https://test.local/wp-json".to_string(),
+        };
+        let db_site = site_repo
+            .upsert_self_hosted_site(&mut conn, &self_hosted_site)
+            .expect("Site creation")
+            .db_site;
+
+        let cache = Arc::new(WpApiCache::try_from(conn).expect("Cache creation should succeed"));
+        let db_site_arc = Arc::new(db_site);
+        PostService::new(api_client, db_site_arc, cache)
+    }
+
+    /// When a large fetch batch times out, the service retries with
+    /// progressively smaller batches. The mock times out for any request of more
+    /// than 5 IDs, so the 100- and 20-post batches fail but the 5-post batches
+    /// succeed — every post still loads, with no failures.
+    #[tokio::test]
+    async fn test_batch_size_degrades_on_timeout() {
+        let service = service_with_small_batch_limit();
+        let metadata: Vec<EntityMetadata> = (1i64..=12)
+            .map(|id| EntityMetadata::new(id, None, None, None))
+            .collect();
+
+        let stats = service
+            .fetch_missing_and_stale_posts(&PostEndpointType::Posts, &metadata)
+            .await;
+
+        assert_eq!(stats.fetched_count, 12);
+        assert_eq!(
+            stats.failed_count, 0,
+            "all posts should load once the batch is small enough"
+        );
+
+        let ids: Vec<i64> = (1..=12).collect();
+        let loaded = service
+            .read_posts_by_ids_from_db(&ids)
+            .expect("re-reading fetched posts should succeed");
+        assert_eq!(loaded.len(), 12);
     }
 
     // State transition tests


### PR DESCRIPTION
## Description

This branch explores retrying post/media fetches by ID with an adaptive batch size when a request times out. **It is intentionally not slated to merge.**

We're instead going with a much simpler change: set the fetch batch size to a constant `5`. In practice a fixed `5` is nearly as efficient as starting at `100` and backing off on timeouts — the sites that need this can't render a large batch anyway — and it avoids the extra machinery entirely.

This branch is kept as a record in case we later decide a more dynamic approach is worth it. Two shapes we've considered:

- **Descending (what this branch implements):** start at `100`, degrade `100 → 20 → 5` and retry the failing chunk when a request times out.
- **Ascending (suggested alternative):** start small and climb `5 → 20 → 100` while requests keep succeeding, stopping (and backing off) as soon as a size hits a timeout.

## Changes

- `39ed4091` — Retry fetching posts by ID with progressively smaller batch sizes (`100 → 20 → 5`) on request timeout, instead of failing the whole batch. Adds `FetchError::is_timeout()`.
- `798ca6f7` — Extract the degrade-and-retry loop into a generic `service::adaptive_batch::load_with_adaptive_batching` (generic over ID type and a per-chunk loader closure), unit-test it directly with a fake loader, and adopt it in `MediaService` so fetching media by ID gains the same resilience.

Requests are still issued one chunk at a time (sequentially); a chunk is one `include=<ids>` list call.

## Changelog

- [x] The branch adds a `## [Unreleased]` entry under `### Changed`. It would be dropped along with the branch, since this isn't intended to merge.
