### PR TITLE
Add `ConnectionError`; make `isSiteUnreachable` cover DNS + connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/stats/post/<post_id>` endpoint for a post's view history, like count, comment count, and metadata
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
-- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (the host did not resolve) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (the host did not resolve, or a connection to it could not be established) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- **BREAKING:** `RequestExecutionErrorReason` gained a `ConnectionError` variant — the host resolved, but no connection to the server could be established (the connection was refused, there was no route, or the host was unreachable). Exhaustive matches over `RequestExecutionErrorReason` (Swift `switch`, Kotlin `when`, Rust `match`) must now handle the new case. `isSiteUnreachable` covers it alongside DNS failures, so it's a single portable "we couldn't reach the site" signal that returns the same answer on every executor; match `NonExistentSiteError` / `ConnectionError` directly to tell a bad domain apart from a server that's down. Refused and unreachable connections previously classified as the generic `HttpError` on Kotlin and reqwest. A connect timeout is not included; it remains `HttpTimeoutError`.
 
 ### Changed
 
@@ -42,14 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Swift: `WpRequestExecutor.sleep(millis:)` converted milliseconds to nanoseconds with the wrong factor (`* 1_000` instead of `* 1_000_000`), so it slept 1000× too short — a `Retry-After: 30` waited 30 ms instead of 30 s. `RetryAfterMiddleware` then re-sent immediately, the server kept returning 429, and after `max_retries` the caller observed `MisconfiguredRateLimitError` where honoring the backoff would usually have succeeded. The executor now waits the full interval, and no longer risks a `fatalError` if the sleep's task is cancelled.
 - Swift: Classify invalid-SSL failures from the failed handshake's `SecTrust` (`URLError.failureURLPeerTrust`), via `SecTrustCopyCertificateChain`, instead of reading the undocumented `NSErrorPeerCertificateChainKey` `userInfo` string that has no public constant. Behavior is unchanged on every platform: iOS/macOS/tvOS still surface the presented certificate as `certificateNotValidForName`, and watchOS — which exposes no peer trust — still degrades to `genericSslError`. ([#1510](https://github.com/Automattic/wordpress-rs/issues/1510))
+- `isSiteUnreachable` now returns the same answer for a refused connection — the host resolves, but nothing is listening (server down, wrong port) — on every executor. Previously it was `NonExistentSiteError` on Swift (so `isSiteUnreachable` was `true`) but the generic `HttpError` on Kotlin and reqwest (so it was `false`); a refused connection is now a `ConnectionError` everywhere, which `isSiteUnreachable` covers. `NonExistentSiteError` is reserved for a DNS-resolution failure.
 
 ### Security
 
 - **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.
-
-### Fixed
-
-- Swift now classifies a refused connection — the host resolves, but nothing is listening (server down, wrong port) — as `RequestExecutionErrorReason.HttpError`, matching the Kotlin and reqwest executors. iOS previously reported it as `NonExistentSiteError`, which now uniformly means a DNS-resolution failure across all three executors.
 
 ## [0.6.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
 - WordPress.com `GET /sites/<site_id>/stats/post/<post_id>` endpoint for a post's view history, like count, comment count, and metadata
 - WordPress.com `GET /sites/<site_id>/plans` endpoint for listing the plans a site can buy, priced for that site, with the plan it's currently on flagged.
-- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (most reliably, a DNS failure) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
+- `RequestExecutionErrorReason` gained `isSiteUnreachable` and `isDeviceOffline` for distinguishing a site that could not be reached (the host did not resolve) from a device with no network connection. Previously consumers had to match the `NonExistentSiteError` / `DeviceIsOfflineError` variants themselves. Available on both platforms as properties on the reason, which is reachable from `WpRequestResult.RequestExecutionFailed` and `WpApiException.RequestExecutionFailed` on Kotlin. Swift additionally exposes both as convenience properties on `WpApiError` and `RequestExecutionError`.
 
 ### Changed
 
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.
+
+### Fixed
+
+- Swift now classifies a refused connection — the host resolves, but nothing is listening (server down, wrong port) — as `RequestExecutionErrorReason.HttpError`, matching the Kotlin and reqwest executors. iOS previously reported it as `NonExistentSiteError`, which now uniformly means a DNS-resolution failure across all three executors.
 
 ## [0.6.0] - 2026-07-16
 

--- a/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpRequestExecutorTest.kt
+++ b/native/kotlin/api/kotlin/src/integrationTest/kotlin/WpRequestExecutorTest.kt
@@ -249,6 +249,38 @@ class WpRequestExecutorTest {
             assertTrue(loggedErrors.isEmpty(), "cancellation should not be logged as an error: $loggedErrors")
         }
 
+    @Test
+    fun `refused connection is mapped to ConnectionError`() = runTest {
+        // Reserve a port with a throwaway server, then shut it down so nothing is
+        // listening — a connection to it is refused (ConnectException). That must
+        // classify as ConnectionError, not the generic HttpError and not
+        // NonExistentSiteError (which is reserved for DNS failures).
+        val closedServer = MockWebServer()
+        closedServer.start()
+        val refusedUrl = closedServer.url("/wp-json")
+        closedServer.shutdown()
+
+        val executor = WpRequestExecutor(
+            httpClient = WpHttpClient.CustomOkHttpClient(OkHttpClient()),
+            networkAvailabilityProvider = NetworkAvailabilityProvider { true }
+        )
+
+        val apiClient = WpApiClient(
+            wpOrgSiteApiRootUrl = URI(refusedUrl.toString()).toURL(),
+            authProvider = WpAuthenticationProvider.none(),
+            requestExecutor = executor
+        )
+
+        val result = apiClient.request { requestBuilder ->
+            requestBuilder.users().listWithEditContext(params = UserListParams())
+        }
+
+        assertIs<WpRequestResult.RequestExecutionFailed<*>>(result)
+        assertIs<RequestExecutionErrorReason.ConnectionError>(
+            (result as WpRequestResult.RequestExecutionFailed<*>).reason
+        )
+    }
+
     /**
      * Resolves media fixtures (e.g. `test_media.jpg`) from the test classpath so uploads can be
      * built without touching the real filesystem layout.

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -8,25 +8,30 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  * Extension properties for classifying connectivity failures.
  *
  * The request executor maps the underlying platform errors onto
- * [RequestExecutionErrorReason.NonExistentSiteError] and
+ * [RequestExecutionErrorReason.NonExistentSiteError],
+ * [RequestExecutionErrorReason.ConnectionError], and
  * [RequestExecutionErrorReason.DeviceIsOfflineError]. These properties expose
- * that distinction without requiring callers to match the variants themselves.
+ * those distinctions without requiring callers to match the variants themselves.
  *
  * The reason is available as `reason` on `WpRequestResult.RequestExecutionFailed`
  * and on `WpApiException.RequestExecutionFailed`.
  */
 
 /**
- * Whether the site could not be reached because its host did not resolve — a
- * DNS-resolution failure ([RequestExecutionErrorReason.NonExistentSiteError]).
+ * Whether the site could not be reached at all — either its host did not resolve
+ * ([RequestExecutionErrorReason.NonExistentSiteError]) or the host resolved but
+ * no connection could be established
+ * ([RequestExecutionErrorReason.ConnectionError]).
+ *
+ * This is a portable signal: every executor classifies both failure modes the
+ * same way. To tell them apart — a domain that doesn't resolve vs. a server
+ * that's down — match the two variants directly.
  *
  * Distinct from [isDeviceOffline]: this indicates a problem reaching *this
- * particular site*, not a loss of device connectivity.
- *
- * Note that a refused connection (the host resolves, but nothing is listening)
- * is a transport failure reported as an HTTP error on every executor, so it does
- * not satisfy this predicate. A malformed site URL never reaches this predicate
- * either; it surfaces as `WpApiException.SiteUrlParsingException`.
+ * particular site*, not a loss of device connectivity. A connect timeout is not
+ * included (it stays [RequestExecutionErrorReason.HttpTimeoutError]); a malformed
+ * site URL never reaches this predicate either — it surfaces as
+ * `WpApiException.SiteUrlParsingException`.
  */
 val RequestExecutionErrorReason.isSiteUnreachable: Boolean
     get() = requestExecutionErrorReasonIsSiteUnreachable(this)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/RequestExecutionErrorReasonExtensions.kt
@@ -17,17 +17,16 @@ import uniffi.wp_api.requestExecutionErrorReasonIsSiteUnreachable
  */
 
 /**
- * Whether the site could not be reached — most reliably, the host did not
- * resolve.
+ * Whether the site could not be reached because its host did not resolve — a
+ * DNS-resolution failure ([RequestExecutionErrorReason.NonExistentSiteError]).
  *
  * Distinct from [isDeviceOffline]: this indicates a problem reaching *this
  * particular site*, not a loss of device connectivity.
  *
  * Note that a refused connection (the host resolves, but nothing is listening)
- * is reported here as an HTTP error rather than an unreachable site, whereas
- * the Swift executor reports it as unreachable. Only a DNS failure is treated
- * as an unreachable site by every executor. A malformed site URL never reaches
- * this predicate; it surfaces as `WpApiException.SiteUrlParsingException`.
+ * is a transport failure reported as an HTTP error on every executor, so it does
+ * not satisfy this predicate. A malformed site URL never reaches this predicate
+ * either; it surfaces as `WpApiException.SiteUrlParsingException`.
  */
 val RequestExecutionErrorReason.isSiteUnreachable: Boolean
     get() = requestExecutionErrorReasonIsSiteUnreachable(this)

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpRequestExecutor.kt
@@ -236,7 +236,7 @@ class WpRequestExecutor @JvmOverloads constructor(
         } catch (e: NoRouteToHostException) {
             RequestExecutionErrorReason.noRouteToHost(e)
         } catch (e: ConnectException) {
-            RequestExecutionErrorReason.HttpError(reason = "Connection failed: ${e.localizedMessage}")
+            RequestExecutionErrorReason.ConnectionError(reason = "Connection failed: ${e.localizedMessage}")
         } catch (e: SocketTimeoutException) {
             RequestExecutionErrorReason.HttpTimeoutError
         } catch (e: InterruptedIOException) {

--- a/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/components/ErrorMessage.kt
+++ b/native/kotlin/example/composeApp/src/commonMain/kotlin/rs/wordpress/example/shared/ui/components/ErrorMessage.kt
@@ -39,6 +39,7 @@ private fun RequestExecutionErrorReason.description(): String = when (this) {
     is RequestExecutionErrorReason.HttpTimeoutError -> "Request timed out"
     is RequestExecutionErrorReason.InvalidSslError -> "SSL error: $reason"
     is RequestExecutionErrorReason.NonExistentSiteError -> errorMessage ?: "Site not found"
+    is RequestExecutionErrorReason.ConnectionError -> "Could not connect to the server: $reason"
     is RequestExecutionErrorReason.HttpAuthenticationRequiredError -> "Authentication required for $hostname"
     is RequestExecutionErrorReason.HttpAuthenticationRejectedError -> "Authentication rejected for $hostname"
     is RequestExecutionErrorReason.HttpForbiddenError -> "Access forbidden for $hostname"

--- a/native/swift/Sources/wordpress-api/Extensions.swift
+++ b/native/swift/Sources/wordpress-api/Extensions.swift
@@ -50,20 +50,24 @@ extension WpApiError {
 }
 
 extension RequestExecutionErrorReason {
-    /// Whether the site could not be reached — most reliably, the host did not
-    /// resolve.
+    /// Whether the site could not be reached at all — either its host did not
+    /// resolve (`NonExistentSiteError`) or the host resolved but no connection
+    /// could be established (`ConnectionError`).
+    ///
+    /// This is a portable signal: every executor classifies both failure modes
+    /// the same way. To tell them apart — a domain that doesn't resolve vs. a
+    /// server that's down — match `.nonExistentSiteError` and `.connectionError`
+    /// directly.
     ///
     /// Distinct from ``isDeviceOffline``: this indicates a problem reaching
     /// *this particular site*, not a loss of device connectivity.
     ///
-    /// - Note: A refused connection (the host resolves, but nothing is
-    ///   listening) is classified differently per platform — Swift reports it
-    ///   here, Kotlin reports it as an HTTP error. Only a DNS failure is treated
-    ///   as an unreachable site by every executor. A site URL rejected while
-    ///   parsing surfaces as `WpApiError.SiteUrlParsingError` and never reaches
-    ///   this predicate; a `.badURL` that only `URLSession` rejects at send time
-    ///   is classified here for lack of a dedicated invalid-URL case, though no
-    ///   known URL actually reaches that branch.
+    /// - Note: A connect timeout is not included (it stays `HttpTimeoutError`). A
+    ///   site URL rejected while parsing surfaces as
+    ///   `WpApiError.SiteUrlParsingError` and never reaches this predicate; a
+    ///   `.badURL` that only `URLSession` rejects at send time is classified as
+    ///   `NonExistentSiteError` for lack of a dedicated invalid-URL case, though
+    ///   no known URL actually reaches that branch.
     public var isSiteUnreachable: Bool {
         requestExecutionErrorReasonIsSiteUnreachable(reason: self)
     }
@@ -88,11 +92,10 @@ public protocol CarriesRequestExecutionErrorReason {
 }
 
 public extension CarriesRequestExecutionErrorReason {
-    /// Whether the site could not be reached — most reliably, the host did not
-    /// resolve.
+    /// Whether the site could not be reached at all — the host did not resolve,
+    /// or the connection could not be established.
     ///
-    /// See ``RequestExecutionErrorReason/isSiteUnreachable`` for the platform
-    /// differences that apply.
+    /// See ``RequestExecutionErrorReason/isSiteUnreachable``.
     var isSiteUnreachable: Bool {
         executionErrorReason?.isSiteUnreachable ?? false
     }

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -98,6 +98,10 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 return handleNonExistentSiteError(error, for: request)
             }
 
+            if errorIsHttpError(error) {
+                return handleHttpError(error, for: request)
+            }
+
             if errorIsDeviceIsOffline(error) {
                 return handleDeviceIsOfflineError(error, for: request)
             }
@@ -225,6 +229,21 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         )
     }
 
+    func handleHttpError(
+        _ error: Error,
+        for request: NetworkRequestContent
+    ) -> Result<WpNetworkResponse, RequestExecutionError> {
+        .failure(
+            .RequestExecutionFailed(
+                statusCode: nil,
+                redirects: executorDelegate.redirects(for: request.requestId()),
+                reason: .httpError(reason: error.localizedDescription),
+                requestUrl: request.url(),
+                requestMethod: request.method()
+            )
+        )
+    }
+
     public func sleep(millis: UInt64) async {
         // `try?`: `Task.sleep` only throws on cancellation, which this non-throwing `sleep`
         // leaves to the request machinery to handle.
@@ -247,20 +266,37 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     private func errorIsNonExistentSiteError(_ error: Error) -> Bool {
-        // `.badURL` is grouped with the non-existent-site errors deliberately.
-        // A malformed URL has no dedicated classification at the executor layer:
-        // `RequestExecutionError` can't produce `WpApiError.SiteUrlParsingError`
-        // (that's a parse-time error, one layer up) and `RequestExecutionErrorReason`
-        // has no invalid-URL case, so `NonExistentSiteError` is the nearest fit.
-        // In practice we could not construct a URL that reaches this branch:
-        // request URLs are normalized by the Rust `url` crate before they arrive,
-        // and modern Foundation repairs the leftovers (e.g. an invalid `%zz`
-        // becomes `%25zz`) rather than raising `.badURL`. It's kept for completeness.
+        // A refused connection (`.cannotConnectToHost` — the host resolves, but
+        // nothing is listening) is deliberately *not* here: it is a transport
+        // failure handled by `errorIsHttpError`, matching the Kotlin and reqwest
+        // executors. This keeps `NonExistentSiteError` — and the
+        // `isSiteUnreachable` predicate built on it — a portable "the host does
+        // not resolve" signal across platforms. See #1495.
+        //
+        // `.badURL` is grouped here deliberately. A malformed URL has no dedicated
+        // classification at the executor layer: `RequestExecutionError` can't
+        // produce `WpApiError.SiteUrlParsingError` (that's a parse-time error, one
+        // layer up) and `RequestExecutionErrorReason` has no invalid-URL case, so
+        // `NonExistentSiteError` is the nearest fit. In practice we could not
+        // construct a URL that reaches this branch: request URLs are normalized by
+        // the Rust `url` crate before they arrive, and modern Foundation repairs
+        // the leftovers (e.g. an invalid `%zz` becomes `%25zz`) rather than raising
+        // `.badURL`. It's kept for completeness.
         [
             .badURL,
-            .cannotConnectToHost,
             .cannotFindHost,
             .dnsLookupFailed
+        ]
+        .contains((error as? URLError)?.code)
+    }
+
+    private func errorIsHttpError(_ error: Error) -> Bool {
+        // A refused connection: the host resolves, but nothing accepts the
+        // connection (server down, wrong port, service not listening). It is a
+        // transport failure, so it maps to `HttpError` — the same classification
+        // the Kotlin (`ConnectException`) and reqwest (io-error) executors use.
+        [
+            .cannotConnectToHost
         ]
         .contains((error as? URLError)?.code)
     }

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -98,8 +98,8 @@ public final class WpRequestExecutor: SafeRequestExecutor {
                 return handleNonExistentSiteError(error, for: request)
             }
 
-            if errorIsHttpError(error) {
-                return handleHttpError(error, for: request)
+            if errorIsConnectionError(error) {
+                return handleConnectionError(error, for: request)
             }
 
             if errorIsDeviceIsOffline(error) {
@@ -229,7 +229,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         )
     }
 
-    func handleHttpError(
+    func handleConnectionError(
         _ error: Error,
         for request: NetworkRequestContent
     ) -> Result<WpNetworkResponse, RequestExecutionError> {
@@ -237,7 +237,7 @@ public final class WpRequestExecutor: SafeRequestExecutor {
             .RequestExecutionFailed(
                 statusCode: nil,
                 redirects: executorDelegate.redirects(for: request.requestId()),
-                reason: .httpError(reason: error.localizedDescription),
+                reason: .connectionError(reason: error.localizedDescription),
                 requestUrl: request.url(),
                 requestMethod: request.method()
             )
@@ -267,9 +267,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
 
     private func errorIsNonExistentSiteError(_ error: Error) -> Bool {
         // A refused connection (`.cannotConnectToHost` — the host resolves, but
-        // nothing is listening) is deliberately *not* here: it is a transport
-        // failure handled by `errorIsHttpError`, matching the Kotlin and reqwest
-        // executors. This keeps `NonExistentSiteError` — and the
+        // nothing is listening) is deliberately *not* here: it is a failed
+        // connection handled by `errorIsConnectionError`, matching the Kotlin and
+        // reqwest executors. This keeps `NonExistentSiteError` — and the
         // `isSiteUnreachable` predicate built on it — a portable "the host does
         // not resolve" signal across platforms. See #1495.
         //
@@ -290,11 +290,12 @@ public final class WpRequestExecutor: SafeRequestExecutor {
         .contains((error as? URLError)?.code)
     }
 
-    private func errorIsHttpError(_ error: Error) -> Bool {
-        // A refused connection: the host resolves, but nothing accepts the
-        // connection (server down, wrong port, service not listening). It is a
-        // transport failure, so it maps to `HttpError` — the same classification
-        // the Kotlin (`ConnectException`) and reqwest (io-error) executors use.
+    private func errorIsConnectionError(_ error: Error) -> Bool {
+        // A failed connection: the host resolves, but nothing accepts the
+        // connection (server down, wrong port, not listening, or no route). It
+        // maps to `ConnectionError` — the same classification the Kotlin
+        // (`ConnectException` / `NoRouteToHostException`) and reqwest (io-error)
+        // executors use. `isSiteUnreachable` covers it alongside a DNS failure.
         [
             .cannotConnectToHost
         ]

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -92,12 +92,12 @@ struct WordPressAPITests {
     }
 
     // A refused connection — the host resolves (loopback), but nothing is
-    // listening on the port — must be classified as `.httpError`, matching the
-    // Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
+    // listening on the port — must be classified as `.connectionError`, matching
+    // the Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
     // which is reserved for DNS failures so `isSiteUnreachable` stays a portable
     // "the host does not resolve" signal across platforms. See #1495.
     @Test(.enabled(if: !isLinux()))
-    func testRefusedConnectionIsHttpError() async throws {
+    func testRefusedConnectionIsConnectionError() async throws {
         // Port 1 on loopback is privileged, so nothing is bound in any test
         // environment, and the OS refuses the connection immediately
         // (`URLError.cannotConnectToHost`).
@@ -131,8 +131,8 @@ struct WordPressAPITests {
                     return false
                 }
 
-                guard case .httpError = reason else {
-                    Issue.record("A refused connection must be `.httpError`, got: \(reason)")
+                guard case .connectionError = reason else {
+                    Issue.record("A refused connection must be `.connectionError`, got: \(reason)")
                     return false
                 }
 

--- a/native/swift/Tests/wordpress-api/WordPressAPITests.swift
+++ b/native/swift/Tests/wordpress-api/WordPressAPITests.swift
@@ -90,6 +90,56 @@ struct WordPressAPITests {
         let details = try await api.apiRoot.get()
         #expect(details.data.siteUrlString() == "https://vanilla.wpmt.co")
     }
+
+    // A refused connection — the host resolves (loopback), but nothing is
+    // listening on the port — must be classified as `.httpError`, matching the
+    // Kotlin and reqwest executors. It must *not* be `.nonExistentSiteError`,
+    // which is reserved for DNS failures so `isSiteUnreachable` stays a portable
+    // "the host does not resolve" signal across platforms. See #1495.
+    @Test(.enabled(if: !isLinux()))
+    func testRefusedConnectionIsHttpError() async throws {
+        // Port 1 on loopback is privileged, so nothing is bound in any test
+        // environment, and the OS refuses the connection immediately
+        // (`URLError.cannotConnectToHost`).
+        let api = try WordPressAPI(
+            siteInfo: .selfHosted(
+                siteUrl: ParsedUrl.parse(input: "http://127.0.0.1:1"),
+                apiRoot: ParsedUrl.parse(input: "http://127.0.0.1:1/wp-json")
+            ),
+            authenticationProvider: .none(),
+            executor: WpRequestExecutor(urlSession: .init(configuration: .ephemeral)),
+            middlewarePipeline: .default,
+            appNotifier: nil
+        )
+
+        await #expect(
+            performing: {
+                _ = try await api.apiRoot.get()
+            },
+            throws: { error in
+                guard
+                    let apiError = error as? WpApiError,
+                    case .RequestExecutionFailed(
+                        statusCode: _,
+                        redirects: _,
+                        reason: let reason,
+                        requestUrl: _,
+                        requestMethod: _
+                    ) = apiError
+                else {
+                    Issue.record("Expected WpApiError.RequestExecutionFailed, got: \(error)")
+                    return false
+                }
+
+                guard case .httpError = reason else {
+                    Issue.record("A refused connection must be `.httpError`, got: \(reason)")
+                    return false
+                }
+
+                return true
+            }
+        )
+    }
 }
 
 private actor CounterMiddleware: Middleware {

--- a/wp_api/src/api_error.rs
+++ b/wp_api/src/api_error.rs
@@ -673,6 +673,12 @@ pub enum RequestExecutionErrorReason {
         error_message: String,
     },
     CancellationError,
+    // The host resolved, but a connection to the server could not be
+    // established — refused, no route, or the host was unreachable. Distinct
+    // from `HttpError`, which is a failure *after* a connection was established.
+    ConnectionError {
+        reason: String,
+    },
     HttpError {
         reason: String,
     },
@@ -682,25 +688,24 @@ pub enum RequestExecutionErrorReason {
 }
 
 impl RequestExecutionErrorReason {
-    /// Whether the site could not be reached — most reliably, the host did not
-    /// resolve.
+    /// Whether the site could not be reached at all — either its host did not
+    /// resolve (`NonExistentSiteError`) or the host resolved but no connection
+    /// could be established (`ConnectionError`: the connection was refused, there
+    /// was no route, or the host was unreachable).
+    ///
+    /// This is a portable signal: every executor (Swift, Kotlin, and `reqwest`)
+    /// classifies both failure modes the same way, so it returns the same answer
+    /// on every platform. To tell the two apart — a domain that doesn't resolve
+    /// vs. a server that's down — match `NonExistentSiteError` and
+    /// `ConnectionError` directly.
     ///
     /// Distinct from [`RequestExecutionErrorReason::is_device_offline`]: this
     /// indicates a problem reaching *this particular site*, not a loss of device
     /// connectivity.
     ///
-    /// # Platform differences
-    ///
-    /// A refused connection (the host resolves, but nothing is listening) is
-    /// **not** classified consistently:
-    ///
-    /// - Swift maps it to `NonExistentSiteError`, so this returns `true`.
-    /// - Kotlin and the `reqwest` executor map it to `HttpError`, so this
-    ///   returns `false`.
-    ///
-    /// Only a DNS failure is treated as an unreachable site by every executor.
-    /// Callers that must behave identically across platforms should rely on that
-    /// case alone until the mappings are aligned.
+    /// A connect *timeout* is **not** included: neither the `reqwest` nor the
+    /// Kotlin executor can reliably separate a connect timeout from a read
+    /// timeout, so those remain `HttpTimeoutError`. See #1495.
     ///
     /// A site URL rejected while parsing never reaches this predicate: it
     /// surfaces as [`WpApiError::SiteUrlParsingError`], which carries no
@@ -711,7 +716,10 @@ impl RequestExecutionErrorReason {
     /// normalized before they reach the platform, which repairs the rest); it is
     /// covered for completeness.
     pub fn is_site_unreachable(&self) -> bool {
-        matches!(self, Self::NonExistentSiteError { .. })
+        matches!(
+            self,
+            Self::NonExistentSiteError { .. } | Self::ConnectionError { .. }
+        )
     }
 
     /// Whether the request failed because the device has no network connection.
@@ -728,7 +736,7 @@ impl RequestExecutionErrorReason {
     /// `reqwest` executor has neither and never constructs `DeviceIsOfflineError`,
     /// so this always returns `false` there — an offline request typically
     /// surfaces as a DNS failure (`NonExistentSiteError`) or a connect error
-    /// (`HttpError`) instead.
+    /// (`ConnectionError`) instead.
     pub fn is_device_offline(&self) -> bool {
         matches!(self, Self::DeviceIsOfflineError { .. })
     }
@@ -782,11 +790,12 @@ impl RequestExecutionErrorReason {
     }
 }
 
-/// Whether the site could not be reached — most reliably, the host did not
-/// resolve.
+/// Whether the site could not be reached at all — the host did not resolve, or
+/// the host resolved but no connection could be established.
 ///
-/// See [`RequestExecutionErrorReason::is_site_unreachable`] for the per-platform
-/// differences in how connectivity failures are classified.
+/// See [`RequestExecutionErrorReason::is_site_unreachable`] for what does and
+/// does not count, and match `NonExistentSiteError` / `ConnectionError` directly
+/// to tell a DNS failure apart from a failed connection.
 #[uniffi::export]
 pub fn request_execution_error_reason_is_site_unreachable(
     reason: &RequestExecutionErrorReason,
@@ -826,6 +835,9 @@ impl WpSupportsLocalization for RequestExecutionErrorReason {
             }
             RequestExecutionErrorReason::DeviceIsOfflineError { error_message } => {
                 WpMessages::just(error_message)
+            }
+            RequestExecutionErrorReason::ConnectionError { reason } => {
+                WpMessages::connection_error(reason)
             }
             RequestExecutionErrorReason::HttpError { reason } => {
                 WpMessages::http_server_error(reason)
@@ -880,11 +892,22 @@ mod tests {
         }
     }
 
+    fn connection_error() -> RequestExecutionErrorReason {
+        RequestExecutionErrorReason::ConnectionError {
+            reason: "connection refused".to_string(),
+        }
+    }
+
     #[test]
-    fn test_is_site_unreachable_matches_non_existent_site_error() {
-        let reason = non_existent_site();
-        assert!(reason.is_site_unreachable());
-        assert!(!reason.is_device_offline());
+    fn test_is_site_unreachable_matches_dns_and_connection_failures() {
+        // The site is unreachable whether its host didn't resolve (DNS) or the
+        // host resolved but the connection couldn't be established.
+        assert!(non_existent_site().is_site_unreachable());
+        assert!(connection_error().is_site_unreachable());
+
+        // Neither is the device being offline.
+        assert!(!non_existent_site().is_device_offline());
+        assert!(!connection_error().is_device_offline());
     }
 
     #[test]
@@ -950,6 +973,15 @@ mod tests {
         assert!(request_execution_error_reason_is_device_offline(&offline));
         assert!(!request_execution_error_reason_is_site_unreachable(
             &offline
+        ));
+
+        // A failed connection is also site-unreachable (the exported fn delegates
+        // to the broadened inherent method), but not device-offline.
+        assert!(request_execution_error_reason_is_site_unreachable(
+            &connection_error()
+        ));
+        assert!(!request_execution_error_reason_is_device_offline(
+            &connection_error()
         ));
     }
 }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -195,6 +195,17 @@ fn request_execution_error_from_reqwest(
         tls_error.into()
     } else if let Some(io_error) = error.as_io_error() {
         match io_error.kind() {
+            // The host resolved, but the connection couldn't be established. This
+            // is caught here (before `is_connect()` below, which is the DNS
+            // `NXDOMAIN` fallback) because a refused/unreachable connection
+            // carries an inner `io::Error`.
+            std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::HostUnreachable
+            | std::io::ErrorKind::NetworkUnreachable => {
+                RequestExecutionErrorReason::ConnectionError {
+                    reason: io_error.to_string(),
+                }
+            }
             std::io::ErrorKind::UnexpectedEof => RequestExecutionErrorReason::HttpError {
                 reason: "The server terminated the connection unexpectedly".to_string(),
             },
@@ -376,10 +387,12 @@ mod tests {
     use crate::request::endpoint::WpEndpointUrl;
 
     // A refused connection — the host resolves (here, loopback), but nothing is
-    // listening on the port — must classify as `HttpError`, not
-    // `NonExistentSiteError`. `NonExistentSiteError` is reserved for DNS
-    // failures, which keeps `is_site_unreachable` a portable "the host does not
-    // resolve" signal across the Swift, Kotlin, and reqwest executors (#1495).
+    // listening on the port — must classify as `ConnectionError`, not
+    // `NonExistentSiteError` (which is reserved for DNS failures) and not the
+    // generic `HttpError` (which is a failure *after* a connection is
+    // established). Keeping the two apart lets `is_site_unreachable` cover both
+    // consistently while callers can still tell a bad domain from a down server
+    // across the Swift, Kotlin, and reqwest executors (#1495).
     //
     // The branch ordering in `request_execution_error_from_reqwest` is
     // load-bearing: `ECONNREFUSED` carries an inner `io::Error`, so it is caught
@@ -388,7 +401,7 @@ mod tests {
     // ordering so a refactor can't silently reclassify a refused connection as
     // an unreachable site.
     #[tokio::test]
-    async fn refused_connection_is_http_error() {
+    async fn refused_connection_is_connection_error() {
         // Port 1 on loopback is privileged, so nothing is bound in any test
         // environment, and the OS refuses the connection immediately.
         let request = WpNetworkRequest::get(WpEndpointUrl("http://127.0.0.1:1".to_string()));
@@ -403,8 +416,8 @@ mod tests {
             panic!("expected RequestExecutionFailed, got: {error:?}");
         };
         assert!(
-            matches!(reason, RequestExecutionErrorReason::HttpError { .. }),
-            "a refused connection must be HttpError, got: {reason:?}"
+            matches!(reason, RequestExecutionErrorReason::ConnectionError { .. }),
+            "a refused connection must be ConnectionError, got: {reason:?}"
         );
     }
 }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -369,3 +369,42 @@ pub(crate) fn find_error<'a, E: Error + 'static>(top: &'a (dyn Error + 'static))
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request::endpoint::WpEndpointUrl;
+
+    // A refused connection — the host resolves (here, loopback), but nothing is
+    // listening on the port — must classify as `HttpError`, not
+    // `NonExistentSiteError`. `NonExistentSiteError` is reserved for DNS
+    // failures, which keeps `is_site_unreachable` a portable "the host does not
+    // resolve" signal across the Swift, Kotlin, and reqwest executors (#1495).
+    //
+    // The branch ordering in `request_execution_error_from_reqwest` is
+    // load-bearing: `ECONNREFUSED` carries an inner `io::Error`, so it is caught
+    // by the `as_io_error` branch *before* `is_connect()` — the DNS-`NXDOMAIN`
+    // fallback that maps to `NonExistentSiteError`. This test guards that
+    // ordering so a refactor can't silently reclassify a refused connection as
+    // an unreachable site.
+    #[tokio::test]
+    async fn refused_connection_is_http_error() {
+        // Port 1 on loopback is privileged, so nothing is bound in any test
+        // environment, and the OS refuses the connection immediately.
+        let request = WpNetworkRequest::get(WpEndpointUrl("http://127.0.0.1:1".to_string()));
+        let executor = ReqwestRequestExecutor::new_with_default_timeout(false);
+
+        let error = executor
+            .execute(request.into())
+            .await
+            .expect_err("connecting to a closed port must fail");
+
+        let RequestExecutionError::RequestExecutionFailed { reason, .. } = error else {
+            panic!("expected RequestExecutionFailed, got: {error:?}");
+        };
+        assert!(
+            matches!(reason, RequestExecutionErrorReason::HttpError { .. }),
+            "a refused connection must be HttpError, got: {reason:?}"
+        );
+    }
+}

--- a/wp_localization/localization/en-US/main.ftl
+++ b/wp_localization/localization/en-US/main.ftl
@@ -26,6 +26,8 @@ http_cancellation_error = The request was cancelled.
 
 http_authentication_rejected_error = The server at {$url} rejected your credentials. Please provide a valid username and password.
 
+connection_error = Couldn't connect to the server: {$reason}. The site may be down or unreachable.
+
 http_server_error = Unable to connect to server: {$reason}. Please contact your server provider.
 
 misconfigured_http_authentication_error = The server is sending invalid HTTP authentication information. Please check your site's HTTP authentication configuration.


### PR DESCRIPTION
## Description

Based on `trunk` — its stack dependencies **#1488** (predicates) and **#1493** (docs) have both merged. Supersedes closed #1523 (GitHub won't reopen a PR whose base branch was deleted on merge).

Fixes #1495: a refused connection (the host resolves, but nothing is listening) was classified as `NonExistentSiteError` on Swift and `HttpError` on Kotlin/reqwest, so the `isSiteUnreachable` predicate from #1488 returned a different answer per platform for the same outage.

The resolution: give refused/unreachable connections their own `ConnectionError` reason, and make **`isSiteUnreachable` mean "couldn't reach the site at all"** — a DNS failure *or* a failed connection. It's now the same answer on every executor. Callers that need to tell "wrong domain" from "server down" match the `NonExistentSiteError` / `ConnectionError` variants directly.

## Changes

### 1. Narrow `NonExistentSiteError` to DNS-only
- Swift: `.cannotConnectToHost` no longer maps to `NonExistentSiteError`. `NonExistentSiteError` now means a DNS-resolution failure on every executor.

### 2. Add `ConnectionError`; broaden `isSiteUnreachable` to cover it
- New `RequestExecutionErrorReason::ConnectionError { reason }` — the host resolved, but no connection to the server could be established.
- Reclassify connection-establishment failures to it across all three executors:
  - **reqwest** — `io::ErrorKind::{ConnectionRefused, HostUnreachable, NetworkUnreachable}`
  - **Kotlin** — `ConnectException`, `NoRouteToHostException`
  - **Swift** — `URLError.cannotConnectToHost`
- `is_site_unreachable` now matches `NonExistentSiteError | ConnectionError`, so it's one portable "couldn't reach the site" signal (no separate predicate). Match the two variants directly to distinguish DNS from a failed connection.
- Localized `connection_error` message (`en-US`; other locales fill in via the translation process).

**Connect timeout is deliberately excluded** — neither reqwest's `is_timeout()` nor OkHttp's `SocketTimeoutException` separates a connect timeout from a read timeout, so those stay `HttpTimeoutError`. A dark IP that times out is therefore not caught; that's #1491's territory.

## Test plan

Refused-connection coverage added and passing on all three executors:

- [x] **Rust** — `refused_connection_is_connection_error` (reqwest against a closed loopback port → `ConnectionError`); `is_site_unreachable` now covers both DNS and connection failures; #1488's predicate tests updated. `cargo test --lib` **1829 pass**. `cargo fmt` / `clippy --tests --all-targets --all-features -D warnings` / `cargo doc` clean.
- [x] **Swift** — built the macOS bindings (`make xcframework-only-macos` + assemble) and ran `swift test --filter testRefusedConnectionIsConnectionError`: **passes** (closed loopback port → `.connectionError`). The full Swift package compiles clean against the regenerated bindings (generated case is `.connectionError`, `isConnectivityFailure` gone).
- [x] **Kotlin** — added `WpRequestExecutorTest` refused-connection test (`:api:kotlin:integrationTest` in Docker: **passes**, regenerating the bindings with `ConnectionError`). The new variant also required a `ConnectionError` branch in the example app's exhaustive `when` (`ErrorMessage.kt`, which had no `else`); verified with `:example:composeApp:compileKotlinDesktop` (**BUILD SUCCESSFUL**) — the same commonMain CI compiles via `:example:androidApp:assembleDebug`.

## Related issues

- Fixes #1495
- Follows the now-merged #1488 (predicates) and #1493 (docs); supersedes closed #1523
- Does **not** resolve #1502 — `HttpError` is still unconstructible from the Swift executor (refused connections now go to `ConnectionError`, not `HttpError`).
- #1491 (Swift connect-timeout → `GenericError`) is the remaining piece for the connect-timeout leg of `isSiteUnreachable`.

## Notes for review

- **`isSiteUnreachable` semantics changed** from #1488's DNS-only to the broad "couldn't reach the site." It's unreleased (merged today, no shipped consumers), so this is the cheapest moment to set it.
- **New enum variant `ConnectionError`** — marked `**BREAKING:**` in the changelog: adding a variant breaks exhaustive matches on `RequestExecutionErrorReason` (Swift `switch`, Kotlin `when`-expression, Rust `match`) for consumers on the last release (0.6.0).

## Changelog

- [x] Updated the `Added` entries and `Fixed` entry under `## [Unreleased]`.


