### PR TITLE
Validate changelog entries under Unreleased

### DIFF
--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -2,6 +2,30 @@
 
 set -euo pipefail
 
+# The top-level "- " entries under "## [Unreleased]", read from stdin and
+# sorted so comm can diff two of these sets.
+unreleased_entries() {
+  awk '
+    $0 == "## [Unreleased]" { in_unreleased = 1; next }
+    in_unreleased && /^## / { exit }
+    in_unreleased && /^- / { print }
+  ' | LC_ALL=C sort -u
+}
+
+# Pass, deleting any failure comment from a prior run so a green run leaves no
+# residue. The delete no-ops if the comment does not exist.
+pass() {
+  printf '%s\n' "$1"
+  comment_on_pr --id changelog-check --if-exist delete "" || true
+  exit 0
+}
+
+fail() {
+  printf '\n%s\n\n' "$1" >&2
+  comment_on_pr --id changelog-check "$1"
+  exit 1
+}
+
 # Only enforce on PR builds — the check is about *new* entries being added
 # alongside the change that ships them.
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
@@ -20,18 +44,40 @@ BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-trunk}"
 echo "--- :git: Fetching origin/${BASE_BRANCH}"
 git fetch --no-tags origin "$BASE_BRANCH"
 
-if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx "CHANGELOG.md"; then
-  echo "CHANGELOG.md was updated"
-  # If a prior run posted a failure comment, clean it up so a green run
-  # leaves no residue. No-ops if the comment doesn't exist.
-  comment_on_pr --id changelog-check --if-exist delete "" || true
-  exit 0
+MERGE_BASE="$(git merge-base "origin/${BASE_BRANCH}" HEAD)"
+CHANGELOG_DIFF="$(git diff "$MERGE_BASE" HEAD -- CHANGELOG.md)"
+
+if ! grep -Fqx '## [Unreleased]' CHANGELOG.md; then
+  fail ':warning: **`CHANGELOG.md` has no `## [Unreleased]` section.**
+
+Restore the section and add this pull request’s changelog entry beneath it.'
+fi
+
+# Release PRs open a new versioned section instead of adding entries to
+# Unreleased. Detect this from the diff, as detect-release.sh does, so it works
+# regardless of the branch name. The here-string avoids a pipefail/SIGPIPE when
+# grep -q exits after finding an early match in a large diff.
+if grep -qE '^\+## \[[0-9]+\.[0-9]+\.[0-9]+' <<< "$CHANGELOG_DIFF"; then
+  pass "CHANGELOG.md opens a new release section"
+fi
+
+# Compare only Unreleased entries so edits to an already released section
+# cannot satisfy the check.
+ADDED_ENTRIES="$(
+  comm -13 \
+    <(git show "${MERGE_BASE}:CHANGELOG.md" | unreleased_entries) \
+    <(unreleased_entries < CHANGELOG.md)
+)"
+
+if [[ -n "$ADDED_ENTRIES" ]]; then
+  pass "CHANGELOG.md adds an entry under ## [Unreleased]:
+$ADDED_ENTRIES"
 fi
 
 FAILURE_MESSAGE=$(cat <<'EOF'
-:warning: **`CHANGELOG.md` was not updated in this PR.**
+:warning: **No changelog entry was added under `## [Unreleased]`.**
 
-Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.md` describing the change for our users. The format follows [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) — use one of:
+Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.md` describing the change for our users. Entries added under an already released version do not satisfy this check. The format follows [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) — use one of:
 
 - `### Added` — for new features
 - `### Changed` — for changes in existing functionality (prefix `**BREAKING:**` if breaking)
@@ -44,10 +90,4 @@ If the change genuinely has no user-visible impact (e.g. CI-only tweaks, interna
 EOF
 )
 
-echo "" >&2
-echo "$FAILURE_MESSAGE" >&2
-echo "" >&2
-
-comment_on_pr --id changelog-check "$FAILURE_MESSAGE"
-
-exit 1
+fail "$FAILURE_MESSAGE"

--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -2,28 +2,15 @@
 
 set -euo pipefail
 
-# The top-level "- " entries under "## [Unreleased]", read from stdin and
-# sorted so comm can diff two of these sets.
-unreleased_entries() {
+# Prints the number of Unreleased entries and versioned release headings.
+changelog_counts() {
   awk '
     $0 == "## [Unreleased]" { in_unreleased = 1; next }
-    in_unreleased && /^## / { exit }
-    in_unreleased && /^- / { print }
-  ' | LC_ALL=C sort -u
-}
-
-# Pass, deleting any failure comment from a prior run so a green run leaves no
-# residue. The delete no-ops if the comment does not exist.
-pass() {
-  printf '%s\n' "$1"
-  comment_on_pr --id changelog-check --if-exist delete "" || true
-  exit 0
-}
-
-fail() {
-  printf '\n%s\n\n' "$1" >&2
-  comment_on_pr --id changelog-check "$1"
-  exit 1
+    in_unreleased && /^## / { in_unreleased = 0 }
+    in_unreleased && /^- / { entries++ }
+    /^## \[[0-9]+\.[0-9]+\.[0-9]+/ { versions++ }
+    END { print entries + 0, versions + 0 }
+  '
 }
 
 # Only enforce on PR builds — the check is about *new* entries being added
@@ -45,33 +32,18 @@ echo "--- :git: Fetching origin/${BASE_BRANCH}"
 git fetch --no-tags origin "$BASE_BRANCH"
 
 MERGE_BASE="$(git merge-base "origin/${BASE_BRANCH}" HEAD)"
-CHANGELOG_DIFF="$(git diff "$MERGE_BASE" HEAD -- CHANGELOG.md)"
 
-if ! grep -Fqx '## [Unreleased]' CHANGELOG.md; then
-  fail ':warning: **`CHANGELOG.md` has no `## [Unreleased]` section.**
+read -r BASE_ENTRIES BASE_VERSIONS < <(
+  git show "${MERGE_BASE}:CHANGELOG.md" | changelog_counts
+)
+read -r ENTRIES VERSIONS < <(changelog_counts < CHANGELOG.md)
 
-Restore the section and add this pull request’s changelog entry beneath it.'
-fi
-
-# Release PRs open a new versioned section instead of adding entries to
-# Unreleased. Detect this from the diff, as detect-release.sh does, so it works
-# regardless of the branch name. The here-string avoids a pipefail/SIGPIPE when
-# grep -q exits after finding an early match in a large diff.
-if grep -qE '^\+## \[[0-9]+\.[0-9]+\.[0-9]+' <<< "$CHANGELOG_DIFF"; then
-  pass "CHANGELOG.md opens a new release section"
-fi
-
-# Compare only Unreleased entries so edits to an already released section
-# cannot satisfy the check.
-ADDED_ENTRIES="$(
-  comm -13 \
-    <(git show "${MERGE_BASE}:CHANGELOG.md" | unreleased_entries) \
-    <(unreleased_entries < CHANGELOG.md)
-)"
-
-if [[ -n "$ADDED_ENTRIES" ]]; then
-  pass "CHANGELOG.md adds an entry under ## [Unreleased]:
-$ADDED_ENTRIES"
+# Normal PRs add an Unreleased entry; release PRs add a version heading.
+if (( ENTRIES > BASE_ENTRIES || VERSIONS > BASE_VERSIONS )); then
+  echo "CHANGELOG.md update is valid"
+  # Delete any failure comment from a prior run so a green run leaves no residue.
+  comment_on_pr --id changelog-check --if-exist delete "" || true
+  exit 0
 fi
 
 FAILURE_MESSAGE=$(cat <<'EOF'
@@ -90,4 +62,6 @@ If the change genuinely has no user-visible impact (e.g. CI-only tweaks, interna
 EOF
 )
 
-fail "$FAILURE_MESSAGE"
+printf '\n%s\n\n' "$FAILURE_MESSAGE" >&2
+comment_on_pr --id changelog-check "$FAILURE_MESSAGE"
+exit 1

--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Prints the non-whitespace contents of every Unreleased section.
+# Prints non-empty contents of every Unreleased section with whitespace normalized.
 unreleased_section() {
   awk '
     /^## \[Unreleased\][[:space:]]*$/ { in_unreleased = 1; next }
@@ -32,7 +32,8 @@ fail() {
 
 warn() {
   printf '\n%s\n\n' "$1" >&2
-  # A GitHub failure must not turn this advisory result into a failed job.
+  # Keep the advisory visible in Buildkite if posting it to GitHub fails.
+  buildkite-agent annotate "$1" --style warning --context changelog-check || true
   comment_on_pr --id changelog-check "$1" || true
   exit 0
 }

--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -7,7 +7,13 @@ unreleased_section() {
   awk '
     /^## \[Unreleased\][[:space:]]*$/ { in_unreleased = 1; next }
     in_unreleased && /^## / { in_unreleased = 0 }
-    in_unreleased && /[^[:space:]]/ { print }
+    in_unreleased {
+      line = $0
+      gsub(/[[:space:]]+/, " ", line)
+      sub(/^ /, "", line)
+      sub(/ $/, "", line)
+      if (line != "") print line
+    }
   '
 }
 

--- a/.buildkite/commands/validate-changelog.sh
+++ b/.buildkite/commands/validate-changelog.sh
@@ -2,19 +2,36 @@
 
 set -euo pipefail
 
-# Prints the number of Unreleased entries and versioned release headings.
-changelog_counts() {
+# Prints the non-whitespace contents of every Unreleased section.
+unreleased_section() {
   awk '
-    $0 == "## [Unreleased]" { in_unreleased = 1; next }
+    /^## \[Unreleased\][[:space:]]*$/ { in_unreleased = 1; next }
     in_unreleased && /^## / { in_unreleased = 0 }
-    in_unreleased && /^- / { entries++ }
-    /^## \[[0-9]+\.[0-9]+\.[0-9]+/ { versions++ }
-    END { print entries + 0, versions + 0 }
+    in_unreleased && /[^[:space:]]/ { print }
   '
 }
 
-# Only enforce on PR builds — the check is about *new* entries being added
-# alongside the change that ships them.
+pass() {
+  echo "$1"
+  # Delete any warning or failure comment left by a prior run.
+  comment_on_pr --id changelog-check --if-exist delete "" || true
+  exit 0
+}
+
+fail() {
+  printf '\n%s\n\n' "$1" >&2
+  comment_on_pr --id changelog-check "$1" || true
+  exit 1
+}
+
+warn() {
+  printf '\n%s\n\n' "$1" >&2
+  # A GitHub failure must not turn this advisory result into a failed job.
+  comment_on_pr --id changelog-check "$1" || true
+  exit 0
+}
+
+# Only enforce on PR builds, where there is a base branch to compare against.
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
   echo "Not a PR build — skipping changelog check"
   exit 0
@@ -32,24 +49,23 @@ echo "--- :git: Fetching origin/${BASE_BRANCH}"
 git fetch --no-tags origin "$BASE_BRANCH"
 
 MERGE_BASE="$(git merge-base "origin/${BASE_BRANCH}" HEAD)"
+CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" HEAD)"
 
-read -r BASE_ENTRIES BASE_VERSIONS < <(
-  git show "${MERGE_BASE}:CHANGELOG.md" | changelog_counts
-)
-read -r ENTRIES VERSIONS < <(changelog_counts < CHANGELOG.md)
-
-# Normal PRs add an Unreleased entry; release PRs add a version heading.
-if (( ENTRIES > BASE_ENTRIES || VERSIONS > BASE_VERSIONS )); then
-  echo "CHANGELOG.md update is valid"
-  # Delete any failure comment from a prior run so a green run leaves no residue.
-  comment_on_pr --id changelog-check --if-exist delete "" || true
-  exit 0
+if [[ -z "$CHANGED_FILES" ]]; then
+  pass "PR has no changed files — skipping changelog check"
 fi
 
-FAILURE_MESSAGE=$(cat <<'EOF'
-:warning: **No changelog entry was added under `## [Unreleased]`.**
+if [[ ! -f CHANGELOG.md ]]; then
+  fail ':warning: **`CHANGELOG.md` is missing.**
 
-Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.md` describing the change for our users. Entries added under an already released version do not satisfy this check. The format follows [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) — use one of:
+Restore the file so releases and future pull requests can continue updating it.'
+fi
+
+if ! grep -Fxq "CHANGELOG.md" <<< "$CHANGED_FILES"; then
+  FAILURE_MESSAGE=$(cat <<'EOF'
+:warning: **`CHANGELOG.md` was not updated in this PR.**
+
+Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.md` describing the change for our users. The format follows [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) — use one of:
 
 - `### Added` — for new features
 - `### Changed` — for changes in existing functionality (prefix `**BREAKING:**` if breaking)
@@ -60,8 +76,38 @@ Every PR should add an entry under the `## [Unreleased]` section of `CHANGELOG.m
 
 If the change genuinely has no user-visible impact (e.g. CI-only tweaks, internal refactors), add a short entry under `### Changed` noting that.
 EOF
+  )
+
+  fail "$FAILURE_MESSAGE"
+fi
+
+if ! grep -Eq '^## \[Unreleased\][[:space:]]*$' CHANGELOG.md; then
+  fail ':warning: **`CHANGELOG.md` has no `## [Unreleased]` section.**
+
+Restore the section; the release flow relies on it to collect the next release notes.'
+fi
+
+# Dedicated changelog PRs may intentionally correct an already released entry.
+if [[ "$CHANGED_FILES" == "CHANGELOG.md" ]]; then
+  pass "Only CHANGELOG.md changed — allowing a dedicated changelog correction"
+fi
+
+BASE_UNRELEASED=""
+if git cat-file -e "${MERGE_BASE}:CHANGELOG.md" 2>/dev/null; then
+  # Consume the whole file so git show cannot receive SIGPIPE under pipefail.
+  BASE_UNRELEASED="$(git show "${MERGE_BASE}:CHANGELOG.md" | unreleased_section)"
+fi
+CURRENT_UNRELEASED="$(unreleased_section < CHANGELOG.md)"
+
+if [[ "$CURRENT_UNRELEASED" != "$BASE_UNRELEASED" ]]; then
+  pass "CHANGELOG.md changes the ## [Unreleased] section"
+fi
+
+WARNING_MESSAGE=$(cat <<'EOF'
+:warning: **No substantive change under `## [Unreleased]` was detected.**
+
+`CHANGELOG.md` was updated, but its `## [Unreleased]` section was not. If this PR changes code, please add or update an entry there. If the changelog update is intentionally correcting an older release, no action is needed.
+EOF
 )
 
-printf '\n%s\n\n' "$FAILURE_MESSAGE" >&2
-comment_on_pr --id changelog-check "$FAILURE_MESSAGE"
-exit 1
+warn "$WARNING_MESSAGE"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 ## Changelog
 
-- [ ] I've updated `CHANGELOG.md`, normally under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
+- [ ] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 ## Changelog
 
-- [ ] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
+- [ ] I've updated `CHANGELOG.md`, normally under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 
 ## [0.7.0] - 2026-08-18
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Removed the obsolete explicit Ruby OpenSSL dependency now that Ruby 3.4.9 provides the fixed OpenSSL 3.3.1 default gem.
 - **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 
 ## [0.7.0] - 2026-08-18
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Removed the obsolete explicit Ruby OpenSSL dependency now that Ruby 3.4.9 provides the fixed OpenSSL 3.3.1 default gem.
 - **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 
 ## [0.7.0] - 2026-08-18
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
 - **Internal:** Removed the obsolete explicit Ruby OpenSSL dependency now that Ruby 3.4.9 provides the fixed OpenSSL 3.3.1 default gem.
 - **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 
 ## [0.7.0] - 2026-08-18
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
 - **Internal:** Removed the obsolete explicit Ruby OpenSSL dependency now that Ruby 3.4.9 provides the fixed OpenSSL 3.3.1 default gem.
 - **BREAKING:** `CommentListParams.status` now takes `WpApiParamCommentsStatus` instead of `CommentStatus`, fixing `status=approved` silently returning no comments and adding typed `all`/`any`. Use `.approve` in place of `Custom("approve")`.
 - **BREAKING:** `product_type` fields on `Product` and `WPComProduct` changed from `String` to `ProductType`. Callers that match on or construct these values will need to wrap/unwrap with `ProductType(...)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Internal:** Require pull requests to add changelog entries under `## [Unreleased]`.
+- **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 
 ## [0.7.0] - 2026-08-18


### PR DESCRIPTION
## Description

Improves changelog validation so missing updates fail while misplaced entries receive an advisory warning.

## Changes

- Require `CHANGELOG.md` to be updated and retain `## [Unreleased]`.
- Warn when code changes do not change non-whitespace content under `## [Unreleased]`.
- Allow dedicated changelog corrections and release-style updates.

## Test plan

- [Advisory CI run](https://buildkite.com/automattic/wordpress-rs/builds/6321#01a03f91-6996-4cad-8210-007d316f42d5): moving this PR's entry under released version `0.7.0` posted a PR warning and a persistent Buildkite annotation without failing the step.
- [Clean changelog step](https://buildkite.com/automattic/wordpress-rs/builds/6322#01a03f92-96d4-4406-8bf5-32a0d0fd524b): restoring the entry under `## [Unreleased]` passed and removed the transient PR warning.
- Tested missing files/headings, historical-only edits, comment failures, large changelogs, and whitespace-only edits in synthetic PR repositories.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using a Keep a Changelog category.
