### PR TITLE
Remove obsolete OpenSSL workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** Removed the obsolete explicit Ruby OpenSSL dependency now that Ruby 3.4.9 provides the fixed OpenSSL 3.3.1 default gem.
 - **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.
 - **BREAKING:** The cache now enables SQLite foreign key enforcement on every connection it prepares, and fails with `SqliteDbError::ForeignKeysUnavailable` if the setting doesn't take effect. Removing a site relies on `ON DELETE CASCADE` to clear its cached rows, so on builds where enforcement defaulted to off those rows were silently left behind.

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gem 'buildkit', '~> 1.6'
 gem 'fastlane', '~> 2.238'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.11'
 gem 'fluent-tools', '~> 0.3'
-gem "openssl", "~> 4.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,6 @@ GEM
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    openssl (4.0.2)
     options (2.3.2)
     optparse (0.8.1)
     os (1.1.4)
@@ -346,7 +345,6 @@ DEPENDENCIES
   fastlane (~> 2.238)
   fastlane-plugin-wpmreleasetoolkit (~> 14.11)
   fluent-tools (~> 0.3)
-  openssl (~> 4.0.2)
 
 BUNDLED WITH
   4.0.17


### PR DESCRIPTION
## Description

Removes the obsolete explicit Ruby OpenSSL dependency as is no longer needed now that we use Ruby 3.4.9 (see paaHJt-aks-p2). 

## Changes

- Removed the explicit OpenSSL dependency and its lockfile entries.
- Added an internal changelog entry.

## Changelog

- [x] Added an entry to CHANGELOG.md under Unreleased > Changed.