### PR TITLE
Send a locale query parameter on WordPress.com requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- WordPress.com requests now carry a locale query parameter, taken from a `WpComLanguageProvider` set on `WpApiClientDelegate.language_provider`. `/rest/v1.1`, `/rest/v1.2` and `/rest/v1.3` get `locale`; `/wpcom/v2` gets `_locale`; `/oauth2` and every WordPress.org namespace get neither. The provider is asked once per request, so a client is free to return a live value.
+
 ### Fixed
 
 - **BREAKING:** Support-bot message sources (`BotMessageContextSource`) now parse when the bot only returns `title`, `content`, and `url`. Some bots (e.g. `jetpack-workflow-chat_mobile_support`) omit `heading`, `blog_id`, `post_id`, `score`, and `last_indexed_at`, which previously failed the untagged `MessageContext` match and aborted parsing of the whole conversation response. Those five fields plus `url` are now optional (`Option<...>`), so binding consumers reading them as non-null must handle the nullable type.

--- a/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
+++ b/native/kotlin/api/kotlin/src/main/kotlin/rs/wordpress/api/kotlin/WpComApiClient.kt
@@ -11,32 +11,42 @@ import uniffi.wp_api.WpApiException
 import uniffi.wp_api.WpApiMiddlewarePipeline
 import uniffi.wp_api.WpAppNotifier
 import uniffi.wp_api.WpAuthenticationProvider
+import uniffi.wp_api.WpComLanguageProvider
 
 class WpComApiClient(
     authProvider: WpAuthenticationProvider,
     private val requestExecutor: RequestExecutor,
     private val appNotifier: WpAppNotifier = EmptyAppNotifier(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val errorLogger: RequestErrorLogger? = null
+    private val errorLogger: RequestErrorLogger? = null,
+    /**
+     * Supplies the language every request asks WordPress.com to localize its response to.
+     * Leave it `null` to send no locale and let the server choose.
+     */
+    private val languageProvider: WpComLanguageProvider? = null
 ) {
 
     /**
      * Convenience constructor that accepts a list of OkHttp interceptors.
      * Uses [WpRequestExecutor] internally with the provided interceptors.
      */
+    // Trailing params are all optional config with defaults; the count is benign here.
+    @Suppress("LongParameterList")
     constructor(
         authProvider: WpAuthenticationProvider,
         interceptors: List<Interceptor>,
         networkAvailabilityProvider: NetworkAvailabilityProvider,
         appNotifier: WpAppNotifier = EmptyAppNotifier(),
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-        errorLogger: RequestErrorLogger? = null
+        errorLogger: RequestErrorLogger? = null,
+        languageProvider: WpComLanguageProvider? = null
     ) : this(
         authProvider,
         requestExecutor = WpRequestExecutor(interceptors, networkAvailabilityProvider),
         appNotifier,
         dispatcher,
-        errorLogger
+        errorLogger,
+        languageProvider
     )
 
     // Don't expose `WpRequestBuilder` directly so we can control how it's used
@@ -46,7 +56,8 @@ class WpComApiClient(
                 authProvider,
                 requestExecutor = requestExecutor,
                 middlewarePipeline = WpApiMiddlewarePipeline(emptyList()),
-                appNotifier
+                appNotifier,
+                languageProvider = languageProvider
             )
         )
     }

--- a/wp_api/src/api_client.rs
+++ b/wp_api/src/api_client.rs
@@ -84,6 +84,7 @@ use crate::{
             },
         },
     },
+    wp_com::language::WpComLanguageProvider,
 };
 use std::sync::Arc;
 
