### PR TITLE
fix: read the SSL peer certificate chain from the documented SecTrust key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Documented how to pick an xcframework build for local work, and added `make help` descriptions for the `xcframework-only-*` targets. Verifying a UniFFI change needs only `make xcframework-only-macos`, not the full 11-target `make xcframework`.
 - **Internal:** Fixed `make xcframework-only-<platform>` building the per-target libraries but never assembling them into the xcframework. The `@# Help:` comments added for those `make help` descriptions became each rule's recipe and silently shadowed the shared `xcframework-only-%` pattern rule that ran the assemble step; each rule now runs the assemble step directly.
 
+### Fixed
+
+- Swift: Classify invalid-SSL failures from the failed handshake's `SecTrust` (`URLError.failureURLPeerTrust`), via `SecTrustCopyCertificateChain`, instead of reading the undocumented `NSErrorPeerCertificateChainKey` `userInfo` string that has no public constant. Behavior is unchanged on every platform: iOS/macOS/tvOS still surface the presented certificate as `certificateNotValidForName`, and watchOS — which exposes no peer trust — still degrades to `genericSslError`. ([#1510](https://github.com/Automattic/wordpress-rs/issues/1510))
+
 ### Security
 
 - **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -290,13 +290,14 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     private func getPeerCertificateChain(_ error: Error) -> [SslCertificateInfo]? {
-        let nserror = error as NSError
-        let info = nserror.userInfo
-
         #if os(Linux) // Linux doesn't support `SecCertificate`
         return []
         #else
-        guard let certChainArray = info["NSErrorPeerCertificateChainKey"] as? [SecCertificate] else {
+        // The certificate chain the server presented during the failed TLS handshake.
+        guard
+            let trust = (error as? URLError)?.failureURLPeerTrust,
+            let certChainArray = SecTrustCopyCertificateChain(trust) as? [SecCertificate]
+        else {
             return nil
         }
 


### PR DESCRIPTION
## Description

`getPeerCertificateChain` in the Swift executor classified invalid-SSL failures by reading `NSErrorPeerCertificateChainKey` — an undocumented CFNetwork `userInfo` string with no public constant. If Apple stops setting it, the executor silently loses the presented certificate and every SSL failure collapses to `.genericSslError`.

This reads the `SecTrust` stored under Apple's documented `NSURLErrorFailingURLPeerTrustErrorKey` instead, and derives the presented certificate chain with `SecTrustCopyCertificateChain` — the same API the authentication-challenge delegate already uses to read the server's certificate.

Fixes #1510. Split out from #1497 (Swift executor URLSession error audit).

## Changes

- **`native/swift/Sources/wordpress-api/SafeRequestExecutor.swift`**: `getPeerCertificateChain` now pulls the `SecTrust` from `NSURLErrorFailingURLPeerTrustErrorKey` and maps `SecTrustCopyCertificateChain` over it. A `CFGetTypeID(...) == SecTrustGetTypeID()` check gates the force-cast to `SecTrust` (see below). The Linux path (`return []`) is unchanged.
- **`CHANGELOG.md`**: `### Fixed` entry under `[Unreleased]`.

No test changes. The existing `LoginTests` Example 17 already asserts the exact per-platform behavior this preserves — `certificateNotValidForName` with the presented hostname on iOS/macOS/tvOS, `genericSslError` on watchOS — so it doubles as the regression test for this change.

## Why not `as? SecTrust`

A conditional downcast from `Any` to a CoreFoundation type such as `SecTrust` **always succeeds without a runtime check** — the compiler rejects it outright (`conditional downcast to CoreFoundation type 'SecTrust' will always succeed`) and points at `CFGetTypeID`. `as?` would let a non-`SecTrust` value through and crash inside `SecTrustCopyCertificateChain`. The `CFGetTypeID` comparison is the checked equivalent; the force-cast that follows is safe because the type is already verified.

## watchOS: the documented key doesn't help either, and that's fine

The documented `SecTrust` is no more available on watchOS than the undocumented key was. I confirmed this on CI ([build 6091](https://buildkite.com/automattic/wordpress-rs/builds/6091)) by temporarily tightening Example 17 to require the certificate on every platform: iOS, macOS, and tvOS passed; watchOS failed with `.invalidSslError(.genericSslError)`. So watchOS behavior is unchanged, `LoginTests` keeps its `#if os(watchOS)` branch, and the benefit here is a documented source on the three platforms that do surface the certificate — not a watchOS improvement.

## Test plan

- [x] Example 17 (`testInvalidHTTPsFails`) passes on macOS via the `.certificateNotValidForName` branch — `make xcframework-only-macos` + `swift test --filter testInvalidHTTPsFails` (1 test, 0.45s). It drives a real mismatch: `https://wordpress-1315525-4803651.cloudwaysapps.com` presents a certificate for `vanilla.wpmt.co`, and the assertions confirm `hostname == "wordpress-1315525-4803651.cloudwaysapps.com"` and `presentedHostnames == ["vanilla.wpmt.co"]`.
- [x] Per-platform behavior confirmed on CI build 6091 (strict-assertion probe, since reverted): iOS/macOS/tvOS surface `.certificateNotValidForName`; watchOS returns `.genericSslError` — matching the `#if os(watchOS)` branch the test keeps.
- [x] `swift-format lint --strict` and `swiftlint` (pinned rules) clean on the changed source.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`.
