### PR TITLE
Route Kotlin integration test dependencies through Reposilite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Use Ruby 3.4.9 for automation tooling.
 - **Internal:** Update translations.
 - **Internal:** Fix a flaky unit test.
+- **Internal:** Route the Kotlin integration tests through the in-VPC Reposilite dependency mirror
 
 ## [0.6.0] - 2026-07-16
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ rust_docker_container := public.ecr.aws/docker/library/rust:$(rust_stable_toolch
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e TEST_ALL_PLUGINS -e CARGO_HOME=/app/.cargo $(rust_docker_container)
 docker_build_and_run := docker build -t foo . && docker run $(docker_opts_shared) -it foo
+gradle_mirror_init_script ?= /var/lib/buildkite-agent/.gradle/init.d/mirror.gradle.kts
 
 swift_package_platform_version = $(shell swift package dump-package | jq -r '.platforms[] | select(.platformName=="$1") | .version')
 swift_package_platform_macos = $(call swift_package_platform_version,macos)
@@ -229,6 +230,7 @@ report-remote-login-integration-test-suite-health:
 
 test-kotlin-integration:
 	@# Help: Run Kotlin integration tests in test server.
+	@if [ -f "$(gradle_mirror_init_script)" ]; then docker exec -i wordpress mkdir -p /root/.gradle/init.d && docker cp "$(gradle_mirror_init_script)" wordpress:/root/.gradle/init.d/mirror.gradle.kts; fi
 	docker exec -i wordpress /bin/bash < ./scripts/run-kotlin-integration-tests.sh
 
 runComposeDesktopApp:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ rust_docker_container := public.ecr.aws/docker/library/rust:$(rust_stable_toolch
 docker_opts_shared := --rm -v "$(PWD)":$(docker_container_repo_dir) -w $(docker_container_repo_dir)
 rust_docker_run := docker run -v $(PWD):/$(docker_container_repo_dir) -w $(docker_container_repo_dir) -it -e TEST_ALL_PLUGINS -e CARGO_HOME=/app/.cargo $(rust_docker_container)
 docker_build_and_run := docker build -t foo . && docker run $(docker_opts_shared) -it foo
-gradle_mirror_init_script ?= /var/lib/buildkite-agent/.gradle/init.d/mirror.gradle.kts
 
 swift_package_platform_version = $(shell swift package dump-package | jq -r '.platforms[] | select(.platformName=="$1") | .version')
 swift_package_platform_macos = $(call swift_package_platform_version,macos)
@@ -230,8 +229,7 @@ report-remote-login-integration-test-suite-health:
 
 test-kotlin-integration:
 	@# Help: Run Kotlin integration tests in test server.
-	@if [ -f "$(gradle_mirror_init_script)" ]; then docker exec -i wordpress mkdir -p /root/.gradle/init.d && docker cp "$(gradle_mirror_init_script)" wordpress:/root/.gradle/init.d/mirror.gradle.kts; fi
-	docker exec -i wordpress /bin/bash < ./scripts/run-kotlin-integration-tests.sh
+	docker exec -i -e REPOSILITE_MIRROR_ENABLED -e REPOSILITE_MIRROR_URL wordpress /bin/bash < ./scripts/run-kotlin-integration-tests.sh
 
 runComposeDesktopApp:
 	@# Help: Run the Compose Multiplatform desktop application.

--- a/scripts/reposilite-mirror.gradle.kts
+++ b/scripts/reposilite-mirror.gradle.kts
@@ -1,0 +1,84 @@
+// Copy of buildkite-ci's Gradle mirror init script. Keep in sync with it:
+// https://github.com/Automattic/buildkite-ci/blob/trunk/src/agents/_shared_/roles/android.install-gradle/files/mirror.gradle.kts
+//
+// Reposilite dependency mirror — redirects Gradle's dependency repositories
+// through our internal Reposilite pull-through cache. Cache misses then egress
+// once through the NAT gateway instead of every ephemeral agent re-resolving
+// from the upstreams, which is what triggers Maven Central's per-source-IP
+// `429 Too Many Requests` throttling.
+//
+// Two escape hatches, both evaluated up front — Gradle does NOT fall through to
+// another repository on transport errors (timeouts/5xx/connection-refused; it
+// only does so on a clean 404), so the decision is made before resolution:
+//   * REPOSILITE_MIRROR_ENABLED=false  -> kill switch: use the public repos
+//   * mirror unreachable               -> automatic fallback to the public repos
+//
+// REPOSILITE_MIRROR_URL overrides the proxy address without re-provisioning, in
+// case the baked-in default below ever changes.
+
+import java.net.HttpURLConnection
+import java.net.URI
+import org.gradle.api.tasks.testing.Test
+
+val reposilite = System.getenv("REPOSILITE_MIRROR_URL") ?: "http://10.0.2.215:8080"
+
+// Default-ON: only REPOSILITE_MIRROR_ENABLED=false turns the mirror off.
+val mirrorEnabled = System.getenv("REPOSILITE_MIRROR_ENABLED")?.lowercase() != "false"
+
+// upstream URL prefix  ->  matching Reposilite repository
+val mirrorMap = linkedMapOf(
+    "https://repo.maven.apache.org/maven2"     to "$reposilite/maven-central",
+    "https://repo1.maven.org/maven2"           to "$reposilite/maven-central",
+    "https://dl.google.com/dl/android/maven2"  to "$reposilite/google",
+    "https://plugins.gradle.org/m2"            to "$reposilite/gradle-plugins",
+)
+
+fun mirrorReachable(): Boolean = runCatching {
+    (URI(reposilite).toURL().openConnection() as HttpURLConnection).apply {
+        requestMethod = "HEAD"
+        connectTimeout = 2000
+        readTimeout = 2000
+        instanceFollowRedirects = false
+        responseCode          // any HTTP response means the server is up
+        disconnect()
+    }
+}.isSuccess                   // any exception (refused / timeout / DNS) -> unreachable
+
+fun RepositoryHandler.redirectToMirror() {
+    withType(MavenArtifactRepository::class.java).configureEach {
+        val target = mirrorMap.entries.firstOrNull { url.toString().startsWith(it.key) }?.value
+        if (target != null) {
+            setUrl(target)
+            // The proxy is plain HTTP on the private network; Gradle rejects
+            // http:// repositories unless this is explicitly opted into.
+            isAllowInsecureProtocol = target.startsWith("http://")
+        }
+    }
+}
+
+when {
+    !mirrorEnabled ->
+        logger.lifecycle("ℹ️  Reposilite mirror disabled via REPOSILITE_MIRROR_ENABLED — using public repositories.")
+    !mirrorReachable() ->
+        logger.warn("⚠️  Reposilite unreachable at $reposilite — using public repositories.")
+    else -> {
+        logger.lifecycle("✅  Routing dependencies through Reposilite at $reposilite.")
+        gradle.beforeSettings {
+            buildscript.repositories.redirectToMirror()
+            pluginManagement.repositories.redirectToMirror()
+        }
+        gradle.settingsEvaluated { dependencyResolutionManagement.repositories.redirectToMirror() }
+        gradle.beforeProject     { buildscript.repositories.redirectToMirror() }
+        gradle.afterProject      { repositories.redirectToMirror() }
+
+        // Robolectric resolves its `android-all` SDK jars at TEST RUNTIME via its
+        // own Maven fetcher, bypassing Gradle's repositories entirely — point it
+        // at the mirror too, or it egresses to Maven Central directly and
+        // re-triggers the 429s. Harmless for projects that don't use Robolectric.
+        gradle.afterProject {
+            tasks.withType(Test::class.java).configureEach {
+                systemProperty("robolectric.dependency.repo.url", "$reposilite/maven-central")
+            }
+        }
+    }
+}

--- a/scripts/run-kotlin-integration-tests.sh
+++ b/scripts/run-kotlin-integration-tests.sh
@@ -3,4 +3,4 @@
 # The project should be mounted to this location
 cd /app/native/kotlin
 
-./gradlew :api:kotlin:integrationTest
+./gradlew --init-script /app/scripts/reposilite-mirror.gradle.kts :api:kotlin:integrationTest


### PR DESCRIPTION
## Description

Route Gradle dependency resolution through internal proxy. We don't want to use Maven Central directly, as it often flags our shared EIP on CI as a heavy consumer, and starts to return `429` errors.

## Changes



## Test plan

CI build is green. You can run the script locally.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
