### PR TITLE
Narrow `NonExistentSiteError` to DNS; add `ConnectionError` + `isConnectivityFailure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
 - `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (the host did not resolve) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- `RequestExecutionErrorReason` gained a `ConnectionError` variant — the host resolved, but no connection to the server could be established (the connection was refused, there was no route, or the host was unreachable) — and an `isConnectivityFailure` predicate (the union of `isSiteUnreachable` and `ConnectionError`) for a single portable "we couldn't reach the site's server" signal, distinct from `isDeviceOffline`. Refused and unreachable connections now classify as `ConnectionError` on every executor (previously the generic `HttpError` on Kotlin and reqwest). A connect timeout is not included; it remains `HttpTimeoutError`.
 
 ### Changed
 
@@ -32,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Swift now classifies a refused connection — the host resolves, but nothing is listening (server down, wrong port) — as `RequestExecutionErrorReason.HttpError`, matching the Kotlin and reqwest executors. iOS previously reported it as `NonExistentSiteError`, which now uniformly means a DNS-resolution failure across all three executors.
+- Swift no longer classifies a refused connection — the host resolves, but nothing is listening (server down, wrong port) — as `NonExistentSiteError`, so `isSiteUnreachable` no longer fires for it. `NonExistentSiteError` now uniformly means a DNS-resolution failure across all three executors (refused connections are a `ConnectionError`; see Added).
 
 ## [0.6.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
-- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (most reliably, a DNS failure) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (the host did not resolve) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
 
 ### Changed
 
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Update translations.
 - **Internal:** Fix a flaky unit test.
 - **Internal:** Route the Kotlin integration tests through the in-VPC Reposilite dependency mirror
+
+### Fixed
+
+- Swift now classifies a refused connection — the host resolves, but nothing is listening (server down, wrong port) — as `RequestExecutionErrorReason.HttpError`, matching the Kotlin and reqwest executors. iOS previously reported it as `NonExistentSiteError`, which now uniformly means a DNS-resolution failure across all three executors.
 
 ## [0.6.0] - 2026-07-16
 

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -1,6 +1,7 @@
 package rs.wordpress.api.kotlin
 
 import uniffi.wp_api.RequestExecutionErrorReason
+import uniffi.wp_api.requestExecutionErrorReasonIsConnectivityFailure
 import uniffi.wp_api.requestExecutionErrorReasonIsDeviceOffline
 import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
 
@@ -8,9 +9,10 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  * Extension properties for classifying connectivity failures.
  *
  * The request executor maps the underlying platform errors onto
- * [RequestExecutionErrorReason.NonExistentSiteError] and
+ * [RequestExecutionErrorReason.NonExistentSiteError],
+ * [RequestExecutionErrorReason.ConnectionError], and
  * [RequestExecutionErrorReason.DeviceIsOfflineError]. These properties expose
- * that distinction without requiring callers to match the variants themselves.
+ * those distinctions without requiring callers to match the variants themselves.
  *
  * The reason is available as `reason` on `WpRequestResult.RequestExecutionFailed`
  * and on `WpApiException.RequestExecutionFailed`.
@@ -24,12 +26,27 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  * particular site*, not a loss of device connectivity.
  *
  * Note that a refused connection (the host resolves, but nothing is listening)
- * is a transport failure reported as an HTTP error on every executor, so it does
- * not satisfy this predicate. A malformed site URL never reaches this predicate
- * either; it surfaces as `WpApiException.SiteUrlParsingException`.
+ * is classified as a [RequestExecutionErrorReason.ConnectionError] on every
+ * executor, so it does not satisfy this predicate — use [isConnectivityFailure]
+ * to cover both. A malformed site URL never reaches this predicate either; it
+ * surfaces as `WpApiException.SiteUrlParsingException`.
  */
 val RequestExecutionErrorReason.isSiteUnreachable: Boolean
     get() = requestExecutionErrorReasonIsSiteUnreachable(this)