@@ -140,9 +141,12 @@ impl WpApiRequestBuilder {
         api_url_resolver: Arc<dyn ApiUrlResolver>,
         auth_provider: Arc<WpAuthenticationProvider>,
     ) -> Self {
+        // No WordPress.org namespace reads a locale query parameter.
+        let language_provider: Option<Arc<dyn WpComLanguageProvider>> = None;
         api_client_generate_request_builder!(
             api_url_resolver,
-            auth_provider;
+            auth_provider,
+            language_provider;
             api_root,
             application_passwords,
             block_directory,
@@ -316,6 +320,10 @@ pub struct WpApiClientDelegate {
     pub request_executor: Arc<dyn RequestExecutor>,
     pub middleware_pipeline: Arc<WpApiMiddlewarePipeline>,
     pub app_notifier: Arc<dyn WpAppNotifier>,
+    /// Supplies the locale query parameter for namespaces that accept one. Namespaces
+    /// that don't, including every WordPress.org namespace, ignore this.
+    #[uniffi(default = None)]
+    pub language_provider: Option<Arc<dyn WpComLanguageProvider>>,
 }
 
 pub trait IsWpApiClientDelegate {
@@ -396,12 +404,13 @@ macro_rules! api_client_generate_endpoint_impl {
 
 #[macro_export]
 macro_rules! api_client_generate_request_builder {
-    ($api_url_resolver:ident, $authentication:ident; $($element:expr),*) => {
+    ($api_url_resolver:ident, $authentication:ident, $language_provider:ident; $($element:expr),*) => {
         paste::paste! {
             Self {
                 $($element: [<$element:camel RequestBuilder>]::new(
                     $api_url_resolver.clone(),
                     $authentication.clone(),
+                    $language_provider.clone(),
                 )
                 .into(),)*
             }

--- a/wp_api/src/jetpack/client.rs
+++ b/wp_api/src/jetpack/client.rs
@@ -18,7 +18,8 @@ impl JetpackApiRequestBuilder {
         auth_provider: Arc<WpAuthenticationProvider>,
     ) -> Self {
         Self {
-            connection: ConnectionRequestBuilder::new(api_url_resolver, auth_provider).into(),
+            // The Jetpack namespace doesn't read a locale query parameter.
+            connection: ConnectionRequestBuilder::new(api_url_resolver, auth_provider, None).into(),
         }
     }
 

--- a/wp_api/src/jetpack/connection.rs
+++ b/wp_api/src/jetpack/connection.rs
@@ -204,6 +204,7 @@ impl JetpackConnectionClient {
             request_executor: self.delegate.request_executor.clone(),
             middleware_pipeline: self.delegate.middleware_pipeline.clone(),
             app_notifier: self.delegate.app_notifier.clone(),
+            language_provider: self.delegate.language_provider.clone(),
         });
         let params = JetpackRemoteConnectionParams {
             secret: provision_info.secret,

--- a/wp_api/src/login/nonce.rs
+++ b/wp_api/src/login/nonce.rs
@@ -73,6 +73,7 @@ impl WpRestNonceRetrieval {
                     request_executor: self.request_executor.clone(),
                     middleware_pipeline: WpApiMiddlewarePipeline::default().into(),
                     app_notifier: Arc::new(EmptyAppNotifier),
+                    language_provider: None,
                 },
             );
             let logged_in = users.retrieve_me_with_edit_context().await?.data.username;

--- a/wp_api/src/request.rs
+++ b/wp_api/src/request.rs
@@ -960,7 +960,7 @@ pub async fn fetch_authentication_state(
     }
 
     let request =
-        ApplicationPasswordsRequestBuilder::new(api_url_resolver, authentication_provider)
+        ApplicationPasswordsRequestBuilder::new(api_url_resolver, authentication_provider, None)
             .retrieve_current_with_edit_context()
             .into();
     let response = request_executor.execute(request).await?;

--- a/wp_api/src/request/endpoint.rs
+++ b/wp_api/src/request/endpoint.rs
@@ -112,6 +112,15 @@ pub trait DerivedRequest {
 
 pub trait AsNamespace: Send + Sync {
     fn namespace_value(&self) -> &'static str;
+
+    /// The query parameter name this namespace reads to localize a response, or
+    /// `None` for namespaces that don't accept one.
+    ///
+    /// Namespaces that return a name have the parameter appended to every request
+    /// built for them, using the value from the client's language provider.
+    fn locale_param_name(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumIter)]

--- a/wp_api/src/request/endpoint/plugins_endpoint.rs
+++ b/wp_api/src/request/endpoint/plugins_endpoint.rs
@@ -33,6 +33,7 @@ mod tests {
             ApiUrlResolver,
             tests::{fixture_wp_org_site_api_url_resolver, validate_wp_v2_endpoint},
         },
+        wp_com::{endpoint::tests::language_provider, language::WPComLanguage},
     };
     use rstest::*;
     use std::sync::Arc;
@@ -198,6 +199,22 @@ mod tests {
         #[case] expected_path: &str,
     ) {
         validate_wp_v2_endpoint(endpoint.update(&plugin_slug), expected_path);
+    }
+
+    #[rstest]
+    fn wp_org_namespace_ignores_a_language_provider(
+        fixture_wp_org_site_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) {
+        // A delegate shared with a WordPress.com client carries a language provider.
+        // `WpNamespace` declares no locale parameter, so nothing is appended here.
+        let endpoint = PluginsRequestEndpoint::with_language_provider(
+            fixture_wp_org_site_api_url_resolver,
+            language_provider(Some(WPComLanguage::Spanish)),
+        );
+        validate_wp_v2_endpoint(
+            endpoint.update(&"classic-editor/classic-editor".into()),
+            "/plugins/classic-editor/classic-editor",
+        );
     }
 
     #[fixture]

--- a/wp_api/src/wp_com/client.rs
+++ b/wp_api/src/wp_com/client.rs
@@ -71,6 +71,7 @@ use crate::{
         segments_endpoint::{SegmentsRequestBuilder, SegmentsRequestExecutor},
         sites_endpoint::{SitesRequestBuilder, SitesRequestExecutor},
     },
+    wp_com::language::WpComLanguageProvider,
 };
 use std::sync::Arc;
 
@@ -118,12 +119,16 @@ pub struct WpComApiRequestBuilder {
 }
 
 impl WpComApiRequestBuilder {
-    pub fn new(auth_provider: Arc<WpAuthenticationProvider>) -> Self {
+    pub fn new(
+        auth_provider: Arc<WpAuthenticationProvider>,
+        language_provider: Option<Arc<dyn WpComLanguageProvider>>,
+    ) -> Self {
         let api_url_resolver: Arc<dyn ApiUrlResolver> =
             Arc::new(WpComApiClientInternalUrlResolver::default());
         api_client_generate_request_builder!(
             api_url_resolver,
-            auth_provider;
+            auth_provider,
+            language_provider;
             domains,
             followers,
             jetpack_connection,

--- a/wp_api/src/wp_com/endpoint.rs
+++ b/wp_api/src/wp_com/endpoint.rs
@@ -159,7 +159,13 @@ impl ApiUrlResolver for WpComApiClientInternalUrlResolver {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{request::endpoint::ApiEndpointUrl, wp_com::WpComNamespace};
+    use crate::{
+        request::endpoint::ApiEndpointUrl,
+        wp_com::{
+            WpComNamespace,
+            language::{WPComLanguage, WpComLanguageProvider},
+        },
+    };
     use rstest::*;
     use std::sync::Arc;
 
@@ -168,6 +174,23 @@ pub(crate) mod tests {
     #[fixture]
     pub fn fixture_wp_com_api_url_resolver() -> Arc<dyn ApiUrlResolver> {
         Arc::new(WpComApiClientInternalUrlResolver::default())
+    }
+
+    /// Returns whichever language it was built with, standing in for a client that
+    /// reads the device or in-app language.
+    #[derive(Debug)]
+    pub struct StubLanguageProvider(pub Option<WPComLanguage>);
+
+    impl WpComLanguageProvider for StubLanguageProvider {
+        fn current_language(&self) -> Option<WPComLanguage> {
+            self.0
+        }
+    }
+
+    pub fn language_provider(
+        language: Option<WPComLanguage>,
+    ) -> Option<Arc<dyn WpComLanguageProvider>> {
+        Some(Arc::new(StubLanguageProvider(language)))
     }
 
     pub fn validate_wp_com_rest_v1_1_endpoint(endpoint_url: ApiEndpointUrl, path: &str) {

--- a/wp_api/src/wp_com/endpoint/domains_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/domains_endpoint.rs
@@ -49,9 +49,11 @@ mod tests {
             WpComSiteId,
             domains::{AllDomainsParams, CountryCode, DomainAvailabilityParams, DomainName},
             endpoint::tests::{
-                fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
-                validate_wp_com_rest_v1_2_endpoint, validate_wp_com_rest_v1_3_endpoint,
+                fixture_wp_com_api_url_resolver, language_provider,
+                validate_wp_com_rest_v1_1_endpoint, validate_wp_com_rest_v1_2_endpoint,
+                validate_wp_com_rest_v1_3_endpoint,
             },
+            language::WPComLanguage,
             segments::SegmentId,
         },
     };
@@ -191,6 +193,66 @@ mod tests {
         validate_wp_com_rest_v1_1_endpoint(endpoint.set_primary(&site_id), expected_path);
     }
 
+    #[rstest]
+    fn site_domains_sends_locale(localized_endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_1_endpoint(
+            localized_endpoint.site_domains(&WpComSiteId(12345)),
+            "/sites/12345/domains?locale=es",
+        );
+    }
+
+    #[rstest]
+    fn all_domains_sends_locale_on_v1_2(localized_endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_2_endpoint(
+            localized_endpoint.all_domains(&AllDomainsParams::default()),
+            "/all-domains?locale=es",
+        );
+    }
+
+    #[rstest]
+    fn is_available_sends_locale_on_v1_3(localized_endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_3_endpoint(
+            localized_endpoint.is_available(
+                &DomainName("example.com".to_string()),
+                &DomainAvailabilityParams::default(),
+            ),
+            "/domains/example.com/is-available?locale=es",
+        );
+    }
+
+    #[rstest]
+    fn locale_precedes_request_params(localized_endpoint: DomainsRequestEndpoint) {
+        // The locale is appended first so an endpoint's own parameters come after it.
+        validate_wp_com_rest_v1_1_endpoint(
+            localized_endpoint.suggestions(&base_domain_suggestions_params()),
+            "/domains/suggestions?locale=es&query=coolsite&quantity=5",
+        );
+    }
+
+    #[rstest]
+    fn post_requests_send_locale(localized_endpoint: DomainsRequestEndpoint) {
+        validate_wp_com_rest_v1_1_endpoint(
+            localized_endpoint.set_primary(&WpComSiteId(12345)),
+            "/sites/12345/domains/primary?locale=es",
+        );
+    }
+
+    #[rstest]
+    fn provider_returning_no_language_sends_no_locale(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) {
+        // A client whose language doesn't map to a `WPComLanguage` sends nothing,
+        // leaving the choice to the server.
+        let endpoint = DomainsRequestEndpoint::with_language_provider(
+            fixture_wp_com_api_url_resolver,
+            language_provider(None),
+        );
+        validate_wp_com_rest_v1_1_endpoint(
+            endpoint.site_domains(&WpComSiteId(12345)),
+            "/sites/12345/domains",
+        );
+    }
+
     fn base_domain_suggestions_params() -> DomainSuggestionsParams {
         DomainSuggestionsParams {
             query: "coolsite".to_string(),
@@ -209,5 +271,15 @@ mod tests {
         fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
     ) -> DomainsRequestEndpoint {
         DomainsRequestEndpoint::new(fixture_wp_com_api_url_resolver)
+    }
+
+    #[fixture]
+    fn localized_endpoint(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) -> DomainsRequestEndpoint {
+        DomainsRequestEndpoint::with_language_provider(
+            fixture_wp_com_api_url_resolver,
+            language_provider(Some(WPComLanguage::Spanish)),
+        )
     }
 }

--- a/wp_api/src/wp_com/endpoint/languages_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/languages_endpoint.rs
@@ -16,3 +16,51 @@ impl DerivedRequest for LanguagesRequest {
         WpComNamespace::V2
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request::endpoint::ApiUrlResolver,
+        wp_com::{
+            endpoint::tests::{
+                fixture_wp_com_api_url_resolver, language_provider, validate_wp_com_v2_endpoint,
+            },
+            language::WPComLanguage,
+        },
+    };
+    use rstest::*;
+    use std::sync::Arc;
+
+    #[rstest]
+    fn v2_namespace_uses_underscore_locale(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) {
+        let endpoint = LanguagesRequestEndpoint::with_language_provider(
+            fixture_wp_com_api_url_resolver,
+            language_provider(Some(WPComLanguage::Spanish)),
+        );
+        validate_wp_com_v2_endpoint(
+            endpoint.get(&LanguagesGetParams::default()),
+            "/i18n/language-names?_locale=es",
+        );
+    }
+
+    #[rstest]
+    fn request_params_override_the_provider(
+        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
+    ) {
+        // `LanguagesGetParams` declares its own `_locale`, so both are on the URL.
+        // The parameter appended last is the one the server reads.
+        let endpoint = LanguagesRequestEndpoint::with_language_provider(
+            fixture_wp_com_api_url_resolver,
+            language_provider(Some(WPComLanguage::Spanish)),
+        );
+        validate_wp_com_v2_endpoint(
+            endpoint.get(&LanguagesGetParams {
+                locale: Some(WPComLanguage::Japanese),
+            }),
+            "/i18n/language-names?_locale=es&_locale=ja",
+        );
+    }
+}

--- a/wp_api/src/wp_com/language.rs
+++ b/wp_api/src/wp_com/language.rs
@@ -1,10 +1,24 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use crate::url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension};
 use serde::{Deserialize, Serialize};
 
-/// This file is optimized for really fast code, not to be pretty. Between the compiler
-/// and the tests, we shouldn't have to worry about half-implemented language codes.
+// This file is optimized for really fast code, not to be pretty. Between the compiler
+// and the tests, we shouldn't have to worry about half-implemented language codes.
+
+/// Supplies the language WordPress.com API responses should be localized to.
+///
+/// The client owns where the value comes from — the device language, an in-app
+/// language override, or the account setting — and is free to cache it. It's asked
+/// once per request, so a client that reads a live value doesn't need to notify
+/// `wp_api` when the language changes.
+#[uniffi::export(with_foreign)]
+pub trait WpComLanguageProvider: Send + Sync + Debug {
+    /// The language to request, or `None` to send no locale at all, which leaves the
+    /// choice to the server. Return `None` when the client's language doesn't map to
+    /// a [`WPComLanguage`].
+    fn current_language(&self) -> Option<WPComLanguage>;
+}
 
 #[derive(Debug, Serialize, Deserialize, uniffi::Record)]
 pub struct WpComRemoteLanguage {

--- a/wp_api/src/wp_com/mod.rs
+++ b/wp_api/src/wp_com/mod.rs
@@ -123,6 +123,17 @@ impl AsNamespace for WpComNamespace {
             WpComNamespace::V2 => "/wpcom/v2",
         }
     }
+
+    fn locale_param_name(&self) -> Option<&'static str> {
+        match self {
+            // `/oauth2` is served outside the REST frameworks that read a locale.
+            WpComNamespace::Oauth2 => None,
+            WpComNamespace::RestV1_1 | WpComNamespace::RestV1_2 | WpComNamespace::RestV1_3 => {
+                Some("locale")
+            }
+            WpComNamespace::V2 => Some("_locale"),
+        }
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, uniffi::Enum)]

--- a/wp_api_integration_tests/src/lib.rs
+++ b/wp_api_integration_tests/src/lib.rs
@@ -61,6 +61,7 @@ pub fn api_client() -> WpApiClient {
             request_executor: Arc::new(ReqwestRequestExecutor::default()),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }
@@ -76,6 +77,7 @@ pub fn api_client_as_author() -> WpApiClient {
             request_executor: Arc::new(ReqwestRequestExecutor::default()),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }
@@ -91,6 +93,7 @@ pub fn api_client_as_subscriber() -> WpApiClient {
             request_executor: Arc::new(ReqwestRequestExecutor::default()),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }
@@ -103,6 +106,7 @@ pub fn api_client_with_auth_provider(auth_provider: Arc<WpAuthenticationProvider
             request_executor: Arc::new(ReqwestRequestExecutor::default()),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }
@@ -138,6 +142,7 @@ pub async fn api_client_with_account_credentials(
             request_executor,
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }
@@ -151,6 +156,7 @@ pub fn wp_com_client() -> WpComApiClient {
         request_executor: Arc::new(ReqwestRequestExecutor::default()),
         middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
         app_notifier: Arc::new(EmptyAppNotifier),
+        language_provider: None,
     })
 }
 
@@ -163,6 +169,7 @@ pub fn wp_com_client_with_invalid_token() -> WpComApiClient {
         request_executor: Arc::new(ReqwestRequestExecutor::default()),
         middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
         app_notifier: Arc::new(EmptyAppNotifier),
+        language_provider: None,
     })
 }
 
@@ -181,6 +188,7 @@ pub fn api_client_backed_by_wp_com(site_id: String) -> WpApiClient {
             request_executor: Arc::new(ReqwestRequestExecutor::default()),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }

--- a/wp_api_integration_tests/tests/test_app_notifier_immut.rs
+++ b/wp_api_integration_tests/tests/test_app_notifier_immut.rs
@@ -66,6 +66,7 @@ fn api_client(
             request_executor,
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier,
+            language_provider: None,
         },
     )
 }

--- a/wp_api_integration_tests/tests/test_login_plain_permalinks_mut.rs
+++ b/wp_api_integration_tests/tests/test_login_plain_permalinks_mut.rs
@@ -65,6 +65,7 @@ async fn login_and_fetch_users_me_on_plain_permalinks_site() {
             request_executor: executor,
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     );
 

--- a/wp_api_integration_tests/tests/test_media_err.rs
+++ b/wp_api_integration_tests/tests/test_media_err.rs
@@ -166,6 +166,7 @@ fn api_client_with_medir_err_networking(test_type: MediaErrNetworkingTestType) -
             request_executor: Arc::new(MediaErrNetworking::new(test_type)),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
 }

--- a/wp_com_e2e/src/api_root_tests.rs
+++ b/wp_com_e2e/src/api_root_tests.rs
@@ -28,6 +28,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
             request_executor: Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60))),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     );
 

