### PR TITLE
ci: cap clippy peak memory by serializing the --tests lint pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `ShoppingCart.coupon` changed from `String` to `CouponCode`, and `ShoppingCartCostOverride.override_code` from `String` to `CostOverrideCode`, so the shopping cart and site plans describe these values with the same types. Callers will need to wrap/unwrap with `CouponCode(...)` / `CostOverrideCode(...)`.
 - Documented `GET /all-domains/` subtypes and parameters. `DomainSubtypeId::DefaultAddress` covers staging and garden subdomains as well as the free WordPress.com address, and is the set v1.1's `no_wpcom=true` excluded; v1.2 has no equivalent parameter, so clients filter this subtype out instead.
 - **Internal:** Corrected `GET /all-domains/` fixtures that claimed subtypes the endpoint never returns (`site_redirect`, `domain_mapping`).
+- **Internal:** Run clippy's `--tests` lint pass with `--jobs 1` to cap the Rust lint step's peak memory at ~4.7 GiB (down from ~9 GiB) on CI.
 - **Internal:** Build the Android JNI libraries with `cargo-ndk` instead of the `rust-android-gradle` Gradle plugin.
 - **Internal:** Upgraded the Android/Kotlin build to Android Gradle Plugin `9.3.0` / Gradle `9.5.0` (Kotlin `2.3.21`, `compileSdk` 36), migrating `api/android` to the AGP 9 variant APIs and splitting the example app into a `com.android.kotlin.multiplatform.library` shared module and a standalone `com.android.application` module.
 - **Internal:** Bumped `syn` from `2.0` to `3.0`, updating the proc-macro crates for its breaking changes.

--- a/Makefile
+++ b/Makefile
@@ -283,9 +283,16 @@ stop-server:
 lint: lint-rust lint-swift
 	@# Help: Run the linter for all languages.
 
+# `--jobs 1` on the --tests pass caps clippy's peak RAM. Each crate in the wp_api
+# family (wp_api, wp_mobile, the integration-test crates, the CLIs) costs ~4.5GB
+# to lint because of the wp_contextual/UniFFI macro-generated code. The first
+# pass's heavy libs form a dependency chain and can't overlap (peak ~4.7GB even
+# at the default -j), so it stays parallel. But the --tests pass builds their
+# independent test targets all at once, spiking to ~9GB — serializing just that
+# pass caps it back at one crate (~4.7GB) without paying serial-dep time twice.
 lint-rust:
 	@# Help: Run the linter for Rust.
-	$(rust_docker_run) /bin/bash -c "rustup component add clippy && cargo clippy --all -- -D warnings && cargo clippy --tests --all -- -D warnings"
+	$(rust_docker_run) /bin/bash -c "rustup component add clippy && cargo clippy --all -- -D warnings && cargo clippy --tests --all --jobs 1 -- -D warnings"
 
 lint-swift:
 	@# Help: Run the linter for Swift.


### PR DESCRIPTION
## Description

Clippy has been using a lot of memory on the `:rust: Lint` CI step. The step runs clippy twice — `cargo clippy --all` then `cargo clippy --tests --all` — and the second pass peaks at **~9.1 GiB** of RAM. This caps it at **~4.7 GiB** by running only the `--tests` pass with `--jobs 1`, for roughly **+2m43s** of wall time on the Lint step (measured on CI — see below).

The memory comes from a family of macro-heavy crates. Each crate in the `wp_api` lineage — `wp_api` (`wp_contextual` context/sparse types), `wp_mobile` (UniFFI scaffolding), the integration-test crates, and the CLIs — costs **~4.5 GiB** to clippy-check. In the first pass those heavy *libraries* form a dependency chain (`wp_api` → `wp_mobile`/tests → e2e/CLI), so they can't compile at the same time and the pass stays at ~4.7 GiB no matter how many cores the agent has. The `--tests` pass builds their *test targets*, which are independent leaves — nothing stops all of them compiling at once, so at the default job count several ~4.5 GiB units overlap and stack to ~9.1 GiB. Serializing that one pass caps the peak back at a single crate.

