### PR TITLE
chore: merge CHANGELOG.md with git's union driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Resolve CHANGELOG conflicts by keeping both sides instead of writing
+# conflict markers. Every PR appends to the same "## [Unreleased]" section,
+# so independent entries collide constantly; git's built-in `union` merge
+# driver takes both. Note it does not deduplicate, so a reworded line can
+# leave a duplicate to tidy by hand.
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Update translations.
 - **Internal:** Fix a flaky unit test.
 - **Internal:** Route the Kotlin integration tests through the in-VPC Reposilite dependency mirror
+- **Internal:** Merge `CHANGELOG.md` with git's built-in `union` driver (via `.gitattributes`), so the frequent conflicts on the `## [Unreleased]` section resolve by keeping both sides instead of emitting conflict markers.
 
 ## [0.6.0] - 2026-07-16
 


### PR DESCRIPTION
## Description

`CHANGELOG.md` collides on nearly every rebase/merge because every PR appends an entry to the same `## [Unreleased]` section. This configures git's built-in `union` merge driver for the file via `.gitattributes`, which resolves a conflicting hunk by keeping **both** sides instead of writing conflict markers — almost always the right outcome for independent changelog entries.

## Prior art

We already do exactly this in the mobile apps: WordPress-iOS and WordPress-Android both set `merge=union` on their `RELEASE-NOTES.txt` (their changelog-equivalent) to absorb the constant release-notes collisions. Same driver, same rationale — this just brings the pattern to `wordpress-rs`'s `CHANGELOG.md`.

- [`WordPress-iOS/.gitattributes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/.gitattributes)
- [`WordPress-Android/.gitattributes`](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/.gitattributes)

## Changes

- Add `.gitattributes` declaring `CHANGELOG.md merge=union`.
- Record the change as an `**Internal:**` entry in the changelog.

## Caveats

- `union` concatenates both sides **without deduplicating**, so a *reworded* existing entry can leave a duplicate to tidy by hand. Independent appends — the common case — merge cleanly.
- `union` is a **built-in** driver, not a custom command, so GitHub honors it: the PR "Conflicting" indicator and the merge button respect it too. (GitHub refuses to run custom command-based drivers for security.)
- Applies to both `git merge` and `git rebase`, since rebase uses the same merge machinery.

## Suggested for contributors: enable `rerere` locally

`.gitattributes` ships with the repo, but there's a complementary per-machine tweak worth turning on. If you re-rebase a stacked branch onto a moving parent, you can hit the *same* conflict repeatedly. Git's "reuse recorded resolution" records how you resolve a conflict once and replays it automatically the next time the identical conflict appears:

```bash
git config --global rerere.enabled true
```

It's local (not committed) and per-contributor, and it complements `union` rather than replacing it — `union` auto-resolves the everyday append collisions, while `rerere` saves you from re-resolving the reword/edit ones by hand.

## Test plan

- [ ] Nothing to run locally — `union` is built into git, so contributors need no config for it to take effect.
- [ ] After this merges, confirm that a follow-up PR appending a `## [Unreleased]` entry no longer reports a `CHANGELOG.md` conflict.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
