### PR TITLE
feat: add connectivity error classification to RequestExecutionErrorReason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
+- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (host did not resolve, connection refused) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
 
 ### Changed
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -17,11 +17,17 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  */
 
 /**
- * Whether the site could not be reached at all — the host did not resolve,
- * refused the connection, or the URL was malformed.
+ * Whether the site could not be reached — most reliably, the host did not
+ * resolve.
  *
  * Distinct from [isDeviceOffline]: this indicates a problem reaching *this
  * particular site*, not a loss of device connectivity.
+ *
+ * Note that a refused connection (the host resolves, but nothing is listening)
+ * is reported here as an HTTP error rather than an unreachable site, whereas
+ * the Swift executor reports it as unreachable. Only a DNS failure is treated
+ * as an unreachable site by every executor. A malformed site URL never reaches
+ * this predicate; it surfaces as `WpApiException.SiteUrlParsingException`.
  */
 val RequestExecutionErrorReason.isSiteUnreachable: Boolean
     get() = requestExecutionErrorReasonIsSiteUnreachable(this)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -1,0 +1,35 @@
+package rs.wordpress.api.kotlin
+
+import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.requestExecutionErrorReasonIsDeviceOffline
+import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
+
+/**
+ * Extension properties for classifying connectivity failures.
+ *
+ * The request executor maps the underlying platform errors onto
+ * [RequestExecutionErrorReason.NonExistentSiteError] and
+ * [RequestExecutionErrorReason.DeviceIsOfflineError]. These properties expose
+ * that distinction without requiring callers to match the variants themselves.
+ *
+ * The reason is available as `reason` on `WpRequestResult.RequestExecutionFailed`
+ * and on `WpApiException.RequestExecutionFailed`.
+ */
+
+/**
+ * Whether the site could not be reached at all — the host did not resolve,
+ * refused the connection, or the URL was malformed.
+ *
+ * Distinct from [isDeviceOffline]: this indicates a problem reaching *this
+ * particular site*, not a loss of device connectivity.
+ */
+val RequestExecutionErrorReason.isSiteUnreachable: Boolean
+    get() = requestExecutionErrorReasonIsSiteUnreachable(this)
+
+/**
+ * Whether the request failed because the device has no network connection.
+ *
+ * Distinct from [isSiteUnreachable]: the site itself may be perfectly healthy.
+ */
+val RequestExecutionErrorReason.isDeviceOffline: Boolean
+    get() = requestExecutionErrorReasonIsDeviceOffline(this)

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -47,7 +47,6 @@ extension WpApiError {
         }
         return false
     }