+
+/**
+ * Whether the site's server could not be reached at all — either its host did
+ * not resolve ([RequestExecutionErrorReason.NonExistentSiteError]) or the host
+ * resolved but no connection could be established
+ * ([RequestExecutionErrorReason.ConnectionError]).
+ *
+ * The broad counterpart to [isSiteUnreachable] (which is strictly the DNS case):
+ * use this for a single "we couldn't reach your site" signal. Distinct from
+ * [isDeviceOffline], the device's own loss of connectivity. A connect timeout is
+ * not included (it stays [RequestExecutionErrorReason.HttpTimeoutError]).
+ */
+val RequestExecutionErrorReason.isConnectivityFailure: Boolean
+    get() = requestExecutionErrorReasonIsConnectivityFailure(this)
 
 /**
  * Whether the request failed because the device has no network connection.

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -17,17 +17,16 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  */
 
 /**
- * Whether the site could not be reached — most reliably, the host did not
- * resolve.
+ * Whether the site could not be reached because its host did not resolve — a
+ * DNS-resolution failure ([RequestExecutionErrorReason.NonExistentSiteError]).
  *
  * Distinct from [isDeviceOffline]: this indicates a problem reaching *this
  * particular site*, not a loss of device connectivity.
  *
  * Note that a refused connection (the host resolves, but nothing is listening)
- * is reported here as an HTTP error rather than an unreachable site, whereas
- * the Swift executor reports it as unreachable. Only a DNS failure is treated
- * as an unreachable site by every executor. A malformed site URL never reaches
- * this predicate; it surfaces as `WpApiException.SiteUrlParsingException`.
+ * is a transport failure reported as an HTTP error on every executor, so it does
+ * not satisfy this predicate. A malformed site URL never reaches this predicate
+ * either; it surfaces as `WpApiException.SiteUrlParsingException`.
  */
 val RequestExecutionErrorReason.isSiteUnreachable: Boolean
     get() = requestExecutionErrorReasonIsSiteUnreachable(this)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -227,7 +227,7 @@ class WpRequestExecutor @JvmOverloads constructor(
             )
         } catch (e: ConnectException) {
             throw requestExecutionFailedWith(
-                RequestExecutionErrorReason.HttpError(
+                RequestExecutionErrorReason.ConnectionError(
                     reason = "Connection failed: ${e.localizedMessage}"
                 ),
                 requestUrl,
@@ -321,7 +321,7 @@ private fun RequestExecutionErrorReason.Companion.unknownHost(
 }
 
 private fun RequestExecutionErrorReason.Companion.noRouteToHost(e: NoRouteToHostException) =
-    RequestExecutionErrorReason.HttpError(
+    RequestExecutionErrorReason.ConnectionError(
         reason = e.localizedMessage
     )
 

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -57,15 +57,28 @@ extension RequestExecutionErrorReason {
     /// *this particular site*, not a loss of device connectivity.
     ///
     /// - Note: A refused connection (the host resolves, but nothing is
-    ///   listening) is classified differently per platform — Swift reports it
-    ///   here, Kotlin reports it as an HTTP error. Only a DNS failure is treated
-    ///   as an unreachable site by every executor. A site URL rejected while
-    ///   parsing surfaces as `WpApiError.SiteUrlParsingError` and never reaches
-    ///   this predicate; a `.badURL` that only `URLSession` rejects at send time
-    ///   is classified here for lack of a dedicated invalid-URL case, though no
-    ///   known URL actually reaches that branch.
+    ///   listening) is classified as a `ConnectionError` on every executor, so it
+    ///   does *not* satisfy this predicate — use ``isConnectivityFailure`` to
+    ///   cover both. A site URL rejected while parsing surfaces as
+    ///   `WpApiError.SiteUrlParsingError` and never reaches this predicate; a
+    ///   `.badURL` that only `URLSession` rejects at send time is classified here
+    ///   for lack of a dedicated invalid-URL case, though no known URL actually
+    ///   reaches that branch.
     public var isSiteUnreachable: Bool {
         requestExecutionErrorReasonIsSiteUnreachable(reason: self)
+    }
+
+    /// Whether the site's server could not be reached at all — either its host
+    /// did not resolve (`NonExistentSiteError`) or the host resolved but no
+    /// connection could be established (`ConnectionError`).
+    ///
+    /// The broad counterpart to ``isSiteUnreachable`` (which is strictly the DNS
+    /// case): use this for a single "we couldn't reach your site" signal, and
+    /// ``isSiteUnreachable`` to tell a bad domain apart from a server that's down.
+    /// Distinct from ``isDeviceOffline``, the device's own loss of connectivity. A
+    /// connect timeout is not included (it stays `HttpTimeoutError`).
+    public var isConnectivityFailure: Bool {
+        requestExecutionErrorReasonIsConnectivityFailure(reason: self)
     }
 
     /// Whether the request failed because the device has no network connection.
@@ -95,6 +108,14 @@ public extension CarriesRequestExecutionErrorReason {
     /// differences that apply.
     var isSiteUnreachable: Bool {
         executionErrorReason?.isSiteUnreachable ?? false
+    }
+
+    /// Whether the site's server could not be reached at all — the host did not
+    /// resolve, or the connection could not be established.
+    ///
+    /// See ``RequestExecutionErrorReason/isConnectivityFailure``.
+    var isConnectivityFailure: Bool {
+        executionErrorReason?.isConnectivityFailure ?? false
     }
 
     /// Whether the request failed because the device has no network connection.

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -98,8 +98,8 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 return handleNonExistentSiteError(error, for: request)
             }
 
-            if errorIsHttpError(error) {
-                return handleHttpError(error, for: request)
+            if errorIsConnectionError(error) {
+                return handleConnectionError(error, for: request)
             }
 
             if errorIsDeviceIsOffline(error) {
@@ -229,7 +229,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         )
     }
 
-    func handleHttpError(
+    func handleConnectionError(
         _ error: Error,
         for request: NetworkRequestContent
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
@@ -237,7 +237,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
             .RequestExecutionFailed(
                 statusCode: nil,
                 redirects: executorDelegate.redirects(for: request.requestId()),
-                reason: .httpError(reason: error.localizedDescription),
+                reason: .connectionError(reason: error.localizedDescription),
                 requestUrl: request.url(),
                 requestMethod: request.method()
             )
@@ -266,9 +266,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
 
     private func errorIsNonExistentSiteError(_ error: Error) -> Bool {
         // A refused connection (`.cannotConnectToHost` — the host resolves, but
-        // nothing is listening) is deliberately *not* here: it is a transport
-        // failure handled by `errorIsHttpError`, matching the Kotlin and reqwest
-        // executors. This keeps `NonExistentSiteError` — and the
+        // nothing is listening) is deliberately *not* here: it is a failed
+        // connection handled by `errorIsConnectionError`, matching the Kotlin and
+        // reqwest executors. This keeps `NonExistentSiteError` — and the
         // `isSiteUnreachable` predicate built on it — a portable "the host does
         // not resolve" signal across platforms. See #1495.
         //
@@ -289,11 +289,12 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         .contains((error as? URLError)?.code)
     }
 
-    private func errorIsHttpError(_ error: Error) -> Bool {
-        // A refused connection: the host resolves, but nothing accepts the
-        // connection (server down, wrong port, service not listening). It is a
-        // transport failure, so it maps to `HttpError` — the same classification
-        // the Kotlin (`ConnectException`) and reqwest (io-error) executors use.
+    private func errorIsConnectionError(_ error: Error) -> Bool {
+        // A failed connection: the host resolves, but nothing accepts the
+        // connection (server down, wrong port, not listening, or no route). It
+        // maps to `ConnectionError` — the same classification the Kotlin
+        // (`ConnectException` / `NoRouteToHostException`) and reqwest (io-error)
+        // executors use, and it backs `isConnectivityFailure`.
         [
             .cannotConnectToHost
         ]

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -98,6 +98,10 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 return handleNonExistentSiteError(error, for: request)
             }
 
+            if errorIsHttpError(error) {
+                return handleHttpError(error, for: request)
+            }
+
             if errorIsDeviceIsOffline(error) {
                 return handleDeviceIsOfflineError(error, for: request)
             }
@@ -225,6 +229,21 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         )
     }
 
+    func handleHttpError(
+        _ error: Error,
+        for request: NetworkRequestContent
+    ) -> Result<WpNetworkResponse, RequestExecutionError> {
+        .failure(
+            .RequestExecutionFailed(
+                statusCode: nil,
+                redirects: executorDelegate.redirects(for: request.requestId()),
+                reason: .httpError(reason: error.localizedDescription),
+                requestUrl: request.url(),
+                requestMethod: request.method()
+            )
+        )
+    }
+
     public func sleep(millis: UInt64) async {
         // swiftlint:disable:next force_try
         try! await Task.sleep(nanoseconds: millis * 1000)
@@ -246,20 +265,37 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     private func errorIsNonExistentSiteError(_ error: Error) -> Bool {
-        // `.badURL` is grouped with the non-existent-site errors deliberately.
-        // A malformed URL has no dedicated classification at the executor layer:
-        // `RequestExecutionError` can't produce `WpApiError.SiteUrlParsingError`
-        // (that's a parse-time error, one layer up) and `RequestExecutionErrorReason`
-        // has no invalid-URL case, so `NonExistentSiteError` is the nearest fit.
-        // In practice we could not construct a URL that reaches this branch:
-        // request URLs are normalized by the Rust `url` crate before they arrive,
-        // and modern Foundation repairs the leftovers (e.g. an invalid `%zz`
-        // becomes `%25zz`) rather than raising `.badURL`. It's kept for completeness.
+        // A refused connection (`.cannotConnectToHost` — the host resolves, but
+        // nothing is listening) is deliberately *not* here: it is a transport
+        // failure handled by `errorIsHttpError`, matching the Kotlin and reqwest
+        // executors. This keeps `NonExistentSiteError` — and the
+        // `isSiteUnreachable` predicate built on it — a portable "the host does
+        // not resolve" signal across platforms. See #1495.
+        //
+        // `.badURL` is grouped here deliberately. A malformed URL has no dedicated
+        // classification at the executor layer: `RequestExecutionError` can't
+        // produce `WpApiError.SiteUrlParsingError` (that's a parse-time error, one
+        // layer up) and `RequestExecutionErrorReason` has no invalid-URL case, so
+        // `NonExistentSiteError` is the nearest fit. In practice we could not
+        // construct a URL that reaches this branch: request URLs are normalized by
+        // the Rust `url` crate before they arrive, and modern Foundation repairs
+        // the leftovers (e.g. an invalid `%zz` becomes `%25zz`) rather than raising
+        // `.badURL`. It's kept for completeness.
         [
             .badURL,
-            .cannotConnectToHost,
             .cannotFindHost,
             .dnsLookupFailed
+        ]
+        .contains((error as? URLError)?.code)
+    }
+
+    private func errorIsHttpError(_ error: Error) -> Bool {
+        // A refused connection: the host resolves, but nothing accepts the
+        // connection (server down, wrong port, service not listening). It is a
+        // transport failure, so it maps to `HttpError` — the same classification
+        // the Kotlin (`ConnectException`) and reqwest (io-error) executors use.
+        [
+            .cannotConnectToHost
         ]
         .contains((error as? URLError)?.code)
     }

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -92,12 +92,12 @@ struct WordPressAPITests {
     }
 
     // A refused connection — the host resolves (loopback), but nothing is
-    // listening on the port — must be classified as `.httpError`, matching the
-    // Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
+    // listening on the port — must be classified as `.connectionError`, matching
+    // the Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
     // which is reserved for DNS failures so `isSiteUnreachable` stays a portable
     // "the host does not resolve" signal across platforms. See #1495.
     @Test(.enabled(if: !isLinux()))
-    func testRefusedConnectionIsHttpError() async throws {
+    func testRefusedConnectionIsConnectionError() async throws {
         // Port 1 on loopback is privileged, so nothing is bound in any test
         // environment, and the OS refuses the connection immediately
         // (`URLError.cannotConnectToHost`).
@@ -131,8 +131,8 @@ struct WordPressAPITests {
                     return false
                 }
 
-                guard case .httpError = reason else {
-                    Issue.record("A refused connection must be `.httpError`, got: \(reason)")
+                guard case .connectionError = reason else {
+                    Issue.record("A refused connection must be `.connectionError`, got: \(reason)")
                     return false
                 }
 

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -90,6 +90,56 @@ struct WordPressAPITests {
         let details = try await api.apiRoot.get()
         #expect(details.data.siteUrlString() == "https://vanilla.wpmt.co")
     }
+
+    // A refused connection — the host resolves (loopback), but nothing is
+    // listening on the port — must be classified as `.httpError`, matching the
+    // Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
+    // which is reserved for DNS failures so `isSiteUnreachable` stays a portable
+    // "the host does not resolve" signal across platforms. See #1495.
+    @Test(.enabled(if: !isLinux()))
+    func testRefusedConnectionIsHttpError() async throws {
+        // Port 1 on loopback is privileged, so nothing is bound in any test
+        // environment, and the OS refuses the connection immediately
+        // (`URLError.cannotConnectToHost`).
+        let api = try WordPressAPI(
+            siteInfo: .selfHosted(
+                siteUrl: ParsedUrl.parse(input: "http://127.0.0.1:1"),
+                apiRoot: ParsedUrl.parse(input: "http://127.0.0.1:1/wp-json")
+            ),
+            authenticationProvider: .none(),
+            executor: WpRequestExecutor(urlSession: .init(configuration: .ephemeral)),
+            middlewarePipeline: .default,
+            appNotifier: nil
+        )
+
+        await #expect(
+            performing: {
+                _ = try await api.apiRoot.get()
+            },
+            throws: { error in
+                guard
+                    let apiError = error as? WpApiError,
+                    case .RequestExecutionFailed(
+                        statusCode: _,
+                        redirects: _,
+                        reason: let reason,
+                        requestUrl: _,
+                        requestMethod: _
+                    ) = apiError
+                else {
+                    Issue.record("Expected WpApiError.RequestExecutionFailed, got: \(error)")
+                    return false
+                }
+
+                guard case .httpError = reason else {
+                    Issue.record("A refused connection must be `.httpError`, got: \(reason)")
+                    return false
+                }
+
+                return true
+            }
+        )
+    }
 }
 
 private actor CounterMiddleware: Middleware {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -673,6 +673,12 @@ pub enum RequestExecutionErrorReason {
         error_message: String,
     },
     CancellationError,
+    // The host resolved, but a connection to the server could not be
+    // established — refused, no route, or the host was unreachable. Distinct
+    // from `HttpError`, which is a failure *after* a connection was established.
+    ConnectionError {
+        reason: String,
+    },
     HttpError {
         reason: String,
     },
@@ -682,25 +688,20 @@ pub enum RequestExecutionErrorReason {
 }
 
 impl RequestExecutionErrorReason {
-    /// Whether the site could not be reached — most reliably, the host did not
-    /// resolve.
+    /// Whether the site could not be reached because its host did not resolve —
+    /// a DNS-resolution failure (`NonExistentSiteError`).
     ///
     /// Distinct from [`RequestExecutionErrorReason::is_device_offline`]: this
     /// indicates a problem reaching *this particular site*, not a loss of device
     /// connectivity.
     ///
-    /// # Platform differences
-    ///
-    /// A refused connection (the host resolves, but nothing is listening) is
-    /// **not** classified consistently:
-    ///
-    /// - Swift maps it to `NonExistentSiteError`, so this returns `true`.
-    /// - Kotlin and the `reqwest` executor map it to `HttpError`, so this
-    ///   returns `false`.
-    ///
-    /// Only a DNS failure is treated as an unreachable site by every executor.
-    /// Callers that must behave identically across platforms should rely on that
-    /// case alone until the mappings are aligned.
+    /// This is a portable signal: every executor (Swift, Kotlin, and `reqwest`)
+    /// maps a DNS failure to `NonExistentSiteError`. A *refused* connection — the
+    /// host resolves, but nothing is listening (the server is down, on the wrong
+    /// port, or not accepting connections) — is classified as `ConnectionError`
+    /// on every executor, so it does **not** satisfy this predicate. For a signal
+    /// that covers both, see
+    /// [`RequestExecutionErrorReason::is_connectivity_failure`].
     ///
     /// A site URL rejected while parsing never reaches this predicate: it
     /// surfaces as [`WpApiError::SiteUrlParsingError`], which carries no
@@ -712,6 +713,29 @@ impl RequestExecutionErrorReason {
     /// covered for completeness.
     pub fn is_site_unreachable(&self) -> bool {
         matches!(self, Self::NonExistentSiteError { .. })
+    }
+
+    /// Whether the site's server could not be reached at all — either its host
+    /// did not resolve (`NonExistentSiteError`) or the host resolved but no
+    /// connection could be established (`ConnectionError`: the connection was
+    /// refused, there was no route, or the host was unreachable).
+    ///
+    /// This is the broad, portable counterpart to
+    /// [`RequestExecutionErrorReason::is_site_unreachable`], which is strictly the
+    /// DNS case. Use this for a single "we couldn't reach your site" signal, and
+    /// `is_site_unreachable` when you need to tell a bad domain apart from a
+    /// server that's down. Distinct from
+    /// [`RequestExecutionErrorReason::is_device_offline`], which is the device's
+    /// own loss of connectivity.
+    ///
+    /// A connect *timeout* is **not** included: neither the `reqwest` nor the
+    /// Kotlin executor can reliably separate a connect timeout from a read
+    /// timeout, so those remain `HttpTimeoutError`. See #1495.
+    pub fn is_connectivity_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::NonExistentSiteError { .. } | Self::ConnectionError { .. }
+        )
     }
 
     /// Whether the request failed because the device has no network connection.
@@ -728,7 +752,7 @@ impl RequestExecutionErrorReason {
     /// `reqwest` executor has neither and never constructs `DeviceIsOfflineError`,
     /// so this always returns `false` there — an offline request typically
     /// surfaces as a DNS failure (`NonExistentSiteError`) or a connect error
-    /// (`HttpError`) instead.
+    /// (`ConnectionError`) instead.
     pub fn is_device_offline(&self) -> bool {
         matches!(self, Self::DeviceIsOfflineError { .. })
     }
@@ -785,13 +809,26 @@ impl RequestExecutionErrorReason {
 /// Whether the site could not be reached — most reliably, the host did not
 /// resolve.
 ///
-/// See [`RequestExecutionErrorReason::is_site_unreachable`] for the per-platform
-/// differences in how connectivity failures are classified.
+/// See [`RequestExecutionErrorReason::is_site_unreachable`] for what does and
+/// does not count (notably, a refused connection is a `ConnectionError`, not
+/// this — use [`request_execution_error_reason_is_connectivity_failure`] to
+/// cover both).
 #[uniffi::export]
 pub fn request_execution_error_reason_is_site_unreachable(
     reason: &RequestExecutionErrorReason,
 ) -> bool {
     reason.is_site_unreachable()
+}
+
+/// Whether the site's server could not be reached at all — the host did not
+/// resolve, or the host resolved but no connection could be established.
+///
+/// See [`RequestExecutionErrorReason::is_connectivity_failure`].
+#[uniffi::export]
+pub fn request_execution_error_reason_is_connectivity_failure(
+    reason: &RequestExecutionErrorReason,
+) -> bool {
+    reason.is_connectivity_failure()
 }
 
 /// Whether the request failed because the device has no network connection.
@@ -826,6 +863,9 @@ impl WpSupportsLocalization for RequestExecutionErrorReason {
             }
             RequestExecutionErrorReason::DeviceIsOfflineError { error_message } => {
                 WpMessages::just(error_message)
+            }
+            RequestExecutionErrorReason::ConnectionError { reason } => {
+                WpMessages::connection_error(reason)
             }
             RequestExecutionErrorReason::HttpError { reason } => {
                 WpMessages::http_server_error(reason)
@@ -880,6 +920,12 @@ mod tests {
         }
     }
 
+    fn connection_error() -> RequestExecutionErrorReason {
+        RequestExecutionErrorReason::ConnectionError {
+            reason: "connection refused".to_string(),
+        }
+    }
+
     #[test]
     fn test_is_site_unreachable_matches_non_existent_site_error() {
         let reason = non_existent_site();
@@ -892,6 +938,29 @@ mod tests {
         let reason = device_is_offline();
         assert!(reason.is_device_offline());
         assert!(!reason.is_site_unreachable());
+    }
+
+    #[test]
+    fn test_is_connectivity_failure_matches_dns_and_connection() {
+        // The broad signal fires for both a DNS failure and a failed connection.
+        assert!(non_existent_site().is_connectivity_failure());
+        assert!(connection_error().is_connectivity_failure());
+
+        // A connection failure is a connectivity failure, but is *not* the narrow
+        // site-unreachable (DNS) case, and is not the device being offline.
+        assert!(!connection_error().is_site_unreachable());
+        assert!(!connection_error().is_device_offline());
+
+        // It does not fire for the device being offline, nor for failures where
+        // the server was actually reached.
+        assert!(!device_is_offline().is_connectivity_failure());
+        assert!(!RequestExecutionErrorReason::HttpTimeoutError.is_connectivity_failure());
+        assert!(
+            !RequestExecutionErrorReason::HttpError {
+                reason: "boom".to_string()
+            }
+            .is_connectivity_failure()
+        );
     }
 
     /// Neither predicate should fire for the other reasons, which represent a
@@ -949,6 +1018,18 @@ mod tests {
 
         assert!(request_execution_error_reason_is_device_offline(&offline));
         assert!(!request_execution_error_reason_is_site_unreachable(
+            &offline
+        ));
+
+        // The connectivity-failure export covers both DNS failures and failed
+        // connections, but not the device being offline.
+        assert!(request_execution_error_reason_is_connectivity_failure(
+            &unreachable
+        ));
+        assert!(request_execution_error_reason_is_connectivity_failure(
+            &connection_error()
+        ));
+        assert!(!request_execution_error_reason_is_connectivity_failure(
             &offline
         ));
     }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -195,6 +195,17 @@ fn request_execution_error_from_reqwest(
         tls_error.into()
     } else if let Some(io_error) = error.as_io_error() {
         match io_error.kind() {
+            // The host resolved, but the connection couldn't be established. This
+            // is caught here (before `is_connect()` below, which is the DNS
+            // `NXDOMAIN` fallback) because a refused/unreachable connection
+            // carries an inner `io::Error`.
+            std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::HostUnreachable
+            | std::io::ErrorKind::NetworkUnreachable => {
+                RequestExecutionErrorReason::ConnectionError {
+                    reason: io_error.to_string(),
+                }
+            }
             std::io::ErrorKind::UnexpectedEof => RequestExecutionErrorReason::HttpError {
                 reason: "The server terminated the connection unexpectedly".to_string(),
             },
@@ -376,10 +387,12 @@ mod tests {
     use crate::request::endpoint::WpEndpointUrl;
 
     // A refused connection — the host resolves (here, loopback), but nothing is
-    // listening on the port — must classify as `HttpError`, not
-    // `NonExistentSiteError`. `NonExistentSiteError` is reserved for DNS
-    // failures, which keeps `is_site_unreachable` a portable "the host does not
-    // resolve" signal across the Swift, Kotlin, and reqwest executors (#1495).
+    // listening on the port — must classify as `ConnectionError`, not
+    // `NonExistentSiteError` (which is reserved for DNS failures) and not the
+    // generic `HttpError` (which is a failure *after* a connection is
+    // established). This keeps `is_site_unreachable` a portable "the host does
+    // not resolve" signal and lets `ConnectionError` back `is_connectivity_failure`
+    // across the Swift, Kotlin, and reqwest executors (#1495).
     //
     // The branch ordering in `request_execution_error_from_reqwest` is
     // load-bearing: `ECONNREFUSED` carries an inner `io::Error`, so it is caught
@@ -388,7 +401,7 @@ mod tests {
     // ordering so a refactor can't silently reclassify a refused connection as
     // an unreachable site.
     #[tokio::test]
-    async fn refused_connection_is_http_error() {
+    async fn refused_connection_is_connection_error() {
         // Port 1 on loopback is privileged, so nothing is bound in any test
         // environment, and the OS refuses the connection immediately.
         let request = WpNetworkRequest::get(WpEndpointUrl("http://127.0.0.1:1".to_string()));
@@ -403,8 +416,8 @@ mod tests {
             panic!("expected RequestExecutionFailed, got: {error:?}");
         };
         assert!(
-            matches!(reason, RequestExecutionErrorReason::HttpError { .. }),
-            "a refused connection must be HttpError, got: {reason:?}"
+            matches!(reason, RequestExecutionErrorReason::ConnectionError { .. }),
+            "a refused connection must be ConnectionError, got: {reason:?}"
         );
     }
 }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -369,3 +369,42 @@ pub(crate) fn find_error<'a, E: Error + 'static>(top: &'a (dyn Error + 'static))
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request::endpoint::WpEndpointUrl;
+
+    // A refused connection — the host resolves (here, loopback), but nothing is
+    // listening on the port — must classify as `HttpError`, not
+    // `NonExistentSiteError`. `NonExistentSiteError` is reserved for DNS
+    // failures, which keeps `is_site_unreachable` a portable "the host does not
+    // resolve" signal across the Swift, Kotlin, and reqwest executors (#1495).
+    //
+    // The branch ordering in `request_execution_error_from_reqwest` is
+    // load-bearing: `ECONNREFUSED` carries an inner `io::Error`, so it is caught
+    // by the `as_io_error` branch *before* `is_connect()` — the DNS-`NXDOMAIN`
+    // fallback that maps to `NonExistentSiteError`. This test guards that
+    // ordering so a refactor can't silently reclassify a refused connection as
+    // an unreachable site.
+    #[tokio::test]
+    async fn refused_connection_is_http_error() {
+        // Port 1 on loopback is privileged, so nothing is bound in any test
+        // environment, and the OS refuses the connection immediately.
+        let request = WpNetworkRequest::get(WpEndpointUrl("http://127.0.0.1:1".to_string()));
+        let executor = ReqwestRequestExecutor::new_with_default_timeout(false);
+
+        let error = executor
+            .execute(request.into())
+            .await
+            .expect_err("connecting to a closed port must fail");
+
+        let RequestExecutionError::RequestExecutionFailed { reason, .. } = error else {
+            panic!("expected RequestExecutionFailed, got: {error:?}");
+        };
+        assert!(
+            matches!(reason, RequestExecutionErrorReason::HttpError { .. }),
+            "a refused connection must be HttpError, got: {reason:?}"
+        );
+    }
+}

--- a/wp_localization/localization/en-US/main.ftl
+++ b/wp_localization/localization/en-US/main.ftl
@@ -26,6 +26,8 @@ http_cancellation_error = The request was cancelled.
 
 http_authentication_rejected_error = The server at {$url} rejected your credentials. Please provide a valid username and password.
 
+connection_error = Couldn't connect to the server: {$reason}. The site may be down or unreachable.
+
 http_server_error = Unable to connect to server: {$reason}. Please contact your server provider.
 
 misconfigured_http_authentication_error = The server is sending invalid HTTP authentication information. Please check your site's HTTP authentication configuration.


### PR DESCRIPTION
## Description

Stacked on #1493 — the top of the #1488 → #1493 connectivity stack. **Draft** for now.

Fixes #1495: a refused connection (the host resolves, but nothing is listening) was classified as `NonExistentSiteError` on Swift and `HttpError` on Kotlin/reqwest, so the `isSiteUnreachable` predicate from #1488 returned a different answer per platform for the same outage.

The semantic decision (per #1495): `NonExistentSiteError` / `isSiteUnreachable` means **the site's host did not resolve** — a DNS failure, nothing else. A refused/unreachable connection is a distinct failure with its own `ConnectionError` reason, and a new broad `isConnectivityFailure` predicate unions the two for a single "we couldn't reach the site's server" signal.

## Changes

### 1. Narrow `NonExistentSiteError` to DNS-only (`f7d305b0`)
- Swift: `.cannotConnectToHost` no longer maps to `NonExistentSiteError`, so `isSiteUnreachable` no longer fires on a refused connection. `NonExistentSiteError` now means a DNS-resolution failure on every executor.

### 2. Add `ConnectionError` + `isConnectivityFailure` (`f8f3db63`)
- New `RequestExecutionErrorReason::ConnectionError { reason }` — the host resolved, but no connection to the server could be established.
- Reclassify connection-establishment failures to it across all three executors:
  - **reqwest** — `io::ErrorKind::{ConnectionRefused, HostUnreachable, NetworkUnreachable}`
  - **Kotlin** — `ConnectException`, `NoRouteToHostException`
  - **Swift** — `URLError.cannotConnectToHost`
- New `isConnectivityFailure` = `NonExistentSiteError ∪ ConnectionError`, exposed on Swift + Kotlin alongside `isSiteUnreachable`.
- Localized `connection_error` message (`en-US`; other locales fill in via the translation process).

**Connect timeout is deliberately excluded** — neither reqwest's `is_timeout()` nor OkHttp's `SocketTimeoutException` separates a connect timeout from a read timeout, so those stay `HttpTimeoutError`. A dark IP that times out is therefore not caught; that's #1491's territory.

## Test plan

- [x] Rust `cargo test --lib` — new `refused_connection_is_connection_error` (reqwest against a closed loopback port → `ConnectionError`) and `test_is_connectivity_failure_matches_dns_and_connection`; #1488's predicate tests still green (**1830** pass).
- [x] `cargo fmt`, `cargo clippy --tests --all-targets --all-features -D warnings`, `cargo doc` clean.
- [ ] Swift `testRefusedConnectionIsConnectionError` (needs Xcode + uniffi binding regen — CI).
- [ ] Kotlin executor reclassification (CI).
- [ ] Regenerate bindings (`make xcframework` / Kotlin uniffi) so the new variant + `isConnectivityFailure` export reach the native wrappers.

## Related issues

- Fixes #1495
- Stacked on #1493 (docs) → #1488 (predicates)
- Does **not** resolve #1502 — `HttpError` is still unconstructible from the Swift executor (refused connections now go to `ConnectionError`, not `HttpError`).
- #1491 (Swift connect-timeout → `GenericError`) is the remaining piece for the connect-timeout leg of `isConnectivityFailure`.

## Notes for review

- **New enum variant `ConnectionError`:** consumers with *exhaustive* matches on `RequestExecutionErrorReason` (Swift `switch`, Kotlin `when`-expression) will need to handle it. Everything here is unreleased (stacked on the unreleased #1488), so nothing ships broken — flag if you want a `**BREAKING:**` marker.
- Swift/Kotlin can't be compiled in my environment (needs uniffi binding regen); the native code is written against #1488's patterns and relies on CI to confirm.

## Changelog

- [x] Added `Added` + `Fixed` entries under `## [Unreleased]`.
