### PR TITLE
Adopt androidx.lifecycle 2.11.0 in the sample app (scoped compileSdk 37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Internal:** Build the Android JNI libraries with `cargo-ndk` instead of the `rust-android-gradle` Gradle plugin.
 - **Internal:** Upgraded the Android/Kotlin build to Android Gradle Plugin `9.3.0` / Gradle `9.5.0` (Kotlin `2.3.21`, `compileSdk` 36), migrating `api/android` to the AGP 9 variant APIs and splitting the example app into a `com.android.kotlin.multiplatform.library` shared module and a standalone `com.android.application` module.
+- **Internal:** Bumped `androidx.lifecycle` `2.10.0` → `2.11.0`. Because 2.11.0 requires `compileSdk 37` (via the transitive `lifecycle-runtime-compose`), the sample app now compiles against a dedicated `example-compileSdk` (37); the published `api/android` library stays on `compileSdk 36` to remain aligned with WPAndroid.
 
 ## [0.6.0] - 2026-07-16
 

--- a/native/kotlin/example/androidApp/build.gradle.kts
+++ b/native/kotlin/example/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
 android {
     namespace = "rs.wordpress.example"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    compileSdk = libs.versions.example.compileSdk.get().toInt()
 
     defaultConfig {
         applicationId = "rs.wordpress.example"

--- a/native/kotlin/example/composeApp/build.gradle.kts
+++ b/native/kotlin/example/composeApp/build.gradle.kts
@@ -34,7 +34,7 @@ val copyDesktopAppResources = tasks.register<Copy>("copyDesktopAppResources") {
 kotlin {
     androidLibrary {
         namespace = "rs.wordpress.example.shared"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        compileSdk = libs.versions.example.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
     jvm("desktop")

--- a/native/kotlin/gradle/libs.versions.toml
+++ b/native/kotlin/gradle/libs.versions.toml
@@ -3,6 +3,11 @@ agp = "9.3.0"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"
+# The sample app compiles against a newer SDK than the published library so it can pull in
+# androidx.lifecycle 2.11.0, which requires compileSdk 37 (via lifecycle-runtime-compose).
+# `:api:android` and the shared `android-compileSdk` stay on 36 to keep the published AAR
+# aligned with WPAndroid (see #1433). Used only by the `:example:*` modules.
+example-compileSdk = "37"
 androidx-activityCompose = "1.13.0"
 androidx-core-ktx = "1.19.0"
 androidx-material3 = "1.4.0"
@@ -17,7 +22,7 @@ kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization-json = "1.6.3"
 landscapist = "2.6.1"
-lifecycle = "2.10.0"
+lifecycle = "2.11.0"
 okHttp = "5.4.0"
 navigationCompose = "2.9.2"
 publish-to-s3-plugin = "0.10.0"


### PR DESCRIPTION
## Description

Bump of `androidx.lifecycle` from `2.10.0` to `2.11.0`, originally proposed by Dependabot in #1408. 2.11.0 transitively pulls `lifecycle-runtime-compose`, whose AAR metadata declares `minCompileSdk=37`, so the consuming module must compile against SDK 37. Rather than raise the shared `android-compileSdk` — which would also rebuild the published `api/android` AAR against 37 and undo the `compileSdk 36` alignment with WPAndroid that #1433 deliberately set — this scopes the SDK 37 bump to the sample-app modules only.

## Changes

- Add a dedicated `example-compileSdk = "37"` version-catalog entry.
- Point `:example:composeApp` and `:example:androidApp` `compileSdk` at `example-compileSdk`.
- Leave the shared `android-compileSdk` on `36`, so `:api:android` is **unchanged** and stays aligned with WPAndroid.
- Bump `lifecycle` `2.10.0` → `2.11.0`.

## Test plan

- [x] `:example:androidApp:assembleDebug` builds against `compileSdk 37` with lifecycle 2.11.0 — confirmed green on Buildkite (scoped variant: build 5933; shared-compileSdk variant: build 5932).
- [x] `publish-wp-api-android` still compiles `:api:android` against `compileSdk 36`.
- [ ] Full PR pipeline green.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`.

## Related issues

- Supersedes #1408 (Dependabot lifecycle bump).
- Builds on #1433 (AGP 9.3.0 migration).
