### PR TITLE
Fetch posts and media by ID in batches of `5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Kotlin: `WpHttpClient.DefaultHttpClient` now applies more forgiving default OkHttp timeouts (connect 15s, read 60s, write 60s) instead of relying on OkHttp's 10s per-operation defaults, preventing premature timeouts when fetching large or slow-to-render responses. The values are configurable via a new `HttpClientTimeouts` type, accepted by both `DefaultHttpClient` and the `WpRequestExecutor` convenience constructor so callers can override them without building an `OkHttpClient` by hand.
+- Posts and media are now fetched by ID in batches of `5` instead of `100`, so sites that can't render a large batch within the request timeout can still sync (at the cost of more, smaller requests).
 - Swift: `WordPressAPI.uploadMedia` and `WpService.uploadMedia` now accept a `Progress` whose total is zero, defaulting the total to the upload file's byte size.
 - Self-hosted login and endpoint requests now work against sites with plain permalinks. Previously, the client path-extended the discovered `?rest_route=/` API root, producing URLs like `…/index.php/wp/v2/users/me?rest_route=/` that WordPress collapsed to the API index ([#1366](https://github.com/Automattic/wordpress-rs/issues/1366)).
 - **Internal:** Hardened the Claude review GitHub Actions workflow with scoped permissions and gated triggers.

--- a/wp_mobile/src/service/media.rs
+++ b/wp_mobile/src/service/media.rs
@@ -32,8 +32,9 @@ use wp_mobile_cache::{
     repository::{entity_state::EntityType, media::MediaRepository},
 };
 
-/// Maximum number of media items to fetch in a single batch request
-const BATCH_FETCH_SIZE: u32 = 100;
+/// Number of media items to fetch in a single batch request. Kept small so sites
+/// that can't render a large batch within the request timeout can still sync.
+const BATCH_FETCH_SIZE: u32 = 5;
 
 /// Core WordPress attachment statuses. Used by `load_media_by_ids` as the
 /// baseline for hydration requests; the caller's filter statuses are unioned

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -34,8 +34,9 @@ use wp_mobile_cache::{
     repository::{entity_state::EntityType, posts::PostRepository},
 };
 
-/// Maximum number of posts to fetch in a single batch request
-const BATCH_FETCH_SIZE: u32 = 100;
+/// Number of posts to fetch in a single batch request. Kept small so sites that
+/// can't render a large batch within the request timeout can still sync.
+const BATCH_FETCH_SIZE: u32 = 5;
 
 // Internal types
 


### PR DESCRIPTION
## Description

During metadata sync, posts and media are fetched by ID in batches. On sites that can't render a large batch within the request timeout, the whole batch failed. This lowers the fetch batch size from `100` to `5` for both posts and media so those sites can still sync — at the cost of more, smaller requests.

A fixed small batch is nearly as efficient as starting at `100` and backing off on timeouts, and it's far simpler. The adaptive alternative was explored in [#1444](https://github.com/Automattic/wordpress-rs/pull/1444) (degrade `100 → 20 → 5` on timeout, or the reverse — climb `5 → 20 → 100` and back off when a size times out); we can revisit it if a more dynamic approach proves worthwhile.

## Changes

- Lower `BATCH_FETCH_SIZE` from `100` to `5` in `PostService` and `MediaService` fetch-by-ID.

## Changelog

- [x] Added an entry under `## [Unreleased]` → `### Changed`.
