### PR TITLE
feat: expose the reqwest RequestExecutor over UniFFI for Swift-on-Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A pure-Rust `RequestExecutor` reachable from Swift-on-Linux via `newReqwestRequestExecutor()`. The default `WpRequestExecutor` runs on swift-corelibs-foundation's libcurl bridge on Linux, which maps every curl SSL failure to `NSURLErrorUnknown` — so TLS errors degrade to `GenericError` and the `allowSSL` exception path is compiled out. The reqwest executor classifies SSL/DNS/timeout errors from rustls directly, identically on every platform. It is not exported to the Apple xcframework, where `URLSession` remains the first-class executor and reqwest/rustls would only add binary weight.
+- A pure-Rust executor for Swift-on-Linux, exposed as `ReqwestRequestExecutor` with a `WordPressLoginClient(executor:)` convenience init. On Linux the default `WpRequestExecutor` runs on swift-corelibs-foundation's libcurl bridge, which maps every curl SSL failure to `NSURLErrorUnknown` — so TLS errors degrade to `GenericError` and the `allowSSL` exception path is compiled out. The reqwest executor classifies SSL/DNS/timeout errors from rustls directly, matching Darwin. It is Linux-only; the Apple xcframework keeps `URLSession` as the first-class executor and gains no reqwest/rustls weight.
 - WordPress.com `POST /me/transactions` endpoint for redeeming a shopping cart with the account's WordPress.com credits, completing a domain purchase
 - WordPress.com `GET /sites/<site_id>/purchases` endpoint for listing a site's purchases (plans, domains, and other subscriptions)
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A pure-Rust `RequestExecutor` reachable from Swift-on-Linux via `newReqwestRequestExecutor()`. The default `WpRequestExecutor` runs on swift-corelibs-foundation's libcurl bridge on Linux, which maps every curl SSL failure to `NSURLErrorUnknown` — so TLS errors degrade to `GenericError` and the `allowSSL` exception path is compiled out. The reqwest executor classifies SSL/DNS/timeout errors from rustls directly, identically on every platform. It is not exported to the Apple xcframework, where `URLSession` remains the first-class executor and reqwest/rustls would only add binary weight.
 - WordPress.com `POST /me/transactions` endpoint for redeeming a shopping cart with the account's WordPress.com credits, completing a domain purchase
 - WordPress.com `GET /sites/<site_id>/purchases` endpoint for listing a site's purchases (plans, domains, and other subscriptions)
 - Publish the Kotlin bindings' per-endpoint Markdown API reference as an `ai-docs` Maven classifier zip on `rs.wordpress.api:kotlin`, generated from the UniFFI bindings for agent/tooling consumption

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ docker-image-web:
 	docker build -t wordpress-rs-web -f wp_rs_web/Dockerfile . --progress=plain
 
 swift-linux-library:
