### PR TITLE
Enable SQLite Foreign Key Enforcement on Every Cache Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.
+- **BREAKING:** The cache now enables SQLite foreign key enforcement on every connection it prepares, and fails with `SqliteDbError::ForeignKeysUnavailable` if the setting doesn't take effect. Removing a site relies on `ON DELETE CASCADE` to clear its cached rows, so on builds where enforcement defaulted to off those rows were silently left behind.
 - **Internal:** Build the Android JNI libraries with `cargo-ndk` instead of the `rust-android-gradle` Gradle plugin.
 - **Internal:** Upgraded the Android/Kotlin build to Android Gradle Plugin `9.3.0` / Gradle `9.5.0` (Kotlin `2.3.21`, `compileSdk` 36), migrating `api/android` to the AGP 9 variant APIs and splitting the example app into a `com.android.kotlin.multiplatform.library` shared module and a standalone `com.android.application` module.
 - **Internal:** Bumped `syn` from `2.0` to `3.0`, updating the proc-macro crates for its breaking changes.

--- a/wp_mobile_cache/src/lib.rs
+++ b/wp_mobile_cache/src/lib.rs
@@ -24,6 +24,7 @@ pub mod test_fixtures;
 pub enum SqliteDbError {
     SqliteError(String),
     ConstraintViolation(String),
+    ForeignKeysUnavailable,
     TableNameMismatch { expected: DbTable, actual: DbTable },
     PerPageMismatch { expected: i64, actual: i64 },
 }