--- a/wp_com_e2e/src/context.rs
+++ b/wp_com_e2e/src/context.rs
@@ -41,6 +41,7 @@ impl TestContext {
             request_executor: Arc::new(ReqwestRequestExecutor::new(false, Duration::from_secs(60))),
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         };
 
         let client = WpComApiClient::new(delegate.clone());

--- a/wp_derive_request_builder/src/generate.rs
+++ b/wp_derive_request_builder/src/generate.rs
@@ -226,7 +226,7 @@ fn generate_async_request_executor(
             pub fn new(api_url_resolver: #static_api_url_resolver, delegate: #static_delegate_type) -> Self {
                 Self {
                     api_url_resolver: api_url_resolver.clone(),
-                    request_builder: #generated_request_builder_ident::new(api_url_resolver, delegate.auth_provider.clone()),
+                    request_builder: #generated_request_builder_ident::new(api_url_resolver, delegate.auth_provider.clone(), delegate.language_provider.clone()),
                     delegate,
                 }
             }
@@ -259,6 +259,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
     let static_api_url_resolver = &config.static_types.api_url_resolver;
     let static_inner_request_builder_type = &config.static_types.inner_request_builder;
     let static_auth_provider_type = &config.static_types.auth_provider;
+    let static_language_provider = &config.static_types.language_provider;
     let static_wp_network_request_type = &config.static_types.wp_network_request;
     let static_wp_multipart_form_request_type = &config.static_types.wp_multipart_form_request;
     let generated_endpoint_ident = &config.generated_idents.endpoint;
@@ -317,9 +318,13 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
             inner: #static_inner_request_builder_type,
         }
         impl #generated_request_builder_ident {
