### PR TITLE
Add wp.com `POST /me/transactions` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- WordPress.com `POST /me/transactions` endpoint for redeeming a shopping cart with the account's WordPress.com credits, completing a domain purchase
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 
 ### Changed
 
+- **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.
 - **Internal:** Build the Android JNI libraries with `cargo-ndk` instead of the `rust-android-gradle` Gradle plugin.
 - **Internal:** Upgraded the Android/Kotlin build to Android Gradle Plugin `9.3.0` / Gradle `9.5.0` (Kotlin `2.3.21`, `compileSdk` 36), migrating `api/android` to the AGP 9 variant APIs and splitting the example app into a `com.android.kotlin.multiplatform.library` shared module and a standalone `com.android.application` module.
 - **Internal:** Bumped `syn` from `2.0` to `3.0`, updating the proc-macro crates for its breaking changes.

--- a/WPCOM_REST_API_CHECKLIST.md
+++ b/WPCOM_REST_API_CHECKLIST.md
@@ -387,7 +387,7 @@ investigate the relevant code before making decisions based on this document.
 
 - [x] `POST /rest/v1.1/me/shopping-cart/$site` — create shopping cart (with site)
 - [x] `POST /rest/v1.1/me/shopping-cart/no-site` — create shopping cart (no site)
-- [ ] `POST /rest/v1.1/me/transactions` — redeem cart using credits
+- [x] `POST /rest/v1.1/me/transactions` — redeem cart using credits
 - [x] `GET /rest/v1.1/me/transactions/supported-countries` — supported countries
 
 ## Verticals

--- a/wp_api/src/wp_com/endpoint/me_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/me_endpoint.rs
@@ -1,5 +1,6 @@
 use crate::wp_com::domains::SupportedCountries;
 use crate::wp_com::me::{DomainContactInformation, WPComUserInfo};
+use crate::wp_com::transactions::{RedeemCartParams, TransactionReceipt};
 use crate::{
     request::endpoint::{AsNamespace, DerivedRequest},
     wp_com::WpComNamespace,
@@ -14,6 +15,8 @@ enum MeRequest {
     TransactionsSupportedCountries,
     #[get(url = "/me/domain-contact-information", output = DomainContactInformation)]
     DomainContactInformation,
+    #[post(url = "/me/transactions", params = &RedeemCartParams, output = TransactionReceipt)]
+    RedeemCart,
 }
 
 impl DerivedRequest for MeRequest {
@@ -58,5 +61,10 @@ mod tests {
             endpoint.domain_contact_information(),
             "/me/domain-contact-information",
         );
+    }
+
+    #[rstest]
+    fn redeem_cart(endpoint: MeRequestEndpoint) {
+        validate_wp_com_rest_v1_1_endpoint(endpoint.redeem_cart(), "/me/transactions");
     }
 }

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
-use crate::{impl_as_query_value_for_new_type, request::endpoint::AsNamespace};
+use crate::{request::endpoint::AsNamespace, wp_content_u64_id};
 use serde::{Deserialize, Serialize};
-use std::{num::ParseIntError, str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 pub mod client;
 pub mod domains;
@@ -39,26 +39,10 @@ pub mod subscribers;
 pub mod support_bots;
 pub mod support_eligibility;
 pub mod support_tickets;
+pub mod transactions;
 pub mod unified_conversations;
 
-impl_as_query_value_for_new_type!(WpComSiteId);
-uniffi::custom_newtype!(WpComSiteId, u64);
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WpComSiteId(pub u64);
-
-impl FromStr for WpComSiteId {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(Self)
-    }
-}
-
-impl std::fmt::Display for WpComSiteId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+wp_content_u64_id!(WpComSiteId);
 
 uniffi::custom_newtype!(CurrencyCode, String);
 /// ISO 4217 currency code (e.g. `"USD"`, `"TRY"`, `"EUR"`).

--- a/wp_api/src/wp_com/products.rs
+++ b/wp_api/src/wp_com/products.rs
@@ -3,6 +3,7 @@ use crate::{
     decimal2::Decimal2,
     url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
     wp_com::{CurrencyCode, TimeSpanUnit, language::WPComLanguage},
+    wp_content_string_id,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -30,6 +31,11 @@ impl std::fmt::Display for ProductId {
         write!(f, "{}", self.0)
     }
 }
+
+// Product category as classified by the billing system (e.g. `"domain_reg"`,
+// `"bundle"`, `"jetpack"`, `"theme"`). The set is open-ended — products define
+// their own type — so this is a newtype rather than an enum.
+wp_content_string_id!(ProductType);
 
 uniffi::custom_newtype!(ProductSlug, String);
 /// WordPress.com product slug (e.g. `"domain_reg"`, `"personal-bundle"`).
