### PR TITLE
Add API to read cached post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `PostService.read_posts_by_ids_from_db(post_ids)`: a cache-only batched read of posts by `PostId` (missing IDs omitted), for resolving data like comment post titles without a fetch.
+
 ## [0.8.0] - 2026-09-01
 
 ### Added

--- a/wp_mobile/src/collection/post_metadata_collection.rs
+++ b/wp_mobile/src/collection/post_metadata_collection.rs
@@ -127,7 +127,7 @@ impl PostMetadataCollectionWithEditContext {
             Vec::new()
         } else {
             self.service
-                .read_posts_by_ids_from_db(&all_ids)
+                .read_post_full_entities_by_ids_from_db(&all_ids)
                 .map_err(|e| CollectionError::DatabaseError {
                     err_message: e.to_string(),
                 })?
@@ -359,7 +359,7 @@ impl PostMetadataCollectionWithEditContext {
 
         let changed_post = self
             .service
-            .read_posts_by_ids_from_db(&[post_id])
+            .read_post_full_entities_by_ids_from_db(&[post_id])
             .map_err(|e| CollectionError::DatabaseError {
                 err_message: e.to_string(),
             })?
@@ -430,7 +430,7 @@ impl PostMetadataCollectionWithEditContext {
             .collect();
         let all_posts = self
             .service
-            .read_posts_by_ids_from_db(&all_post_ids)
+            .read_post_full_entities_by_ids_from_db(&all_post_ids)
             .map_err(|e| CollectionError::DatabaseError {
                 err_message: e.to_string(),
             })?;

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -632,7 +632,10 @@ impl PostService {
     /// Read posts by IDs from the database cache.
     ///
     /// Returns full entity data for all requested IDs that exist in the cache.
-    /// Posts not in the cache are silently omitted from the result.
+    /// Posts not in the cache are silently omitted from the result. Each
+    /// distinct ID yields at most one entity: duplicate IDs in `ids` collapse
+    /// to a single result at the first occurrence's position. The result
+    /// follows the order of `ids`.
     ///
     /// # Arguments
     /// * `ids` - Post IDs to load
@@ -650,17 +653,21 @@ impl PostService {
 
         let repo = PostRepository::<EditContext>::new();
 
-        // TODO: query database for all IDs in one call instead of iterating?
         self.cache.execute(|connection| {
-            ids.iter()
-                .map(|&id| repo.select_by_post_id(connection, &self.db_site, PostId(id)))
-                .collect::<Result<Vec<_>, _>>()
+            repo.select_by_post_ids(connection, &self.db_site, ids)
                 .map(|posts| {
-                    posts
+                    // The IN query returns one row per distinct matching post in
+                    // scan order. Reorder to follow `ids`, taking each post out
+                    // of the map on first use so a repeated ID resolves once
+                    // (set-style lookup) instead of aliasing the same entity.
+                    let mut by_id: std::collections::HashMap<i64, _> = posts
                         .into_iter()
-                        .flatten()
-                        .map(|db_post| FullEntity::new(db_post.entity_id, db_post.data.post))
-                        .collect()
+                        .map(|db_post| {
+                            let full_entity = FullEntity::new(db_post.entity_id, db_post.data.post);
+                            (full_entity.data.id.0, full_entity)
+                        })
+                        .collect();
+                    ids.iter().filter_map(|id| by_id.remove(id)).collect()
                 })
         })
     }
@@ -708,7 +715,9 @@ impl PostService {
     /// from the result; callers that need to distinguish missing posts must
     /// compare the result against the requested IDs.
     ///
-    /// Results are returned in the order of `post_ids`.
+    /// Results follow the order of `post_ids`. Each distinct ID yields at most
+    /// one post: duplicate IDs collapse to a single entry at the first
+    /// occurrence's position, so this behaves as a set-style batch lookup.
     pub fn read_posts_by_ids_from_db(
         &self,
         post_ids: Vec<PostId>,
@@ -1164,6 +1173,53 @@ mod tests {
 
         // Assert: the service only reads posts for its own site
         assert!(posts.is_empty(), "another site's post must not be returned");
+    }
+
+    #[rstest]
+    fn test_read_posts_by_ids_from_db_orders_dedupes_and_maps_terms(
+        post_service_ctx: PostServiceTestContext,
+    ) {
+        use wp_api::terms::TermId;
+
+        // Two cached posts, each with a distinct category, to exercise the
+        // batched multi-row path and per-post term association.
+        let first = PostBuilder::minimal()
+            .with_id(101)
+            .with_title("First")
+            .with_slug("first")
+            .with_categories(vec![TermId(11)])
+            .build();
+        let second = PostBuilder::minimal()
+            .with_id(102)
+            .with_title("Second")
+            .with_slug("second")
+            .with_categories(vec![TermId(22)])
+            .build();
+        post_service_ctx
+            .cache
+            .execute(|conn| {
+                let repo = PostRepository::<EditContext>::new();
+                repo.upsert(conn, &post_service_ctx.db_site, &first)?;
+                repo.upsert(conn, &post_service_ctx.db_site, &second)
+            })
+            .expect("Post inserts should succeed");
+
+        // Request in reverse order, with a duplicate and a missing ID mixed in.
+        let posts = post_service_ctx
+            .post_service
+            .read_posts_by_ids_from_db(vec![PostId(102), PostId(101), PostId(102), PostId(99999)])
+            .expect("Database read should succeed");
+
+        // Set-style lookup: distinct posts in first-occurrence order, missing
+        // omitted, the repeated ID resolved once.
+        assert_eq!(
+            posts.iter().map(|p| p.id).collect::<Vec<_>>(),
+            vec![PostId(102), PostId(101)],
+            "results follow first-occurrence order with duplicates collapsed"
+        );
+        // Batched term relationships are associated with the correct post.
+        assert_eq!(posts[0].categories, Some(vec![TermId(22)]));
+        assert_eq!(posts[1].categories, Some(vec![TermId(11)]));
     }
 
     #[rstest]

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -718,7 +718,7 @@ impl PostService {
     /// Results follow the order of `post_ids`. Each distinct ID yields at most
     /// one post: duplicate IDs collapse to a single entry at the first
     /// occurrence's position, so this behaves as a set-style batch lookup.
-    pub fn read_posts_by_ids_from_db(
+    pub async fn read_posts_by_ids_from_db(
         &self,
         post_ids: Vec<PostId>,
     ) -> Result<Vec<AnyPostWithEditContext>, wp_mobile_cache::SqliteDbError> {
@@ -1122,7 +1122,8 @@ mod tests {
     }
 
     #[rstest]
-    fn test_read_posts_by_ids_from_db_returns_present_and_omits_missing(
+    #[tokio::test]
+    async fn test_read_posts_by_ids_from_db_returns_present_and_omits_missing(
         post_service_ctx: PostServiceTestContext,
     ) {
         // Setup: one post in the cache; PostId(99999) is never inserted
@@ -1131,6 +1132,7 @@ mod tests {
         let posts = post_service_ctx
             .post_service
             .read_posts_by_ids_from_db(vec![test_post.id, PostId(99999)])
+            .await
             .expect("Database read should succeed");
 
         // Assert: the cached post is returned, the missing ID is omitted
@@ -1139,7 +1141,10 @@ mod tests {
     }
 
     #[rstest]
-    fn test_read_posts_by_ids_from_db_is_site_scoped(post_service_ctx: PostServiceTestContext) {
+    #[tokio::test]
+    async fn test_read_posts_by_ids_from_db_is_site_scoped(
+        post_service_ctx: PostServiceTestContext,
+    ) {
         // Setup: a post that belongs to a different site in the same database
         let other_site = post_service_ctx
             .cache
@@ -1169,6 +1174,7 @@ mod tests {
         let posts = post_service_ctx
             .post_service
             .read_posts_by_ids_from_db(vec![PostId(7)])
+            .await
             .expect("Database read should succeed");
 
         // Assert: the service only reads posts for its own site
@@ -1176,7 +1182,8 @@ mod tests {
     }
 
     #[rstest]
-    fn test_read_posts_by_ids_from_db_orders_dedupes_and_maps_terms(
+    #[tokio::test]
+    async fn test_read_posts_by_ids_from_db_orders_dedupes_and_maps_terms(
         post_service_ctx: PostServiceTestContext,
     ) {
         use wp_api::terms::TermId;
@@ -1208,6 +1215,7 @@ mod tests {
         let posts = post_service_ctx
             .post_service
             .read_posts_by_ids_from_db(vec![PostId(102), PostId(101), PostId(102), PostId(99999)])
+            .await
             .expect("Database read should succeed");
 
         // Set-style lookup: distinct posts in first-occurrence order, missing

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -700,6 +700,27 @@ impl PostService {
         .into()
     }
 
+    /// Read posts by their WordPress post IDs from the database cache.
+    ///
+    /// Cache-only: no network request is made, so this is safe to call for
+    /// resolving display data (e.g. post titles for a comments list) without
+    /// triggering fetches. IDs not present in the cache are silently omitted
+    /// from the result; callers that need to distinguish missing posts must
+    /// compare the result against the requested IDs.
+    ///
+    /// Results are returned in the order of `post_ids`.
+    pub fn read_posts_by_ids_from_db(
+        &self,
+        post_ids: Vec<PostId>,
+    ) -> Result<Vec<AnyPostWithEditContext>, wp_mobile_cache::SqliteDbError> {
+        let ids: Vec<i64> = post_ids.iter().map(|post_id| post_id.0).collect();
+        Ok(self
+            .read_post_full_entities_by_ids_from_db(&ids)?
+            .into_iter()
+            .map(|full_entity| full_entity.data)
+            .collect())
+    }
+
     /// Get the total count of posts for this site
     ///
     /// Returns the number of posts stored in the cache for this site.
@@ -1089,6 +1110,60 @@ mod tests {
         // Assert: Post was found and matches what we inserted
         let full_entity = result.expect("Post should be found in cache");
         test_post.assert_matches(&full_entity.data);
+    }
+
+    #[rstest]
+    fn test_read_posts_by_ids_from_db_returns_present_and_omits_missing(
+        post_service_ctx: PostServiceTestContext,
+    ) {
+        // Setup: one post in the cache; PostId(99999) is never inserted
+        let test_post = insert_test_post(&post_service_ctx);
+
+        let posts = post_service_ctx
+            .post_service
+            .read_posts_by_ids_from_db(vec![test_post.id, PostId(99999)])
+            .expect("Database read should succeed");
+
+        // Assert: the cached post is returned, the missing ID is omitted
+        assert_eq!(posts.len(), 1, "missing IDs must be omitted, not errors");
+        test_post.assert_matches(&posts[0]);
+    }
+
+    #[rstest]
+    fn test_read_posts_by_ids_from_db_is_site_scoped(post_service_ctx: PostServiceTestContext) {
+        // Setup: a post that belongs to a different site in the same database
+        let other_site = post_service_ctx
+            .cache
+            .execute(|conn| {
+                SiteRepository.upsert_self_hosted_site(
+                    conn,
+                    &SelfHostedSite {
+                        url: "https://other.local".to_string(),
+                        api_root: "https://other.local/wp-json".to_string(),
+                    },
+                )
+            })
+            .expect("Site creation should succeed")
+            .db_site;
+        let other_post = PostBuilder::minimal()
+            .with_id(7)
+            .with_title("Other Site Post")
+            .with_slug("other-site-post")
+            .build();
+        post_service_ctx
+            .cache
+            .execute(|conn| {
+                PostRepository::<EditContext>::new().upsert(conn, &other_site, &other_post)
+            })
+            .expect("Post insert should succeed");
+
+        let posts = post_service_ctx
+            .post_service
+            .read_posts_by_ids_from_db(vec![PostId(7)])
+            .expect("Database read should succeed");
+
+        // Assert: the service only reads posts for its own site
+        assert!(posts.is_empty(), "another site's post must not be returned");
     }
 
     #[rstest]

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -640,7 +640,7 @@ impl PostService {
     /// # Returns
     /// - `Ok(Vec<FullEntity>)` with posts found in cache
     /// - `Err` if database error occurs
-    pub fn read_posts_by_ids_from_db(
+    pub fn read_post_full_entities_by_ids_from_db(
         &self,
         ids: &[i64],
     ) -> Result<Vec<FullEntity<AnyPostWithEditContext>>, wp_mobile_cache::SqliteDbError> {

--- a/wp_mobile_cache/src/repository/posts.rs
+++ b/wp_mobile_cache/src/repository/posts.rs
@@ -310,6 +310,66 @@ impl<C: PostContext> PostRepository<C> {
         }))
     }
 
+    /// Select multiple posts by their WordPress post IDs for a given site.
+    ///
+    /// Unlike calling `select_by_post_id` in a loop, this runs one query for
+    /// the posts and one for their term relationships, which keeps the time
+    /// the shared connection is held proportional to two queries rather than
+    /// two per ID. IDs with no matching post are omitted from the result.
+    /// Row order follows SQLite's scan order, not `post_ids`; callers that
+    /// need input order must reorder.
+    pub fn select_by_post_ids(
+        &self,
+        executor: &impl QueryExecutor,
+        site: &DbSite,
+        post_ids: &[i64],
+    ) -> Result<Vec<FullEntity<C::DbPost>>, SqliteDbError> {
+        if post_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Batch load term relationships for all requested posts
+        let term_repo = TermRelationshipRepository;
+        let terms_map = term_repo.get_terms_for_objects(executor, site, post_ids)?;
+
+        // Inline the numeric IDs directly rather than binding one variable per
+        // ID. They are i64 values (no injection risk), and inlining keeps the
+        // query clear of SQLite's bound-variable limit, which a large batch of
+        // IDs could otherwise exceed. This mirrors
+        // TermRelationshipRepository::get_terms_for_objects above.
+        let ids_str = post_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT * FROM {} WHERE db_site_id = ? AND id IN ({})",
+            Self::table_name(),
+            ids_str
+        );
+
+        let mut stmt = executor.prepare(&sql)?;
+        let posts = stmt
+            .query_map([site.row_id], |row| {
+                let post_id: i64 = row.get("id")?;
+                C::from_row_with_terms(row, || {
+                    Ok(terms_map.get(&post_id).cloned().unwrap_or_default())
+                })
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(SqliteDbError::from)?;
+
+        Ok(posts
+            .into_iter()
+            .map(|db_post| {
+                let rowid = C::rowid(&db_post);
+                let entity_id = Arc::new(EntityId::new(*site, C::table(), rowid));
+                FullEntity::new(entity_id, db_post)
+            })
+            .collect())
+    }
+
     /// Select `modified_gmt` timestamps for multiple posts by their WordPress post IDs.
     ///
     /// This is a lightweight query used for staleness detection - it only fetches

--- a/wp_mobile_integration_tests/tests/test_posts_mut.rs
+++ b/wp_mobile_integration_tests/tests/test_posts_mut.rs
@@ -501,8 +501,8 @@ async fn test_load_posts_by_ids_includes_trashed_post() {
     let cached_posts = ctx
         .service
         .posts()
-        .read_posts_by_ids_from_db(&[created.id.0])
-        .expect("read_posts_by_ids_from_db should succeed");
+        .read_post_full_entities_by_ids_from_db(&[created.id.0])
+        .expect("read_post_full_entities_by_ids_from_db should succeed");
     assert_eq!(cached_posts.len(), 1, "should have 1 cached post");
     assert_eq!(
         cached_posts[0].data.status,
@@ -572,8 +572,8 @@ async fn test_load_posts_by_ids_includes_mixed_status_posts() {
     let cached_posts = ctx
         .service
         .posts()
-        .read_posts_by_ids_from_db(&[draft.id.0, to_trash.id.0])
-        .expect("read_posts_by_ids_from_db should succeed");
+        .read_post_full_entities_by_ids_from_db(&[draft.id.0, to_trash.id.0])
+        .expect("read_post_full_entities_by_ids_from_db should succeed");
     assert_eq!(cached_posts.len(), 2, "should have 2 cached posts");
 
     let draft_post = cached_posts


### PR DESCRIPTION
## Description

I want to use this API to read cached post in the comments screens, to show what post the comment is posted on.

I'd like to use the function signature `read_posts_by_ids_from_db -> AnyPostWithEditContext`. The function name is already taken. So I changed the existing function to `read_post_full_entities_by_ids_from_db -> FullEntity<AnyPostWithEditContext>`.