### PR TITLE
Update fastlane to 2.238.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal:** Documented how to pick an xcframework build for local work, and added `make help` descriptions for the `xcframework-only-*` targets. Verifying a UniFFI change needs only `make xcframework-only-macos`, not the full 11-target `make xcframework`.
 - **Internal:** Update translations.
 - **Internal:** Fixed `make xcframework-only-<platform>` building the per-target libraries but never assembling them into the xcframework. The `@# Help:` comments added for those `make help` descriptions became each rule's recipe and silently shadowed the shared `xcframework-only-%` pattern rule that ran the assemble step; each rule now runs the assemble step directly.
+- **Internal:** Use fastlane 2.238.0 for automation tooling.
 
 ### Fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'buildkit', '~> 1.6'
-gem 'fastlane', '~> 2.237'
+gem 'fastlane', '~> 2.238'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.11'
 gem 'fluent-tools', '~> 0.3'
 gem "openssl", "~> 4.0.2"
-
-# Security: https://github.com/lostisland/faraday/pull/1665
-# Faraday 2.0 is not compatible with Fastlane
-gem 'faraday', '~> 2.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,8 +343,7 @@ PLATFORMS
 
 DEPENDENCIES
   buildkit (~> 1.6)
-  faraday (~> 2.14)
-  fastlane (~> 2.237)
+  fastlane (~> 2.238)
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   fluent-tools (~> 0.3)
   openssl (~> 4.0.2)


### PR DESCRIPTION
## Description

Update `fastlane` gem to `2.238.0`

This also allows us to remove the explicit declaration of the faraday 2.x dependency in our Gemfile as faraday 2.x is now a transitive dependency of fastlane since https://github.com/fastlane/fastlane/pull/30089 landed

This is a follow-up on https://github.com/Automattic/wordpress-rs/pull/1559/changes#r3779795443

## Changes

 - Bump `gem 'fastlane'` to `~> 2.238.0`
 - Remove the explicit declaration of `gem 'faraday', '~> 2.14'` in the `Gemfile` now that it comes as a transitive dependency of `fastlane`

## Test plan

Notice how, in `Gemfile.lock`, even if `faraday (~> 2.14)` line was removed as a _direct_ dependency on line L346, the _resolved_ version of `faraday` [did not change on line 53 and is still pinned at version `2.14.3`](https://github.com/Automattic/wordpress-rs/pull/1567/changes#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR53)

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