@@ -116,7 +122,7 @@ pub struct Product {
     pub product_name: String,
     pub product_slug: ProductSlug,
     pub description: String,
-    pub product_type: String,
+    pub product_type: ProductType,
     pub available: bool,
     pub billing_product_slug: ProductSlug,
     pub is_domain_registration: bool,
@@ -391,7 +397,7 @@ mod tests {
         let backup = products
             .get("fake_jetpack_backup_daily")
             .expect("fake_jetpack_backup_daily missing");
-        assert_eq!(backup.product_type, "jetpack");
+        assert_eq!(backup.product_type, ProductType("jetpack".to_string()));
         assert!(!backup.is_domain_registration);
         assert!(backup.introductory_offer.is_none());
 
@@ -399,7 +405,7 @@ mod tests {
         let security = products
             .get("fake_jetpack_security_yearly")
             .expect("fake_jetpack_security_yearly missing");
-        assert_eq!(security.product_type, "jetpack");
+        assert_eq!(security.product_type, ProductType("jetpack".to_string()));
         let offer = security
             .introductory_offer
             .as_ref()
@@ -411,6 +417,6 @@ mod tests {
         let complete = products
             .get("fake_jetpack_complete")
             .expect("fake_jetpack_complete missing");
-        assert_eq!(complete.product_type, "bundle");
+        assert_eq!(complete.product_type, ProductType("bundle".to_string()));
     }
 }

--- a/wp_api/src/wp_com/shopping_cart.rs
+++ b/wp_api/src/wp_com/shopping_cart.rs
@@ -3,7 +3,7 @@ use crate::{
     decimal2::Decimal2,
     wp_com::{
         CurrencyCode, WpComSiteId,
-        domains::DomainName,
+        domains::{CountryCode, DomainName},
         products::{ProductId, ProductSlug},
         subscribers::SubscriptionId,
     },
@@ -312,6 +312,48 @@ pub struct ShoppingCartCostOverride {
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct ShoppingCartTax {
     pub display_taxes: bool,
+    /// Where the cart is taxed. Empty when the server has no location for it.
+    pub location: ShoppingCartTaxLocation,
+}
+
+/// The location a cart's tax is calculated from.
+///
+/// Every field is individually optional — the server omits the ones it has no
+/// value for. This must round-trip: a cart submitted to
+/// `POST /me/transactions` carries its tax location back to the server, which
+/// reads it from here and has no fallback, so dropping a field changes the tax
+/// charged.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct ShoppingCartTaxLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub country_code: Option<CountryCode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub postal_code: Option<String>,
+    /// State, province or other subdivision code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub subdivision_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub ip_address: Option<String>,
+    /// The customer's VAT registration ID, for business purchases.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub vat_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub organization: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub city: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub is_for_business: Option<bool>,
 }
 
 /// Messages returned with the shopping cart response.
@@ -480,6 +522,45 @@ mod tests {
             "12345"
         );
         assert_eq!(CartKey::NoSite.to_string(), "no-site");
+    }
+
+    #[test]
+    fn test_tax_location_round_trips() {
+        // A cart is sent back to the server verbatim when it's redeemed, and
+        // the server reads the tax location from it with no fallback, so every
+        // field has to survive being deserialized and serialized again.
+        let json = r#"{
+            "display_taxes": true,
+            "location": {
+                "country_code": "CA",
+                "postal_code": "V6B 1A1",
+                "subdivision_code": "BC",
+                "ip_address": "198.51.100.7",
+                "vat_id": "FAKE-VAT-000789",
+                "organization": "Fake Corp",
+                "address": "1 Example Street",
+                "city": "Faketown",
+                "is_for_business": true
+            }
+        }"#;
+
+        let tax: ShoppingCartTax = serde_json::from_str(json).expect("should deserialize");
+        let expected: serde_json::Value = serde_json::from_str(json).expect("should parse");
+        let actual = serde_json::to_value(&tax).expect("should serialize");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_empty_tax_location_serializes_as_empty_object() {
+        // The server sends `{}` when it has no location; it must not come back
+        // as a set of nulls.
+        let file = File::open("tests/wpcom/shopping_cart/cart-with-site.json")
+            .expect("Failed to open file");
+        let cart: ShoppingCart = serde_json::from_reader(file).expect("Unable to parse JSON");
+        assert!(cart.tax.location.country_code.is_none());
+
+        let json = serde_json::to_value(&cart.tax).expect("should serialize");
+        assert_eq!(json["location"], serde_json::json!({}));
     }
 
     #[test]

--- a/wp_api/src/wp_com/sites.rs
+++ b/wp_api/src/wp_com/sites.rs
@@ -4,7 +4,11 @@ use crate::{
         AppendUrlQueryPairs, FromUrlQueryPairs, QueryPairs, QueryPairsExtension, UrlQueryPairsMap,
     },
     users::UserCapabilitiesMap,
-    wp_com::{WpComSiteId, me::WpComUserId, products::ProductSlug},
+    wp_com::{
+        WpComSiteId,
+        me::WpComUserId,
+        products::{ProductSlug, ProductType},
+    },
     wp_content_string_id,
 };
 
@@ -302,7 +306,7 @@ pub struct WPComProduct {
     pub product_slug: ProductSlug,
     pub product_name: String,
     pub product_name_short: String,
-    pub product_type: String,
+    pub product_type: ProductType,
     pub expired: bool,
     pub user_is_owner: bool,
 }

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -59,11 +59,27 @@ pub struct RedeemCartParams {
     pub domain_details: Option<DomainContactInformation>,
 }
 
+/// Deserialize an [`OrderId`] that the server may report as an empty string.
+fn deserialize_optional_order_id<'de, D>(deserializer: D) -> Result<Option<OrderId>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    wp_serde_helper::deserialize_u64_or_none_from_number_or_string(deserializer)
+        .map(|order_id| order_id.map(OrderId))
+}
+
 /// Response from `POST /me/transactions` — a receipt for the redeemed cart.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct TransactionReceipt {
     pub receipt_id: ReceiptId,
-    pub order_id: OrderId,
+    /// The billing order behind this receipt.
+    ///
+    /// `None` when the payment processor didn't return one — the server sends
+    /// an empty string in that case, after the transaction has already been
+    /// charged.
+    #[serde(default, deserialize_with = "deserialize_optional_order_id")]
+    #[uniffi(default = None)]
+    pub order_id: Option<OrderId>,
     /// Whether every product in the cart was purchased.
     ///
     /// `false` does not mean nothing happened. Receiving this type at all means
