### PR TITLE
Add new `WpApiParamCommentsStatus` to be used in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.
 - **BREAKING:** The cache now enables SQLite foreign key enforcement on every connection it prepares, and fails with `SqliteDbError::ForeignKeysUnavailable` if the setting doesn't take effect. Removing a site relies on `ON DELETE CASCADE` to clear its cached rows, so on builds where enforcement defaulted to off those rows were silently left behind.
 - **BREAKING:** `ShoppingCart.coupon` changed from `String` to `CouponCode`, and `ShoppingCartCostOverride.override_code` from `String` to `CostOverrideCode`, so the shopping cart and site plans describe these values with the same types. Callers will need to wrap/unwrap with `CouponCode(...)` / `CostOverrideCode(...)`.

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -186,6 +186,7 @@ public typealias CommentCreateParams = WordPressAPIInternal.CommentCreateParams
 public typealias CommentUpdateParams = WordPressAPIInternal.CommentUpdateParams
 public typealias CommentDeleteParams = WordPressAPIInternal.CommentDeleteParams
 public typealias CommentStatus = WordPressAPIInternal.CommentStatus
+public typealias WpApiParamCommentsStatus = WordPressAPIInternal.WpApiParamCommentsStatus
 public typealias CommentType = WordPressAPIInternal.CommentType
 public typealias CommentsRequestExecutor = WordPressAPIInternal.CommentsRequestExecutor
 