-	cargo build --release --features export-uncancellable-endpoints --package wp_mobile
+	cargo build --release --features export-uncancellable-endpoints,reqwest-request-executor --package wp_mobile
 	./scripts/swift-bindings.sh target/release/libwp_mobile.a
 	mkdir -p target/release/libwordpressFFI-linux
 	cp target/release/swift-bindings/Headers/* target/release/libwordpressFFI-linux/

--- a/native/swift/Sources/wordpress-api/ReqwestRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/ReqwestRequestExecutor.swift
@@ -1,0 +1,74 @@
+#if os(Linux)
+import Foundation
+import WordPressAPIInternal
+
+/// A pure-Rust `SafeRequestExecutor`, backed by `reqwest` and `rustls`. Linux only.
+///
+/// On Linux the default ``WpRequestExecutor`` runs on swift-corelibs-foundation's
+/// libcurl bridge, which maps every curl SSL failure to `NSURLErrorUnknown`. So a
+/// TLS failure can't be classified and degrades to `.genericError`
+/// (Automattic/wordpress-rs#1509), and the `allowSSL` exception path is compiled
+/// out. This executor reads the error from `rustls` directly, so its SSL, DNS,
+/// timeout, and offline classification matches Darwin. Prefer it over
+/// ``WpRequestExecutor`` on Linux — e.g. `WordPressLoginClient(executor:)`.
+///
+/// It is not part of the Apple xcframework: there `URLSession` is the first-class
+/// executor, and pulling in `reqwest`/`rustls` would only add binary weight.
+public final class ReqwestRequestExecutor: SafeRequestExecutor {
+    private let inner: any RequestExecutor
+
+    public init() {
+        self.inner = newReqwestRequestExecutor()
+    }
+
+    public func execute(
+        _ request: WpNetworkRequest
+    ) async -> Result<WpNetworkResponse, RequestExecutionError> {
+        do {
+            return .success(try await inner.execute(request: request))
+        } catch let error as RequestExecutionError {
+            return .failure(error)
+        } catch {
+            // The reqwest executor only ever throws `RequestExecutionError`; this is defensive.
+            return .failure(
+                .RequestExecutionFailed(
+                    statusCode: nil,
+                    redirects: nil,
+                    reason: .genericError(errorMessage: error.localizedDescription),
+                    requestUrl: request.url(),
+                    requestMethod: request.method()
+                )
+            )
+        }
+    }
+
+    public func upload(
+        request: WpMultipartFormRequest
+    ) async -> Result<WpNetworkResponse, RequestExecutionError> {
+        do {
+            return .success(try await inner.upload(request: request))
+        } catch let error as RequestExecutionError {
+            return .failure(error)
+        } catch {
+            // The reqwest executor only ever throws `RequestExecutionError`; this is defensive.
+            return .failure(
+                .RequestExecutionFailed(
+                    statusCode: nil,
+                    redirects: nil,
+                    reason: .genericError(errorMessage: error.localizedDescription),
+                    requestUrl: request.url(),
+                    requestMethod: request.method()
+                )
+            )
+        }
+    }
+
+    public func sleep(millis: UInt64) async {
+        await inner.sleep(millis: millis)
+    }
+
+    public func cancel(context: RequestContext) {
+        inner.cancel(context: context)
+    }
+}
+#endif

--- a/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
+++ b/native/swift/Sources/wordpress-api/SafeRequestExecutor.swift
@@ -34,6 +34,14 @@ extension SafeRequestExecutor {
     }
 }
 
+/// A `SafeRequestExecutor` backed by `URLSession`.
+///
+/// On Apple platforms this is the first-class executor. On Linux, `URLSession`
+/// runs on swift-corelibs-foundation's libcurl bridge, which maps every curl SSL
+/// failure to `NSURLErrorUnknown` — so a TLS failure can't be classified and
+/// degrades to `.genericError` (Automattic/wordpress-rs#1509), and the `allowSSL`
+/// exception path is compiled out. Linux consumers who need SSL/DNS/offline
+/// classification should use `ReqwestRequestExecutor` instead.
 public final class WpRequestExecutor: SafeRequestExecutor {
     private let session: URLSession
     private let executorDelegate: RequestExecutorDelegate

--- a/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
+++ b/native/swift/Sources/wordpress-api/WordPressLoginClient.swift
@@ -84,6 +84,19 @@ public final class WordPressLoginClient: @unchecked Sendable {
     }
 }
 
+#if os(Linux)
+extension WordPressLoginClient {
+    /// Creates a login client backed by a custom executor.
+    ///
+    /// On Linux, prefer this with a `ReqwestRequestExecutor` over `init(urlSession:)`:
+    /// the URLSession-backed `WpRequestExecutor` runs on libcurl and can't classify
+    /// TLS failures (Automattic/wordpress-rs#1509).
+    public convenience init(executor: SafeRequestExecutor, middleware: MiddlewarePipeline = .default) {
+        self.init(requestExecutor: executor, middleware: middleware)
+    }
+}
+#endif
+
 extension DiscoveredAuthenticationMechanism {
 
     public func loginURL(for application: Application) -> URL? {

--- a/native/swift/Tests/wordpress-api/ReqwestExecutorLinuxTests.swift
+++ b/native/swift/Tests/wordpress-api/ReqwestExecutorLinuxTests.swift
@@ -1,0 +1,65 @@
+#if os(Linux)
+import Foundation
+import FoundationNetworking
+import Testing
+
+@testable import WordPressAPI
+
+// swiftlint:disable line_length
+
+/// Linux counterpart to `LoginTests.testInvalidHTTPsFails`, which is disabled on
+/// Linux because the URLSession executor degrades TLS failures to `.genericError`
+/// (Automattic/wordpress-rs#1509). `ReqwestRequestExecutor` classifies them from
+/// `rustls`, so on Linux it produces the `.invalidSslError` the Apple suite asserts.
+@Suite("Reqwest executor (Linux)")
+struct ReqwestExecutorLinuxTests {
+
+    @Test("Invalid SSL certificate is classified, not dropped to GenericError")
+    func testInvalidSslIsClassified() async throws {
+        let client = WordPressLoginClient(executor: ReqwestRequestExecutor())
+
+        await #expect(
+            performing: {
+                _ = try await client.details(ofSite: "https://wordpress-1315525-4803651.cloudwaysapps.com")
+            },
+            throws: { error in
+                let reason = try #require(Self.requestExecutionErrorReason(from: error))
+
+                guard case .invalidSslError(let underlyingReason) = reason else {
+                    Issue.record("The transport error must be `invalidSslError`, got \(reason)")
+                    return false
+                }
+
+                guard case .certificateNotValidForName = underlyingReason else {
+                    Issue.record("The underlying error must be `certificateNotValidForName`, got \(underlyingReason)")
+                    return false
+                }
+
+                return true
+            }
+        )
+    }
+
+    /// Pulls the transport reason out of the auto-discovery failure, whichever
+    /// stage the TLS error surfaced in (homepage fetch or API-root fetch).
+    private static func requestExecutionErrorReason(from error: any Error) -> RequestExecutionErrorReason? {
+        guard let failure = error as? AutoDiscoveryAttemptFailure else { return nil }
+
+        if case .FindApiRoot(_, let findFailure) = failure,
+            case .fetchHomepage(let transportError) = findFailure,
+            case .RequestExecutionFailed(_, _, let reason, _, _) = transportError {
+            return reason
+        }
+
+        if case .FetchAndParseApiRoot(parsedSiteUrl: _, apiRootUrl: _, let parseFailure) = failure,
+            case .fetchApiRoot(let transportError) = parseFailure,
+            case .RequestExecutionFailed(_, _, let reason, _, _) = transportError {
+            return reason
+        }
+
+        return nil
+    }
+}
+
+// swiftlint:enable line_length
+#endif

--- a/wp_api/Cargo.toml
+++ b/wp_api/Cargo.toml
@@ -29,7 +29,14 @@ url = { workspace = true }
 parse_link_header = { workspace = true }
 paste = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true, features = [ "multipart", "json", "stream", "gzip", "brotli", "zstd", "deflate", "rustls-tls", "hickory-dns", "cookies" ], optional = true }
+# Declared directly (not `workspace = true`) so we can set `default-features = false`,
+# which Cargo forbids when inheriting a workspace dependency. That drops reqwest's
+# `default-tls` (native-tls/OpenSSL), which the executor never uses — it always selects
+# rustls via `.use_rustls_tls()`. Beyond being dead weight, native-tls's OpenSSL symbols
+# break the Swift-on-Linux link: `wp_mobile` ships as a staticlib linked without cargo's
+# `openssl-sys` link directives. `http2`, `charset`, and `system-proxy` are the non-TLS
+# reqwest defaults, re-added. Keep the version in sync with the workspace `reqwest`.
+reqwest = { version = "0.12.28", default-features = false, features = [ "multipart", "json", "stream", "gzip", "brotli", "zstd", "deflate", "rustls-tls", "hickory-dns", "cookies", "http2", "charset", "system-proxy" ], optional = true }
 roxmltree = { workspace = true }
 rustls = { workspace = true, optional = true }
 scraper = { workspace = true }

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -59,6 +59,23 @@ impl ReqwestRequestExecutor {
     }
 }
 
+/// Constructs the pure-Rust [`ReqwestRequestExecutor`] and hands it back as a
+/// [`RequestExecutor`] trait object the bindings can pass straight to a client.
+///
+/// This exists chiefly for Swift-on-Linux. There the default executor is
+/// `WpRequestExecutor`, which runs on swift-corelibs-foundation's libcurl bridge
+/// — a bridge that maps every curl SSL failure to `NSURLErrorUnknown`, so TLS
+/// errors degrade to `GenericError` (Automattic/wordpress-rs#1509) and the
+/// `allowSSL` exception path is compiled out entirely. `ReqwestRequestExecutor`
+/// classifies errors from rustls directly, so its behaviour is identical on every
+/// platform. It is not exported to the Apple xcframework, where `URLSession` is
+/// the first-class executor and pulling in reqwest/rustls would only add binary
+/// weight.
+#[uniffi::export]
+pub fn new_reqwest_request_executor() -> Arc<dyn RequestExecutor> {
+    Arc::new(ReqwestRequestExecutor::default())
+}
+
 impl ReqwestRequestExecutor {
     pub async fn async_request(
         &self,

--- a/wp_api/src/reqwest_request_executor.rs
+++ b/wp_api/src/reqwest_request_executor.rs
@@ -59,21 +59,101 @@ impl ReqwestRequestExecutor {
     }
 }
 
-/// Constructs the pure-Rust [`ReqwestRequestExecutor`] and hands it back as a
+/// Wraps [`ReqwestRequestExecutor`] with an owned multi-threaded Tokio runtime so
+/// it can be driven by UniFFI's async bridge.
+///
+/// reqwest/hyper require a running Tokio reactor; direct Rust callers already have
+/// one (`#[tokio::main]`, `#[tokio::test]`). UniFFI, however, drives exported async
+/// methods on its own executor, so a request made through the bindings fails with
+/// "there is no reactor running". Each call hops onto this runtime and the result
+/// is returned over a `oneshot` channel, whose receiver is pollable from any
+/// executor — so the reqwest work runs on Tokio while UniFFI drives the wrapper.
+struct UniffiReqwestExecutor {
+    inner: Arc<ReqwestRequestExecutor>,
+    runtime: tokio::runtime::Runtime,
+}
+
+impl UniffiReqwestExecutor {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(ReqwestRequestExecutor::default()),
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("the reqwest executor's Tokio runtime should build"),
+        }
+    }
+}
+
+// The runtime hangs up only if it is torn down mid-request, so this is defensive.
+fn reqwest_runtime_unavailable() -> RequestExecutionError {
+    RequestExecutionError::RequestExecutionFailed {
+        status_code: None,
+        redirects: None,
+        reason: RequestExecutionErrorReason::CancellationError,
+        request_url: String::new(),
+        request_method: RequestMethod::GET,
+    }
+}
+
+#[async_trait]
+impl RequestExecutor for UniffiReqwestExecutor {
+    async fn execute(
+        &self,
+        request: Arc<WpNetworkRequest>,
+    ) -> Result<WpNetworkResponse, RequestExecutionError> {
+        let inner = Arc::clone(&self.inner);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.runtime.spawn(async move {
+            let _ = tx.send(inner.execute(request).await);
+        });
+        rx.await.unwrap_or_else(|_| Err(reqwest_runtime_unavailable()))
+    }
+
+    async fn upload(
+        &self,
+        request: Arc<WpMultipartFormRequest>,
+    ) -> Result<WpNetworkResponse, RequestExecutionError> {
+        let inner = Arc::clone(&self.inner);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.runtime.spawn(async move {
+            let _ = tx.send(inner.upload(request).await);
+        });
+        rx.await.unwrap_or_else(|_| Err(reqwest_runtime_unavailable()))
+    }
+
+    async fn sleep(&self, millis: u64) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.runtime.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(millis)).await;
+            let _ = tx.send(());
+        });
+        let _ = rx.await;
+    }
+
+    fn cancel(&self, context: Arc<RequestContext>) {
+        self.inner.cancel(context);
+    }
+}
+
+/// Constructs the pure-Rust reqwest executor and hands it back as a
 /// [`RequestExecutor`] trait object the bindings can pass straight to a client.
 ///
 /// This exists chiefly for Swift-on-Linux. There the default executor is
 /// `WpRequestExecutor`, which runs on swift-corelibs-foundation's libcurl bridge
 /// — a bridge that maps every curl SSL failure to `NSURLErrorUnknown`, so TLS
 /// errors degrade to `GenericError` (Automattic/wordpress-rs#1509) and the
-/// `allowSSL` exception path is compiled out entirely. `ReqwestRequestExecutor`
+/// `allowSSL` exception path is compiled out entirely. The reqwest executor
 /// classifies errors from rustls directly, so its behaviour is identical on every
 /// platform. It is not exported to the Apple xcframework, where `URLSession` is
 /// the first-class executor and pulling in reqwest/rustls would only add binary
 /// weight.
+///
+/// The returned executor owns a Tokio runtime (see [`UniffiReqwestExecutor`]);
+/// reqwest needs one and UniFFI's async bridge does not provide it.
 #[uniffi::export]
 pub fn new_reqwest_request_executor() -> Arc<dyn RequestExecutor> {
-    Arc::new(ReqwestRequestExecutor::default())
+    Arc::new(UniffiReqwestExecutor::new())
 }
 
 impl ReqwestRequestExecutor {


### PR DESCRIPTION
## Description

On Linux the Swift `WpRequestExecutor` runs on swift-corelibs-foundation's libcurl bridge, whose `urlErrorCode(for:)` maps every curl SSL failure (`CURLE_PEER_FAILED_VERIFICATION`, `CURLE_SSL_CONNECT_ERROR`, expired/self-signed/wrong-name) to `NSURLErrorUnknown`. So `errorIsHttpsError` never fires and TLS failures degrade to `GenericError` (#1509), the `allowSSL` exception path is compiled out (`#if !os(Linux)`), and the offline/unreachable predicates degrade the same way.

The pure-Rust reqwest executor classifies these errors correctly from rustls, but wasn't reachable across the FFI. This exposes it to Swift-on-Linux as a first-class executor.

## Changes

- **`wp_api/src/reqwest_request_executor.rs`**: export `new_reqwest_request_executor() -> Arc<dyn RequestExecutor>` (feature-gated). It returns a `UniffiReqwestExecutor` that owns a Tokio runtime and bridges each call onto it — reqwest needs a Tokio reactor, and UniFFI drives exported async on its own executor. The shared `ReqwestRequestExecutor` (and its Rust consumers, already under `#[tokio::main]`/`#[tokio::test]`) is unchanged.
- **`wp_api/Cargo.toml`**: declare reqwest directly with `default-features = false` (rustls only). Its default `default-tls` pulled in native-tls/OpenSSL; the executor never uses it, and its OpenSSL symbols break the Swift-on-Linux link.
- **`Makefile`**: enable `reqwest-request-executor` on the `swift-linux-library` target only. The Apple xcframework build (`--no-default-features`) is untouched.
- **`ReqwestRequestExecutor.swift`** (`#if os(Linux)`): a `public final class ReqwestRequestExecutor: SafeRequestExecutor` wrapping the exported executor, so it drops into the Swift clients like `WpRequestExecutor`.
- **`WordPressLoginClient.swift`** (`#if os(Linux)`): a public `init(executor:)` so Linux consumers can inject it — the only existing public init forces the URLSession path.
- **`SafeRequestExecutor.swift`**: doc note on `WpRequestExecutor` documenting the Linux TLS degradation and pointing to `ReqwestRequestExecutor` (the "at minimum, document it" from #1509).
- **`ReqwestExecutorLinuxTests.swift`** (`#if os(Linux)`): the Linux counterpart to `LoginTests.testInvalidHTTPsFails` (disabled on Linux), asserting a bad-cert host classifies as `.invalidSslError(.certificateNotValidForName)` rather than `.genericError`.
- **`CHANGELOG.md`**: `Added` entry.

```swift
let client = WordPressLoginClient(executor: ReqwestRequestExecutor())
```

## Two things running it on Linux caught

Compile + bindgen checks passed, but the executor didn't actually work until the Linux test ran:

1. The `wp_mobile` staticlib failed to **link** from Swift with undefined OpenSSL symbols (`SSL_CTX_free`, …) — reqwest's default `default-tls` (native-tls). cargo links OpenSSL for its own binaries; Swift links the staticlib without those directives. Fixed by dropping to rustls-only.
2. Requests then failed with **"there is no reactor running"** — reqwest needs a Tokio runtime, which UniFFI's async bridge doesn't provide. Fixed by the `UniffiReqwestExecutor` runtime bridge.

## Why not just fix `errorIsHttpsError` on Linux?

The durable fix is an upstream swift-corelibs-foundation change to `MultiHandle.swift`'s error mapping — out of our hands and unshipped (the related client-cert PR swiftlang/swift-corelibs-foundation#4937 has been open since 2024). The only in-repo alternative is string-matching `localizedDescription` against curl messages, the brittleness the executor audit (#1497) exists to remove. Routing Linux consumers to the Rust executor sidesteps Foundation entirely.

## Scope

- **Linux-only.** Every Swift addition is `#if os(Linux)`; the Rust export is off in the Apple xcframework build; the reqwest dependency change only affects `wp_mobile`'s graph (the integration-test crates keep their own reqwest).
- **Apple**: unchanged. `URLSession`/`WpRequestExecutor` stays first-class.
- **Kotlin/Android**: not addressed. OkHttp has no libcurl mapping gap.

## Test plan

- [x] `cargo build --release --features export-uncancellable-endpoints,reqwest-request-executor --package wp_mobile` compiles
- [x] Swift bindings generate the reqwest executor
- [x] `ReqwestExecutorLinuxTests` passes on Linux (built + run in the `wordpress` Docker container): bad-cert host → `.invalidSslError(.certificateNotValidForName)`
- [ ] Apple xcframework bindings unchanged (feature off there) — to confirm on CI

## Related issues

- Addresses #1509 via the "steer Linux consumers to the reqwest executor" path the issue calls out as the pragmatic alternative, plus the documentation it asks for at minimum
- Split from the Swift executor audit #1497 (finding 12, Section C)

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`.