@@ -192,7 +208,7 @@ mod tests {
         let receipt = receipt("tests/wpcom/transactions/redeem-cart-success.json");
 
         assert_eq!(receipt.receipt_id, ReceiptId(11223344));
-        assert_eq!(receipt.order_id, OrderId(55667788));
+        assert_eq!(receipt.order_id, Some(OrderId(55667788)));
         assert!(receipt.success);
         assert!(receipt.failed_purchases.is_empty());
         assert_eq!(receipt.price_integer, 2825);
@@ -306,6 +322,25 @@ mod tests {
             .expect("expected tax_vendor_info");
         assert_eq!(tax.vat_id, Some(TaxVendorId("FAKE-VAT-000456".to_string())));
         assert_eq!(tax.tax_name, Some(TaxName("VAT".to_string())));
+    }
+
+    #[test]
+    fn test_receipt_with_empty_order_id() {
+        // The server defaults `order_id` to an empty string and only fills it
+        // in when the payment processor returned one. The receipt still has to
+        // deserialize — by this point the transaction has been charged.
+        let mut json: serde_json::Value = serde_json::from_reader(
+            File::open("tests/wpcom/transactions/redeem-cart-success.json")
+                .expect("Failed to open file"),
+        )
+        .expect("Unable to parse JSON");
+        json["order_id"] = serde_json::json!("");
+
+        let receipt: TransactionReceipt =
+            serde_json::from_value(json).expect("a receipt without an order id should deserialize");
+
+        assert!(receipt.order_id.is_none());
+        assert_eq!(receipt.receipt_id, ReceiptId(11223344));
     }
 
     fn fixture_cart() -> ShoppingCart {

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use wp_serde_helper::deserialize_u64_or_string_or_none_as_t;
 
 wp_content_u64_id!(ReceiptId);
 wp_content_u64_id!(OrderId);
@@ -60,15 +61,6 @@ pub struct RedeemCartParams {
     pub domain_details: Option<DomainContactInformation>,
 }
 
-/// Deserialize an [`OrderId`] that the server may report as an empty string.
-fn deserialize_optional_order_id<'de, D>(deserializer: D) -> Result<Option<OrderId>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    wp_serde_helper::deserialize_u64_or_none_from_number_or_string(deserializer)
-        .map(|order_id| order_id.map(OrderId))
-}
-
 /// Response from `POST /me/transactions` — a receipt for the redeemed cart.
 ///
 /// The API also declares `error_code` and `error_message`, which are omitted
@@ -82,7 +74,7 @@ pub struct TransactionReceipt {
     /// `None` when the payment processor didn't return one — the server sends
     /// an empty string in that case, after the transaction has already been
     /// charged.
-    #[serde(default, deserialize_with = "deserialize_optional_order_id")]
+    #[serde(default, deserialize_with = "deserialize_u64_or_string_or_none_as_t")]
     #[uniffi(default = None)]
     pub order_id: Option<OrderId>,
     /// Whether every product in the cart was purchased.

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -182,15 +182,20 @@ pub struct TransactionTaxVendorInfo {
     pub address: Vec<String>,
     /// Each tax charged, mapped to the vendor's registration ID for it.
     pub tax_name_and_vendor_id_array: HashMap<TaxName, TaxVendorId>,
-    /// Superseded by [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
-    /// and not sent by this endpoint.
+    /// Every vendor ID in
+    /// [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
+    /// joined with `" / "` — e.g. `"790004303 / PST-1464-5919"` where two taxes
+    /// apply. Kept by the backend for backwards compatibility and not observed
+    /// on this endpoint's responses; prefer the map.
     #[serde(default)]
     #[uniffi(default = None)]
-    pub vat_id: Option<TaxVendorId>,
-    /// See [`vat_id`](Self::vat_id).
+    pub vat_id: Option<String>,
+    /// The tax names from
+    /// [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
+    /// joined the same way — e.g. `"GST / PST"`. See [`vat_id`](Self::vat_id).
     #[serde(default)]
     #[uniffi(default = None)]
-    pub tax_name: Option<TaxName>,
+    pub tax_name: Option<String>,
 }
 
 #[cfg(test)]
@@ -261,7 +266,8 @@ mod tests {
                 .get(&TaxName("GST".to_string())),
             Some(&TaxVendorId("FAKE-GST-000123".to_string()))
         );
-        // This endpoint serializes the vendor info without these legacy fields.
+        // Not present on the captured response this fixture came from; the
+        // fields are modelled defensively rather than because they were seen.
         assert!(tax.vat_id.is_none());
         assert!(tax.tax_name.is_none());
     }
@@ -320,8 +326,8 @@ mod tests {
             .tax_vendor_info
             .as_ref()
             .expect("expected tax_vendor_info");
-        assert_eq!(tax.vat_id, Some(TaxVendorId("FAKE-VAT-000456".to_string())));
-        assert_eq!(tax.tax_name, Some(TaxName("VAT".to_string())));
+        assert_eq!(tax.vat_id.as_deref(), Some("FAKE-VAT-000456"));
+        assert_eq!(tax.tax_name.as_deref(), Some("VAT"));
     }
 
     #[test]

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -179,20 +179,6 @@ pub struct TransactionTaxVendorInfo {
     pub address: Vec<String>,
     /// Each tax charged, mapped to the vendor's registration ID for it.
     pub tax_name_and_vendor_id_array: HashMap<TaxName, TaxVendorId>,
-    /// Every vendor ID in
-    /// [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
-    /// joined with `" / "` — e.g. `"790004303 / PST-1464-5919"` where two taxes
-    /// apply. Kept by the backend for backwards compatibility and not observed
-    /// on this endpoint's responses; prefer the map.
-    #[serde(default)]
-    #[uniffi(default = None)]
-    pub vat_id: Option<String>,
-    /// The tax names from
-    /// [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
-    /// joined the same way — e.g. `"GST / PST"`. See [`vat_id`](Self::vat_id).
-    #[serde(default)]
-    #[uniffi(default = None)]
-    pub tax_name: Option<String>,
 }
 
 #[cfg(test)]
@@ -263,10 +249,6 @@ mod tests {
                 .get(&TaxName("GST".to_string())),
             Some(&TaxVendorId("FAKE-GST-000123".to_string()))
         );
-        // Not present on the captured response this fixture came from; the
-        // fields are modelled defensively rather than because they were seen.
-        assert!(tax.vat_id.is_none());
-        assert!(tax.tax_name.is_none());
     }
 
     /// There is no way to capture a real partial failure without paying for
