### PR TITLE
Model the per-post stats response against the wp.com source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- WordPress.com `GET /sites/<site_id>/stats/post/<post_id>` endpoint for per-post stats. Returns the post's view history, like and comment counts, and post metadata — everything the "Latest Post Summary" card needs. The API's `fields`/`data` column table is flattened into `daily_views` while deserializing; callers wanting a trailing window slice its tail, which can run to thousands of entries. Passing `PostId(0)` returns stats for the site's home page, for which `post`, `discussion`, and `like_count` are `None`.
 - WordPress.com `POST /me/transactions` endpoint for redeeming a shopping cart with the account's WordPress.com credits, completing a domain purchase
 - WordPress.com `GET /sites/<site_id>/purchases` endpoint for listing a site's purchases (plans, domains, and other subscriptions)
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption
 - WordPress.com `POST /sites/<site_id>/domains/primary` endpoint for setting a site's primary domain
+- WordPress.com `GET /sites/<site_id>/stats/post/<post_id>` endpoint for a post's view history, like count, comment count, and metadata
 
 ### Changed
 

--- a/wp_api/src/wp_com/endpoint/stats_post_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_post_endpoint.rs
@@ -1,13 +1,15 @@
 use crate::{
-    posts::PostId,
     request::endpoint::{AsNamespace, DerivedRequest},
-    wp_com::{WpComNamespace, WpComSiteId, stats_post::StatsPostResponse},
+    wp_com::{
+        WpComNamespace, WpComSiteId,
+        stats_post::{StatsPostResponse, StatsPostTarget},
+    },
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum StatsPostRequest {
-    #[get(url = "/sites/<wp_com_site_id>/stats/post/<post_id>", output = StatsPostResponse)]
+    #[get(url = "/sites/<wp_com_site_id>/stats/post/<stats_post_target>", output = StatsPostResponse)]
     GetStatsPost,
 }
 
@@ -21,6 +23,7 @@ impl DerivedRequest for StatsPostRequest {
 mod tests {
     use super::*;
     use crate::{
+        posts::PostId,
         request::endpoint::ApiUrlResolver,
         wp_com::endpoint::tests::{
             fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
@@ -30,20 +33,30 @@ mod tests {
     use std::sync::Arc;
 
     #[rstest]
-    #[case::numeric_id(WpComSiteId(12345), PostId(2729), "/sites/12345/stats/post/2729")]
+    #[case::numeric_id(
+        WpComSiteId(12345),
+        StatsPostTarget::Post { id: PostId(2729) },
+        "/sites/12345/stats/post/2729"
+    )]
     #[case::large_ids(
         WpComSiteId(229889220),
-        PostId(9007199254740991),
+        StatsPostTarget::Post { id: PostId(9007199254740991) },
         "/sites/229889220/stats/post/9007199254740991"
+    )]
+    // The API addresses the site's home page as post 0.
+    #[case::home_page(
+        WpComSiteId(12345),
+        StatsPostTarget::HomePage,
+        "/sites/12345/stats/post/0"
     )]
     fn get_stats_post(
         endpoint: StatsPostRequestEndpoint,
         #[case] site_id: WpComSiteId,
-        #[case] post_id: PostId,
+        #[case] target: StatsPostTarget,
         #[case] expected_path: &str,
     ) {
         validate_wp_com_rest_v1_1_endpoint(
-            endpoint.get_stats_post(&site_id, &post_id),
+            endpoint.get_stats_post(&site_id, &target),
             expected_path,
         );
     }

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -587,6 +587,10 @@ mod tests {
         assert_eq!(response.like_count, Some(0));
         assert_eq!(response.discussion.expect("present").comment_count, 0);
 
+        // With no view to anchor on, the API reports every year from 1970.
+        assert!(response.years.contains_key("1970"));
+        assert!(response.averages.contains_key("1970"));
+
         // The API sends `months` as an empty array rather than an empty object.
         let year = response.years.get("2026").expect("2026 should exist");
         assert_eq!(year.total, 0);

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -1,10 +1,12 @@
 use crate::{
-    date::WpGmtDateTime, posts::PostId, users::UserId, wp_com::stats_visits::StatsVisitsDataValue,
+    date::WpGmtDateTime,
+    posts::PostId,
+    wp_com::{me::WpComUserId, stats_visits::StatsVisitsDataValue},
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 use wp_serde_helper::{
-    deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_i64_or_string_as_t,
+    deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_u64_or_string_as_t,
 };
 
 // The column names the API uses for the daily view history.
@@ -374,9 +376,9 @@ pub struct StatsPostDetails {
     /// The ID of the post's author.
     #[serde(
         rename = "post_author",
-        deserialize_with = "deserialize_i64_or_string_as_t"
+        deserialize_with = "deserialize_u64_or_string_as_t"
     )]
-    pub author_id: UserId,
+    pub author_id: WpComUserId,
     /// The post's public URL. `None` if the API doesn't supply one.
     ///
     /// Unlike the fields around it this isn't a stored column — the stats
@@ -469,7 +471,7 @@ mod tests {
             )
         );
         // The API sends `post_author` as a string.
-        assert_eq!(post.author_id, UserId(5399133));
+        assert_eq!(post.author_id, WpComUserId(5399133));
     }
 
     #[test]

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -11,6 +11,9 @@ use wp_serde_helper::{
 const PERIOD_COLUMN: &str = "period";
 const VIEWS_COLUMN: &str = "views";
 
+/// The id the API addresses the site's home page by.
+const HOME_PAGE_POST_ID: PostId = PostId(0);
+
 /// What a per-post stats request is about.
 ///
 /// The API addresses the site's home page as post `0`, which is not a valid
@@ -29,6 +32,19 @@ impl fmt::Display for StatsPostTarget {
         match self {
             Self::Post { id } => write!(f, "{id}"),
             Self::HomePage => write!(f, "0"),
+        }
+    }
+}
+
+impl From<PostId> for StatsPostTarget {
+    /// Resolves the API's home page id, so callers working from a list that
+    /// includes it — `/stats/top-posts` reports one — don't each repeat the
+    /// check.
+    fn from(id: PostId) -> Self {
+        if id == HOME_PAGE_POST_ID {
+            Self::HomePage
+        } else {
+            Self::Post { id }
         }
     }
 }
@@ -392,6 +408,13 @@ mod tests {
         let fields: Vec<String> = fields.iter().map(|f| f.to_string()).collect();
         let data = serde_json::from_str(data).expect("Unable to parse JSON");
         daily_views(&fields, data)
+    }
+
+    #[rstest]
+    #[case::home_page(PostId(0), StatsPostTarget::HomePage)]
+    #[case::post(PostId(2729), StatsPostTarget::Post { id: PostId(2729) })]
+    fn test_stats_post_target_from_post_id(#[case] id: PostId, #[case] expected: StatsPostTarget) {
+        assert_eq!(StatsPostTarget::from(id), expected);
     }
 
     #[test]

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -361,8 +361,12 @@ pub struct StatsPostDetails {
         deserialize_with = "deserialize_i64_or_string_as_t"
     )]
     pub author_id: UserId,
-    /// The post's public URL.
-    pub permalink: String,
+    /// The post's public URL. `None` if the API doesn't supply one.
+    ///
+    /// Unlike the fields around it this isn't a stored column — the stats
+    /// service derives it per request.
+    #[serde(default, deserialize_with = "deserialize_false_as_none")]
+    pub permalink: Option<String>,
     /// The post's globally unique identifier. Use [`Self::permalink`] for a
     /// URL that resolves.
     pub guid: String,
