### PR TITLE
docs: correct the platform claims in the connectivity predicate docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
-- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (host did not resolve, connection refused) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (most reliably, a DNS failure) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
 
 ### Changed
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -36,6 +36,13 @@ val RequestExecutionErrorReason.isSiteUnreachable: Boolean
  * Whether the request failed because the device has no network connection.
  *
  * Distinct from [isSiteUnreachable]: the site itself may be perfectly healthy.
+ *
+ * This is only reported when the [NetworkAvailabilityProvider] supplied to the
+ * executor reports the device offline at the moment a DNS lookup fails. It is
+ * therefore best-effort: with no real provider wired in (the default reports the
+ * device as always available) this never returns `true`, and a device that drops
+ * offline mid-request — surfacing as a connect or timeout error rather than a DNS
+ * failure — is not detected here either.
  */
 val RequestExecutionErrorReason.isDeviceOffline: Boolean
     get() = requestExecutionErrorReasonIsDeviceOffline(this)

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -61,8 +61,9 @@ extension RequestExecutionErrorReason {
     ///   here, Kotlin reports it as an HTTP error. Only a DNS failure is treated
     ///   as an unreachable site by every executor. A site URL rejected while
     ///   parsing surfaces as `WpApiError.SiteUrlParsingError` and never reaches
-    ///   this predicate; a URL that only `URLSession` rejects at request time
-    ///   (`.badURL`) does map here.
+    ///   this predicate; a `.badURL` that only `URLSession` rejects at send time
+    ///   is classified here for lack of a dedicated invalid-URL case, though no
+    ///   known URL actually reaches that branch.
     public var isSiteUnreachable: Bool {
         requestExecutionErrorReasonIsSiteUnreachable(reason: self)
     }

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -59,8 +59,10 @@ extension RequestExecutionErrorReason {
     /// - Note: A refused connection (the host resolves, but nothing is
     ///   listening) is classified differently per platform — Swift reports it
     ///   here, Kotlin reports it as an HTTP error. Only a DNS failure is treated
-    ///   as an unreachable site by every executor. A malformed site URL never
-    ///   reaches this predicate; it surfaces as `WpApiError.SiteUrlParsingError`.
+    ///   as an unreachable site by every executor. A site URL rejected while
+    ///   parsing surfaces as `WpApiError.SiteUrlParsingError` and never reaches
+    ///   this predicate; a URL that only `URLSession` rejects at request time
+    ///   (`.badURL`) does map here.
     public var isSiteUnreachable: Bool {
         requestExecutionErrorReasonIsSiteUnreachable(reason: self)
     }

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -246,6 +246,15 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     private func errorIsNonExistentSiteError(_ error: Error) -> Bool {
+        // `.badURL` is grouped with the non-existent-site errors deliberately.
+        // A malformed URL has no dedicated classification at the executor layer:
+        // `RequestExecutionError` can't produce `WpApiError.SiteUrlParsingError`
+        // (that's a parse-time error, one layer up) and `RequestExecutionErrorReason`
+        // has no invalid-URL case, so `NonExistentSiteError` is the nearest fit.
+        // In practice we could not construct a URL that reaches this branch:
+        // request URLs are normalized by the Rust `url` crate before they arrive,
+        // and modern Foundation repairs the leftovers (e.g. an invalid `%zz`
+        // becomes `%25zz`) rather than raising `.badURL`. It's kept for completeness.
         [
             .badURL,
             .cannotConnectToHost,

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -704,9 +704,12 @@ impl RequestExecutionErrorReason {
     ///
     /// A site URL rejected while parsing never reaches this predicate: it
     /// surfaces as [`WpApiError::SiteUrlParsingError`], which carries no
-    /// `RequestExecutionErrorReason`. On Swift, however, a URL that only
-    /// `URLSession` rejects at request time (`badURL`) maps to
-    /// `NonExistentSiteError`, so it *does* reach here.
+    /// `RequestExecutionErrorReason`. On Swift a URL that only `URLSession`
+    /// rejects at request time (`badURL`) is classified as `NonExistentSiteError`
+    /// — the executor has no dedicated invalid-URL reason, so it's the nearest
+    /// fit. That branch appears unreachable in practice (request URLs are
+    /// normalized before they reach the platform, which repairs the rest); it is
+    /// covered for completeness.
     pub fn is_site_unreachable(&self) -> bool {
         matches!(self, Self::NonExistentSiteError { .. })
     }

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -694,17 +694,19 @@ impl RequestExecutionErrorReason {
     /// A refused connection (the host resolves, but nothing is listening) is
     /// **not** classified consistently:
     ///
-    /// - Swift and the `reqwest` executor map it to `NonExistentSiteError`, so
-    ///   this returns `true`.
-    /// - Kotlin maps it to `HttpError`, so this returns `false`.
+    /// - Swift maps it to `NonExistentSiteError`, so this returns `true`.
+    /// - Kotlin and the `reqwest` executor map it to `HttpError`, so this
+    ///   returns `false`.
     ///
     /// Only a DNS failure is treated as an unreachable site by every executor.
     /// Callers that must behave identically across platforms should rely on that
     /// case alone until the mappings are aligned.
     ///
-    /// Note also that a malformed site URL never reaches this predicate: it
+    /// A site URL rejected while parsing never reaches this predicate: it
     /// surfaces as [`WpApiError::SiteUrlParsingError`], which carries no
-    /// `RequestExecutionErrorReason`.
+    /// `RequestExecutionErrorReason`. On Swift, however, a URL that only
+    /// `URLSession` rejects at request time (`badURL`) maps to
+    /// `NonExistentSiteError`, so it *does* reach here.
     pub fn is_site_unreachable(&self) -> bool {
         matches!(self, Self::NonExistentSiteError { .. })
     }
@@ -716,13 +718,14 @@ impl RequestExecutionErrorReason {
     ///
     /// # Platform differences
     ///
-    /// Offline detection requires an executor that can consult a
-    /// `NetworkAvailabilityProvider` — currently only the Swift and Kotlin
-    /// executors. The `reqwest` executor never constructs `DeviceIsOfflineError`,
-    /// so this always returns `false` there, and an offline failure is reported
-    /// as `NonExistentSiteError` (the DNS lookup fails) — meaning
-    /// [`RequestExecutionErrorReason::is_site_unreachable`] returns `true`
-    /// instead.
+    /// Offline detection depends on a platform signal, so it is not uniform.
+    /// Swift derives it from the OS-reported `URLError` codes
+    /// (`notConnectedToInternet`, `networkConnectionLost`); Kotlin consults a
+    /// caller-supplied `NetworkAvailabilityProvider` when a DNS lookup fails. The
+    /// `reqwest` executor has neither and never constructs `DeviceIsOfflineError`,
+    /// so this always returns `false` there — an offline request typically
+    /// surfaces as a DNS failure (`NonExistentSiteError`) or a connect error
+    /// (`HttpError`) instead.
     pub fn is_device_offline(&self) -> bool {
         matches!(self, Self::DeviceIsOfflineError { .. })
     }
@@ -776,8 +779,11 @@ impl RequestExecutionErrorReason {
     }
 }
 
-/// Whether the site could not be reached at all — the host did not resolve,
-/// refused the connection, or the URL was malformed.
+/// Whether the site could not be reached — most reliably, the host did not
+/// resolve.
+///
+/// See [`RequestExecutionErrorReason::is_site_unreachable`] for the per-platform
+/// differences in how connectivity failures are classified.
 #[uniffi::export]
 pub fn request_execution_error_reason_is_site_unreachable(
     reason: &RequestExecutionErrorReason,


### PR DESCRIPTION
## Description

Corrects the documentation on the `isSiteUnreachable` / `isDeviceOffline` predicates added in #1488 to match what the executors actually do. **Documentation and code comments only — no behavior change.** Stacked on `feat/expose-connectivity-error-classification` so the predicate docs are accurate when #1488 merges.

## Changes

- `is_site_unreachable` doc: a refused connection is `HttpError` on Kotlin **and** `reqwest` (only Swift maps it to `NonExistentSiteError`) — the previous doc incorrectly grouped `reqwest` with Swift.
- `is_device_offline` doc: offline is detected from `URLError` codes on Swift and a `NetworkAvailabilityProvider` on Kotlin — not a shared provider, and `reqwest` has neither.
- Kotlin `isDeviceOffline` KDoc: documented that it depends on a wired `NetworkAvailabilityProvider` (it never returns `true` with the default always-available stub) and only detects offline on the DNS-failure path — the Rust doc explained this, but the Android-facing KDoc did not.
- The exported `#[uniffi::export]` doc no longer claims a malformed URL or a refused connection is universally "unreachable."
- Documented *why* a Swift `.badURL` (a URL `URLSession` only rejects at send time) is classified as `NonExistentSiteError`: the executor has no dedicated invalid-URL reason — it can't produce `WpApiError.SiteUrlParsingError` (a parse-time error, one layer up) and `RequestExecutionErrorReason` has no invalid-URL case — so it's the nearest fit. A comment at the classification site in `SafeRequestExecutor.swift` records this. That branch is unreachable in practice — request URLs are normalized by the Rust `url` crate before the platform sees them, and modern Foundation repairs the rest (an invalid `%zz` becomes `%25zz`) rather than raising `.badURL` — so it's kept for completeness.
- Swift property docs and the CHANGELOG entry aligned to the same wording.

## Test plan

- [x] `cargo check -p wp_api` — compiles.
- [x] `cargo doc` — the intra-doc links resolve (only pre-existing `bare_urls` warnings remain, in untouched files).
- Docs/comments only. The Swift/Kotlin changes are doc-comment only; there's no runtime behavior to test.

## Related

- Part of #1488 (base branch) — makes the predicate docs accurate on the first go.
- The refused-connection cross-platform inconsistency this documents is tracked for resolution in #1495.
- The behavioral executor gaps this documents — Swift dropping timeouts (#1491) and Kotlin misclassifying cancellation (#1492) — are tracked separately and will land as their own PRs later.