@@ -330,8 +312,12 @@ mod tests {
             .tax_vendor_info
             .as_ref()
             .expect("expected tax_vendor_info");
-        assert_eq!(tax.vat_id.as_deref(), Some("FAKE-VAT-000456"));
-        assert_eq!(tax.tax_name.as_deref(), Some("VAT"));
+        assert_eq!(tax.country_code, CountryCode("IE".to_string()));
+        assert_eq!(
+            tax.tax_name_and_vendor_id_array
+                .get(&TaxName("VAT".to_string())),
+            Some(&TaxVendorId("FAKE-VAT-000456".to_string()))
+        );
     }
 
     #[test]

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -113,7 +113,8 @@ pub struct TransactionPurchase {
     pub product_name_short: Option<String>,
     pub product_type: ProductType,
     pub is_domain_registration: bool,
-    /// Product-specific detail — the domain name for domain products.
+    /// The domain name, for domain products. Products of other types either
+    /// store their own identifier here or leave it unset.
     pub meta: Option<String>,
     /// The site this purchase belongs to.
     pub blog_id: Option<WpComSiteId>,
@@ -166,7 +167,8 @@ pub struct TransactionFailedPurchase {
     pub product_id: ProductId,
     pub product_name: String,
     pub product_slug: ProductSlug,
-    /// Product-specific detail — the domain name for domain products.
+    /// The domain name, for domain products. Products of other types either
+    /// store their own identifier here or leave it unset.
     pub product_meta: Option<String>,
     pub product_cost: Decimal2,
 }

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -27,12 +27,12 @@ wp_content_string_id!(TaxVendorId);
 
 /// How a transaction is paid for.
 ///
-/// Only credit redemption is offered. The server accepts several other payment
-/// methods (stored cards, Stripe, PayPal, and various redirect processors), but
-/// those answer with a redirect/pending body — `redirect_url`, `qr_code` and
-/// friends — rather than a receipt. Adding a variant here therefore means
-/// giving the endpoint a response type that can represent both shapes; it is
-/// not just a matter of another string.
+/// Only credit redemption is offered, which is all this client needs. The
+/// server accepts several other methods (stored cards, Stripe, PayPal and
+/// various redirect processors); adding one here is not just another string,
+/// because a payment that needs the user to be sent elsewhere answers with a
+/// `redirect_url`/`qr_code` body instead of a receipt, and
+/// [`TransactionReceipt`] cannot represent that.
 #[derive(Debug, Clone, Serialize, uniffi::Enum)]
 pub enum TransactionPaymentMethod {
     /// Charge the account's WordPress.com credits.
@@ -53,7 +53,8 @@ pub struct RedeemCartParams {
     pub cart: ShoppingCart,
     pub payment: TransactionPayment,
     /// WHOIS contact information. Required when the cart contains a domain
-    /// registration or transfer, ignored otherwise.
+    /// registration or transfer and isn't made up purely of renewals; ignored
+    /// otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[uniffi(default = None)]
     pub domain_details: Option<DomainContactInformation>,
@@ -69,6 +70,10 @@ where
 }
 
 /// Response from `POST /me/transactions` — a receipt for the redeemed cart.
+///
+/// The API also declares `error_code` and `error_message`, which are omitted
+/// here: the backend hardcodes both to an empty string on this path and
+/// reports real failures as HTTP errors.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct TransactionReceipt {
     pub receipt_id: ReceiptId,

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -272,11 +272,14 @@ mod tests {
         assert!(tax.tax_name.is_none());
     }
 
-    /// The server has no reachable code path that populates `failed_purchases`
-    /// safely enough to capture, so this fixture is hand-written from the
-    /// `WPCOM_Store_API::checkout()` assembly logic rather than a real
-    /// response. It also exercises the purchase fields that only appear for
-    /// transfers, marketplace products and quantity upgrades.
+    /// There is no way to capture a real partial failure without paying for
+    /// one, so this fixture is hand-written from the
+    /// `WPCOM_Store_API::checkout()` assembly logic. Its purchases follow that
+    /// logic's constraints — the fields gated on a subscription
+    /// (`expiry`, `ownership_id`, `is_renewal`, `will_auto_renew`,
+    /// `new_quantity`, `saas_redirect_url`) only appear together — and it
+    /// covers the fields that show up solely for transfers, marketplace
+    /// products and quantity upgrades.
     #[test]
     fn test_redeem_cart_partial_failure_deserialization() {
         let receipt = receipt("tests/wpcom/transactions/redeem-cart-partial-failure.json");
@@ -315,12 +318,16 @@ mod tests {
             saas.saas_redirect_url.as_deref(),
             Some("https://example.com/setup?intent-id=fake-intent")
         );
-        assert!(
-            saas.expiry.is_none(),
-            "a purchase without a subscription has no expiry"
-        );
-        assert!(saas.ownership_id.is_none());
         assert!(saas.meta.is_none());
+
+        // A product that creates no subscription: no expiry, no ownership, and
+        // nothing to renew.
+        let one_time = &purchases[2];
+        assert!(one_time.expiry.is_none());
+        assert!(one_time.ownership_id.is_none());
+        assert!(!one_time.will_auto_renew);
+        assert!(!one_time.is_renewal);
+        assert!(one_time.product_name_short.is_none());
 
         let tax = saas
             .tax_vendor_info

--- a/wp_api/src/wp_com/transactions.rs
+++ b/wp_api/src/wp_com/transactions.rs
@@ -1,0 +1,369 @@
+use crate::{
+    date::WpDateString,
+    decimal2::Decimal2,
+    wp_com::{
+        CurrencyCode, WpComSiteId,
+        domains::CountryCode,
+        me::DomainContactInformation,
+        products::{ProductId, ProductSlug, ProductType},
+        shopping_cart::ShoppingCart,
+    },
+    wp_content_string_id, wp_content_u64_id,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+wp_content_u64_id!(ReceiptId);
+wp_content_u64_id!(OrderId);
+
+// Identifies the subscription a purchase created or renewed.
+wp_content_u64_id!(OwnershipId);
+
+// Localized name of a tax, e.g. `"VAT"`, `"GST"`.
+wp_content_string_id!(TaxName);
+
+// The vendor's registration ID for a given tax.
+wp_content_string_id!(TaxVendorId);
+
+/// How a transaction is paid for.
+///
+/// Only credit redemption is offered. The server accepts several other payment
+/// methods (stored cards, Stripe, PayPal, and various redirect processors), but
+/// those answer with a redirect/pending body — `redirect_url`, `qr_code` and
+/// friends — rather than a receipt. Adding a variant here therefore means
+/// giving the endpoint a response type that can represent both shapes; it is
+/// not just a matter of another string.
+#[derive(Debug, Clone, Serialize, uniffi::Enum)]
+pub enum TransactionPaymentMethod {
+    /// Charge the account's WordPress.com credits.
+    #[serde(rename = "WPCOM_Billing_WPCOM")]
+    UseCredits,
+}
+
+/// Payment details for a transaction.
+#[derive(Debug, Clone, Serialize, uniffi::Record)]
+pub struct TransactionPayment {
+    pub payment_method: TransactionPaymentMethod,
+}
+
+/// Parameters for `POST /me/transactions`.
+#[derive(Debug, Clone, Serialize, uniffi::Record)]
+pub struct RedeemCartParams {
+    /// The cart to redeem, as returned by `POST /me/shopping-cart/<cart_key>`.
+    pub cart: ShoppingCart,
+    pub payment: TransactionPayment,
+    /// WHOIS contact information. Required when the cart contains a domain
+    /// registration or transfer, ignored otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[uniffi(default = None)]
+    pub domain_details: Option<DomainContactInformation>,
+}
+
+/// Response from `POST /me/transactions` — a receipt for the redeemed cart.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct TransactionReceipt {
+    pub receipt_id: ReceiptId,
+    pub order_id: OrderId,
+    /// Whether every product in the cart was purchased.
+    ///
+    /// `false` does not mean nothing happened. Receiving this type at all means
+    /// the transaction was charged and a receipt exists; `false` narrows that
+    /// to a partial result, where some products couldn't be provisioned and are
+    /// listed in [`failed_purchases`](Self::failed_purchases). Requests that
+    /// fail outright — an empty cart, missing contact details, insufficient
+    /// credits — return an HTTP error rather than a receipt.
+    pub success: bool,
+    /// Completed purchases, keyed by the site they belong to.
+    pub purchases: HashMap<WpComSiteId, Vec<TransactionPurchase>>,
+    /// Products that could not be purchased, keyed by site. Empty when
+    /// everything succeeded.
+    pub failed_purchases: HashMap<WpComSiteId, Vec<TransactionFailedPurchase>>,
+    /// Receipt total formatted for display (e.g. `"C$33.90"`).
+    pub display_price: String,
+    /// Receipt total in the smallest unit of [`currency`](Self::currency).
+    pub price_integer: u64,
+    /// Receipt total as a decimal amount.
+    pub price_float: Decimal2,
+    pub currency: CurrencyCode,
+    pub is_gift_purchase: bool,
+    /// Whether the receipt is for a Gravatar domain purchase.
+    pub is_gravatar_domain: bool,
+}
+
+/// A product successfully purchased as part of a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct TransactionPurchase {
+    pub product_id: ProductId,
+    pub product_slug: ProductSlug,
+    pub product_name: String,
+    /// Abbreviated product name, when the product defines one.
+    pub product_name_short: Option<String>,
+    pub product_type: ProductType,
+    pub is_domain_registration: bool,
+    /// Product-specific detail — the domain name for domain products.
+    pub meta: Option<String>,
+    /// The site this purchase belongs to.
+    pub blog_id: Option<WpComSiteId>,
+    /// The subscription this purchase created or renewed.
+    pub ownership_id: Option<OwnershipId>,
+    pub is_renewal: bool,
+    pub will_auto_renew: bool,
+    pub is_gift_purchase: bool,
+    pub free_trial: bool,
+    /// Email address of the buyer.
+    pub user_email: String,
+    /// Amount paid in the smallest unit of the receipt's currency.
+    pub price_integer: u64,
+    /// When the purchased subscription expires. `None` for products that
+    /// don't create a subscription.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub expiry: Option<WpDateString>,
+    /// Details of the entity that collected tax on this purchase, present
+    /// only when tax was charged.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub tax_vendor_info: Option<TransactionTaxVendorInfo>,
+    /// Whether provisioning is deferred, for domain transfers.
+    #[serde(default)]
+    #[uniffi(default = false)]
+    pub delayed_provisioning: bool,
+    /// Whether this is a 100-year domain registration or transfer.
+    #[serde(default)]
+    #[uniffi(default = false)]
+    pub is_hundred_year_domain: bool,
+    /// For a mapped subdomain, whether its root domain is registered with
+    /// WordPress.com.
+    #[serde(default)]
+    #[uniffi(default = false)]
+    pub is_root_domain_with_us: bool,
+    /// The purchased quantity, for products sold in upgradable quantities.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub new_quantity: Option<u32>,
+    /// Where to send the user to finish setting up a marketplace SaaS product.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub saas_redirect_url: Option<String>,
+}
+
+/// A product that could not be purchased as part of a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct TransactionFailedPurchase {
+    pub product_id: ProductId,
+    pub product_name: String,
+    pub product_slug: ProductSlug,
+    /// Product-specific detail — the domain name for domain products.
+    pub product_meta: Option<String>,
+    pub product_cost: Decimal2,
+}
+
+/// The entity that collected tax on a purchase, for display on a receipt.
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct TransactionTaxVendorInfo {
+    pub country_code: CountryCode,
+    /// The entity's mailing address, one entry per line.
+    pub address: Vec<String>,
+    /// Each tax charged, mapped to the vendor's registration ID for it.
+    pub tax_name_and_vendor_id_array: HashMap<TaxName, TaxVendorId>,
+    /// Superseded by [`tax_name_and_vendor_id_array`](Self::tax_name_and_vendor_id_array)
+    /// and not sent by this endpoint.
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub vat_id: Option<TaxVendorId>,
+    /// See [`vat_id`](Self::vat_id).
+    #[serde(default)]
+    #[uniffi(default = None)]
+    pub tax_name: Option<TaxName>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    fn receipt(json_file_path: &str) -> TransactionReceipt {
+        let file = File::open(json_file_path).expect("Failed to open file");
+        serde_json::from_reader(file).expect("Unable to parse JSON")
+    }
+
+    #[test]
+    fn test_redeem_cart_success_deserialization() {
+        let receipt = receipt("tests/wpcom/transactions/redeem-cart-success.json");
+
+        assert_eq!(receipt.receipt_id, ReceiptId(11223344));
+        assert_eq!(receipt.order_id, OrderId(55667788));
+        assert!(receipt.success);
+        assert!(receipt.failed_purchases.is_empty());
+        assert_eq!(receipt.price_integer, 2825);
+        assert_eq!(receipt.price_float, Decimal2::from_hundredths(2825));
+        assert_eq!(receipt.currency, CurrencyCode("USD".to_string()));
+
+        // The `purchases` map is keyed by site ID, which arrives as a JSON
+        // object key — i.e. a string — rather than a number.
+        let site_purchases = receipt
+            .purchases
+            .get(&WpComSiteId(98765432))
+            .expect("purchases should be keyed by site ID");
+        assert_eq!(site_purchases.len(), 2);
+
+        let domain = &site_purchases[0];
+        assert_eq!(domain.product_id, ProductId(501));
+        assert_eq!(
+            domain.product_slug,
+            ProductSlug("dotblog_domain".to_string())
+        );
+        assert_eq!(domain.product_type, ProductType("domain_reg".to_string()));
+        assert!(domain.is_domain_registration);
+        assert_eq!(domain.meta.as_deref(), Some("fake-test-domain.blog"));
+        assert_eq!(domain.ownership_id, Some(OwnershipId(77001)));
+        assert_eq!(domain.blog_id, Some(WpComSiteId(98765432)));
+        assert_eq!(
+            domain.expiry,
+            Some(WpDateString("2030-01-15".to_string())),
+            "expiry is a date without a time component"
+        );
+        assert!(domain.product_name_short.is_none());
+        assert!(domain.will_auto_renew);
+        assert!(!domain.is_renewal);
+
+        // Optional fields absent from a plain domain purchase.
+        assert!(!domain.delayed_provisioning);
+        assert!(!domain.is_hundred_year_domain);
+        assert!(!domain.is_root_domain_with_us);
+        assert!(domain.new_quantity.is_none());
+        assert!(domain.saas_redirect_url.is_none());
+
+        let tax = domain
+            .tax_vendor_info
+            .as_ref()
+            .expect("a taxed purchase should have tax_vendor_info");
+        assert_eq!(tax.country_code, CountryCode("CA".to_string()));
+        assert_eq!(tax.address.len(), 4);
+        assert_eq!(
+            tax.tax_name_and_vendor_id_array
+                .get(&TaxName("GST".to_string())),
+            Some(&TaxVendorId("FAKE-GST-000123".to_string()))
+        );
+        // This endpoint serializes the vendor info without these legacy fields.
+        assert!(tax.vat_id.is_none());
+        assert!(tax.tax_name.is_none());
+    }
+
+    /// The server has no reachable code path that populates `failed_purchases`
+    /// safely enough to capture, so this fixture is hand-written from the
+    /// `WPCOM_Store_API::checkout()` assembly logic rather than a real
+    /// response. It also exercises the purchase fields that only appear for
+    /// transfers, marketplace products and quantity upgrades.
+    #[test]
+    fn test_redeem_cart_partial_failure_deserialization() {
+        let receipt = receipt("tests/wpcom/transactions/redeem-cart-partial-failure.json");
+
+        assert!(
+            !receipt.success,
+            "a partial failure is signalled through success and failed_purchases"
+        );
+
+        let failed = receipt
+            .failed_purchases
+            .get(&WpComSiteId(12345678))
+            .expect("failed_purchases should be keyed by site ID");
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].product_id, ProductId(603));
+        assert_eq!(
+            failed[0].product_meta.as_deref(),
+            Some("fake-failed-domain.example")
+        );
+        assert_eq!(failed[0].product_cost, Decimal2::from_hundredths(1800));
+
+        let purchases = receipt
+            .purchases
+            .get(&WpComSiteId(12345678))
+            .expect("purchases should be keyed by site ID");
+
+        let transfer = &purchases[0];
+        assert!(transfer.delayed_provisioning);
+        assert!(transfer.is_hundred_year_domain);
+        assert!(transfer.is_root_domain_with_us);
+        assert_eq!(transfer.product_name_short.as_deref(), Some("Transfer"));
+
+        let saas = &purchases[1];
+        assert_eq!(saas.new_quantity, Some(25));
+        assert_eq!(
+            saas.saas_redirect_url.as_deref(),
+            Some("https://example.com/setup?intent-id=fake-intent")
+        );
+        assert!(
+            saas.expiry.is_none(),
+            "a purchase without a subscription has no expiry"
+        );
+        assert!(saas.ownership_id.is_none());
+        assert!(saas.meta.is_none());
+
+        let tax = saas
+            .tax_vendor_info
+            .as_ref()
+            .expect("expected tax_vendor_info");
+        assert_eq!(tax.vat_id, Some(TaxVendorId("FAKE-VAT-000456".to_string())));
+        assert_eq!(tax.tax_name, Some(TaxName("VAT".to_string())));
+    }
+
+    fn fixture_cart() -> ShoppingCart {
+        let file = File::open("tests/wpcom/shopping_cart/cart-with-site.json")
+            .expect("Failed to open file");
+        serde_json::from_reader(file).expect("Unable to parse JSON")
+    }
+
+    #[test]
+    fn test_redeem_cart_params_serializes_credits_payment_method() {
+        let params = RedeemCartParams {
+            cart: fixture_cart(),
+            payment: TransactionPayment {
+                payment_method: TransactionPaymentMethod::UseCredits,
+            },
+            domain_details: None,
+        };
+
+        let json: serde_json::Value =
+            serde_json::to_value(&params).expect("params should serialize");
+
+        assert_eq!(json["payment"]["payment_method"], "WPCOM_Billing_WPCOM");
+        assert!(
+            json.get("domain_details").is_none(),
+            "domain_details should be omitted rather than sent as null"
+        );
+        assert_eq!(json["cart"]["cart_key"], 12345678);
+    }
+
+    #[test]
+    fn test_redeem_cart_params_serializes_domain_details() {
+        let params = RedeemCartParams {
+            cart: fixture_cart(),
+            payment: TransactionPayment {
+                payment_method: TransactionPaymentMethod::UseCredits,
+            },
+            domain_details: Some(DomainContactInformation {
+                first_name: Some("Jane".to_string()),
+                last_name: Some("Smith".to_string()),
+                organization: None,
+                address_1: None,
+                address_2: None,
+                postal_code: None,
+                city: None,
+                state: None,
+                country_code: Some(CountryCode("US".to_string())),
+                email: Some("jane@example.com".to_string()),
+                phone: None,
+                fax: None,
+                extra: None,
+            }),
+        };
+
+        let json: serde_json::Value =
+            serde_json::to_value(&params).expect("params should serialize");
+
+        assert_eq!(json["domain_details"]["first_name"], "Jane");
+        assert_eq!(json["domain_details"]["country_code"], "US");
+        assert_eq!(json["payment"]["payment_method"], "WPCOM_Billing_WPCOM");
+    }
+}