--- a/wp_api/src/comments.rs
+++ b/wp_api/src/comments.rs
@@ -130,8 +130,12 @@ pub struct CommentListParams {
     pub post: Vec<PostId>,
     /// Limit result set to comments assigned a specific status. Requires authorization.
     /// Default: approve
+    ///
+    /// This is a [`WpApiParamCommentsStatus`], not a [`CommentStatus`],
+    /// because the query vocabulary differs from the stored status
+    /// vocabulary. See the type's documentation.
     #[uniffi(default = None)]
-    pub status: Option<CommentStatus>,
+    pub status: Option<WpApiParamCommentsStatus>,
     /// Limit result set to comments assigned a specific type. Requires authorization.
     /// Default: comment
     #[uniffi(default = None)]
@@ -465,6 +469,54 @@ fn comment_status_from_string(value: String) -> CommentStatus {
     CommentStatus::from_str(value.as_str()).unwrap_or(CommentStatus::Custom(value))
 }
 
+/// Comment status values accepted by the `status` query param when listing
+/// comments.
+///
+/// This is deliberately a different type from [`CommentStatus`]. WordPress
+/// core's `WP_Comment_Query` recognizes the query values `approve`, `hold`,
+/// `all`, and `any`, and passes any other value through as a literal
+/// `comment_approved` column value. Approved comments are stored as `'1'`,
+/// so querying with the stored/response vocabulary (`status=approved`)
+/// matches nothing and silently returns an empty result set.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    uniffi::Enum,
+    strum_macros::EnumString,
+    strum_macros::Display,
+)]
+#[uniffi::export(Display)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum WpApiParamCommentsStatus {
+    /// Approved and pending (hold) comments. Spam and trash are excluded.
+    All,
+    /// Every comment regardless of status, including spam, trash, and
+    /// custom statuses. `WP_Comment_Query` removes the status predicate
+    /// entirely for this value.
+    Any,
+    /// Approved comments. This is the server default when no status is sent,
+    /// and the only value permitted for unauthenticated requests.
+    Approve,
+    /// Pending comments.
+    Hold,
+    Spam,
+    Trash,
+    /// A custom `comment_approved` value, passed through as a literal.
+    #[serde(untagged)]
+    #[strum(default)]
+    Custom(String),
+}
+
+impl_as_query_value_from_to_string!(WpApiParamCommentsStatus);
+
 #[uniffi::export]
 fn comment_type_from_string(value: String) -> CommentType {
     CommentType::from_str(value.as_str()).unwrap_or(CommentType::Custom(value))
@@ -509,11 +561,13 @@ mod tests {
     #[case(generate!(CommentListParams, (parent, vec![CommentId(44444), CommentId(44445)])), "parent=44444%2C44445")]
     #[case(generate!(CommentListParams, (parent_exclude, vec![CommentId(55555), CommentId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(CommentListParams, (post, vec![PostId(66666), PostId(66667)])), "post=66666%2C66667")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Hold))), "status=hold")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approved))), "status=approved")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Spam))), "status=spam")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Trash))), "status=trash")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Custom("foo".to_string())))), "status=foo")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::All))), "status=all")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Any))), "status=any")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Approve))), "status=approve")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Hold))), "status=hold")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Spam))), "status=spam")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Trash))), "status=trash")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Custom("foo".to_string())))), "status=foo")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Comment))), "type=comment")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Pingback))), "type=pingback")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Trackback))), "type=trackback")]
@@ -536,7 +590,7 @@ mod tests {
             parent: vec![CommentId(44444), CommentId(44445)],
             parent_exclude: vec![CommentId(55555), CommentId(55556)],
             post: vec![PostId(66666), PostId(66667)],
-            status: Some(CommentStatus::Spam),
+            status: Some(WpApiParamCommentsStatus::Spam),
             comment_type: Some(CommentType::Pingback),
             password: Some("p_q".to_string()),
         },

--- a/wp_api/src/request/endpoint/comments_endpoint.rs
+++ b/wp_api/src/request/endpoint/comments_endpoint.rs
@@ -38,9 +38,9 @@ mod tests {
     use crate::{
         UserId, WpApiParamOrder,
         comments::{
-            CommentDeleteParams, CommentId, CommentRetrieveParams, CommentStatus, CommentType,
+            CommentDeleteParams, CommentId, CommentRetrieveParams, CommentType,
             SparseCommentFieldWithEditContext, SparseCommentFieldWithEmbedContext,
-            SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy,
+            SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy, WpApiParamCommentsStatus,
         },
         generate,
         posts::PostId,
@@ -80,11 +80,13 @@ mod tests {
     #[case(generate!(CommentListParams, (parent, vec![CommentId(44444), CommentId(44445)])), "parent=44444%2C44445")]
     #[case(generate!(CommentListParams, (parent_exclude, vec![CommentId(55555), CommentId(55556)])), "parent_exclude=55555%2C55556")]
     #[case(generate!(CommentListParams, (post, vec![PostId(66666), PostId(66667)])), "post=66666%2C66667")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Hold))), "status=hold")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Approved))), "status=approved")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Spam))), "status=spam")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Trash))), "status=trash")]
-    #[case(generate!(CommentListParams, (status, Some(CommentStatus::Custom("foo".to_string())))), "status=foo")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::All))), "status=all")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Any))), "status=any")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Approve))), "status=approve")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Hold))), "status=hold")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Spam))), "status=spam")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Trash))), "status=trash")]
+    #[case(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Custom("foo".to_string())))), "status=foo")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Comment))), "type=comment")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Pingback))), "type=pingback")]
     #[case(generate!(CommentListParams, (comment_type, Some(CommentType::Trackback))), "type=trackback")]
@@ -194,7 +196,7 @@ mod tests {
             parent: vec![CommentId(44444), CommentId(44445)],
             parent_exclude: vec![CommentId(55555), CommentId(55556)],
             post: vec![PostId(66666), PostId(66667)],
-            status: Some(CommentStatus::Spam),
+            status: Some(WpApiParamCommentsStatus::Spam),
             comment_type: Some(CommentType::Pingback),
             password: Some("p_q".to_string()),
         }

--- a/wp_api_integration_tests/tests/test_comments_err.rs
+++ b/wp_api_integration_tests/tests/test_comments_err.rs
@@ -324,6 +324,8 @@ async fn list_err_forbidden_param_comment_type(
 async fn list_err_forbidden_param_status(
     #[values(
         WpApiParamCommentsStatus::Hold,
+        WpApiParamCommentsStatus::All,
+        WpApiParamCommentsStatus::Any,
         WpApiParamCommentsStatus::Spam,
         WpApiParamCommentsStatus::Trash
     )]

--- a/wp_api_integration_tests/tests/test_comments_err.rs
+++ b/wp_api_integration_tests/tests/test_comments_err.rs
@@ -2,6 +2,7 @@ use wp_api::{
     comments::{
         CommentCreateParams, CommentCreateParamsBuilder, CommentDeleteParams, CommentListParams,
         CommentRetrieveParams, CommentStatus, CommentType, CommentUpdateParams,
+        WpApiParamCommentsStatus,
     },
     posts::PostId,
 };
@@ -321,7 +322,12 @@ async fn list_err_forbidden_param_comment_type(
 #[rstest]
 #[parallel]
 async fn list_err_forbidden_param_status(
-    #[values(CommentStatus::Hold, CommentStatus::Spam, CommentStatus::Trash)] status: CommentStatus,
+    #[values(
+        WpApiParamCommentsStatus::Hold,
+        WpApiParamCommentsStatus::Spam,
+        WpApiParamCommentsStatus::Trash
+    )]
+    status: WpApiParamCommentsStatus,
 ) {
     api_client_as_subscriber()
         .comments()

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -3,7 +3,7 @@ use wp_api::{
     comments::{
         CommentId, CommentListParams, CommentRetrieveParams, CommentStatus, CommentType,
         SparseCommentFieldWithEditContext, SparseCommentFieldWithEmbedContext,
-        SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy,
+        SparseCommentFieldWithViewContext, WpApiParamCommentsOrderBy, WpApiParamCommentsStatus,
     },
     posts::PostId,
     users::UserAvatarSize,
@@ -49,7 +49,7 @@ async fn list_with_status_approve_returns_comments() {
     let response = api_client()
         .comments()
         .list_with_edit_context(&CommentListParams {
-            status: Some(CommentStatus::Approved),
+            status: Some(WpApiParamCommentsStatus::Approve),
             per_page: Some(100),
             ..Default::default()
         })
@@ -59,6 +59,32 @@ async fn list_with_status_approve_returns_comments() {
         !response.data.is_empty(),
         "listing comments with the approved status filter must not return an empty set"
     );
+}
+
+#[tokio::test]
+#[parallel]
+async fn list_with_status_all_and_any_are_supersets() {
+    let count = |status| async move {
+        api_client()
+            .comments()
+            .list_with_edit_context(&CommentListParams {
+                status: Some(status),
+                per_page: Some(100),
+                ..Default::default()
+            })
+            .await
+            .assert_response()
+            .data
+            .len()
+    };
+    let approve = count(WpApiParamCommentsStatus::Approve).await;
+    let all = count(WpApiParamCommentsStatus::All).await;
+    let any = count(WpApiParamCommentsStatus::Any).await;
+    // The test site seeds hold comments (excluded from approve) and
+    // spam/trash comments (excluded from all).
+    assert!(approve > 0, "approve must not be empty");
+    assert!(all > approve, "all (approve + hold) must exceed approve");
+    assert!(any > all, "any (no status filter) must exceed all");
 }
 
 #[tokio::test]
@@ -262,10 +288,12 @@ async fn parse_extras() {
 #[case::parent(generate!(CommentListParams, (parent, vec![CommentId(1), CommentId(2)])))]
 #[case::parent_exclude(generate!(CommentListParams, (parent, vec![CommentId(1), CommentId(2)])))]
 #[case::post(generate!(CommentListParams, (post, vec![PostId(1), PostId(2)])))]
-#[case::status_hold(generate!(CommentListParams, (status, Some(CommentStatus::Hold))))]
-#[case::status_approve(generate!(CommentListParams, (status, Some(CommentStatus::Approved))))]
-#[case::status_spam(generate!(CommentListParams, (status, Some(CommentStatus::Spam))))]
-#[case::status_trash(generate!(CommentListParams, (status, Some(CommentStatus::Trash))))]
+#[case::status_hold(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Hold))))]
+#[case::status_approve(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Approve))))]
+#[case::status_all(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::All))))]
+#[case::status_any(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Any))))]
+#[case::status_spam(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Spam))))]
+#[case::status_trash(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Trash))))]
 #[case::comment_type_comment(generate!(CommentListParams, (comment_type, Some(CommentType::Comment))))]
 #[case::comment_type_pingback(generate!(CommentListParams, (comment_type, Some(CommentType::Pingback))))]
 #[case::comment_type_trackback(generate!(CommentListParams, (comment_type, Some(CommentType::Trackback))))]

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -286,7 +286,7 @@ async fn parse_extras() {
 #[case::order(generate!(CommentListParams, (order, Some(WpApiParamOrder::Asc))))]
 #[case::orderby(generate!(CommentListParams, (orderby, Some(WpApiParamCommentsOrderBy::Id))))]
 #[case::parent(generate!(CommentListParams, (parent, vec![CommentId(1), CommentId(2)])))]
-#[case::parent_exclude(generate!(CommentListParams, (parent, vec![CommentId(1), CommentId(2)])))]
+#[case::parent_exclude(generate!(CommentListParams, (parent_exclude, vec![CommentId(1), CommentId(2)])))]
 #[case::post(generate!(CommentListParams, (post, vec![PostId(1), PostId(2)])))]
 #[case::status_hold(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Hold))))]
 #[case::status_approve(generate!(CommentListParams, (status, Some(WpApiParamCommentsStatus::Approve))))]

--- a/wp_api_integration_tests/tests/test_comments_immut.rs
+++ b/wp_api_integration_tests/tests/test_comments_immut.rs
@@ -45,6 +45,24 @@ async fn list_with_view_context(#[case] params: CommentListParams) {
 
 #[tokio::test]
 #[parallel]
+async fn list_with_status_approve_returns_comments() {
+    let response = api_client()
+        .comments()
+        .list_with_edit_context(&CommentListParams {
+            status: Some(CommentStatus::Approved),
+            per_page: Some(100),
+            ..Default::default()
+        })
+        .await
+        .assert_response();
+    assert!(
+        !response.data.is_empty(),
+        "listing comments with the approved status filter must not return an empty set"
+    );
+}
+
+#[tokio::test]
+#[parallel]
 async fn retrieve_with_edit_context() {
     api_client()
         .comments()


### PR DESCRIPTION
## Description

At the moment, the `CommentStatus` (the enum that's used to parse the comment status response) is used to query by comment status in GET requests. However, "approved" (`CommentStatus.approved) is not an acceptable status value in the GET endpoint: it's "approve".

This PR introduce a new WpApiParamCommentsStatus to be used in the GET request query.

The Android app currently workaround this issue by [using the `custom` variant](https://github.com/wordpress-mobile/WordPress-Android/blob/6a06b107e1f9f2e46551b3687e34f3c11c09a833/WordPress/src/main/java/org/wordpress/android/ui/commentsrs/CommentsRsListTab.kt#L45-L50). @nbradbury FYI, this PR introduces breaking changes: you will need to change that code (and the `CommentStatus.custom("all")") once this PR is released.