-
 }
 
 extension RequestExecutionErrorReason {

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -48,71 +48,20 @@ extension WpApiError {
         return false
     }
 
-    /// Whether the site could not be reached at all — the host did not resolve,
-    /// refused the connection, or the URL was malformed.
-    ///
-    /// Distinct from ``isDeviceOffline``: this indicates a problem reaching
-    /// *this particular site*, not a loss of device connectivity.
-    public var isSiteUnreachable: Bool {
-        executionErrorReason?.isSiteUnreachable ?? false
-    }
-
-    /// Whether the request failed because the device has no network connection.
-    ///
-    /// Distinct from ``isSiteUnreachable``: the site itself may be perfectly
-    /// healthy.
-    public var isDeviceOffline: Bool {
-        executionErrorReason?.isDeviceOffline ?? false
-    }
-
-    /// The underlying reason when this is a request execution failure, otherwise `nil`.
-    private var executionErrorReason: RequestExecutionErrorReason? {
-        if case .RequestExecutionFailed(
-            statusCode: _,
-            redirects: _,
-            reason: let reason,
-            requestUrl: _,
-            requestMethod: _
-        ) = self {
-            return reason
-        }
-        return nil
-    }
-}
-
-extension RequestExecutionError {
-    /// Whether the site could not be reached at all — the host did not resolve,
-    /// refused the connection, or the URL was malformed.
-    public var isSiteUnreachable: Bool {
-        executionErrorReason?.isSiteUnreachable ?? false
-    }
-
-    /// Whether the request failed because the device has no network connection.
-    public var isDeviceOffline: Bool {
-        executionErrorReason?.isDeviceOffline ?? false
-    }
-
-    /// The underlying reason when this is a request execution failure, otherwise `nil`.
-    private var executionErrorReason: RequestExecutionErrorReason? {
-        if case .RequestExecutionFailed(
-            statusCode: _,
-            redirects: _,
-            reason: let reason,
-            requestUrl: _,
-            requestMethod: _
-        ) = self {
-            return reason
-        }
-        return nil
-    }
 }
 
 extension RequestExecutionErrorReason {
-    /// Whether the site could not be reached at all — the host did not resolve,
-    /// refused the connection, or the URL was malformed.
+    /// Whether the site could not be reached — most reliably, the host did not
+    /// resolve.
     ///
     /// Distinct from ``isDeviceOffline``: this indicates a problem reaching
     /// *this particular site*, not a loss of device connectivity.
+    ///
+    /// - Note: A refused connection (the host resolves, but nothing is
+    ///   listening) is classified differently per platform — Swift reports it
+    ///   here, Kotlin reports it as an HTTP error. Only a DNS failure is treated
+    ///   as an unreachable site by every executor. A malformed site URL never
+    ///   reaches this predicate; it surfaces as `WpApiError.SiteUrlParsingError`.
     public var isSiteUnreachable: Bool {
         requestExecutionErrorReasonIsSiteUnreachable(reason: self)
     }
@@ -123,6 +72,65 @@ extension RequestExecutionErrorReason {
     /// healthy.
     public var isDeviceOffline: Bool {
         requestExecutionErrorReasonIsDeviceOffline(reason: self)
+    }
+}
+
+/// An error that may carry a ``RequestExecutionErrorReason``.
+///
+/// Implemented by both `WpApiError` and `RequestExecutionError`, which share the
+/// same `RequestExecutionFailed` payload, so the connectivity predicates only
+/// need to be written once.
+public protocol CarriesRequestExecutionErrorReason {
+    /// The underlying reason when this is a request execution failure, otherwise `nil`.
+    var executionErrorReason: RequestExecutionErrorReason? { get }
+}
+
+public extension CarriesRequestExecutionErrorReason {
+    /// Whether the site could not be reached — most reliably, the host did not
+    /// resolve.
+    ///
+    /// See ``RequestExecutionErrorReason/isSiteUnreachable`` for the platform
+    /// differences that apply.
+    var isSiteUnreachable: Bool {
+        executionErrorReason?.isSiteUnreachable ?? false
+    }
+
+    /// Whether the request failed because the device has no network connection.
+    ///
+    /// See ``RequestExecutionErrorReason/isDeviceOffline`` for the platform
+    /// differences that apply.
+    var isDeviceOffline: Bool {
+        executionErrorReason?.isDeviceOffline ?? false
+    }
+}
+
+extension WpApiError: CarriesRequestExecutionErrorReason {
+    public var executionErrorReason: RequestExecutionErrorReason? {
+        if case .RequestExecutionFailed(
+            statusCode: _,
+            redirects: _,
+            reason: let reason,
+            requestUrl: _,
+            requestMethod: _
+        ) = self {
+            return reason
+        }
+        return nil
+    }
+}
+
+extension RequestExecutionError: CarriesRequestExecutionErrorReason {
+    public var executionErrorReason: RequestExecutionErrorReason? {
+        if case .RequestExecutionFailed(
+            statusCode: _,
+            redirects: _,
+            reason: let reason,
+            requestUrl: _,
+            requestMethod: _
+        ) = self {
+            return reason
+        }
+        return nil
     }
 }
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -47,6 +47,83 @@ extension WpApiError {
         }
         return false
     }