--- a/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
+++ b/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
@@ -52,9 +52,7 @@
           ],
           "tax_name_and_vendor_id_array": {
             "VAT": "FAKE-VAT-000456"
-          },
-          "vat_id": "FAKE-VAT-000456",
-          "tax_name": "VAT"
+          }
         }
       },
       {

--- a/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
+++ b/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
@@ -1,0 +1,82 @@
+{
+  "receipt_id": 22334455,
+  "purchases": {
+    "12345678": [
+      {
+        "is_gift_purchase": false,
+        "will_auto_renew": false,
+        "expiry": "2130-03-01",
+        "user_email": "buyer@example.com",
+        "product_id": 601,
+        "product_slug": "domain_transfer",
+        "product_name": "Domain Transfer",
+        "product_name_short": "Transfer",
+        "product_type": "domain_transfer",
+        "free_trial": false,
+        "is_domain_registration": false,
+        "meta": "fake-transfer-domain.com",
+        "ownership_id": 88001,
+        "is_renewal": false,
+        "blog_id": 12345678,
+        "price_integer": 900,
+        "delayed_provisioning": true,
+        "is_hundred_year_domain": true,
+        "is_root_domain_with_us": true
+      },
+      {
+        "is_gift_purchase": true,
+        "will_auto_renew": true,
+        "user_email": "buyer@example.com",
+        "product_id": 602,
+        "product_slug": "fake_marketplace_saas_monthly",
+        "product_name": "Fake Marketplace Add-on",
+        "product_name_short": "Add-on",
+        "product_type": "saas_plugin",
+        "free_trial": false,
+        "is_domain_registration": false,
+        "meta": null,
+        "ownership_id": null,
+        "is_renewal": true,
+        "blog_id": 12345678,
+        "price_integer": 1200,
+        "new_quantity": 25,
+        "saas_redirect_url": "https://example.com/setup?intent-id=fake-intent",
+        "tax_vendor_info": {
+          "country_code": "IE",
+          "address": [
+            "Fake Payments Ltd.",
+            "1 Example Street",
+            "Faketown, FK1 2AB",
+            "Fakeland"
+          ],
+          "tax_name_and_vendor_id_array": {
+            "VAT": "FAKE-VAT-000456"
+          },
+          "vat_id": "FAKE-VAT-000456",
+          "tax_name": "VAT"
+        }
+      }
+    ]
+  },
+  "display_price": "$21.00",
+  "price_integer": 2100,
+  "price_float": 21,
+  "currency": "USD",
+  "is_gift_purchase": false,
+  "is_gravatar_domain": false,
+  "success": false,
+  "error_code": "",
+  "error_message": "",
+  "order_id": 66778899,
+  "failed_purchases": {
+    "12345678": [
+      {
+        "product_id": 603,
+        "product_name": ".example Domain Registration",
+        "product_slug": "dotexample_domain",
+        "product_meta": "fake-failed-domain.example",
+        "product_cost": 18
+      }
+    ]
+  }
+}

--- a/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
+++ b/wp_api/tests/wpcom/transactions/redeem-cart-partial-failure.json
@@ -26,6 +26,7 @@
       {
         "is_gift_purchase": true,
         "will_auto_renew": true,
+        "expiry": "2027-02-01",
         "user_email": "buyer@example.com",
         "product_id": 602,
         "product_slug": "fake_marketplace_saas_monthly",
@@ -35,7 +36,7 @@
         "free_trial": false,
         "is_domain_registration": false,
         "meta": null,
-        "ownership_id": null,
+        "ownership_id": 88002,
         "is_renewal": true,
         "blog_id": 12345678,
         "price_integer": 1200,
@@ -55,6 +56,23 @@
           "vat_id": "FAKE-VAT-000456",
           "tax_name": "VAT"
         }
+      },
+      {
+        "is_gift_purchase": false,
+        "will_auto_renew": false,
+        "user_email": "buyer@example.com",
+        "product_id": 604,
+        "product_slug": "fake_one_time_theme",
+        "product_name": "Fake Premium Theme",
+        "product_name_short": null,
+        "product_type": "theme",
+        "free_trial": false,
+        "is_domain_registration": false,
+        "meta": null,
+        "ownership_id": null,
+        "is_renewal": false,
+        "blog_id": 12345678,
+        "price_integer": 0
       }
     ]
   },