-            pub fn new(api_url_resolver: #static_api_url_resolver, auth_provider: #static_auth_provider_type) -> Self {
+            pub fn new(
+                api_url_resolver: #static_api_url_resolver,
+                auth_provider: #static_auth_provider_type,
+                language_provider: #static_language_provider,
+            ) -> Self {
                 Self {
-                    endpoint: #generated_endpoint_ident::new(api_url_resolver),
+                    endpoint: #generated_endpoint_ident::with_language_provider(api_url_resolver, language_provider),
                     inner: #static_inner_request_builder_type::new(auth_provider),
                 }
             }
@@ -333,6 +338,7 @@ fn generate_request_builder(config: &Config, parsed_enum: &ParsedEnum) -> TokenS
 fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStream {
     let static_api_url_resolver = &config.static_types.api_url_resolver;
     let static_api_endpoint_url_type = &config.static_types.api_endpoint_url;
+    let static_language_provider = &config.static_types.language_provider;
     let generated_endpoint_ident = &config.generated_idents.endpoint;
 
     let functions = parsed_enum.variants.iter().map(|variant| {
@@ -348,6 +354,8 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
             fn_body_query_pairs(&config.crate_ident, params_type.as_ref(), request_type);
         let additional_query_pairs =
             fn_body_additional_query_pairs(&parsed_enum.enum_ident, &variant.variant_ident);
+        let locale_query_pair =
+            fn_body_locale_query_pair(&parsed_enum.enum_ident, &variant.variant_ident);
 
         ContextAndFilterHandler::from_request_type(
             request_type,
@@ -371,6 +379,9 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
             quote! {
                 pub #fn_signature -> #static_api_endpoint_url_type {
                     #url_from_api_url_resolver
+                    // Appended before the request's own params so that an endpoint
+                    // declaring its own locale parameter overrides this one.
+                    #locale_query_pair
                     #context_query_pair
                     #query_pairs
                     #additional_query_pairs
@@ -385,11 +396,20 @@ fn generate_endpoint_type(config: &Config, parsed_enum: &ParsedEnum) -> TokenStr
     quote! {
         pub struct #generated_endpoint_ident {
             api_url_resolver: #static_api_url_resolver,
+            language_provider: #static_language_provider,
         }
 
         impl #generated_endpoint_ident {
+            /// Builds URLs without a locale query parameter, whatever the namespace.
             pub fn new(api_url_resolver: #static_api_url_resolver) -> Self {
-                Self { api_url_resolver }
+                Self { api_url_resolver, language_provider: None }
+            }
+
+            pub fn with_language_provider(
+                api_url_resolver: #static_api_url_resolver,
+                language_provider: #static_language_provider,
+            ) -> Self {
+                Self { api_url_resolver, language_provider }
             }
 
             #(#functions)*
@@ -521,6 +541,7 @@ pub struct ConfigStaticTypes {
     pub api_endpoint_url: TokenStream,
     pub inner_request_builder: TokenStream,
     pub auth_provider: TokenStream,
+    pub language_provider: TokenStream,
     pub wp_network_request: TokenStream,
     pub wp_multipart_form_request: TokenStream,
 }
@@ -532,6 +553,7 @@ impl ConfigStaticTypes {
             api_endpoint_url: quote! { #crate_ident::request::endpoint::ApiEndpointUrl },
             inner_request_builder: quote! { #crate_ident::request::InnerRequestBuilder },
             auth_provider: quote! { std::sync::Arc<#crate_ident::auth::WpAuthenticationProvider> },
+            language_provider: quote! { Option<std::sync::Arc<dyn #crate_ident::wp_com::language::WpComLanguageProvider>> },
             wp_network_request: quote! { #crate_ident::request::WpNetworkRequest },
             wp_multipart_form_request: quote! { #crate_ident::request::WpMultipartFormRequest },
         }

--- a/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
+++ b/wp_derive_request_builder/src/generate/helpers_to_generate_tokens.rs
@@ -356,6 +356,27 @@ pub fn fn_body_additional_query_pairs(enum_ident: &Ident, variant_ident: &Ident)
     }
 }
 
+/// Appends the locale query parameter for namespaces that read one, using the name
+/// the namespace asks for and the language the client's provider returns.
+///
+/// Expands to a no-op at runtime for namespaces without a locale parameter, which
+/// includes every WordPress.org namespace.
+pub fn fn_body_locale_query_pair(enum_ident: &Ident, variant_ident: &Ident) -> TokenStream {
+    quote! {
+        if let Some(locale_param_name) =
+            #enum_ident::namespace(&#enum_ident::#variant_ident).locale_param_name()
+        {
+            if let Some(language) = self
+                .language_provider
+                .as_ref()
+                .and_then(|provider| provider.current_language())
+            {
+                url.query_pairs_mut().append_pair(locale_param_name, language.slug_str());
+            }
+        }
+    }
+}
+
 pub fn fn_body_fields_query_pairs(
     crate_ident: &Ident,
     context_and_filter_handler: &ContextAndFilterHandler,

--- a/wp_mobile/src/service/media.rs
+++ b/wp_mobile/src/service/media.rs
@@ -1000,6 +1000,7 @@ mod tests {
                 request_executor: mock_executor,
                 middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
                 app_notifier: Arc::new(EmptyAppNotifier),
+                language_provider: None,
             },
         ));
 

--- a/wp_mobile/src/service/posts.rs
+++ b/wp_mobile/src/service/posts.rs
@@ -1406,6 +1406,7 @@ mod tests {
                 request_executor: mock_executor,
                 middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
                 app_notifier: Arc::new(EmptyAppNotifier),
+                language_provider: None,
             },
         ));
 

--- a/wp_mobile/src/testing/test_fixtures.rs
+++ b/wp_mobile/src/testing/test_fixtures.rs
@@ -84,6 +84,7 @@ pub fn mock_api_client() -> Arc<WpApiClient> {
             request_executor: mock_executor,
             middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
             app_notifier: Arc::new(EmptyAppNotifier),
+            language_provider: None,
         },
     )
     .into()

--- a/wp_mobile_integration_tests/src/lib.rs
+++ b/wp_mobile_integration_tests/src/lib.rs
@@ -32,6 +32,7 @@ pub fn api_client_delegate() -> WpApiClientDelegate {
         request_executor: Arc::new(ReqwestRequestExecutor::default()),
         middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
         app_notifier: Arc::new(EmptyAppNotifier),
+        language_provider: None,
     }
 }
 
@@ -101,6 +102,7 @@ pub fn create_test_context_with_site(
         request_executor: Arc::new(ReqwestRequestExecutor::default()),
         middleware_pipeline: Arc::new(WpApiMiddlewarePipeline::default()),
         app_notifier: Arc::new(EmptyAppNotifier),
+        language_provider: None,
     };
 
     let cache = Arc::new(WpApiCache::new(None).expect("Failed to create in-memory cache"));

--- a/wp_rs_cli/src/bin/wp_rs_cli/main.rs
+++ b/wp_rs_cli/src/bin/wp_rs_cli/main.rs
@@ -432,6 +432,7 @@ async fn build_api_client(args: &AuthArgs, url: &Option<String>) -> Result<WpApi
             request_executor,
             middleware_pipeline,
             app_notifier: Arc::new(CliAppNotifier),
+            language_provider: None,
         },
     ))
 }


### PR DESCRIPTION
## Description

WordPress.com localizes a response when the request carries a locale query parameter. Nothing in the generated request builders sent one, so a handful of endpoints picked it up only because they happened to declare `locale` in their own params type, and the rest sent nothing.

If you'd like to see this in action, please see https://github.com/wordpress-mobile/WordPress-Android/pull/23265 to see how it's being integrated. Feel free to follow the testing instructions in that PR to validate that the locale is being sent as expected.

## Changes

- `AsNamespace` gained `locale_param_name`, defaulting to `None`. `WpComNamespace` overrides it: `locale` for `/rest/v1.1`, `/rest/v1.2` and `/rest/v1.3`, `_locale` for `/wpcom/v2`, none for `/oauth2`. Every other namespace inherits the default, so WordPress.org and Jetpack are unaffected without opting out.
- New `WpComLanguageProvider` trait (`#[uniffi::export(with_foreign)]`), carried on `WpApiClientDelegate.language_provider` and threaded through the generated request executor and builder. It's asked once per request, so a client returning a live value needs no invalidation when the language changes.
- `WpDerivedRequest` codegen appends the pair after resolving the URL and *before* the request's own params, so an endpoint declaring `locale` still takes precedence.
- The generated endpoint type gained a `with_language_provider` constructor; `new` continues to build URLs without a locale.

Tests cover v1.1/v1.2/v1.3 and `/wpcom/v2`, a provider returning no language, precedence over an endpoint's own parameter, and a WordPress.org endpoint handed a provider sending no locale.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.