@@ -436,8 +440,10 @@ mod tests {
         assert_eq!(post.post_type, "post");
         assert_eq!(post.guid, "https://example.com/?p=2729");
         assert_eq!(
-            post.permalink,
-            "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/"
+            post.permalink.as_deref(),
+            Some(
+                "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/"
+            )
         );
         // The API sends `post_author` as a string.
         assert_eq!(post.author_id, UserId(5399133));

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -2,7 +2,7 @@ use crate::{
     date::WpGmtDateTime, posts::PostId, users::UserId, wp_com::stats_visits::StatsVisitsDataValue,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::HashMap, fmt};
 use wp_serde_helper::{
     deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_i64_or_string_as_t,
 };
@@ -14,7 +14,7 @@ const VIEWS_COLUMN: &str = "views";
 /// What a per-post stats request is about.
 ///
 /// The API addresses the site's home page as post `0`, which is not a valid
-/// [`PostId`] anywhere else in the crate, so it gets its own variant here.
+/// [`PostId`] anywhere else in the crate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum StatsPostTarget {
     /// A specific post or page.
@@ -24,8 +24,8 @@ pub enum StatsPostTarget {
     HomePage,
 }
 
-impl Display for StatsPostTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for StatsPostTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Post { id } => write!(f, "{id}"),
             Self::HomePage => write!(f, "0"),
@@ -86,10 +86,8 @@ pub struct StatsPostResponse {
     pub highest_month: u64,
     /// The highest monthly average of daily views the target reached.
     pub highest_day_average: u64,
-    /// The highest single-day view count across the last few weeks.
-    ///
-    /// Despite the name the API gives it, this is neither a weekly figure nor
-    /// an average.
+    /// The highest single-day view count across the last few weeks. Despite the
+    /// name, this is neither a weekly figure nor an average.
     pub highest_week_average: u64,
     /// The post's like count. `None` for the site's home page.
     pub like_count: Option<u64>,
@@ -118,11 +116,10 @@ struct RawStatsPostResponse {
     highest_day_average: u64,
     highest_week_average: u64,
     // The home page has no post behind it, so the API sends these as `null` —
-    // and `post` as boolean `false` rather than `null` when the site's front
-    // page is set to "latest posts".
+    // and `post` as boolean `false` rather than `null`.
     like_count: Option<u64>,
     discussion: Option<StatsPostDiscussion>,
-    #[serde(default, deserialize_with = "deserialize_false_as_none")]
+    #[serde(deserialize_with = "deserialize_false_as_none")]
     post: Option<StatsPostDetails>,
 }
 
@@ -317,11 +314,9 @@ pub struct StatsPostDiscussion {
 
 /// The post the stats belong to.
 ///
-/// This is WordPress' raw post row plus the [`Self::permalink`] the stats
-/// service computes for it, so it carries the post's editorial metadata but
-/// none of its rendered representation — there is no featured image here.
-/// Fields the API sends that aren't modelled (ping status, menu order, and
-/// similar) are ignored.
+/// This mirrors WordPress' raw post row, so it carries the post's editorial
+/// metadata. Fields the API sends that aren't modelled here (post content,
+/// ping status, and similar) are ignored.
 ///
 /// The row's `comment_count` is deliberately omitted: the API sends it as a
 /// string here, and [`StatsPostDiscussion::comment_count`] carries the same
@@ -367,9 +362,6 @@ pub struct StatsPostDetails {
     )]
     pub author_id: UserId,
     /// The post's public URL.
-    ///
-    /// The stats service computes this and attaches it to the row; it is not
-    /// one of the post's stored columns.
     pub permalink: String,
     /// The post's globally unique identifier. Use [`Self::permalink`] for a
     /// URL that resolves.
@@ -414,7 +406,6 @@ mod tests {
         assert_eq!(year.total, 6146);
         assert_eq!(year.months.get("6"), Some(&3224));
 
-        // The API truncates averages to whole numbers before sending them.
         let average = response.averages.get("2013").expect("2013 should exist");
         assert_eq!(average.overall, 31);
         assert_eq!(average.months.get("6"), Some(&293));
@@ -444,7 +435,6 @@ mod tests {
         assert_eq!(post.status, "publish");
         assert_eq!(post.post_type, "post");
         assert_eq!(post.guid, "https://example.com/?p=2729");
-        // The stats service attaches this; it isn't one of the post's columns.
         assert_eq!(
             post.permalink,
             "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/"
@@ -461,62 +451,50 @@ mod tests {
 
         let first = &weeks[0];
         assert_eq!(first.days.len(), 7);
-        assert_eq!(first.days[0].day, "2026-07-20");
-        assert_eq!(first.total, 0);
-        assert_eq!(first.average, 0);
+        assert_eq!(first.days[0].day, "2026-06-29");
+        assert_eq!(first.days[0].count, 2);
+        assert_eq!(first.total, 7);
+        assert_eq!(first.average, 1);
         assert!(first.change.is_none(), "the first week has no prior week");
 
-        // The API sends `{"isInfinity": true}` when the previous week had no views.
         let second = &weeks[1];
-        assert_eq!(second.total, 14);
-        assert_eq!(second.average, 2);
-        assert_eq!(second.change, Some(StatsPostChange::Infinite));
-
-        // Only the current week is partial, and today is left out of its
-        // average, so 9 views over 3 elapsed days averages 3.
-        let last = &weeks[2];
-        assert_eq!(last.days.len(), 4, "the current week may be partial");
-        assert_eq!(last.total, 10);
-        assert_eq!(last.average, 3);
+        assert_eq!(second.days.len(), 4, "a week may be partial");
+        assert_eq!(second.total, 6);
         assert_eq!(
-            last.change,
-            Some(StatsPostChange::Percentage { value: 50.0 })
+            second.change,
+            Some(StatsPostChange::Percentage {
+                value: 133.33333333333334
+            })
         );
+
+        // The API sends `{"isInfinity": true}` when the previous week had no views.
+        let last = &weeks[2];
+        assert_eq!(last.change, Some(StatsPostChange::Infinite));
     }
 
     #[test]
     fn test_stats_post_change_round_trips() {
         let weeks = parse(WITH_VIEWS).weeks;
 
+        assert_eq!(serde_json::to_string(&weeks[0].change).unwrap(), "null");
         assert_eq!(
-            serde_json::to_string(&weeks[0].change).expect("should serialize"),
-            "null"
+            serde_json::to_string(&weeks[1].change).unwrap(),
+            "133.33333333333334"
         );
         assert_eq!(
-            serde_json::to_string(&weeks[1].change).expect("should serialize"),
+            serde_json::to_string(&weeks[2].change).unwrap(),
             r#"{"isInfinity":true}"#
-        );
-        assert_eq!(
-            serde_json::to_string(&weeks[2].change).expect("should serialize"),
-            "50.0"
         );
     }
 
     #[test]
     fn test_stats_post_response_round_trips() {
-        // The response deserializes from a `fields`/`data` column table and
-        // serializes back into one, so a serialized response can be read again.
         let response = parse(WITH_VIEWS);
-        let json = serde_json::to_string(&response).expect("should serialize");
+        let json = serde_json::to_string(&response).expect("Unable to serialize response");
         let reparsed: StatsPostResponse =
-            serde_json::from_str(&json).expect("a serialized response should parse back");
+            serde_json::from_str(&json).expect("Unable to parse JSON");
 
         assert_eq!(reparsed.daily_views, response.daily_views);
-        assert_eq!(reparsed.views, response.views);
-        assert_eq!(
-            reparsed.post.expect("present").id,
-            response.post.expect("present").id
-        );
     }
 
     #[test]
@@ -555,10 +533,6 @@ mod tests {
         vec![("2026-08-04", 5), ("2026-08-06", 7)]
     )]
     #[case::missing_views_column(&["period"], r#"[["2026-08-04"]]"#, vec![])]
-    // The API has a no-history fallback row carrying a year-less date and a
-    // string-typed count. Neither is a usable data point, so the row is
-    // dropped rather than parsed into a bogus one.
-    #[case::no_history_fallback_row(&["period", "views"], r#"[["8-06", "0"]]"#, vec![])]
     fn test_stats_post_daily_views_column_handling(
         #[case] fields: &[&str],
         #[case] data: &str,
@@ -599,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_post_never_viewed() {
+    fn test_stats_post_without_views() {
         let response = parse(NO_VIEWS);
 
         assert_eq!(response.views, 0);
@@ -607,18 +581,15 @@ mod tests {
         assert_eq!(response.like_count, Some(0));
         assert_eq!(response.discussion.expect("present").comment_count, 0);
 
-        // Without a view to anchor on, the API reports every year from 1970
-        // instead of the years the post existed for.
-        let year = response.years.get("1970").expect("1970 should exist");
+        // The API sends `months` as an empty array rather than an empty object.
+        let year = response.years.get("2026").expect("2026 should exist");
         assert_eq!(year.total, 0);
-        // Each one sends `months` as an empty array rather than an empty object.
         assert!(year.months.is_empty());
 
-        let average = response.averages.get("1970").expect("1970 should exist");
+        let average = response.averages.get("2026").expect("2026 should exist");
         assert_eq!(average.overall, 0);
         assert!(average.months.is_empty());
 
-        // The daily history is still padded, so it stays readable.
         assert_eq!(response.daily_views.len(), 3);
         assert!(response.daily_views.iter().all(|d| d.views == 0));
     }

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -7,7 +7,7 @@ use wp_serde_helper::{
     deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_i64_or_string_as_t,
 };
 
-/// The column names the API uses for the daily view history.
+// The column names the API uses for the daily view history.
 const PERIOD_COLUMN: &str = "period";
 const VIEWS_COLUMN: &str = "views";
 

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -63,7 +63,8 @@ pub struct StatsPostResponse {
     /// Yearly view totals, keyed by year (e.g. `"2026"`).
     ///
     /// A target with no recorded views gets an entry for every year from 1970
-    /// to the present rather than an empty map.
+    /// to the present, each with an empty `months` map, rather than a map
+    /// covering only the years the target existed for.
     pub years: HashMap<String, StatsPostYear>,
     /// Yearly view averages, keyed by year (e.g. `"2026"`). Populated on the
     /// same basis as [`Self::years`].
@@ -75,11 +76,11 @@ pub struct StatsPostResponse {
     /// The API sends this as a `fields`/`data` column table; it is flattened
     /// while deserializing so callers never handle the column indirection.
     ///
-    /// Empty when the response doesn't name both the `period` and `views`
-    /// columns, and also when the target has never been viewed — the API then
-    /// sends one placeholder row carrying a year-less date and a string-typed
-    /// count, which is discarded. [`Self::weeks`] still reports zero-filled
-    /// days in that case, so prefer it for a freshly published post.
+    /// The history is padded rather than sparse: a target with no views still
+    /// gets one zero-count entry per day since it was published.
+    ///
+    /// Empty if the response doesn't name both the `period` and `views`
+    /// columns.
     pub daily_views: Vec<StatsPostDailyView>,
     /// The highest view count the target reached in a single month.
     pub highest_month: u64,
@@ -316,9 +317,11 @@ pub struct StatsPostDiscussion {
 
 /// The post the stats belong to.
 ///
-/// This mirrors WordPress' raw post row, so it carries the post's editorial
-/// metadata. Fields the API sends that aren't modelled here (ping status, menu
-/// order, and similar) are ignored.
+/// This is WordPress' raw post row plus the [`Self::permalink`] the stats
+/// service computes for it, so it carries the post's editorial metadata but
+/// none of its rendered representation — there is no featured image here.
+/// Fields the API sends that aren't modelled (ping status, menu order, and
+/// similar) are ignored.
 ///
 /// The row's `comment_count` is deliberately omitted: the API sends it as a
 /// string here, and [`StatsPostDiscussion::comment_count`] carries the same
@@ -363,7 +366,13 @@ pub struct StatsPostDetails {
         deserialize_with = "deserialize_i64_or_string_as_t"
     )]
     pub author_id: UserId,
-    /// The post's globally unique identifier. Not a permalink.
+    /// The post's public URL.
+    ///
+    /// The stats service computes this and attaches it to the row; it is not
+    /// one of the post's stored columns.
+    pub permalink: String,
+    /// The post's globally unique identifier. Use [`Self::permalink`] for a
+    /// URL that resolves.
     pub guid: String,
 }
 
@@ -435,6 +444,11 @@ mod tests {
         assert_eq!(post.status, "publish");
         assert_eq!(post.post_type, "post");
         assert_eq!(post.guid, "https://example.com/?p=2729");
+        // The stats service attaches this; it isn't one of the post's columns.
+        assert_eq!(
+            post.permalink,
+            "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/"
+        );
         // The API sends `post_author` as a string.
         assert_eq!(post.author_id, UserId(5399133));
     }
@@ -541,10 +555,10 @@ mod tests {
         vec![("2026-08-04", 5), ("2026-08-06", 7)]
     )]
     #[case::missing_views_column(&["period"], r#"[["2026-08-04"]]"#, vec![])]
-    // A target with no recorded views gets one placeholder row instead of a
-    // history: a year-less date and a string-typed count. Neither is a usable
-    // data point, so the row is dropped and `daily_views` comes back empty.
-    #[case::placeholder_row(&["period", "views"], r#"[["8-06", "0"]]"#, vec![])]
+    // The API has a no-history fallback row carrying a year-less date and a
+    // string-typed count. Neither is a usable data point, so the row is
+    // dropped rather than parsed into a bogus one.
+    #[case::no_history_fallback_row(&["period", "views"], r#"[["8-06", "0"]]"#, vec![])]
     fn test_stats_post_daily_views_column_handling(
         #[case] fields: &[&str],
         #[case] data: &str,
@@ -585,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_post_without_recent_views() {
+    fn test_stats_post_never_viewed() {
         let response = parse(NO_VIEWS);
 
         assert_eq!(response.views, 0);
@@ -593,15 +607,18 @@ mod tests {
         assert_eq!(response.like_count, Some(0));
         assert_eq!(response.discussion.expect("present").comment_count, 0);
 
-        // The API sends `months` as an empty array rather than an empty object.
-        let year = response.years.get("2026").expect("2026 should exist");
+        // Without a view to anchor on, the API reports every year from 1970
+        // instead of the years the post existed for.
+        let year = response.years.get("1970").expect("1970 should exist");
         assert_eq!(year.total, 0);
+        // Each one sends `months` as an empty array rather than an empty object.
         assert!(year.months.is_empty());
 
-        let average = response.averages.get("2026").expect("2026 should exist");
+        let average = response.averages.get("1970").expect("1970 should exist");
         assert_eq!(average.overall, 0);
         assert!(average.months.is_empty());
 
+        // The daily history is still padded, so it stays readable.
         assert_eq!(response.daily_views.len(), 3);
         assert!(response.daily_views.iter().all(|d| d.views == 0));
     }

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -487,14 +487,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_stats_post_response_round_trips() {
-        let response = parse(WITH_VIEWS);
-        let json = serde_json::to_string(&response).expect("Unable to serialize response");
+    #[rstest]
+    #[case::with_views(WITH_VIEWS)]
+    #[case::no_views(NO_VIEWS)]
+    #[case::homepage(HOMEPAGE)]
+    fn test_stats_post_response_round_trips(#[case] json_file_path: &str) {
+        let serialized =
+            serde_json::to_value(parse(json_file_path)).expect("Unable to serialize response");
         let reparsed: StatsPostResponse =
-            serde_json::from_str(&json).expect("Unable to parse JSON");
+            serde_json::from_value(serialized.clone()).expect("Unable to parse JSON");
 
-        assert_eq!(reparsed.daily_views, response.daily_views);
+        assert_eq!(
+            serde_json::to_value(reparsed).expect("Unable to serialize response"),
+            serialized
+        );
     }
 
     #[test]

--- a/wp_api/src/wp_com/stats_post.rs
+++ b/wp_api/src/wp_com/stats_post.rs
@@ -1,48 +1,94 @@
-use crate::{posts::PostId, wp_com::stats_visits::StatsVisitsDataValue};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use wp_serde_helper::{
-    deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_u64_or_string,
+use crate::{
+    date::WpGmtDateTime, posts::PostId, users::UserId, wp_com::stats_visits::StatsVisitsDataValue,
 };
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Display};
+use wp_serde_helper::{
+    deserialize_empty_array_or_hashmap, deserialize_false_as_none, deserialize_i64_or_string_as_t,
+};
+
+/// The column names the API uses for the daily view history.
+const PERIOD_COLUMN: &str = "period";
+const VIEWS_COLUMN: &str = "views";
+
+/// What a per-post stats request is about.
+///
+/// The API addresses the site's home page as post `0`, which is not a valid
+/// [`PostId`] anywhere else in the crate, so it gets its own variant here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum StatsPostTarget {
+    /// A specific post or page.
+    Post { id: PostId },
+    /// The site's home page. See [`StatsPostResponse`] for what the API counts
+    /// for it, which depends on how the site's front page is configured.
+    HomePage,
+}
+
+impl Display for StatsPostTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Post { id } => write!(f, "{id}"),
+            Self::HomePage => write!(f, "0"),
+        }
+    }
+}
 
 /// Response from the per-post stats endpoint.
 ///
-/// The endpoint returns the post's complete view history, so
+/// The endpoint returns the target's complete view history, so
 /// [`Self::daily_views`] can hold thousands of entries for a long-lived post.
 /// Callers that only need a trailing window (such as the "Latest Post Summary"
-/// card) should slice the tail of it — `daily_views.suffix(7)` in Swift,
+/// card) should slice the tail of it — `dailyViews.suffix(7)` in Swift,
 /// `dailyViews.takeLast(7)` in Kotlin.
 ///
 /// # The site's home page
 ///
-/// Requesting `PostId(0)` returns view stats for the site's home page, which
-/// `/stats/top-posts` reports as a pseudo-entry with that id. The home page
-/// isn't a post, so [`Self::post`], [`Self::discussion`] and [`Self::like_count`]
-/// are all `None` for it; every view field is populated as usual.
+/// [`StatsPostTarget::HomePage`] requests post `0`, which `/stats/top-posts`
+/// also reports as a pseudo-entry. What the view figures cover then depends on
+/// how the site's front page is configured, and the two cases are
+/// indistinguishable in the response:
+///
+/// - a "latest posts" front page — the views recorded against the home page
+/// - a static front page — the whole site's view history
+///
+/// The home page is not a post either way, so [`Self::post`],
+/// [`Self::discussion`] and [`Self::like_count`] are `None` for both.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
-#[serde(from = "RawStatsPostResponse")]
+#[serde(from = "RawStatsPostResponse", into = "RawStatsPostResponse")]
 pub struct StatsPostResponse {
     /// The date the stats were generated for (format: YYYY-MM-DD).
     pub date: String,
-    /// The post's all-time view count.
+    /// The target's all-time view count.
     pub views: u64,
     /// Yearly view totals, keyed by year (e.g. `"2026"`).
+    ///
+    /// A target with no recorded views gets an entry for every year from 1970
+    /// to the present rather than an empty map.
     pub years: HashMap<String, StatsPostYear>,
-    /// Yearly view averages, keyed by year (e.g. `"2026"`).
+    /// Yearly view averages, keyed by year (e.g. `"2026"`). Populated on the
+    /// same basis as [`Self::years`].
     pub averages: HashMap<String, StatsPostAverage>,
     /// The most recent weeks of daily views, oldest first.
     pub weeks: Vec<StatsPostWeek>,
-    /// The post's complete daily view history, oldest first.
+    /// The target's complete daily view history, oldest first.
     ///
     /// The API sends this as a `fields`/`data` column table; it is flattened
     /// while deserializing so callers never handle the column indirection.
-    /// Empty if the response doesn't name both the `period` and `views` columns.
+    ///
+    /// Empty when the response doesn't name both the `period` and `views`
+    /// columns, and also when the target has never been viewed — the API then
+    /// sends one placeholder row carrying a year-less date and a string-typed
+    /// count, which is discarded. [`Self::weeks`] still reports zero-filled
+    /// days in that case, so prefer it for a freshly published post.
     pub daily_views: Vec<StatsPostDailyView>,
-    /// The highest view count the post reached in a single month.
+    /// The highest view count the target reached in a single month.
     pub highest_month: u64,
-    /// The highest daily view average the post reached.
+    /// The highest monthly average of daily views the target reached.
     pub highest_day_average: u64,
-    /// The highest weekly view average the post reached.
+    /// The highest single-day view count across the last few weeks.
+    ///
+    /// Despite the name the API gives it, this is neither a weekly figure nor
+    /// an average.
     pub highest_week_average: u64,
     /// The post's like count. `None` for the site's home page.
     pub like_count: Option<u64>,
@@ -54,7 +100,7 @@ pub struct StatsPostResponse {
 
 /// The response as the API sends it, before the `fields`/`data` column table is
 /// flattened into [`StatsPostResponse::daily_views`].
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct RawStatsPostResponse {
     date: String,
     views: u64,
@@ -70,11 +116,12 @@ struct RawStatsPostResponse {
     highest_month: u64,
     highest_day_average: u64,
     highest_week_average: u64,
-    // The home page (`PostId(0)`) has no post behind it, so the API sends these
-    // as `null` — and `post` as boolean `false` rather than `null`.
+    // The home page has no post behind it, so the API sends these as `null` —
+    // and `post` as boolean `false` rather than `null` when the site's front
+    // page is set to "latest posts".
     like_count: Option<u64>,
     discussion: Option<StatsPostDiscussion>,
-    #[serde(deserialize_with = "deserialize_false_as_none")]
+    #[serde(default, deserialize_with = "deserialize_false_as_none")]
     post: Option<StatsPostDetails>,
 }
 
@@ -97,6 +144,35 @@ impl From<RawStatsPostResponse> for StatsPostResponse {
     }
 }
 
+impl From<StatsPostResponse> for RawStatsPostResponse {
+    fn from(response: StatsPostResponse) -> Self {
+        Self {
+            date: response.date,
+            views: response.views,
+            years: response.years,
+            averages: response.averages,
+            weeks: response.weeks,
+            fields: vec![PERIOD_COLUMN.to_string(), VIEWS_COLUMN.to_string()],
+            data: response
+                .daily_views
+                .into_iter()
+                .map(|daily_view| {
+                    vec![
+                        StatsVisitsDataValue::String(daily_view.period),
+                        StatsVisitsDataValue::Number(daily_view.views),
+                    ]
+                })
+                .collect(),
+            highest_month: response.highest_month,
+            highest_day_average: response.highest_day_average,
+            highest_week_average: response.highest_week_average,
+            like_count: response.like_count,
+            discussion: response.discussion,
+            post: response.post,
+        }
+    }
+}
+
 /// Flattens the `fields`/`data` column table into data points, skipping rows the
 /// columns can't be read from.
 ///
@@ -104,8 +180,8 @@ impl From<RawStatsPostResponse> for StatsPostResponse {
 /// copied — the history runs to thousands of rows on a long-lived post.
 fn daily_views(fields: &[String], data: Vec<Vec<StatsVisitsDataValue>>) -> Vec<StatsPostDailyView> {
     let (Some(period_index), Some(views_index)) = (
-        fields.iter().position(|field| field == "period"),
-        fields.iter().position(|field| field == "views"),
+        fields.iter().position(|field| field == PERIOD_COLUMN),
+        fields.iter().position(|field| field == VIEWS_COLUMN),
     ) else {
         return vec![];
     };
@@ -149,13 +225,15 @@ pub struct StatsPostYear {
 }
 
 /// A year's view averages.
+///
+/// The API truncates every average to a whole number before sending it.
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct StatsPostAverage {
     /// View averages keyed by month number (`"1"` through `"12"`).
     #[serde(deserialize_with = "deserialize_empty_array_or_hashmap")]
-    pub months: HashMap<String, f64>,
+    pub months: HashMap<String, u64>,
     /// The average views across the whole year.
-    pub overall: f64,
+    pub overall: u64,
 }
 
 /// A week of daily views.
@@ -165,8 +243,9 @@ pub struct StatsPostWeek {
     pub days: Vec<StatsPostDay>,
     /// The total views for the week.
     pub total: u64,
-    /// The average daily views for the week.
-    pub average: f64,
+    /// The average daily views for the week, truncated to a whole number by the
+    /// API.
+    pub average: u64,
     /// The change from the previous week, or `None` for the first week.
     pub change: Option<StatsPostChange>,
 }
@@ -175,7 +254,7 @@ pub struct StatsPostWeek {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, uniffi::Enum)]
 #[serde(from = "RawStatsPostChange", into = "RawStatsPostChange")]
 pub enum StatsPostChange {
-    /// The percentage change from the previous week.
+    /// The percentage change from the previous week. Negative when views fell.
     Percentage { value: f64 },
     /// The previous week had no views, so the change is unbounded. The API
     /// sends this as `{"isInfinity": true}` because the underlying value is
@@ -186,10 +265,9 @@ pub enum StatsPostChange {
 /// The wire representations the API uses for a week's `change`.
 ///
 /// These three shapes — a number, `{"isInfinity": true}`, and `null` (handled by
-/// the surrounding `Option`) — are the only ones observed across 60 real
-/// responses spanning 15 sites. A week following a zero-view week always reports
-/// an integer `0` rather than a not-a-number marker, so there is no `isNan`
-/// counterpart to model.
+/// the surrounding `Option`) — are the only ones the endpoint produces. A week
+/// following a zero-view week reports an integer `0` rather than a not-a-number
+/// marker, so there is no `isNan` counterpart to model.
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
 enum RawStatsPostChange {
@@ -239,8 +317,8 @@ pub struct StatsPostDiscussion {
 /// The post the stats belong to.
 ///
 /// This mirrors WordPress' raw post row, so it carries the post's editorial
-/// metadata but not a permalink. Fields the API sends that aren't modelled here
-/// (post content, ping status, and similar) are ignored.
+/// metadata. Fields the API sends that aren't modelled here (ping status, menu
+/// order, and similar) are ignored.
 ///
 /// The row's `comment_count` is deliberately omitted: the API sends it as a
 /// string here, and [`StatsPostDiscussion::comment_count`] carries the same
@@ -251,17 +329,26 @@ pub struct StatsPostDetails {
     #[serde(rename = "ID")]
     pub id: PostId,
     /// The post's title.
+    ///
+    /// When the stats service can't resolve the stored title, the API
+    /// substitutes a generated placeholder of the form `#<id> (not found)`.
     #[serde(rename = "post_title")]
     pub title: String,
+    /// The post's excerpt. Empty when the post has none.
+    #[serde(rename = "post_excerpt")]
+    pub excerpt: String,
     /// The post's publication date in the site's timezone (format: YYYY-MM-DD HH:MM:SS).
     #[serde(rename = "post_date")]
     pub date: String,
-    /// The post's publication date in GMT (format: YYYY-MM-DD HH:MM:SS).
+    /// The post's publication date in GMT.
     #[serde(rename = "post_date_gmt")]
-    pub date_gmt: String,
-    /// The date the post was last modified (format: YYYY-MM-DD HH:MM:SS).
+    pub date_gmt: WpGmtDateTime,
+    /// The date the post was last modified, in the site's timezone (format: YYYY-MM-DD HH:MM:SS).
     #[serde(rename = "post_modified")]
     pub modified: String,
+    /// The date the post was last modified, in GMT.
+    #[serde(rename = "post_modified_gmt")]
+    pub modified_gmt: WpGmtDateTime,
     /// The post's slug.
     #[serde(rename = "post_name")]
     pub slug: String,
@@ -271,8 +358,11 @@ pub struct StatsPostDetails {
     /// The post's type, e.g. `"post"` or `"page"`.
     pub post_type: String,
     /// The ID of the post's author.
-    #[serde(rename = "post_author", deserialize_with = "deserialize_u64_or_string")]
-    pub author_id: u64,
+    #[serde(
+        rename = "post_author",
+        deserialize_with = "deserialize_i64_or_string_as_t"
+    )]
+    pub author_id: UserId,
     /// The post's globally unique identifier. Not a permalink.
     pub guid: String,
 }
@@ -315,9 +405,10 @@ mod tests {
         assert_eq!(year.total, 6146);
         assert_eq!(year.months.get("6"), Some(&3224));
 
+        // The API truncates averages to whole numbers before sending them.
         let average = response.averages.get("2013").expect("2013 should exist");
-        assert_eq!(average.overall, 31.0);
-        assert_eq!(average.months.get("6"), Some(&293.0));
+        assert_eq!(average.overall, 31);
+        assert_eq!(average.months.get("6"), Some(&293));
     }
 
     #[test]
@@ -329,9 +420,14 @@ mod tests {
             post.title,
             "The Last Version of FeedDemon is Here, and it's Free"
         );
+        assert_eq!(post.excerpt, "The wait is over.");
         assert_eq!(post.date, "2013-06-20 09:15:49");
-        assert_eq!(post.date_gmt, "2013-06-20 13:15:49");
+        assert_eq!(post.date_gmt.0.to_rfc3339(), "2013-06-20T13:15:49+00:00");
         assert_eq!(post.modified, "2013-06-23 21:57:23");
+        assert_eq!(
+            post.modified_gmt.0.to_rfc3339(),
+            "2013-06-24T01:57:23+00:00"
+        );
         assert_eq!(
             post.slug,
             "the-last-version-of-feeddemon-is-here-and-its-free"
@@ -340,7 +436,7 @@ mod tests {
         assert_eq!(post.post_type, "post");
         assert_eq!(post.guid, "https://example.com/?p=2729");
         // The API sends `post_author` as a string.
-        assert_eq!(post.author_id, 5399133);
+        assert_eq!(post.author_id, UserId(5399133));
     }
 
     #[test]
@@ -351,39 +447,61 @@ mod tests {
 
         let first = &weeks[0];
         assert_eq!(first.days.len(), 7);
-        assert_eq!(first.days[0].day, "2026-06-29");
-        assert_eq!(first.days[0].count, 2);
-        assert_eq!(first.total, 7);
-        assert_eq!(first.average, 1.0);
+        assert_eq!(first.days[0].day, "2026-07-20");
+        assert_eq!(first.total, 0);
+        assert_eq!(first.average, 0);
         assert!(first.change.is_none(), "the first week has no prior week");
 
-        let second = &weeks[1];
-        assert_eq!(second.days.len(), 4, "a week may be partial");
-        assert_eq!(second.total, 6);
-        assert_eq!(
-            second.change,
-            Some(StatsPostChange::Percentage {
-                value: 133.33333333333334
-            })
-        );
-
         // The API sends `{"isInfinity": true}` when the previous week had no views.
+        let second = &weeks[1];
+        assert_eq!(second.total, 14);
+        assert_eq!(second.average, 2);
+        assert_eq!(second.change, Some(StatsPostChange::Infinite));
+
+        // Only the current week is partial, and today is left out of its
+        // average, so 9 views over 3 elapsed days averages 3.
         let last = &weeks[2];
-        assert_eq!(last.change, Some(StatsPostChange::Infinite));
+        assert_eq!(last.days.len(), 4, "the current week may be partial");
+        assert_eq!(last.total, 10);
+        assert_eq!(last.average, 3);
+        assert_eq!(
+            last.change,
+            Some(StatsPostChange::Percentage { value: 50.0 })
+        );
     }
 
     #[test]
     fn test_stats_post_change_round_trips() {
         let weeks = parse(WITH_VIEWS).weeks;
 
-        assert_eq!(serde_json::to_string(&weeks[0].change).unwrap(), "null");
         assert_eq!(
-            serde_json::to_string(&weeks[1].change).unwrap(),
-            "133.33333333333334"
+            serde_json::to_string(&weeks[0].change).expect("should serialize"),
+            "null"
         );
         assert_eq!(
-            serde_json::to_string(&weeks[2].change).unwrap(),
+            serde_json::to_string(&weeks[1].change).expect("should serialize"),
             r#"{"isInfinity":true}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&weeks[2].change).expect("should serialize"),
+            "50.0"
+        );
+    }
+
+    #[test]
+    fn test_stats_post_response_round_trips() {
+        // The response deserializes from a `fields`/`data` column table and
+        // serializes back into one, so a serialized response can be read again.
+        let response = parse(WITH_VIEWS);
+        let json = serde_json::to_string(&response).expect("should serialize");
+        let reparsed: StatsPostResponse =
+            serde_json::from_str(&json).expect("a serialized response should parse back");
+
+        assert_eq!(reparsed.daily_views, response.daily_views);
+        assert_eq!(reparsed.views, response.views);
+        assert_eq!(
+            reparsed.post.expect("present").id,
+            response.post.expect("present").id
         );
     }
 
@@ -423,6 +541,10 @@ mod tests {
         vec![("2026-08-04", 5), ("2026-08-06", 7)]
     )]
     #[case::missing_views_column(&["period"], r#"[["2026-08-04"]]"#, vec![])]
+    // A target with no recorded views gets one placeholder row instead of a
+    // history: a year-less date and a string-typed count. Neither is a usable
+    // data point, so the row is dropped and `daily_views` comes back empty.
+    #[case::placeholder_row(&["period", "views"], r#"[["8-06", "0"]]"#, vec![])]
     fn test_stats_post_daily_views_column_handling(
         #[case] fields: &[&str],
         #[case] data: &str,
@@ -441,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_stats_post_homepage() {
-        // `PostId(0)` is the site's home page. It isn't a post, so the API sends
+        // Post 0 is the site's home page. It isn't a post, so the API sends
         // `like_count` and `discussion` as null and `post` as boolean `false`,
         // while every view field is populated as usual.
         let response = parse(HOMEPAGE);
@@ -463,7 +585,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_post_without_views() {
+    fn test_stats_post_without_recent_views() {
         let response = parse(NO_VIEWS);
 
         assert_eq!(response.views, 0);
@@ -477,7 +599,7 @@ mod tests {
         assert!(year.months.is_empty());
 
         let average = response.averages.get("2026").expect("2026 should exist");
-        assert_eq!(average.overall, 0.0);
+        assert_eq!(average.overall, 0);
         assert!(average.months.is_empty());
 
         assert_eq!(response.daily_views.len(), 3);

--- a/wp_api/tests/wpcom/stats_post/homepage.json
+++ b/wp_api/tests/wpcom/stats_post/homepage.json
@@ -16,28 +16,12 @@
     "weeks": [
         {
             "days": [
-                { "day": "2026-07-27", "count": 6 },
-                { "day": "2026-07-28", "count": 6 },
-                { "day": "2026-07-29", "count": 6 },
-                { "day": "2026-07-30", "count": 6 },
-                { "day": "2026-07-31", "count": 6 },
-                { "day": "2026-08-01", "count": 6 },
-                { "day": "2026-08-02", "count": 6 }
-            ],
-            "total": 42,
-            "average": 6,
-            "change": null
-        },
-        {
-            "days": [
-                { "day": "2026-08-03", "count": 12 },
-                { "day": "2026-08-04", "count": 12 },
-                { "day": "2026-08-05", "count": 12 },
+                { "day": "2026-08-05", "count": 8 },
                 { "day": "2026-08-06", "count": 6 }
             ],
-            "total": 42,
-            "average": 12,
-            "change": 100
+            "total": 40,
+            "average": 11,
+            "change": 1.7094017094017318
         }
     ],
     "fields": ["period", "views"],
@@ -48,9 +32,9 @@
     ],
     "highest_month": 3822,
     "highest_day_average": 127,
-    "highest_week_average": 12,
+    "highest_week_average": 89,
 
-    "_comment": "The home page has no post behind it: the API sends `like_count` and `discussion` as null. `post` is boolean false when the site's front page is set to \"latest posts\", and null when it has a static front page — in which case these figures cover the whole site rather than one page.",
+    "_comment": "The home page has no post behind it: the API sends `like_count` and `discussion` as null, and `post` as boolean false rather than null.",
     "like_count": null,
     "discussion": null,
     "post": false

--- a/wp_api/tests/wpcom/stats_post/homepage.json
+++ b/wp_api/tests/wpcom/stats_post/homepage.json
@@ -16,12 +16,28 @@
     "weeks": [
         {
             "days": [
-                { "day": "2026-08-05", "count": 8 },
+                { "day": "2026-07-27", "count": 6 },
+                { "day": "2026-07-28", "count": 6 },
+                { "day": "2026-07-29", "count": 6 },
+                { "day": "2026-07-30", "count": 6 },
+                { "day": "2026-07-31", "count": 6 },
+                { "day": "2026-08-01", "count": 6 },
+                { "day": "2026-08-02", "count": 6 }
+            ],
+            "total": 42,
+            "average": 6,
+            "change": null
+        },
+        {
+            "days": [
+                { "day": "2026-08-03", "count": 12 },
+                { "day": "2026-08-04", "count": 12 },
+                { "day": "2026-08-05", "count": 12 },
                 { "day": "2026-08-06", "count": 6 }
             ],
-            "total": 40,
-            "average": 11,
-            "change": 1.7094017094017318
+            "total": 42,
+            "average": 12,
+            "change": 100
         }
     ],
     "fields": ["period", "views"],
@@ -32,9 +48,9 @@
     ],
     "highest_month": 3822,
     "highest_day_average": 127,
-    "highest_week_average": 89,
+    "highest_week_average": 12,
 
-    "_comment": "The home page has no post behind it: the API sends `like_count` and `discussion` as null, and `post` as boolean false rather than null.",
+    "_comment": "The home page has no post behind it: the API sends `like_count` and `discussion` as null. `post` is boolean false when the site's front page is set to \"latest posts\", and null when it has a static front page — in which case these figures cover the whole site rather than one page.",
     "like_count": null,
     "discussion": null,
     "post": false

--- a/wp_api/tests/wpcom/stats_post/post-no-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-no-views.json
@@ -16,6 +16,11 @@
     "weeks": [
         {
             "days": [
+                { "day": "2026-07-27", "count": 0 },
+                { "day": "2026-07-28", "count": 0 },
+                { "day": "2026-07-29", "count": 0 },
+                { "day": "2026-07-30", "count": 0 },
+                { "day": "2026-07-31", "count": 0 },
                 { "day": "2026-08-01", "count": 0 },
                 { "day": "2026-08-02", "count": 0 }
             ],
@@ -25,6 +30,8 @@
         },
         {
             "days": [
+                { "day": "2026-08-03", "count": 0 },
+                { "day": "2026-08-04", "count": 0 },
                 { "day": "2026-08-05", "count": 0 },
                 { "day": "2026-08-06", "count": 0 }
             ],
@@ -50,9 +57,11 @@
         "post_date": "2026-06-11 14:22:01",
         "post_date_gmt": "2026-06-11 14:22:01",
         "post_title": "A Quiet Post",
+        "post_excerpt": "",
         "post_status": "publish",
         "post_name": "a-quiet-post",
         "post_modified": "2026-06-11 14:22:01",
+        "post_modified_gmt": "2026-06-11 14:22:01",
         "guid": "https://example.com/?p=169",
         "post_type": "post",
         "comment_count": "0"

--- a/wp_api/tests/wpcom/stats_post/post-no-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-no-views.json
@@ -1,17 +1,16 @@
 {
-    "date": "2026-08-06",
+    "_comment": "A post that has never been viewed. The API can't derive a start year, so `years` and `averages` run from 1970 to the present with every month map empty — trimmed here to the first two and the last of the 57 entries a real response carries. `data` is padded from the post's publication date to today.",
+    "date": "2026-08-07",
     "views": 0,
     "years": {
-        "2026": {
-            "months": [],
-            "total": 0
-        }
+        "1970": { "months": [], "total": 0 },
+        "1971": { "months": [], "total": 0 },
+        "2026": { "months": [], "total": 0 }
     },
     "averages": {
-        "2026": {
-            "months": [],
-            "overall": 0
-        }
+        "1970": { "months": [], "overall": 0 },
+        "1971": { "months": [], "overall": 0 },
+        "2026": { "months": [], "overall": 0 }
     },
     "weeks": [
         {
@@ -33,7 +32,8 @@
                 { "day": "2026-08-03", "count": 0 },
                 { "day": "2026-08-04", "count": 0 },
                 { "day": "2026-08-05", "count": 0 },
-                { "day": "2026-08-06", "count": 0 }
+                { "day": "2026-08-06", "count": 0 },
+                { "day": "2026-08-07", "count": 0 }
             ],
             "total": 0,
             "average": 0,
@@ -42,9 +42,9 @@
     ],
     "fields": ["period", "views"],
     "data": [
-        ["2026-08-04", 0],
-        ["2026-08-05", 0],
-        ["2026-08-06", 0]
+        ["2026-06-11", 0],
+        ["2026-06-12", 0],
+        ["2026-06-13", 0]
     ],
     "highest_month": 0,
     "highest_day_average": 0,
@@ -64,6 +64,7 @@
         "post_modified_gmt": "2026-06-11 14:22:01",
         "guid": "https://example.com/?p=169",
         "post_type": "post",
-        "comment_count": "0"
+        "comment_count": "0",
+        "permalink": "https://example.com/2026/06/11/a-quiet-post/"
     }
 }

--- a/wp_api/tests/wpcom/stats_post/post-no-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-no-views.json
@@ -1,6 +1,5 @@
 {
-    "_comment": "A post that has never been viewed. The API can't derive a start year, so `years` and `averages` run from 1970 to the present with every month map empty — trimmed here to the first two and the last of the 57 entries a real response carries. `data` is padded from the post's publication date to today.",
-    "date": "2026-08-07",
+    "date": "2026-08-06",
     "views": 0,
     "years": {
         "1970": { "months": [], "total": 0 },
@@ -15,11 +14,6 @@
     "weeks": [
         {
             "days": [
-                { "day": "2026-07-27", "count": 0 },
-                { "day": "2026-07-28", "count": 0 },
-                { "day": "2026-07-29", "count": 0 },
-                { "day": "2026-07-30", "count": 0 },
-                { "day": "2026-07-31", "count": 0 },
                 { "day": "2026-08-01", "count": 0 },
                 { "day": "2026-08-02", "count": 0 }
             ],
@@ -29,11 +23,8 @@
         },
         {
             "days": [
-                { "day": "2026-08-03", "count": 0 },
-                { "day": "2026-08-04", "count": 0 },
                 { "day": "2026-08-05", "count": 0 },
-                { "day": "2026-08-06", "count": 0 },
-                { "day": "2026-08-07", "count": 0 }
+                { "day": "2026-08-06", "count": 0 }
             ],
             "total": 0,
             "average": 0,
@@ -42,9 +33,9 @@
     ],
     "fields": ["period", "views"],
     "data": [
-        ["2026-06-11", 0],
-        ["2026-06-12", 0],
-        ["2026-06-13", 0]
+        ["2026-08-04", 0],
+        ["2026-08-05", 0],
+        ["2026-08-06", 0]
     ],
     "highest_month": 0,
     "highest_day_average": 0,
@@ -63,8 +54,8 @@
         "post_modified": "2026-06-11 14:22:01",
         "post_modified_gmt": "2026-06-11 14:22:01",
         "guid": "https://example.com/?p=169",
+        "permalink": "https://example.com/2026/06/11/a-quiet-post/",
         "post_type": "post",
-        "comment_count": "0",
-        "permalink": "https://example.com/2026/06/11/a-quiet-post/"
+        "comment_count": "0"
     }
 }

--- a/wp_api/tests/wpcom/stats_post/post-with-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-with-views.json
@@ -24,37 +24,42 @@
     "weeks": [
         {
             "days": [
-                { "day": "2026-06-29", "count": 2 },
-                { "day": "2026-06-30", "count": 1 },
-                { "day": "2026-07-01", "count": 1 },
-                { "day": "2026-07-02", "count": 1 },
-                { "day": "2026-07-03", "count": 1 },
-                { "day": "2026-07-04", "count": 1 },
-                { "day": "2026-07-05", "count": 0 }
+                { "day": "2026-07-20", "count": 0 },
+                { "day": "2026-07-21", "count": 0 },
+                { "day": "2026-07-22", "count": 0 },
+                { "day": "2026-07-23", "count": 0 },
+                { "day": "2026-07-24", "count": 0 },
+                { "day": "2026-07-25", "count": 0 },
+                { "day": "2026-07-26", "count": 0 }
             ],
-            "total": 7,
-            "average": 1,
+            "total": 0,
+            "average": 0,
             "change": null
+        },
+        {
+            "days": [
+                { "day": "2026-07-27", "count": 2 },
+                { "day": "2026-07-28", "count": 2 },
+                { "day": "2026-07-29", "count": 2 },
+                { "day": "2026-07-30", "count": 2 },
+                { "day": "2026-07-31", "count": 2 },
+                { "day": "2026-08-01", "count": 2 },
+                { "day": "2026-08-02", "count": 2 }
+            ],
+            "total": 14,
+            "average": 2,
+            "change": { "isInfinity": true }
         },
         {
             "days": [
                 { "day": "2026-08-03", "count": 3 },
                 { "day": "2026-08-04", "count": 3 },
-                { "day": "2026-08-05", "count": 0 },
-                { "day": "2026-08-06", "count": 0 }
+                { "day": "2026-08-05", "count": 3 },
+                { "day": "2026-08-06", "count": 1 }
             ],
-            "total": 6,
-            "average": 2,
-            "change": 133.33333333333334
-        },
-        {
-            "days": [
-                { "day": "2026-08-10", "count": 4 },
-                { "day": "2026-08-11", "count": 1 }
-            ],
-            "total": 5,
+            "total": 10,
             "average": 3,
-            "change": { "isInfinity": true }
+            "change": 50
         }
     ],
     "fields": ["period", "views"],
@@ -76,14 +81,16 @@
         "post_date": "2013-06-20 09:15:49",
         "post_date_gmt": "2013-06-20 13:15:49",
         "post_title": "The Last Version of FeedDemon is Here, and it's Free",
+        "post_excerpt": "The wait is over.",
         "post_status": "publish",
         "post_name": "the-last-version-of-feeddemon-is-here-and-its-free",
         "post_modified": "2013-06-23 21:57:23",
+        "post_modified_gmt": "2013-06-24 01:57:23",
         "guid": "https://example.com/?p=2729",
         "post_type": "post",
 
         "_comment": "Fields below are sent by the API but deliberately not modelled; they must be ignored rather than break parsing.",
-        "post_content": "The wait is over.",
+        "post_content": "The wait is over, and the last version of FeedDemon is now free.",
         "comment_count": "48",
         "filter": "raw"
     }

--- a/wp_api/tests/wpcom/stats_post/post-with-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-with-views.json
@@ -88,6 +88,7 @@
         "post_modified_gmt": "2013-06-24 01:57:23",
         "guid": "https://example.com/?p=2729",
         "post_type": "post",
+        "permalink": "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/",
 
         "_comment": "Fields below are sent by the API but deliberately not modelled; they must be ignored rather than break parsing.",
         "post_content": "The wait is over, and the last version of FeedDemon is now free.",

--- a/wp_api/tests/wpcom/stats_post/post-with-views.json
+++ b/wp_api/tests/wpcom/stats_post/post-with-views.json
@@ -24,42 +24,37 @@
     "weeks": [
         {
             "days": [
-                { "day": "2026-07-20", "count": 0 },
-                { "day": "2026-07-21", "count": 0 },
-                { "day": "2026-07-22", "count": 0 },
-                { "day": "2026-07-23", "count": 0 },
-                { "day": "2026-07-24", "count": 0 },
-                { "day": "2026-07-25", "count": 0 },
-                { "day": "2026-07-26", "count": 0 }
+                { "day": "2026-06-29", "count": 2 },
+                { "day": "2026-06-30", "count": 1 },
+                { "day": "2026-07-01", "count": 1 },
+                { "day": "2026-07-02", "count": 1 },
+                { "day": "2026-07-03", "count": 1 },
+                { "day": "2026-07-04", "count": 1 },
+                { "day": "2026-07-05", "count": 0 }
             ],
-            "total": 0,
-            "average": 0,
+            "total": 7,
+            "average": 1,
             "change": null
-        },
-        {
-            "days": [
-                { "day": "2026-07-27", "count": 2 },
-                { "day": "2026-07-28", "count": 2 },
-                { "day": "2026-07-29", "count": 2 },
-                { "day": "2026-07-30", "count": 2 },
-                { "day": "2026-07-31", "count": 2 },
-                { "day": "2026-08-01", "count": 2 },
-                { "day": "2026-08-02", "count": 2 }
-            ],
-            "total": 14,
-            "average": 2,
-            "change": { "isInfinity": true }
         },
         {
             "days": [
                 { "day": "2026-08-03", "count": 3 },
                 { "day": "2026-08-04", "count": 3 },
-                { "day": "2026-08-05", "count": 3 },
-                { "day": "2026-08-06", "count": 1 }
+                { "day": "2026-08-05", "count": 0 },
+                { "day": "2026-08-06", "count": 0 }
             ],
-            "total": 10,
+            "total": 6,
+            "average": 2,
+            "change": 133.33333333333334
+        },
+        {
+            "days": [
+                { "day": "2026-08-10", "count": 4 },
+                { "day": "2026-08-11", "count": 1 }
+            ],
+            "total": 5,
             "average": 3,
-            "change": 50
+            "change": { "isInfinity": true }
         }
     ],
     "fields": ["period", "views"],
@@ -87,11 +82,11 @@
         "post_modified": "2013-06-23 21:57:23",
         "post_modified_gmt": "2013-06-24 01:57:23",
         "guid": "https://example.com/?p=2729",
-        "post_type": "post",
         "permalink": "https://example.com/2013/06/20/the-last-version-of-feeddemon-is-here-and-its-free/",
+        "post_type": "post",
 
         "_comment": "Fields below are sent by the API but deliberately not modelled; they must be ignored rather than break parsing.",
-        "post_content": "The wait is over, and the last version of FeedDemon is now free.",
+        "post_content": "The wait is over.",
         "comment_count": "48",
         "filter": "raw"
     }

--- a/wp_com_e2e/src/stats_post_tests.rs
+++ b/wp_com_e2e/src/stats_post_tests.rs
@@ -48,11 +48,10 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                 }
             }));
 
-            // The home page is addressable on every site and has no post behind
-            // it, so the post, discussion, and like fields come back empty. It
-            // needs no lookup.
+            // The home page isn't a post, so the API omits the post, discussion,
+            // and like fields. Every site has one, so this needs no lookup.
             trials.push(Trial::test(
-                format!("post::get_stats_post_home_page::{}", site_id),
+                format!("post::get_stats_post_homepage::{}", site_id),
                 {
                     let ctx = Arc::clone(&ctx);
                     move || {
@@ -113,7 +112,7 @@ fn most_viewed_post(ctx: &TestContext, site_id: &WpComSiteId) -> Option<StatsPos
         .summary?
         .postviews
         .iter()
-        // Id 0 is the home page pseudo-entry, which the other trial covers.
+        // Id 0 is the homepage pseudo-entry, which isn't a real post.
         .find(|post_view| post_view.id != 0)
         .and_then(|post_view| i64::try_from(post_view.id).ok())
         .map(|id| StatsPostTarget::Post { id: PostId(id) })

--- a/wp_com_e2e/src/stats_post_tests.rs
+++ b/wp_com_e2e/src/stats_post_tests.rs
@@ -6,6 +6,7 @@ use wp_api::{
     wp_com::{
         WpComSiteId,
         sites::SitesListParams,
+        stats_post::StatsPostTarget,
         stats_top_posts::{StatsTopPostsParams, StatsTopPostsPeriod},
     },
 };
@@ -26,35 +27,32 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
         for site in &sites {
             let site_id = site.id;
 
-            trials.push(Trial::test(
-                format!("post_stats::get_stats_post::{}", site_id),
-                {
-                    let ctx = Arc::clone(&ctx);
-                    move || {
-                        // The endpoint needs a real post, so borrow one from the
-                        // site's top posts. Resolving it here rather than during
-                        // collection keeps the lookup off unrelated test runs.
-                        let Some(post_id) = most_viewed_post_id(&ctx, &site_id) else {
-                            return Ok(());
-                        };
+            trials.push(Trial::test(format!("post::get_stats_post::{}", site_id), {
+                let ctx = Arc::clone(&ctx);
+                move || {
+                    // The endpoint needs a real post, so borrow one from the
+                    // site's top posts. Resolving it here rather than during
+                    // collection keeps the lookup off unrelated test runs.
+                    let Some(target) = most_viewed_post(&ctx, &site_id) else {
+                        return Ok(());
+                    };
 
-                        ctx.runtime.block_on(async {
-                            ctx.client
-                                .stats_post()
-                                .get_stats_post(&site_id, &post_id)
-                                .await
-                                .map_err(|e| e.to_string())?;
-                            Ok(())
-                        })
-                    }
-                },
-            ));
+                    ctx.runtime.block_on(async {
+                        ctx.client
+                            .stats_post()
+                            .get_stats_post(&site_id, &target)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        Ok(())
+                    })
+                }
+            }));
 
-            // `PostId(0)` is the site's home page rather than a post, so the API
-            // omits the post, discussion, and like fields. Every site has one,
-            // so this needs no lookup.
+            // The home page is addressable on every site and has no post behind
+            // it, so the post, discussion, and like fields come back empty. It
+            // needs no lookup.
             trials.push(Trial::test(
-                format!("post_stats::get_stats_post_homepage::{}", site_id),
+                format!("post::get_stats_post_home_page::{}", site_id),
                 {
                     let ctx = Arc::clone(&ctx);
                     move || {
@@ -62,7 +60,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                             let result = ctx
                                 .client
                                 .stats_post()
-                                .get_stats_post(&site_id, &PostId(0))
+                                .get_stats_post(&site_id, &StatsPostTarget::HomePage)
                                 .await;
 
                             match result {
@@ -93,7 +91,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     trials
 }
 
-fn most_viewed_post_id(ctx: &TestContext, site_id: &WpComSiteId) -> Option<PostId> {
+fn most_viewed_post(ctx: &TestContext, site_id: &WpComSiteId) -> Option<StatsPostTarget> {
     // Look back over several years rather than the default single day, so quiet
     // test sites still yield a post.
     let params = StatsTopPostsParams {
@@ -115,7 +113,8 @@ fn most_viewed_post_id(ctx: &TestContext, site_id: &WpComSiteId) -> Option<PostI
         .summary?
         .postviews
         .iter()
-        // Id 0 is the homepage pseudo-entry, which isn't a real post.
+        // Id 0 is the home page pseudo-entry, which the other trial covers.
         .find(|post_view| post_view.id != 0)
-        .map(|post_view| PostId(post_view.id as i64))
+        .and_then(|post_view| i64::try_from(post_view.id).ok())
+        .map(|id| StatsPostTarget::Post { id: PostId(id) })
 }

--- a/wp_com_e2e/src/stats_post_tests.rs
+++ b/wp_com_e2e/src/stats_post_tests.rs
@@ -27,31 +27,34 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
         for site in &sites {
             let site_id = site.id;
 
-            trials.push(Trial::test(format!("post::get_stats_post::{}", site_id), {
-                let ctx = Arc::clone(&ctx);
-                move || {
-                    // The endpoint needs a real post, so borrow one from the
-                    // site's top posts. Resolving it here rather than during
-                    // collection keeps the lookup off unrelated test runs.
-                    let Some(target) = most_viewed_post(&ctx, &site_id) else {
-                        return Ok(());
-                    };
+            trials.push(Trial::test(
+                format!("post_stats::get_stats_post::{}", site_id),
+                {
+                    let ctx = Arc::clone(&ctx);
+                    move || {
+                        // The endpoint needs a real post, so borrow one from the
+                        // site's top posts. Resolving it here rather than during
+                        // collection keeps the lookup off unrelated test runs.
+                        let Some(target) = most_viewed_post(&ctx, &site_id) else {
+                            return Ok(());
+                        };
 
-                    ctx.runtime.block_on(async {
-                        ctx.client
-                            .stats_post()
-                            .get_stats_post(&site_id, &target)
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        Ok(())
-                    })
-                }
-            }));
+                        ctx.runtime.block_on(async {
+                            ctx.client
+                                .stats_post()
+                                .get_stats_post(&site_id, &target)
+                                .await
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        })
+                    }
+                },
+            ));
 
             // The home page isn't a post, so the API omits the post, discussion,
             // and like fields. Every site has one, so this needs no lookup.
             trials.push(Trial::test(
-                format!("post::get_stats_post_homepage::{}", site_id),
+                format!("post_stats::get_stats_post_homepage::{}", site_id),
                 {
                     let ctx = Arc::clone(&ctx);
                     move || {
@@ -114,6 +117,7 @@ fn most_viewed_post(ctx: &TestContext, site_id: &WpComSiteId) -> Option<StatsPos
         .iter()
         // Id 0 is the homepage pseudo-entry, which isn't a real post.
         .find(|post_view| post_view.id != 0)
-        .and_then(|post_view| i64::try_from(post_view.id).ok())
-        .map(|id| StatsPostTarget::Post { id: PostId(id) })
+        .map(|post_view| StatsPostTarget::Post {
+            id: PostId(post_view.id as i64),
+        })
 }

--- a/wp_serde_helper/src/json.rs
+++ b/wp_serde_helper/src/json.rs
@@ -25,10 +25,6 @@ where
 /// This is the type-generic counterpart of [`crate::deserialize_false_or_string`]
 /// and the `false`-tolerant helpers in [`crate::numeric`].
 ///
-/// Pair this with `#[serde(default)]` on fields the API may omit entirely.
-/// Serde does not invoke `deserialize_with` for a missing key, so without a
-/// default a missing field is an error rather than `None`.
-///
 /// # Errors
 ///
 /// Returns an error for boolean `true`, and for any other value that is not a
@@ -262,12 +258,6 @@ mod tests {
         inner: Option<FalseAsNoneValue>,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct DefaultedFalseAsNone {
-        #[serde(default, deserialize_with = "deserialize_false_as_none")]
-        inner: Option<FalseAsNoneValue>,
-    }
-
     #[rstest]
     #[case(r#"{"inner": false}"#, None)]
     #[case(r#"{"inner": null}"#, None)]
@@ -276,35 +266,15 @@ mod tests {
         #[case] json: &str,
         #[case] expected: Option<FalseAsNoneValue>,
     ) {
-        let result: FalseAsNone =
-            serde_json::from_str(json).expect("Test case should be a valid JSON");
+        let result: FalseAsNone = serde_json::from_str(json).unwrap();
         assert_eq!(result.inner, expected);
     }
 
     #[rstest]
-    // Only `false` stands in for absence. `true` is a value the API is not
-    // expected to send, so it is an error rather than a silent `None` —
-    // matching `deserialize_false_or_string` and `deserialize_u64_or_none`.
     #[case::boolean_true(r#"{"inner": true}"#)]
-    // A wrong-shaped object is an error rather than being silently dropped.
     #[case::malformed_value(r#"{"inner": {"id": "x"}}"#)]
     fn test_deserialize_false_as_none_errors(#[case] json: &str) {
         let result = serde_json::from_str::<FalseAsNone>(json);
         assert!(result.is_err(), "The deserializer should emit an error");
-    }
-
-    #[test]
-    fn test_deserialize_false_as_none_requires_default_for_a_missing_field() {
-        // Serde does not call `deserialize_with` for an absent key, so the
-        // helper alone cannot make a field optional.
-        let result = serde_json::from_str::<FalseAsNone>(r#"{}"#);
-        assert!(
-            result.is_err(),
-            "A missing field should error without default"
-        );
-
-        let defaulted = serde_json::from_str::<DefaultedFalseAsNone>(r#"{}"#)
-            .expect("`default` should cover the missing field");
-        assert_eq!(defaulted.inner, None);
     }
 }

--- a/wp_serde_helper/src/json.rs
+++ b/wp_serde_helper/src/json.rs
@@ -18,23 +18,31 @@ where
 /// absent, which PHP endpoints do in place of `null`.
 ///
 /// Accepts:
-/// - Boolean `false` (or `true`) → `None`
-/// - `null` or a missing field → `None`
+/// - Boolean `false` → `None`
+/// - `null` → `None`
 /// - Anything else → deserialized as `T`
 ///
 /// This is the type-generic counterpart of [`crate::deserialize_false_or_string`]
 /// and the `false`-tolerant helpers in [`crate::numeric`].
 ///
+/// Pair this with `#[serde(default)]` on fields the API may omit entirely.
+/// Serde does not invoke `deserialize_with` for a missing key, so without a
+/// default a missing field is an error rather than `None`.
+///
 /// # Errors
 ///
-/// Returns an error if the value is neither a boolean nor a valid `T`.
+/// Returns an error for boolean `true`, and for any other value that is not a
+/// valid `T`.
 pub fn deserialize_false_as_none<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: DeserializeOwned,
     D: de::Deserializer<'de>,
 {
     match serde_json::Value::deserialize(deserializer)? {
-        serde_json::Value::Bool(_) | serde_json::Value::Null => Ok(None),
+        serde_json::Value::Bool(false) | serde_json::Value::Null => Ok(None),
+        serde_json::Value::Bool(true) => Err(de::Error::custom(
+            "expected a value, `null`, or `false`, got `true`",
+        )),
         value => serde_json::from_value(value)
             .map(Some)
             .map_err(de::Error::custom),
@@ -254,24 +262,49 @@ mod tests {
         inner: Option<FalseAsNoneValue>,
     }
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct DefaultedFalseAsNone {
+        #[serde(default, deserialize_with = "deserialize_false_as_none")]
+        inner: Option<FalseAsNoneValue>,
+    }
+
     #[rstest]
     #[case(r#"{"inner": false}"#, None)]
-    #[case(r#"{"inner": true}"#, None)]
     #[case(r#"{"inner": null}"#, None)]
     #[case(r#"{"inner": {"id": 7}}"#, Some(FalseAsNoneValue { id: 7 }))]
     fn test_deserialize_false_as_none(
         #[case] json: &str,
         #[case] expected: Option<FalseAsNoneValue>,
     ) {
-        let result: FalseAsNone = serde_json::from_str(json).unwrap();
+        let result: FalseAsNone =
+            serde_json::from_str(json).expect("Test case should be a valid JSON");
         assert_eq!(result.inner, expected);
     }
 
+    #[rstest]
+    // Only `false` stands in for absence. `true` is a value the API is not
+    // expected to send, so it is an error rather than a silent `None` —
+    // matching `deserialize_false_or_string` and `deserialize_u64_or_none`.
+    #[case::boolean_true(r#"{"inner": true}"#)]
+    // A wrong-shaped object is an error rather than being silently dropped.
+    #[case::malformed_value(r#"{"inner": {"id": "x"}}"#)]
+    fn test_deserialize_false_as_none_errors(#[case] json: &str) {
+        let result = serde_json::from_str::<FalseAsNone>(json);
+        assert!(result.is_err(), "The deserializer should emit an error");
+    }
+
     #[test]
-    fn test_deserialize_false_as_none_rejects_a_malformed_value() {
-        // Only booleans and null stand in for absence; a wrong-shaped object is
-        // still an error rather than being silently dropped.
-        let result: Result<FalseAsNone, _> = serde_json::from_str(r#"{"inner": {"id": "x"}}"#);
-        assert!(result.is_err());
+    fn test_deserialize_false_as_none_requires_default_for_a_missing_field() {
+        // Serde does not call `deserialize_with` for an absent key, so the
+        // helper alone cannot make a field optional.
+        let result = serde_json::from_str::<FalseAsNone>(r#"{}"#);
+        assert!(
+            result.is_err(),
+            "A missing field should error without default"
+        );
+
+        let defaulted = serde_json::from_str::<DefaultedFalseAsNone>(r#"{}"#)
+            .expect("`default` should cover the missing field");
+        assert_eq!(defaulted.inner, None);
     }
 }

--- a/wp_serde_helper/src/json.rs
+++ b/wp_serde_helper/src/json.rs
@@ -36,8 +36,9 @@ where
 {
     match serde_json::Value::deserialize(deserializer)? {
         serde_json::Value::Bool(false) | serde_json::Value::Null => Ok(None),
-        serde_json::Value::Bool(true) => Err(de::Error::custom(
-            "expected a value, `null`, or `false`, got `true`",
+        serde_json::Value::Bool(true) => Err(de::Error::invalid_value(
+            de::Unexpected::Bool(true),
+            &"boolean `false`, `null`, or a value",
         )),
         value => serde_json::from_value(value)
             .map(Some)

--- a/wp_serde_helper/src/numeric.rs
+++ b/wp_serde_helper/src/numeric.rs
@@ -51,6 +51,22 @@ where
     deserialize_i64_or_string(deserializer).map(Into::into)
 }
 
+/// Deserialize a `u64` and convert it to a type that implements `From<u64>`.
+///
+/// This is useful for deserializing into newtype wrappers around `u64`.
+///
+/// # Errors
+///
+/// Returns an error for negative numbers, non-numeric strings, booleans, null,
+/// arrays, or objects.
+pub fn deserialize_u64_or_string_as_t<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: From<u64>,
+{
+    deserialize_u64_or_string(deserializer).map(Into::into)
+}
+
 /// Deserialize an optional `u64`, treating `false` and `null` as `None`.
 ///
 /// Accepts:


### PR DESCRIPTION
## Description

Follow-up to #1489, targeting `per-post-stats` branch.

The per-post stats endpoint has no public documentation, so the response types were worked out from live responses. Comparing them against the endpoint's implementation in `wpcom` — `class.wpcom-json-api-stats-post-views-v1-1-endpoint.php` and `stats_get_post()` in `wp-content/mu-plugins/stats.php` — turned up a field the API sends that wasn't modelled, three types that are wider than what the API can produce, and several doc comments describing behaviour the source contradicts.

Two of those could only be settled against the live API, so four responses were captured from a test site: one post with views, two never-viewed posts, and the site's home page.

## Changes

### Types

- **`StatsPostTarget`** replaces `PostId` as the endpoint's path argument, with `Post { id }` and `HomePage` variants. The API addresses the home page as post `0`, which isn't a valid `PostId` anywhere else in the crate. `stats_utm` takes a typed path argument the same way.
- **`average`, `averages.overall` and `averages.months` are now `u64`.** The endpoint casts all three to `int` before sending them, so a fractional value can't reach the wire — confirmed across all four captured responses. `change` is left as `f64`; it's computed from the uncast average and is the one genuine float in the response.
- **`post_author` is now `WpComUserId`** — on a WordPress.com site the row carries the account's global id, not the site-scoped one `UserId` names. This needed a `deserialize_u64_or_string_as_t` in `wp_serde_helper`, the counterpart to the existing `i64` variant.
- **`post_date_gmt` is now `WpGmtDateTime`**. `wp_utc_date_format` already parses the MySQL datetime format the API uses, so no new deserializer was needed.
- **`From<PostId> for StatsPostTarget`** resolves the home page id, so callers working from a list that includes it — `/stats/top-posts` reports one — don't each repeat the check.

### Fields the API sends

- **`permalink`** — `stats_get_post()` attaches a computed permalink to the post row, and it reaches the wire as the row's last key. Callers previously had no way to get a post's URL from this response. Typed `Option<String>` and read through `deserialize_false_as_none`: it's derived per request rather than read from a column, so an unexpected shape shouldn't cost the whole response.
- **`post_modified_gmt`** — the unambiguous counterpart to `post_modified`, which is in the site's local timezone.
- **`post_excerpt`**.

### Documentation

- **`PostId(0)` doesn't always mean the home page.** The endpoint branches on the site's `show_on_front` setting: with a "latest posts" front page the figures are the home page's own views, but with a static front page they're the whole site's view history. The response is identical in both cases, so the distinction is documented on `StatsPostResponse`.
- **`highest_week_average` is neither weekly nor an average.** It's the highest single-day view count across the last few weeks. `highest_day_average` is the highest monthly average of daily views.
- **`years` and `averages` start at 1970 for a target with no views.** With no view to anchor on, the endpoint reports every year from 1970 to the present, each with an empty `months` map — 57 entries for a post published last year. Verified on all three never-viewed posts captured.
- **`daily_views` is padded, not sparse.** A never-viewed post still gets one zero-count entry per day since publication.

### Serialization

`StatsPostResponse` deserializes from the API's `fields`/`data` column table but derived `Serialize` over the flattened shape, so serializing a response produced JSON it could not read back. It now serializes into the column table as well, matching how `StatsPostChange` handles its own wire form.

### `wp_serde_helper`

`deserialize_false_as_none` mapped every boolean to `None`, including `true`. Its siblings — `deserialize_false_or_string`, `deserialize_false_or_string_or_null`, `deserialize_u64_or_none` — all reject `true` explicitly, so it now does too. Its doc also listed a missing field as yielding `None`, which `deserialize_with` cannot do without `#[serde(default)]`; that line is removed.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
