### PR TITLE
Clean up XCFramework build intermediates before release

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -28,6 +28,13 @@ echo "--- :rust: Building XCFramework"
 make xcframework-package-sign
 make xcframework-package-checksum
 
+echo "--- :wastebasket: Removing XCFramework build intermediates"
+rm -rf \
+  target/*-apple-* \
+  target/debug \
+  target/release \
+  target/libwordpressFFI.xcframework
+
 release_version="$1"
 echo "--- :rocket: Publish release $release_version"
 bundle exec fastlane release "version:$release_version"


### PR DESCRIPTION
[The 0.6.0 release CI job](https://buildkite.com/automattic/wordpress-rs/builds/5901#019f6da8-c2c0-49e3-819b-63f0eea93ff4) failed due to no disk space on the machine. This PR updates the CI script to remove most of the rust target dir content once the xcframework is built.

I will merge this PR to unblock the release.