### PR TITLE
Bump pinned Rust toolchain to 1.97.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Added a scheduled Buildkite health digest for the quarantined `test_login_remote` tests that reads the soft-fail step's real pass/fail from the Buildkite API, separates external `*.wpmt.co` timeouts from genuine failures, and posts a summary to Slack.
 - **Internal:** Updated `aes-gcm` from `0.10` to `0.11`, migrating the password encryption transformer to the `aead` 0.6 API. The AES-256-GCM scheme and stored `salt:nonce:ciphertext` format are unchanged.
 - **Internal:** Bumped the CI Rust toolchain from `1.90.0` to `1.97.0` and added a pinned `rust-toolchain.toml` so local and CI compilers can't drift, fixed the clippy lints the newer toolchain surfaced (`iter_kv_map`, `manual_filter`, `useless_borrows_in_formatting`), and added a nightly Buildkite check that nudges Slack when the pin falls behind stable ([#1436](https://github.com/Automattic/wordpress-rs/issues/1436)).
+- **Internal:** Bumped the pinned CI Rust toolchain from `1.97.0` to `1.97.1` (latest stable) in lockstep across `rust-toolchain.toml`, the `Makefile`, and `wp_rs_web/Dockerfile`. No new clippy lints surfaced ([#1436](https://github.com/Automattic/wordpress-rs/issues/1436)).
 
 ## [0.5.0] - 2026-06-18
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ docker_container_repo_dir=/app
 # Pinned Rust toolchain version. Keep in lockstep with `rust-toolchain.toml` and
 # `wp_rs_web/Dockerfile` so local `cargo`, the CI Docker image, and the pinned
 # toolchain never drift. See https://github.com/Automattic/wordpress-rs/issues/1436.
-rust_stable_toolchain := 1.97.0
+rust_stable_toolchain := 1.97.1
 rust_docker_container := public.ecr.aws/docker/library/rust:$(rust_stable_toolchain)
 
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,6 +7,6 @@
 #   - `rust_stable_toolchain` in `Makefile`
 #   - `FROM rust:<version>` in `wp_rs_web/Dockerfile`
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/wp_rs_web/Dockerfile
+++ b/wp_rs_web/Dockerfile
@@ -1,6 +1,6 @@
 # Keep this version in lockstep with `rust-toolchain.toml` and `rust_stable_toolchain`
 # in the `Makefile`. See https://github.com/Automattic/wordpress-rs/issues/1436.
-FROM rust:1.97.0 AS builder
+FROM rust:1.97.1 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

The nightly `check-rust-toolchain-current.sh` job flagged that the pinned Rust toolchain (`1.97.0`) had fallen behind the latest stable release (`1.97.1`) and posted the reminder to Slack. This bumps the pin in lockstep across the three places it lives, clearing the alert.

`1.97.1` was confirmed as the current stable via the same source the check uses — `channel-rust-stable.toml` — rather than trusting the alert text.

Context: [#1436](https://github.com/Automattic/wordpress-rs/issues/1436), the (closed) tracking issue all three pins link to. This is a routine response to that issue's nightly nudge, not a re-fix — the issue stays closed.

## Changes

- **`rust-toolchain.toml`** — `channel = "1.97.1"`
- **`Makefile`** — `rust_stable_toolchain := 1.97.1`
- **`wp_rs_web/Dockerfile`** — `FROM rust:1.97.1 AS builder`
- **`CHANGELOG.md`** — `**Internal:**` entry under `### Changed`

## Test plan

Ran against the newly pinned `1.97.1` toolchain locally (CI runs the Dockerized `make lint-rust` equivalent):

- [x] `check-rust-toolchain-current.sh` → `Rust toolchain pin (1.97.1) is up to date with the latest stable release.` (exit 0)
- [x] `cargo clippy --tests --all-targets --all-features -- -D warnings` passes — the patch bump surfaced **no** new clippy lints
- [x] `cargo fmt --all -- --check` passes

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.