### PR TITLE
chore(deps): bump rand to 0.9.3 / 0.8.6 (RUSTSEC-2026-0097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Merge `CHANGELOG.md` with git's built-in `union` driver (via `.gitattributes`), so the frequent conflicts on the `## [Unreleased]` section resolve by keeping both sides instead of emitting conflict markers.
 - **Internal:** Documented how to pick an xcframework build for local work, and added `make help` descriptions for the `xcframework-only-*` targets. Verifying a UniFFI change needs only `make xcframework-only-macos`, not the full 11-target `make xcframework`.
 
+### Security
+
+- **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.
+
 ## [0.6.0] - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -1599,7 +1599,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "thiserror 2.0.19",
  "tinyvec",
@@ -1621,7 +1621,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -1642,7 +1642,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.19",
@@ -3030,9 +3030,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3041,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3273,7 +3273,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -3392,7 +3392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 2.0.118",
 ]
 


### PR DESCRIPTION
## Description

Clears Dependabot alert [#55](https://github.com/Automattic/wordpress-rs/security/dependabot/55) ([GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) / [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html)). `rand` 0.9.2 and 0.8.5 are affected by a **low-severity unsoundness** — safe code can trigger UB (an aliased mutable reference, violating Stacked Borrows) when a custom `log` logger calls `rand::rng()` and that call reseeds the `ThreadRng`.

We don't hit that path: `rand` is a transitive dependency only (reqwest/hickory-resolver's DNS resolver, plus `rocket` and `rstest_reuse`), and nothing here installs a custom logger that reaches back into `rand`. This is housekeeping to keep the alert list clean, not a live exposure.

## Changes

- Bumped `rand` `0.9.2` → `0.9.3` and `0.8.5` → `0.8.6` via `cargo update --precise`. Lockfile-only, no code changes.
- Added a `### Security` entry to `CHANGELOG.md` under `## [Unreleased]`.

`rand 0.10.2` was already unaffected (0.10.0 was the only vulnerable 0.10.x, patched in 0.10.1).

## Test plan

- [x] `cargo tree -i rand@0.9.3` / `rand@0.8.6` resolve cleanly; no `0.9.2` or `0.8.5` remain in `Cargo.lock`.
- [x] `git diff` confirms the bump touches only `Cargo.lock` (version + checksum lines and the transitive dependents).
- [x] CI green — [Buildkite #6079](https://buildkite.com/automattic/wordpress-rs/builds/6079) passed, full build + test across all Rust/Swift/Kotlin targets.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]` (`Security`).