### PR TITLE
Bump nanoid from 3.3.16 to 3.3.18 in wp_rs_web (CVE-2026-67213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Internal:** Bumped the transitive `rand` dependency to `0.9.3` and `0.8.6` to clear [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (`GHSA-cq8v-f236-94qc`), a low-severity unsoundness in `rand` 0.9.2 / 0.8.5. Lockfile-only; the affected code path (a custom `log` logger calling `rand::rng()` during reseed) is not exercised here.
+- **Internal:** Bumped `wp_rs_web`'s transitive `nanoid` dependency from `3.3.16` to `3.3.18` to clear [CVE-2026-67213](https://nvd.nist.gov/vuln/detail/CVE-2026-67213) ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)), a denial-of-service via an infinite loop in `nanoid`'s `customAlphabet`/`customRandom` when called with a size of `0`. Lockfile-only; `nanoid` is pulled in only by Tailwind's build-time `postcss`, which never reaches the affected functions.
 
 ## [0.6.0] - 2026-07-16
 

--- a/wp_rs_web/package-lock.json
+++ b/wp_rs_web/package-lock.json
@@ -1908,9 +1908,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Description

Fixes Dependabot alert [#87](https://github.com/Automattic/wordpress-rs/security/dependabot/87) ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / [CVE-2026-67213](https://nvd.nist.gov/vuln/detail/CVE-2026-67213)) by bumping `wp_rs_web`'s transitive `nanoid` from `3.3.16` to `3.3.18`.

`nanoid` before `3.3.17` has an infinite loop in `customAlphabet`/`customRandom` when called with a `size` of `0` — a potential denial of service (CWE-835). In `wp_rs_web` — our internal web tool for debugging connection issues — `nanoid` is pulled in only transitively, by Tailwind's build-time `postcss` (`nanoid: "^3.3.16"`), which never calls those functions with an attacker-controlled size. **The vulnerable path is never reached**, so this is a hygiene bump to clear the alert. `3.3.18` stays within postcss's `^3.3.16` caret range.

## Changes

- Bump `nanoid` `3.3.16` → `3.3.18` in `wp_rs_web/package-lock.json`. Lockfile-only — `node_modules` is not vendored and `package.json` doesn't name `nanoid`, so nothing else changes.
- Add a `### Security` entry to `CHANGELOG.md`, mirroring the recent `rand` / RUSTSEC-2026-0097 bump.

## Test plan

- [x] `npm ci --dry-run` resolves the full 54-package tree and verifies integrity against the edited lockfile (confirms `nanoid` → `3.3.18` and that the hand-edited entry is internally consistent).
- [x] `npm audit --package-lock-only` reports 0 vulnerabilities.
- [x] Diff is scoped to exactly the three `nanoid` lines — I reverted an `npm update` that incidentally stripped `libc` metadata from a dozen optional native packages, then edited the entry by hand and re-verified the integrity hash against the registry.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
