### PR TITLE
Add failing precondition tests: unspam/untrash must not demote a non-spam/trash comment

### DIFF
--- a/wp_api_integration_tests/tests/test_comments_mut.rs
+++ b/wp_api_integration_tests/tests/test_comments_mut.rs
@@ -136,6 +136,81 @@ async fn untrash_comment_restores_previous_status() {
     RestoreServer::db().await;
 }
 
+// ASPIRATIONAL / currently FAILING — the proposed contract for the not-spam/not-trash path.
+//
+// Today `unspam()`/`untrash()` blindly POST `status=unspam|untrash`. WordPress core
+// (`wp_unspam_comment`/`wp_untrash_comment`) restores the status saved in
+// `_wp_trash_meta_status`; when the comment is NOT currently spam/trash that meta is absent,
+// core falls back to `hold` and returns HTTP 200 — silently demoting an approved comment
+// into the moderation queue (NOT the HTTP 500 the endpoint's doc comment claims). The desired
+// contract: the client refuses to unspam/untrash a comment that isn't spam/trash, surfaces an
+// error, and leaves the comment untouched. These fail today and should pass once a
+// precondition guard is added.
+
+#[tokio::test]
+#[serial]
+async fn unspam_on_non_spam_comment_should_error_without_demoting() {
+    // FIRST_COMMENT_ID is approved in the seed data — it is NOT spam.
+    let result = api_client().comments().unspam(&FIRST_COMMENT_ID).await;
+
+    // Read the resulting server-side status, then restore before asserting.
+    let status = api_client()
+        .comments()
+        .retrieve_with_edit_context(
+            &FIRST_COMMENT_ID,
+            &wp_api::comments::CommentRetrieveParams::default(),
+        )
+        .await
+        .assert_response()
+        .data
+        .status;
+    RestoreServer::db().await;
+
+    // The approved comment must never be demoted...
+    assert_eq!(
+        status,
+        CommentStatus::Approved,
+        "unspam silently demoted an approved comment"
+    );
+    // ...and the caller must be told, not handed a bogus success.
+    assert!(
+        result.is_err(),
+        "unspam on a non-spam comment should return an error, not silently succeed"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn untrash_on_non_trashed_comment_should_error_without_demoting() {
+    // FIRST_COMMENT_ID is approved in the seed data — it is NOT trash.
+    let result = api_client().comments().untrash(&FIRST_COMMENT_ID).await;
+
+    // Read the resulting server-side status, then restore before asserting.
+    let status = api_client()
+        .comments()
+        .retrieve_with_edit_context(
+            &FIRST_COMMENT_ID,
+            &wp_api::comments::CommentRetrieveParams::default(),
+        )
+        .await
+        .assert_response()
+        .data
+        .status;
+    RestoreServer::db().await;
+
+    // The approved comment must never be demoted...
+    assert_eq!(
+        status,
+        CommentStatus::Approved,
+        "untrash silently demoted an approved comment"
+    );
+    // ...and the caller must be told, not handed a bogus success.
+    assert!(
+        result.is_err(),
+        "untrash on a non-trashed comment should return an error, not silently succeed"
+    );
+}
+
 generate_update_test!(
     update_author,
     author,


### PR DESCRIPTION
## Description

Follow-up to #1564, stacked on its branch. `unspam()`/`untrash()` blindly POST `status=unspam|untrash`. WordPress core (`wp_unspam_comment`/`wp_untrash_comment`) restores the status saved in `_wp_trash_meta_status`, and **defaults to `hold` when that meta is absent** — so calling either endpoint on a comment that is *not* currently spam/trash returns **HTTP 200 and silently demotes an approved comment to pending** (verified against WordPress 6.8.1), rather than the `HTTP 500` the endpoint's doc comment claims. The `status`-only 500 branch in `WP_REST_Comments_Controller::update_item` is in fact unreachable for a real request, because `prepare_item_for_database` always populates `comment_author_IP` — which also means the call overwrites the comment's stored author IP with the caller's.

These are **aspirational tests that currently fail** — they encode the contract we want (reject the call, surface an error, leave the comment untouched) so #1564 can be adjusted to make them pass. Opened as a draft because CI will be red until a precondition guard lands.

## Changes

- Add `unspam_on_non_spam_comment_should_error_without_demoting` and `untrash_on_non_trashed_comment_should_error_without_demoting` to `wp_api_integration_tests/tests/test_comments_mut.rs`.
- Each asserts the comment is left `Approved` (no silent demotion) **and** that the call returns an error rather than a bogus success.

## Test plan

- [x] Verified locally against the WordPress 6.8.1 test server: both **fail today** with `left: Hold, right: Approved`.
- [ ] Both pass once a client-side precondition guard is added to `unspam()`/`untrash()` (refuse when the comment isn't currently spam/trash). Realistic options: fetch-then-act inside the method, accept an expected-current-status argument, or enforce at a higher layer.
- [ ] If a silent no-op success is preferred over an error, drop the `assert!(result.is_err(), …)` line — the `== Approved` assertion alone still pins "no demotion".

## Changelog

- [ ] N/A — test-only, no library behavior change (the fix that makes these pass will carry the changelog entry).