@@ -62,7 +80,7 @@
   "price_integer": 2100,
   "price_float": 21,
   "currency": "USD",
-  "is_gift_purchase": false,
+  "is_gift_purchase": true,
   "is_gravatar_domain": false,
   "success": false,
   "error_code": "",

--- a/wp_api/tests/wpcom/transactions/redeem-cart-success.json
+++ b/wp_api/tests/wpcom/transactions/redeem-cart-success.json
@@ -1,0 +1,78 @@
+{
+  "receipt_id": 11223344,
+  "purchases": {
+    "98765432": [
+      {
+        "is_gift_purchase": false,
+        "will_auto_renew": true,
+        "expiry": "2030-01-15",
+        "user_email": "buyer@example.com",
+        "product_id": 501,
+        "product_slug": "dotblog_domain",
+        "product_name": ".blog Domain Registration",
+        "product_name_short": null,
+        "product_type": "domain_reg",
+        "free_trial": false,
+        "is_domain_registration": true,
+        "meta": "fake-test-domain.blog",
+        "ownership_id": 77001,
+        "is_renewal": false,
+        "blog_id": 98765432,
+        "price_integer": 2500,
+        "tax_vendor_info": {
+          "country_code": "CA",
+          "address": [
+            "Fake Payments Ltd.",
+            "1 Example Street",
+            "Faketown, FK1 2AB",
+            "Fakeland"
+          ],
+          "tax_name_and_vendor_id_array": {
+            "GST": "FAKE-GST-000123"
+          }
+        }
+      },
+      {
+        "is_gift_purchase": false,
+        "will_auto_renew": true,
+        "expiry": "2030-01-15",
+        "user_email": "buyer@example.com",
+        "product_id": 502,
+        "product_slug": "domain_map",
+        "product_name": "Domain Connection",
+        "product_name_short": null,
+        "product_type": "domain_map",
+        "free_trial": false,
+        "is_domain_registration": false,
+        "meta": "fake-test-domain.blog",
+        "ownership_id": 77002,
+        "is_renewal": false,
+        "blog_id": 98765432,
+        "price_integer": 0,
+        "tax_vendor_info": {
+          "country_code": "CA",
+          "address": [
+            "Fake Payments Ltd.",
+            "1 Example Street",
+            "Faketown, FK1 2AB",
+            "Fakeland"
+          ],
+          "tax_name_and_vendor_id_array": {
+            "GST": "FAKE-GST-000123"
+          }
+        }
+      }
+    ]
+  },
+  "display_price": "$28.25",
+  "price_integer": 2825,
+  "price_float": 28.25,
+  "currency": "USD",
+  "is_gift_purchase": false,
+  "is_gravatar_domain": false,
+  "success": true,
+  "error_code": "",
+  "error_message": "",
+  "order_id": 55667788,
+  "failed_purchases": {}
+}

