### PR TITLE
fix: run the assemble step for xcframework-only-<platform> builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Route the Kotlin integration tests through the in-VPC Reposilite dependency mirror
 - **Internal:** Merge `CHANGELOG.md` with git's built-in `union` driver (via `.gitattributes`), so the frequent conflicts on the `## [Unreleased]` section resolve by keeping both sides instead of emitting conflict markers.
 - **Internal:** Documented how to pick an xcframework build for local work, and added `make help` descriptions for the `xcframework-only-*` targets. Verifying a UniFFI change needs only `make xcframework-only-macos`, not the full 11-target `make xcframework`.
+- **Internal:** Fixed `make xcframework-only-<platform>` building the per-target libraries but never assembling them into the xcframework. The `@# Help:` comments added for those `make help` descriptions became each rule's recipe and silently shadowed the shared `xcframework-only-%` pattern rule that ran the assemble step; each rule now runs the assemble step directly.
 
 ## [0.6.0] - 2026-07-16
 

--- a/Makefile
+++ b/Makefile
@@ -127,16 +127,26 @@ build-apple-watchOS: $(build-apple-platform-watchos)
 # Creating xcframework for one single platform, including real device and simulator.
 # NOTE: these REPLACE the xcframework rather than adding a slice to it. Use
 # `xcframework-only-macos` for local `swift build`, which links the macOS slice.
+#
+# Each rule builds its platform's targets (prerequisites), then assembles them
+# into the xcframework (recipe). The assemble command is inlined per rule on
+# purpose: these rules previously shared a single `xcframework-only-%` pattern
+# rule for the assemble recipe, but adding a `@# Help:` comment to the
+# otherwise-recipe-less explicit rules silently shadowed that pattern recipe,
+# so the assemble step stopped running (#1490). Keep each rule's recipe
+# self-contained so `make help` and the actual build never drift again.
 xcframework-only-macos: $(build-apple-platform-macos)
 	@# Help: Build an xcframework containing only macOS (~18GB). Use this to verify UniFFI changes locally.
+	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-macos)
 xcframework-only-ios: $(build-apple-platform-ios)
 	@# Help: Build an xcframework containing only iOS (~24GB). Replaces any existing xcframework.
+	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-ios)
 xcframework-only-tvos: $(build-apple-platform-tvos)
 	@# Help: Build an xcframework containing only tvOS. Replaces any existing xcframework.
+	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-tvos)
 xcframework-only-watchos: $(build-apple-platform-watchos)
 	@# Help: Build an xcframework containing only watchOS. Replaces any existing xcframework.
-xcframework-only-%:
-	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-$*)
+	cargo run --quiet --bin xcframework -- --profile $(CARGO_PROFILE) --targets $(apple-platform-targets-watchos)
 
 # Assemble pre-built targets into an xcframework (without building targets).
 xcframework-assemble:


### PR DESCRIPTION
## Description

Fixes a bug where `make xcframework-only-macos` (and the `-ios`/`-tvos`/`-watchos` variants) built the per-target static libraries but **never assembled them into `libwordpressFFI.xcframework`**. A subsequent `swift build` then linked a stale — or entirely missing — framework.

## Root Cause

These rules declare only their per-platform build prerequisites; the shared `xcframework-only-%` **pattern rule** supplied the assemble recipe (`cargo run --bin xcframework`).

#1490 added a `@# Help:` comment under each explicit rule so `make help` could document them. In Make, an explicit rule with *any* recipe — even a no-op `@#` comment — takes precedence over a pattern rule, so the pattern rule's recipe silently stopped running. No warning is emitted because the two rules are different types. The regression shipped in this repo's HEAD (`c2f8a25f`, #1490), whose own purpose was to steer local UniFFI verification toward `make xcframework-only-macos`.

`make -n xcframework-only-macos` on `trunk` ends at the `# Help:` comment — the `cargo run --bin xcframework` assemble step is absent.

## Fix

Inline the assemble command into each of the four explicit rules and drop the now-unused `xcframework-only-%` pattern rule, so each rule's recipe is self-contained. Added a comment explaining why the recipe is inlined, so the footgun isn't reintroduced.

## Test Plan

- [x] `make -n xcframework-only-{macos,ios,tvos,watchos}` now ends with `cargo run --bin xcframework -- ... --targets <the platform's targets>` ✅
- [x] The assemble step runs **last**, after both target builds and their `swift-bindings.sh` steps ✅
- [x] `make help` output for the `xcframework-only-*` rows is byte-for-byte unchanged ✅
- [x] Makefile still parses (no `missing separator` / tab errors) ✅

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

## Related issues

- Regressed in #1490