@@ -34,6 +35,12 @@ impl std::fmt::Display for SqliteDbError {
             SqliteDbError::SqliteError(message) => write!(f, "SqliteDbError: message={}", message),
             SqliteDbError::ConstraintViolation(message) => {
                 write!(f, "Constraint violation: {}", message)
+            }
+            SqliteDbError::ForeignKeysUnavailable => {
+                write!(
+                    f,
+                    "Foreign key enforcement could not be enabled on the connection"
+                )
             }
             SqliteDbError::TableNameMismatch { expected, actual } => {
                 write!(
@@ -439,6 +446,7 @@ impl TryFrom<Connection> for WpApiCache {
     /// This is typically used in tests to create a cache from an already-migrated
     /// in-memory database connection.
     fn try_from(connection: Connection) -> Result<Self, Self::Error> {
+        enable_foreign_keys(&connection)?;
         register_url_functions(&connection)?;
         Ok(Self {
             inner: DBManager {
@@ -473,8 +481,9 @@ impl<'a> MigrationManager<'a> {
     pub fn new(connection: &'a Connection) -> Result<Self, SqliteDbError> {
         // Cover raw-connection paths that bypass WpApiCache construction
         // (test fixtures that hand a Connection straight to the repository
-        // layer). The registration is idempotent, so connections that were
-        // already prepared by DBManager / From<Connection> are unaffected.
+        // layer). Both calls are idempotent, so connections that were already
+        // prepared by DBManager / TryFrom<Connection> are unaffected.
+        enable_foreign_keys(connection)?;
         register_url_functions(connection)?;
         Ok(Self { connection })
     }
@@ -610,11 +619,32 @@ impl DBManager {
             Connection::open_in_memory()?
         };
 
+        enable_foreign_keys(&connection)?;
         register_url_functions(&connection)?;
 
         Ok(Self {
             connection: Mutex::new(connection),
         })
+    }
+}
+
+/// Turn on foreign key enforcement for `conn` and confirm it took effect.
+///
+/// The schema relies on `ON DELETE CASCADE` to clear the rows belonging to a
+/// deleted parent. SQLite honours those clauses only while `foreign_keys` is
+/// on — a per-connection setting whose default is not guaranteed — and when it
+/// is off the delete still succeeds and silently leaves the children behind.
+///
+/// The value is read back rather than assumed because `PRAGMA foreign_keys` is
+/// a no-op inside an open transaction and reports no error when it is ignored.
+pub(crate) fn enable_foreign_keys(conn: &Connection) -> Result<(), SqliteDbError> {
+    conn.pragma_update(None, "foreign_keys", true)?;
+
+    let enabled: bool = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+    if enabled {
+        Ok(())
+    } else {
+        Err(SqliteDbError::ForeignKeysUnavailable)
     }
 }
 
@@ -653,6 +683,123 @@ uniffi::setup_scaffolding!();
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::get_table_column_names;
+
+    fn foreign_keys_enabled(conn: &Connection) -> bool {
+        conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .expect("Failed to read foreign_keys pragma")
+    }
+
+    /// A connection with enforcement explicitly turned off, standing in for a
+    /// SQLite build whose default leaves it off.
+    fn connection_without_foreign_keys() -> Connection {
+        let conn = Connection::open_in_memory().expect("Failed to open in-memory database");
+        conn.pragma_update(None, "foreign_keys", false)
+            .expect("Failed to disable foreign_keys");
+        assert!(!foreign_keys_enabled(&conn));
+        conn
+    }
+
+    #[test]
+    fn test_cache_constructor_enables_foreign_keys() {
+        let cache = WpApiCache::new(None).expect("Cache creation should succeed");
+        assert!(
+            cache.execute(|conn| foreign_keys_enabled(conn)),
+            "WpApiCache::new must enable foreign key enforcement"
+        );
+    }
+
+    #[test]
+    fn test_try_from_enables_foreign_keys_on_a_connection_that_had_them_off() {
+        let cache = WpApiCache::try_from(connection_without_foreign_keys())
+            .expect("Cache creation should succeed");
+        assert!(
+            cache.execute(|conn| foreign_keys_enabled(conn)),
+            "WpApiCache::try_from must enable foreign key enforcement rather than \
+             inherit whatever the incoming connection had"
+        );
+    }
+
+    #[test]
+    fn test_migration_manager_enables_foreign_keys_on_a_connection_that_had_them_off() {
+        let conn = connection_without_foreign_keys();
+        MigrationManager::new(&conn).expect("MigrationManager creation should succeed");
+        assert!(
+            foreign_keys_enabled(&conn),
+            "MigrationManager::new must enable foreign key enforcement so that raw \
+             connections handed straight to the repository layer are also covered"
+        );
+    }
+
+    /// `SiteRepository::delete_site` deletes only the `db_sites` row and relies on
+    /// `ON DELETE CASCADE` for everything else, so a child table that reaches
+    /// `db_sites` without that clause leaks its rows on every site removal.
+    ///
+    /// `entity_state` is the deliberate exception: it carries no constraint and is
+    /// cleared by an explicit `DELETE` in `delete_site`.
+    #[test]
+    fn test_every_table_referencing_db_sites_cascades_on_delete() {
+        const NO_CASCADE_CONSTRAINT: [DbTable; 1] = [DbTable::EntityState];
+
+        let conn = Connection::open_in_memory().expect("Failed to open in-memory database");
+        let mut migration_manager =
+            MigrationManager::new(&conn).expect("Failed to create MigrationManager");
+        migration_manager
+            .perform_migrations()
+            .expect("All migrations should succeed");
+
+        // Read the table list from the schema rather than from `DbTable`, so a
+        // table added by a future migration is covered whether or not it is
+        // also exposed as a `DbTable` variant.
+        let exempt: Vec<&str> = NO_CASCADE_CONSTRAINT
+            .iter()
+            .map(|table| table.table_name())
+            .collect();
+        let tables: Vec<String> = conn
+            .prepare(
+                "SELECT name FROM sqlite_master \
+                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != '_migrations'",
+            )
+            .expect("Failed to prepare sqlite_master query")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("Failed to execute sqlite_master query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to collect table names");
+
+        let mut checked = 0;
+        for table in tables {
+            let has_db_site_id = get_table_column_names(&conn, &table)
+                .iter()
+                .any(|column| column == "db_site_id");
+            if !has_db_site_id || exempt.contains(&table.as_str()) {
+                continue;
+            }
+
+            // (referenced table, on_delete) for each outgoing foreign key
+            let foreign_keys: Vec<(String, String)> = conn
+                .prepare(&format!("PRAGMA foreign_key_list({})", table))
+                .expect("Failed to prepare PRAGMA query")
+                .query_map([], |row| Ok((row.get(2)?, row.get(6)?)))
+                .expect("Failed to execute PRAGMA query")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("Failed to collect foreign keys");
+
+            assert!(
+                foreign_keys.contains(&(
+                    DbTable::DbSites.table_name().to_string(),
+                    "CASCADE".to_string()
+                )),
+                "{} has a db_site_id column but no ON DELETE CASCADE foreign key to {}; \
+                 its rows would survive delete_site. Foreign keys found: {:?}",
+                table,
+                DbTable::DbSites,
+                foreign_keys
+            );
+            checked += 1;
+        }
+
+        assert!(checked > 0, "No tables were checked");
+    }
 
     #[test]
     fn test_migration_works() {

--- a/wp_mobile_cache/src/repository/sites.rs
+++ b/wp_mobile_cache/src/repository/sites.rs
@@ -444,8 +444,12 @@ impl SiteRepository {
 mod tests {
     use super::*;
     use crate::{
-        MigrationManager, db_types::row_ext::ColumnIndex,
-        db_types::wordpress_com_site::DbWordPressComSiteColumn, entity::EntityId,
+        MigrationManager,
+        db_types::row_ext::ColumnIndex,
+        db_types::wordpress_com_site::DbWordPressComSiteColumn,
+        entity::EntityId,
+        list_metadata::{ListKey, ListState},
+        repository::list_metadata::{ListMetadataItemInput, ListMetadataRepository},
         test_fixtures::get_table_column_names,
     };
     use rstest::*;
@@ -741,6 +745,75 @@ mod tests {
         assert_eq!(
             count_self_hosted_after, 0,
             "Site should be deleted from self_hosted_sites table"
+        );
+    }
+
+    /// `list_metadata` cascades from `db_sites`, and its items and state rows
+    /// cascade again from `list_metadata`. The second hop only fires because
+    /// SQLite applies cascades recursively, so it is worth asserting directly.
+    #[rstest]
+    fn test_delete_site_cascades_through_list_metadata_to_items_and_state(
+        mut test_conn: Connection,
+    ) {
+        let repo = SiteRepository;
+        let site = SelfHostedSite {
+            url: "https://example.com".to_string(),
+            api_root: "https://example.com/wp-json".to_string(),
+        };
+        let entity_id = repo
+            .upsert_self_hosted_site(&mut test_conn, &site)
+            .expect("Failed to upsert site");
+
+        let key = ListKey::from("edit:posts:publish");
+        let list_metadata_id =
+            ListMetadataRepository::get_or_create(&test_conn, &entity_id.db_site, &key, 20)
+                .expect("Failed to create list metadata");
+        ListMetadataRepository::set_items_by_list_metadata_id(
+            &test_conn,
+            list_metadata_id,
+            &[ListMetadataItemInput {
+                entity_id: 1,
+                modified_gmt: None,
+                parent: None,
+                menu_order: None,
+            }],
+        )
+        .expect("Failed to set list items");
+        ListMetadataRepository::update_state_by_list_metadata_id(
+            &test_conn,
+            list_metadata_id,
+            ListState::Idle,
+            None,
+        )
+        .expect("Failed to set list state");
+
+        assert_eq!(
+            ListMetadataRepository::get_items_by_list_metadata_id(&test_conn, list_metadata_id)
+                .expect("Failed to read list items")
+                .len(),
+            1
+        );
+
+        repo.delete_site(&mut test_conn, &entity_id.db_site)
+            .expect("Failed to delete site");
+
+        assert!(
+            ListMetadataRepository::get_header(&test_conn, &entity_id.db_site, &key)
+                .expect("Failed to read list header")
+                .is_none(),
+            "list_metadata should cascade from db_sites"
+        );
+        assert!(
+            ListMetadataRepository::get_items_by_list_metadata_id(&test_conn, list_metadata_id)
+                .expect("Failed to read list items")
+                .is_empty(),
+            "list_metadata_items should cascade from list_metadata"
+        );
+        assert!(
+            ListMetadataRepository::get_state_by_list_metadata_id(&test_conn, list_metadata_id)
+                .expect("Failed to read list state")
+                .is_none(),
+            "list_metadata_state should cascade from list_metadata"
         );
     }
 


### PR DESCRIPTION
## Description

The cache schema relies on `ON DELETE CASCADE` to clear a site's rows when the site is removed — `SiteRepository::delete_site` deletes the `db_sites` row and lets the cascade take care of the rest. SQLite only honours those clauses while `foreign_keys` is on, and that is a per-connection setting whose default depends on the SQLite build in use. Where it defaults to off, the delete still succeeds and silently leaves every child row behind; because `db_sites.id` is `AUTOINCREMENT`, those rows are never reachable again.

This turns enforcement on explicitly for every connection the cache prepares, and reads the value back rather than assuming it — `PRAGMA foreign_keys` is a no-op inside an open transaction and reports no error when it is ignored.

> [!Note]
> This overlaps with #1471, which fixes the same problem. I discussed it with @crazytonyli, and he asked me to open this change as a PR.

## Changes

- Added `enable_foreign_keys`, which sets the pragma and reads it back, returning the new `SqliteDbError::ForeignKeysUnavailable` variant when the setting doesn't take effect.
- Called it from `DBManager::new`, `TryFrom<Connection> for WpApiCache`, and `MigrationManager::new` — together these cover every path in the crate that prepares a connection, including the raw connections that test fixtures hand straight to the repository layer.
- Added tests asserting each of those three entry points enables enforcement, using a fixture connection with the pragma explicitly turned off.
- Added a schema-level test requiring every table with a `db_site_id` column to declare an `ON DELETE CASCADE` foreign key to `db_sites`. It reads the table list from `sqlite_master` rather than from `DbTable`, so a table added by a future migration is covered either way. `entity_state` is the deliberate exception — it carries no constraint and `delete_site` clears it with an explicit `DELETE`.
- Added a test covering the two-hop cascade from `db_sites` through `list_metadata` to its item and state rows, which only fires because SQLite applies cascades recursively.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
