### PR TITLE
fix: Swift sleep(millis:) slept 1000× too short, breaking Retry-After backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Documented how to pick an xcframework build for local work, and added `make help` descriptions for the `xcframework-only-*` targets. Verifying a UniFFI change needs only `make xcframework-only-macos`, not the full 11-target `make xcframework`.
 - **Internal:** Fixed `make xcframework-only-<platform>` building the per-target libraries but never assembling them into the xcframework. The `@# Help:` comments added for those `make help` descriptions became each rule's recipe and silently shadowed the shared `xcframework-only-%` pattern rule that ran the assemble step; each rule now runs the assemble step directly.
 
+### Fixed
+
+- Swift: `WpRequestExecutor.sleep(millis:)` converted milliseconds to nanoseconds with the wrong factor (`* 1_000` instead of `* 1_000_000`), so it slept 1000× too short — a `Retry-After: 30` waited 30 ms instead of 30 s. `RetryAfterMiddleware` then re-sent immediately, the server kept returning 429, and after `max_retries` the caller observed `MisconfiguredRateLimitError` where honoring the backoff would usually have succeeded. The executor now waits the full interval, and no longer risks a `fatalError` if the sleep's task is cancelled.
+
 ### Security
 
 - **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -226,8 +226,9 @@ public final class WpRequestExecutor: SafeRequestExecutor {
     }
 
     public func sleep(millis: UInt64) async {
-        // swiftlint:disable:next force_try
-        try! await Task.sleep(nanoseconds: millis * 1000)
+        // `try?`: `Task.sleep` only throws on cancellation, which this non-throwing `sleep`
+        // leaves to the request machinery to handle.
+        try? await Task.sleep(for: .milliseconds(millis))
     }
 
     private func errorIsHttpsError(_ error: Error) -> Bool {

--- a/native/swift/Tests/wordpress-api/SafeRequestExecutorTests.swift
+++ b/native/swift/Tests/wordpress-api/SafeRequestExecutorTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import WordPressAPI
+@testable import WordPressAPIInternal
+
+@Suite("SafeRequestExecutor")
+struct SafeRequestExecutorTests {
+
+    // Regression test for #1513: `sleep(millis:)` converted milliseconds to nanoseconds with the
+    // wrong factor (`millis * 1_000` instead of `* 1_000_000`), so it slept 1000× too short and
+    // `RetryAfterMiddleware` never actually honored a `Retry-After` backoff.
+    @Test("sleep(millis:) waits for approximately the requested duration")
+    func testSleepHonorsMillisecondDuration() async {
+        let executor = WpRequestExecutor(urlSession: .shared)
+
+        let requestedMillis: UInt64 = 200
+        let clock = ContinuousClock()
+        let start = clock.now
+        await executor.sleep(millis: requestedMillis)
+        let elapsed = start.duration(to: clock.now)
+
+        // The old bug slept ~0.2 ms for a 200 ms request. `Task.sleep` waits *at least* the
+        // requested duration, so a 150 ms lower bound sits comfortably above the buggy value and
+        // below the target — catching the regression without flaking on scheduling jitter.
+        #expect(elapsed >= .milliseconds(150))
+    }
+}

--- a/native/swift/Tests/wordpress-api/SafeRequestExecutorTests.swift
+++ b/native/swift/Tests/wordpress-api/SafeRequestExecutorTests.swift
@@ -19,9 +19,11 @@ struct SafeRequestExecutorTests {
         await executor.sleep(millis: requestedMillis)
         let elapsed = start.duration(to: clock.now)
 
-        // The old bug slept ~0.2 ms for a 200 ms request. `Task.sleep` waits *at least* the
-        // requested duration, so a 150 ms lower bound sits comfortably above the buggy value and
-        // below the target — catching the regression without flaking on scheduling jitter.
+        // `Task.sleep` waits *at least* the requested duration, so bound both sides. The 150 ms
+        // floor catches the old 1000×-too-short bug (~0.2 ms for a 200 ms request); the 2 s
+        // ceiling catches the symmetric slip (e.g. `.seconds` in place of `.milliseconds`, ~200 s)
+        // while staying well clear of scheduling jitter, which is milliseconds, not seconds.
         #expect(elapsed >= .milliseconds(150))
+        #expect(elapsed < .seconds(2))
     }
 }