`--jobs 1` on the `--tests` pass also sidesteps a separate, intermittent `error: extern location for serde does not exist` race that a parallel `clippy --tests --all` can hit from a clean target.

## Changes

- **`make lint-rust`**: add `--jobs 1` to the `cargo clippy --tests --all` command. The first `cargo clippy --all` pass is left parallel — serializing it costs wall time for no memory benefit (see below). Added a comment explaining the rationale.

## Measurements

Peak memory was measured locally on macOS (M4 Max, 16 cores) with the repo's pinned toolchain (`rustc`/`clippy` 1.97.1 — the version CI uses). Peak = concurrent RSS of the whole `cargo`→`clippy-driver` process tree. `cargo` defaults `--jobs` to the visible core count, so on a Linux agent with more than 16 cores the unbounded peak would be **higher** than this, not lower.

| Pass | default `-j` (current) | `--jobs 1` |
|---|---|---|
| `cargo clippy --all` | 4.67 GiB / 90s | 4.66 GiB / 165s |
| `cargo clippy --tests --all` | **9.13 GiB** / 88s | **4.69 GiB** / 180s |

**Confirmed on CI** (build #6076): the `:rust: Lint` job passed. CI-to-CI the job went from **6m14s** (trunk #6066) to **8m57s** (this PR) — **+2m43s (~+44%)**. That's larger than the local wall-time delta because `--jobs 1` can't use the agent's other cores, so its single-core speed dominates. Buildkite doesn't expose per-job peak memory, so the RAM figures above are the local measurement; CI corroborates only that the job now completes.

## What else was considered

- **`--jobs 1` on both passes.** Same ~4.7 GiB peak but slower. Rejected: the first pass is already single-crate-bound (4.67 → 4.66 GiB), so serializing it adds wall time for no memory benefit.
- **Build before linting** (reuse a `cargo build`/`cargo test` target dir). Rejected: clippy runs `clippy-driver` under a cache separate from `rustc`, so it re-analyzes every workspace crate regardless — clippy after a full build still peaked 9.23 GiB, and the build itself peaks higher (`cargo test --no-run` hit 11.01 GiB). It dodges nothing.
- **`--jobs 2`/`--jobs 4` on the `--tests` pass.** A middle ground that lands the peak between ~4.7 and ~9 GiB with less added time. Not chosen here to get a hard single-crate cap; easy to dial up if the wall-time cost matters and the agent has headroom.

## A floor worth knowing about

**~4.7 GiB is a floor this can't go under.** One `wp_api`-family crate needs ~4.5 GiB regardless of job count. If the Linux agent's available RAM is below ~5 GiB, this isn't enough on its own — that would need more agent RAM or shrinking the `wp_contextual`/UniFFI codegen. This helps when the ceiling sits between ~4.7 and ~9 GiB.

## An unrelated, intermittent OOM (not this change)

`:rust: Build and Test` (the test suite — untouched by this PR) failed on the first run of build #6076: its log stops mid-`Compiling wp_api` during the test build with `exit_status: -1` and no error, the signature of an OOM kill. It's intermittent — the same step passed on trunk #6066 and passed again when I retried it on #6076 — and is the same memory problem from a worse angle: `cargo test`'s build peaks ~11 GiB, higher than clippy. This PR neither causes nor fixes it; limiting that step's parallelism is a likely follow-up.

## Test plan

- [x] Benchmarked locally (toolchain 1.97.1): `cargo clippy --tests --all --jobs 1` peaks at 4.69 GiB vs 9.13 GiB at the default job count, both exit 0 (table above).
- [x] `:rust: Lint` passed on CI (build #6076) in 8m57s, vs 6m14s on trunk #6066. Buildkite doesn't expose per-job peak memory, so the RAM drop itself is the local measurement above; CI confirms the job completes cleanly with the change.

## Changelog

- [x] Added a `### Changed` / `**Internal:**` entry noting the CI lint memory change.