--- a/wp_com_e2e/src/main.rs
+++ b/wp_com_e2e/src/main.rs
@@ -24,6 +24,7 @@ mod subscribers_by_user_type_tests;
 mod support_bot_tests;
 mod support_eligibility_test;
 mod support_tickets_test;
+mod transactions_tests;
 mod unified_conversations_tests;
 mod wp_service_tests;
 
@@ -71,6 +72,7 @@ fn collect_tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     tests.extend(stats_top_posts_tests::tests(Arc::clone(&ctx)));
     tests.extend(subscribers_by_user_type_tests::tests(Arc::clone(&ctx)));
     tests.extend(products_tests::tests(Arc::clone(&ctx)));
+    tests.extend(transactions_tests::tests(Arc::clone(&ctx)));
     tests.extend(wp_service_tests::tests(Arc::clone(&ctx)));
     tests
 }

--- a/wp_com_e2e/src/products_tests.rs
+++ b/wp_com_e2e/src/products_tests.rs
@@ -51,7 +51,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
 
                 // All returned products should be domain-related.
                 for (slug, product) in &products {
-                    if !product.product_type.contains("domain") {
+                    if !product.product_type.0.contains("domain") {
                         return Err(format!(
                             "expected domain product type for {slug}, got {}",
                             product.product_type

--- a/wp_com_e2e/src/transactions_tests.rs
+++ b/wp_com_e2e/src/transactions_tests.rs
@@ -1,0 +1,92 @@
+use crate::context::TestContext;
+use libtest_mimic::Trial;
+use std::sync::Arc;
+use wp_api::{
+    api_error::WpApiError,
+    decimal2::Decimal2,
+    wp_com::{
+        CurrencyCode, WpComSiteId,
+        shopping_cart::{CartKey, ShoppingCart, ShoppingCartMessages, ShoppingCartTax},
+        transactions::{RedeemCartParams, TransactionPayment, TransactionPaymentMethod},
+    },
+};
+
+/// Builds a cart with nothing in it.
+///
+/// Redeeming a cart is a real, irreversible purchase that spends the account's
+/// credits, so there is no safe happy path to exercise here. An empty cart is
+/// rejected with `empty_cart` before the server charges anything, which still
+/// covers the URL, authentication and request serialization.
+fn empty_cart(site_id: WpComSiteId) -> ShoppingCart {
+    ShoppingCart {
+        cart_generated_at_timestamp: 0,
+        blog_id: site_id,
+        cart_key: CartKey::Site { id: site_id },
+        coupon: String::new(),
+        is_coupon_applied: false,
+        has_auto_renew_coupon_been_automatically_applied: false,
+        next_domain_is_free: false,
+        next_domain_condition: String::new(),
+        products: vec![],
+        unmerged_products: vec![],
+        total_cost: Decimal2::from_hundredths(0),
+        currency: CurrencyCode("USD".to_string()),
+        total_cost_integer: 0,
+        temporary: true,
+        tax: ShoppingCartTax {
+            display_taxes: false,
+        },
+        coupon_savings_total_integer: 0,
+        sub_total_with_taxes_integer: 0,
+        sub_total_integer: 0,
+        total_tax: Decimal2::from_hundredths(0),
+        total_tax_integer: 0,
+        credits: Decimal2::from_hundredths(0),
+        credits_integer: 0,
+        allowed_payment_methods: vec![],
+        is_gift_purchase: false,
+        messages: ShoppingCartMessages {
+            errors: vec![],
+            success: vec![],
+            persistent_errors: vec![],
+        },
+        bundled_domain: None,
+    }
+}
+
+pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
+    let mut trials = vec![];
+
+    trials.push(Trial::test("transactions::redeem_empty_cart", {
+        let ctx = Arc::clone(&ctx);
+        move || {
+            ctx.runtime.block_on(async {
+                let result = ctx
+                    .client
+                    .me()
+                    .redeem_cart(&RedeemCartParams {
+                        cart: empty_cart(ctx.site_id),
+                        payment: TransactionPayment {
+                            payment_method: TransactionPaymentMethod::UseCredits,
+                        },
+                        domain_details: None,
+                    })
+                    .await;
+
+                match result {
+                    Ok(_) => Err("expected redeeming an empty cart to fail".into()),
+                    // wp.com sends `{"error", "message"}`, which the error layer
+                    // doesn't parse, so the code is matched in the raw body.
+                    Err(WpApiError::UnknownError { response, .. })
+                        if response.contains("empty_cart") =>
+                    {
+                        Ok(())
+                    }
+                    Err(e) => Err(format!("Unexpected error: {e:?}").into()),
+                }
+            })
+        }
+    }));
+
+    trials
+}

--- a/wp_com_e2e/src/transactions_tests.rs
+++ b/wp_com_e2e/src/transactions_tests.rs
@@ -6,7 +6,9 @@ use wp_api::{
     decimal2::Decimal2,
     wp_com::{
         CurrencyCode, WpComSiteId,
-        shopping_cart::{CartKey, ShoppingCart, ShoppingCartMessages, ShoppingCartTax},
+        shopping_cart::{
+            CartKey, ShoppingCart, ShoppingCartMessages, ShoppingCartTax, ShoppingCartTaxLocation,
+        },
         transactions::{RedeemCartParams, TransactionPayment, TransactionPaymentMethod},
     },
 };
@@ -35,6 +37,17 @@ fn empty_cart(site_id: WpComSiteId) -> ShoppingCart {
         temporary: true,
         tax: ShoppingCartTax {
             display_taxes: false,
+            location: ShoppingCartTaxLocation {
+                country_code: None,
+                postal_code: None,
+                subdivision_code: None,
+                ip_address: None,
+                vat_id: None,
+                organization: None,
+                address: None,
+                city: None,
+                is_for_business: None,
+            },
         },
         coupon_savings_total_integer: 0,
         sub_total_with_taxes_integer: 0,

--- a/wp_serde_helper/src/numeric.rs
+++ b/wp_serde_helper/src/numeric.rs
@@ -108,6 +108,47 @@ where
     deserialize_u64_or_string(deserializer).map(|v| if v == 0 { None } else { Some(v) })
 }
 
+/// Deserialize an optional `u64` from a number or a string, treating an empty
+/// string and `null` as `None`.
+///
+/// Some WordPress.com fields are documented as integers but fall back to an
+/// empty string when the underlying value is unavailable.
+///
+/// Accepts:
+/// - `123` or `"123"` → `Some(123)`
+/// - `""` → `None`
+/// - `null` → `None`
+///
+/// # Errors
+///
+/// Returns an error for non-numeric strings, negative numbers, booleans,
+/// arrays, or objects.
+pub fn deserialize_u64_or_none_from_number_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumberOrString {
+        Number(u64),
+        String(String),
+    }
+
+    match Option::<NumberOrString>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(NumberOrString::Number(number)) => Ok(Some(number)),
+        Some(NumberOrString::String(string)) => {
+            if string.is_empty() {
+                Ok(None)
+            } else {
+                string.parse().map(Some).map_err(de::Error::custom)
+            }
+        }
+    }
+}
+
 /// Deserialize an optional `u64`, treating `false`, `null`, and negative numbers as `None`.
 ///
 /// Accepts:

--- a/wp_serde_helper/src/numeric.rs
+++ b/wp_serde_helper/src/numeric.rs
@@ -108,8 +108,8 @@ where
     deserialize_u64_or_string(deserializer).map(|v| if v == 0 { None } else { Some(v) })
 }
 
-/// Deserialize an optional `u64` from a number or a string, treating an empty
-/// string and `null` as `None`.
+/// Deserialize an optional `u64` from either a number or a string, treating an
+/// empty string and `null` as `None`.
 ///
 /// Some WordPress.com fields are documented as integers but fall back to an
 /// empty string when the underlying value is unavailable.
@@ -123,9 +123,7 @@ where
 ///
 /// Returns an error for non-numeric strings, negative numbers, booleans,
 /// arrays, or objects.
-pub fn deserialize_u64_or_none_from_number_or_string<'de, D>(
-    deserializer: D,
-) -> Result<Option<u64>, D::Error>
+pub fn deserialize_u64_or_string_or_none<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -147,6 +145,26 @@ where
             }
         }
     }