--- a/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
+++ b/native/swift/Tests/wordpress-api/Support/HTTPStubs.swift
@@ -97,8 +97,8 @@ final class HTTPStubs: SafeRequestExecutor {
     }
 
     func sleep(millis: UInt64) async {
-        // swiftlint:disable:next force_try
-        try! await Task.sleep(nanoseconds: millis * 1000)
+        // No-op: the stub doesn't wait, so Retry-After/backoff tests run instantly.
+        // Mirrors the no-op `sleep` in the Rust middleware unit tests.
     }
 
     func cancel(context: RequestContext) {


### PR DESCRIPTION
## Description

Every `Retry-After` backoff on Swift finished almost instantly instead of waiting. `WpRequestExecutor.sleep(millis:)` converted milliseconds to nanoseconds with the wrong factor — `millis * 1_000` instead of `millis * 1_000_000` — so it slept **1000× too short**: a `Retry-After: 30` waited 30 ms, not 30 s. `RetryAfterMiddleware` then re-sent immediately, the server kept returning 429, and after `max_retries` the caller observed `MisconfiguredRateLimitError` where honoring the backoff would usually have succeeded. Swift was the only executor that didn't actually wait — reqwest uses `Duration::from_millis`, Kotlin uses `delay(millis)`.

The same method's `try!` was a second, latent problem: a cancelled sleep would `fatalError`. It's unreachable today (uniffi 0.32 never cancels the backing task) but a loaded gun.

Split out from #1497 (Swift executor URLSession error audit). Fixes #1513.

## Changes

- **Fix the conversion** in `WpRequestExecutor.sleep(millis:)` — now `try? await Task.sleep(for: .milliseconds(millis))`. `try?` replaces `try!`, so a cancelled sleep returns instead of crashing.
- **Fix the identical copy** in the `HTTPStubs` test mock, which had its own `try! await Task.sleep(nanoseconds: millis * 1_000)`. It's now a no-op.
- **Add a regression test** (`SafeRequestExecutorTests.swift`) that calls the real `WpRequestExecutor.sleep(millis: 200)` and asserts it waited at least 150 ms.

**`Task.sleep(for:)` replaces the manual nanosecond math so the bug can't recur.** Same result as the issue's suggested `nanoseconds: millis * 1_000_000`, but the `Duration` API takes milliseconds directly, won't trap on `UInt64` multiplication overflow, and matches how reqwest and Kotlin express the same wait. It's available on every deployment target (iOS 16 / macOS 13 / tvOS 16 / watchOS 9) and already used elsewhere in the Swift test suite.

**The mock is a no-op, not a faithful sleep.** The rate-limit test asserts error classification, not timing, and routes through the mock; a faithful sleep would add ~3 s of real wall-clock wait (3 retries × the 1 s `Retry-After`) for nothing it checks. This mirrors the no-op `sleep` in the Rust middleware unit tests, and the production sleep's timing is covered by the new regression test instead.

## Test plan

- [x] Full Swift unit suite via `BUILDKITE=1 swift test` (reproduces the CI-macOS config, excluding the Docker integration target): **77 tests in 18 suites passed**, build clean with 0 warnings.
- [x] New regression test `sleep(millis:) waits for approximately the requested duration` passes after **0.218 s** (it waited ~200 ms). Reintroducing the `millis * 1_000` conversion makes it fail — `Expectation failed: (elapsed → 0.00127625 seconds) >= (.milliseconds(150) → 0.15 seconds)` — so the assertion catches the exact bug.
- [x] `Login Spec Example 15: Rate Limited that never succeeds` still classifies as `MisconfiguredRateLimitError`, and ran at its baseline (~3.5 s, in line with its sibling login-flow tests) — confirming the no-op mock added no real sleep.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]` (`Fixed`).