+
+    /// Whether the site could not be reached at all — the host did not resolve,
+    /// refused the connection, or the URL was malformed.
+    ///
+    /// Distinct from ``isDeviceOffline``: this indicates a problem reaching
+    /// *this particular site*, not a loss of device connectivity.
+    public var isSiteUnreachable: Bool {
+        executionErrorReason?.isSiteUnreachable ?? false
+    }
+
+    /// Whether the request failed because the device has no network connection.
+    ///
+    /// Distinct from ``isSiteUnreachable``: the site itself may be perfectly
+    /// healthy.
+    public var isDeviceOffline: Bool {
+        executionErrorReason?.isDeviceOffline ?? false
+    }
+
+    /// The underlying reason when this is a request execution failure, otherwise `nil`.
+    private var executionErrorReason: RequestExecutionErrorReason? {
+        if case .RequestExecutionFailed(
+            statusCode: _,
+            redirects: _,
+            reason: let reason,
+            requestUrl: _,
+            requestMethod: _
+        ) = self {
+            return reason
+        }
+        return nil
+    }
+}
+
+extension RequestExecutionError {
+    /// Whether the site could not be reached at all — the host did not resolve,
+    /// refused the connection, or the URL was malformed.
+    public var isSiteUnreachable: Bool {
+        executionErrorReason?.isSiteUnreachable ?? false
+    }
+
+    /// Whether the request failed because the device has no network connection.
+    public var isDeviceOffline: Bool {
+        executionErrorReason?.isDeviceOffline ?? false
+    }
+
+    /// The underlying reason when this is a request execution failure, otherwise `nil`.
+    private var executionErrorReason: RequestExecutionErrorReason? {
+        if case .RequestExecutionFailed(
+            statusCode: _,
+            redirects: _,
+            reason: let reason,
+            requestUrl: _,
+            requestMethod: _
+        ) = self {
+            return reason
+        }
+        return nil
+    }
+}
+
+extension RequestExecutionErrorReason {
+    /// Whether the site could not be reached at all — the host did not resolve,
+    /// refused the connection, or the URL was malformed.
+    ///
+    /// Distinct from ``isDeviceOffline``: this indicates a problem reaching
+    /// *this particular site*, not a loss of device connectivity.
+    public var isSiteUnreachable: Bool {
+        requestExecutionErrorReasonIsSiteUnreachable(reason: self)
+    }
+
+    /// Whether the request failed because the device has no network connection.
+    ///
+    /// Distinct from ``isSiteUnreachable``: the site itself may be perfectly
+    /// healthy.
+    public var isDeviceOffline: Bool {
+        requestExecutionErrorReasonIsDeviceOffline(reason: self)
+    }
 }
 
 // MARK: - Enum initialization and unpacking

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -682,6 +682,24 @@ pub enum RequestExecutionErrorReason {
 }
 
 impl RequestExecutionErrorReason {
+    /// Whether the site could not be reached at all — the host did not resolve,
+    /// refused the connection, or the URL was malformed.
+    ///
+    /// Distinct from [`RequestExecutionErrorReason::is_device_offline`]: this
+    /// indicates a problem reaching *this particular site*, not a loss of device
+    /// connectivity.
+    pub fn is_site_unreachable(&self) -> bool {
+        matches!(self, Self::NonExistentSiteError { .. })
+    }
+
+    /// Whether the request failed because the device has no network connection.
+    ///
+    /// Distinct from [`RequestExecutionErrorReason::is_site_unreachable`]: the
+    /// site itself may be perfectly healthy.
+    pub fn is_device_offline(&self) -> bool {
+        matches!(self, Self::DeviceIsOfflineError { .. })
+    }
+
     pub fn try_from_response(response: &WpNetworkResponse) -> Option<Self> {
         if response.status_code != 401 && response.status_code != 403 {
             return None;
@@ -729,6 +747,23 @@ impl RequestExecutionErrorReason {
         };
         Some(reason)
     }
+}
+
+/// Whether the site could not be reached at all — the host did not resolve,
+/// refused the connection, or the URL was malformed.
+#[uniffi::export]
+pub fn request_execution_error_reason_is_site_unreachable(
+    reason: &RequestExecutionErrorReason,
+) -> bool {
+    reason.is_site_unreachable()
+}
+
+/// Whether the request failed because the device has no network connection.
+#[uniffi::export]
+pub fn request_execution_error_reason_is_device_offline(
+    reason: &RequestExecutionErrorReason,
+) -> bool {
+    reason.is_device_offline()
 }
 
 impl WpSupportsLocalization for RequestExecutionErrorReason {
@@ -788,5 +823,92 @@ impl From<RequestExecutionError> for WpApiError {
                 Self::MediaFileNotFound { file_path }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn non_existent_site() -> RequestExecutionErrorReason {
+        RequestExecutionErrorReason::NonExistentSiteError {
+            error_message: None,
+            suggested_action: None,
+        }
+    }
+
+    fn device_is_offline() -> RequestExecutionErrorReason {
+        RequestExecutionErrorReason::DeviceIsOfflineError {
+            error_message: "offline".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_is_site_unreachable_matches_non_existent_site_error() {
+        let reason = non_existent_site();
+        assert!(reason.is_site_unreachable());
+        assert!(!reason.is_device_offline());
+    }
+
+    #[test]
+    fn test_is_device_offline_matches_device_is_offline_error() {
+        let reason = device_is_offline();
+        assert!(reason.is_device_offline());
+        assert!(!reason.is_site_unreachable());
+    }
+
+    /// Neither predicate should fire for the other reasons, which represent a
+    /// site that *was* reached but responded unusably, or a failure unrelated to
+    /// connectivity.
+    #[rstest]
+    #[case::http_timeout(RequestExecutionErrorReason::HttpTimeoutError)]
+    #[case::cancellation(RequestExecutionErrorReason::CancellationError)]
+    #[case::misconfigured_rate_limit(RequestExecutionErrorReason::MisconfiguredRateLimitError)]
+    #[case::invalid_ssl(RequestExecutionErrorReason::InvalidSslError {
+        reason: InvalidSslErrorReason::GenericSslError,
+    })]
+    #[case::http_forbidden(RequestExecutionErrorReason::HttpForbiddenError {
+        hostname: "example.com".to_string(),
+    })]
+    #[case::http_authentication_required(
+        RequestExecutionErrorReason::HttpAuthenticationRequiredError {
+            hostname: "example.com".to_string(),
+            method: None,
+        }
+    )]
+    #[case::http_authentication_rejected(
+        RequestExecutionErrorReason::HttpAuthenticationRejectedError {
+            hostname: "example.com".to_string(),
+            method: None,
+        }
+    )]
+    #[case::http_error(RequestExecutionErrorReason::HttpError {
+        reason: "connection failed".to_string(),
+    })]
+    #[case::generic(RequestExecutionErrorReason::GenericError {
+        error_message: "boom".to_string(),
+    })]
+    fn test_neither_predicate_matches_other_reasons(#[case] reason: RequestExecutionErrorReason) {
+        assert!(!reason.is_site_unreachable());
+        assert!(!reason.is_device_offline());
+    }
+
+    #[test]
+    fn test_exported_functions_delegate_to_inherent_methods() {
+        let unreachable = non_existent_site();
+        let offline = device_is_offline();
+
+        assert!(request_execution_error_reason_is_site_unreachable(
+            &unreachable
+        ));
+        assert!(!request_execution_error_reason_is_device_offline(
+            &unreachable
+        ));
+
+        assert!(request_execution_error_reason_is_device_offline(&offline));
+        assert!(!request_execution_error_reason_is_site_unreachable(
+            &offline
+        ));
     }
 }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -910,6 +910,11 @@ mod tests {
             method: None,
         }
     )]