+}
+
+/// Deserialize an optional `u64` from either a number or a string and convert
+/// it to a type that implements `From<u64>`, treating an empty string and
+/// `null` as `None`.
+///
+/// This is useful for newtype wrappers around `u64`.
+///
+/// # Errors
+///
+/// Returns an error for non-numeric strings, negative numbers, booleans,
+/// arrays, or objects.
+pub fn deserialize_u64_or_string_or_none_as_t<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: From<u64>,
+{
+    deserialize_u64_or_string_or_none(deserializer).map(|value| value.map(Into::into))
 }
 
 /// Deserialize an optional `u64`, treating `false`, `null`, and negative numbers as `None`.


### PR DESCRIPTION
### Description

Redeems a shopping cart against the account's WordPress.com credits. The response is a receipt describing what was purchased.

- `RedeemCartParams` plus the receipt response types (`TransactionReceipt`, `TransactionPurchase`, `TransactionFailedPurchase`, `TransactionTaxVendorInfo`) in a new `wp_com/transactions.rs`
- `TransactionPaymentMethod` offers only `UseCredits`; the server's other payment methods answer with a redirect/pending body that the receipt type can't represent
- New `ReceiptId`, `OrderId`, `OwnershipId`, `TaxName` and `TaxVendorId` newtypes, and a `ProductType` newtype replacing the raw `String` on `Product.product_type` and `WPComProduct.product_type`
- `WpComSiteId` now uses `wp_content_u64_id!`, which supplies the `Hash` it needs as the key of the `purchases` map
- `RedeemCart` `POST` variant on `MeRequest` (`RestV1.1`) + URL unit test
- Deserialization tests against an anonymized capture and a synthetic partial-failure fixture
- `transactions::redeem_empty_cart` e2e test covering the error path only; a successful redemption is a real, irreversible purchase

### Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