+    #[case::misconfigured_http_authentication(
+        RequestExecutionErrorReason::MisconfiguredHttpAuthenticationError {
+            issue: HttpAuthMethodParsingError::Unknown,
+        }
+    )]
     #[case::http_error(RequestExecutionErrorReason::HttpError {
         reason: "connection failed".to_string(),
     })]

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -682,12 +682,29 @@ pub enum RequestExecutionErrorReason {
 }
 
 impl RequestExecutionErrorReason {
-    /// Whether the site could not be reached at all — the host did not resolve,
-    /// refused the connection, or the URL was malformed.
+    /// Whether the site could not be reached — most reliably, the host did not
+    /// resolve.
     ///
     /// Distinct from [`RequestExecutionErrorReason::is_device_offline`]: this
     /// indicates a problem reaching *this particular site*, not a loss of device
     /// connectivity.
+    ///
+    /// # Platform differences
+    ///
+    /// A refused connection (the host resolves, but nothing is listening) is
+    /// **not** classified consistently:
+    ///
+    /// - Swift and the `reqwest` executor map it to `NonExistentSiteError`, so
+    ///   this returns `true`.
+    /// - Kotlin maps it to `HttpError`, so this returns `false`.
+    ///
+    /// Only a DNS failure is treated as an unreachable site by every executor.
+    /// Callers that must behave identically across platforms should rely on that
+    /// case alone until the mappings are aligned.
+    ///
+    /// Note also that a malformed site URL never reaches this predicate: it
+    /// surfaces as [`WpApiError::SiteUrlParsingError`], which carries no
+    /// `RequestExecutionErrorReason`.
     pub fn is_site_unreachable(&self) -> bool {
         matches!(self, Self::NonExistentSiteError { .. })
     }
@@ -696,6 +713,16 @@ impl RequestExecutionErrorReason {
     ///
     /// Distinct from [`RequestExecutionErrorReason::is_site_unreachable`]: the
     /// site itself may be perfectly healthy.
+    ///
+    /// # Platform differences
+    ///
+    /// Offline detection requires an executor that can consult a
+    /// `NetworkAvailabilityProvider` — currently only the Swift and Kotlin
+    /// executors. The `reqwest` executor never constructs `DeviceIsOfflineError`,
+    /// so this always returns `false` there, and an offline failure is reported
+    /// as `NonExistentSiteError` (the DNS lookup fails) — meaning
+    /// [`RequestExecutionErrorReason::is_site_unreachable`] returns `true`
+    /// instead.
     pub fn is_device_offline(&self) -> bool {
         matches!(self, Self::DeviceIsOfflineError { .. })
     }


### PR DESCRIPTION
## Description

The request executors map the underlying platform errors onto `NonExistentSiteError` and `DeviceIsOfflineError`, but consumers have to match those variants themselves to tell "this site could not be reached" from "this device has no connection". That is fragile — it breaks whenever the enum gains a case — and the knowledge belongs to the library rather than to each consumer.

Raised in [GutenbergKit review feedback](https://github.com/wordpress-mobile/GutenbergKit/pull/572#discussion_r3706841604), tracked by [GutenbergKit#578](https://github.com/wordpress-mobile/GutenbergKit/issues/578), where the iOS demo app hand-rolls both checks.

## Changes

- `RequestExecutionErrorReason::is_site_unreachable()` and `is_device_offline()` as inherent methods, for Rust callers
- `request_execution_error_reason_is_site_unreachable` / `..._is_device_offline` as `#[uniffi::export]` free functions, for the bindings
- Swift: properties on `RequestExecutionErrorReason`, plus convenience properties on `WpApiError` and `RequestExecutionError`. Both conform to a `CarriesRequestExecutionErrorReason` protocol, so the predicates are written once and each type supplies only the reason accessor.
- Kotlin: extension properties on `RequestExecutionErrorReason`
- Unit tests covering all 12 `RequestExecutionErrorReason` variants — two positives, ten negatives

Additive only; no behaviour change to existing APIs.

### Why these live on the reason rather than on `WpApiError`

The variants are defined on `RequestExecutionErrorReason`, and the reason is what consumers actually hold:

- **Swift** — `WordPress-iOS` reaches the reason from two different outer errors (`SelfHostedSiteAuthenticator.swift` has both a `log(error: WpApiError)` and a `log(error: RequestExecutionError)` overload that funnel into the same reason handler). Predicates on the reason serve both; the `WpApiError` convenience property preserves the `error.isCancellationError` shape that `Extensions/Error.swift` already uses.
- **Kotlin** — `WpApiException` is largely internal plumbing; consumers hold a `WpRequestResult`. In GutenbergKit's Android demo app, all four files that touch wordpress-rs errors use `WpRequestResult` and none reference `WpApiException`. `WpRequestResult.RequestExecutionFailed` exposes `reason` directly.

### Export shape

Follows `application_passwords_url` in `login::url_discovery` — a `#[uniffi::export]` free function taking a data-carrying `uniffi::Enum` by reference, with an inherent method behind it. Every `#[uniffi::export] impl` block in `wp_api/src/` targets a `uniffi::Object`, so an exported `impl` on an enum would be novel here.

## Open questions for review

1. **Predicate placement.** Reason vs. `WpApiError`. The evidence above favours the reason, but I did not find a precedent that settles it either way — happy to move them if you'd rather they sat on the error.
2. **Naming.** `request_execution_error_reason_is_site_unreachable` generates `requestExecutionErrorReasonIsSiteUnreachable(reason:)`, which is a mouthful. The type-prefixed convention is my own; `application_passwords_url` is unprefixed. Shorter names welcome.
3. **`bool` vs `Option<bool>`.** Both patterns exist (`FindApiRootFailure::is_network_error` returns `bool`; `is_application_passwords_disabled` returns `Option<bool>`). I used `bool` since the question always applies to a reason, but flagging the choice.

## Known limitation: the executor mappings disagree

The three executors do not classify the same failure the same way. The doc comments on both predicates now spell this out, but it is worth stating plainly here.

**Connection refused** — Kotlin is the odd one out:

| Condition | Swift (`SafeRequestExecutor`) | Rust (`ReqwestRequestExecutor`) | Kotlin (`WpRequestExecutor`) |
| --- | --- | --- | --- |
| Host does not resolve | `NonExistentSiteError` | `NonExistentSiteError` | `NonExistentSiteError` |
| Connection refused | `NonExistentSiteError` (`.cannotConnectToHost`) | `NonExistentSiteError` (`is_connect()`) | `HttpError` (`ConnectException`) |
| No route to host | `NonExistentSiteError` | `NonExistentSiteError` | `HttpError` (`NoRouteToHostException`) |

So `isSiteUnreachable` returns `true` on Swift and `false` on Kotlin for the same real-world failure — e.g. a local dev server that is not running. Verified with okhttp 5.4.0: a closed local port throws `java.net.ConnectException`, which `WpRequestExecutor` maps to `HttpError`. `HttpError` is included as a negative case in the unit tests so the current behaviour is explicit.

**Offline detection is platform-only.** `DeviceIsOfflineError` is constructed exclusively by the Swift and Kotlin executors, which consult a `NetworkAvailabilityProvider`. `ReqwestRequestExecutor` has no such mapping, so for consumers that build it directly — `wp_rs_web`, `wp_com_e2e` — `is_device_offline()` is always `false`. Worse, an offline failure there fails DNS resolution and is reported as `NonExistentSiteError`, so `is_site_unreachable()` returns `true` instead. The two predicates are effectively inverted on that path.

**Only a DNS failure means the same thing everywhere.** Callers needing identical behaviour across all three executors should rely on that case alone until the mappings are aligned.

This PR does not change the mappings, because aligning Kotlin with Swift is a behaviour change with a downstream hazard. In WordPress-Android, `MediaRSApiRestClient` maps `NonExistentSiteError` to `MediaErrorType.NOT_FOUND`, and `MediaDeleteService` responds to `NOT_FOUND` by deleting the local media record. Today a refused connection yields `HttpError` → `GENERIC_ERROR`, which is non-destructive. Remapping without fixing that first would make an unreachable site look like deleted remote media. The `when` in question is exhaustive with no `else`, so the change would compile silently, and there is no test covering that arm.

Suggested sequencing, if the alignment is wanted: fix the WordPress-Android media mapping first, then align `ConnectException` (and probably `NoRouteToHostException`) in a follow-up PR here. Giving `ReqwestRequestExecutor` a way to report offline is a separate question, since it has no `NetworkAvailabilityProvider` equivalent.

## Test plan

Automated:

- [x] `cargo test -p wp_api --lib api_error` — 13 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p wp_api --lib --all-features -- -D warnings` — clean
- [x] `swift build --target WordPressAPI` — 35/35 files, 0 errors
- [x] `./gradlew :api:kotlin:compileKotlin :api:kotlin:detekt` — BUILD SUCCESSFUL, 0 findings

Manual, via GutenbergKit's iOS demo app pointed at this PR's snapshot branch:

- [x] wp-env stopped, network up → `isSiteUnreachable`, correct guidance shown
- [x] Airplane mode with a saved account → `isDeviceOffline`, offline editor configuration applied
- [x] Site host blocked in `/etc/hosts`, network up → `isSiteUnreachable` true and `isDeviceOffline` false on the same error, so the offline fallback correctly does *not* apply

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

