### PR TITLE
Remove the per-endpoint locale parameter from WordPress.com requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Support-bot message sources (`BotMessageContextSource`) now parse when the bot only returns `title`, `content`, and `url`. Some bots (e.g. `jetpack-workflow-chat_mobile_support`) omit `heading`, `blog_id`, `post_id`, `score`, and `last_indexed_at`, which previously failed the untagged `MessageContext` match and aborted parsing of the whole conversation response. Those five fields plus `url` are now optional (`Option<...>`), so binding consumers reading them as non-null must handle the nullable type.
 
+### Removed
+
+- **BREAKING:** The per-endpoint `locale` parameter is gone from every WordPress.com params type that carried one — `ProductsParams`, `SitePlansParams`, and the `Stats*Params` types. The locale now comes from the client's `WpComLanguageProvider`, so drop the field from any call site that sets it. `StatsSummaryParams`, `StatsInsightsParams` and `LanguagesGetParams` held nothing else and are removed entirely, so `get_stats_summary`, `get_stats_insights` and the languages `get` no longer take a params argument.
+
 ### Changed
 
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.

--- a/native/swift/Sources/wordpress-api/Exports.swift
+++ b/native/swift/Sources/wordpress-api/Exports.swift
@@ -302,7 +302,6 @@ public typealias WpComSiteIdentifier = WordPressAPIInternal.WpComSiteIdentifier
 
 // MARK: Languages
 public typealias WPComLanguage = WordPressAPIInternal.WpComLanguage
-public typealias LanguagesGetParams = WordPressAPIInternal.LanguagesGetParams
 
 // MARK: Subscribers
 public typealias SubscribersListParams = WordPressAPIInternal.SubscribersListParams

--- a/wp_api/src/wp_com/endpoint/languages_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/languages_endpoint.rs
@@ -1,4 +1,4 @@
-use crate::wp_com::language::{LanguagesGetParams, WpComRemoteLanguageMap};
+use crate::wp_com::language::WpComRemoteLanguageMap;
 use crate::{
     request::endpoint::{AsNamespace, DerivedRequest},
     wp_com::WpComNamespace,
@@ -7,7 +7,7 @@ use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum LanguagesRequest {
-    #[get(url = "/i18n/language-names", params = &LanguagesGetParams, output = WpComRemoteLanguageMap)]
+    #[get(url = "/i18n/language-names", output = WpComRemoteLanguageMap)]
     Get,
 }
 
@@ -40,27 +40,6 @@ mod tests {
             fixture_wp_com_api_url_resolver,
             language_provider(Some(WPComLanguage::Spanish)),
         );
-        validate_wp_com_v2_endpoint(
-            endpoint.get(&LanguagesGetParams::default()),
-            "/i18n/language-names?_locale=es",
-        );
-    }
-
-    #[rstest]
-    fn request_params_override_the_provider(
-        fixture_wp_com_api_url_resolver: Arc<dyn ApiUrlResolver>,
-    ) {
-        // `LanguagesGetParams` declares its own `_locale`, so both are on the URL.
-        // The parameter appended last is the one the server reads.
-        let endpoint = LanguagesRequestEndpoint::with_language_provider(
-            fixture_wp_com_api_url_resolver,
-            language_provider(Some(WPComLanguage::Spanish)),
-        );
-        validate_wp_com_v2_endpoint(
-            endpoint.get(&LanguagesGetParams {
-                locale: Some(WPComLanguage::Japanese),
-            }),
-            "/i18n/language-names?_locale=es&_locale=ja",
-        );
+        validate_wp_com_v2_endpoint(endpoint.get(), "/i18n/language-names?_locale=es");
     }
 }

--- a/wp_api/src/wp_com/endpoint/products_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/products_endpoint.rs
@@ -28,7 +28,6 @@ mod tests {
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_1_endpoint,
             },
-            language::WPComLanguage,
             products::{ProductTypeFilter, ProductsParams},
         },
     };
@@ -45,7 +44,6 @@ mod tests {
         validate_wp_com_rest_v1_1_endpoint(
             endpoint.list(&ProductsParams {
                 product_type: Some(ProductTypeFilter::Domains),
-                ..Default::default()
             }),
             "/products?type=domains",
         );
@@ -56,7 +54,6 @@ mod tests {
         validate_wp_com_rest_v1_1_endpoint(
             endpoint.list(&ProductsParams {
                 product_type: Some(ProductTypeFilter::Jetpack),
-                ..Default::default()
             }),
             "/products?type=jetpack",
         );
@@ -69,31 +66,8 @@ mod tests {
                 product_type: Some(ProductTypeFilter::Other {
                     value: "theme".to_string(),
                 }),
-                ..Default::default()
             }),
             "/products?type=theme",
-        );
-    }
-
-    #[rstest]
-    fn list_with_locale(endpoint: ProductsRequestEndpoint) {
-        validate_wp_com_rest_v1_1_endpoint(
-            endpoint.list(&ProductsParams {
-                locale: Some(WPComLanguage::Spanish),
-                ..Default::default()
-            }),
-            "/products?locale=es",
-        );
-    }
-
-    #[rstest]
-    fn list_with_type_and_locale(endpoint: ProductsRequestEndpoint) {
-        validate_wp_com_rest_v1_1_endpoint(
-            endpoint.list(&ProductsParams {
-                product_type: Some(ProductTypeFilter::Domains),
-                locale: Some(WPComLanguage::Japanese),
-            }),
-            "/products?type=domains&locale=ja",
         );
     }
 

--- a/wp_api/src/wp_com/endpoint/site_plans_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/site_plans_endpoint.rs
@@ -29,7 +29,6 @@ mod tests {
             endpoint::tests::{
                 fixture_wp_com_api_url_resolver, validate_wp_com_rest_v1_3_endpoint,
             },
-            language::WPComLanguage,
         },
     };
     use rstest::*;
@@ -50,44 +49,15 @@ mod tests {
     }
 
     #[rstest]
-    fn list_with_locale(endpoint: SitePlansRequestEndpoint) {
-        validate_wp_com_rest_v1_3_endpoint(
-            endpoint.list(
-                &WpComSiteId(12345),
-                &SitePlansParams {
-                    locale: Some(WPComLanguage::Spanish),
-                    ..Default::default()
-                },
-            ),
-            "/sites/12345/plans?locale=es",
-        );
-    }
-
-    #[rstest]
     fn list_with_coupon_code(endpoint: SitePlansRequestEndpoint) {
         validate_wp_com_rest_v1_3_endpoint(
             endpoint.list(
                 &WpComSiteId(12345),
                 &SitePlansParams {
                     coupon_code: Some(CouponCode("SPRING25".to_string())),
-                    ..Default::default()
                 },
             ),
             "/sites/12345/plans?coupon_code=SPRING25",
-        );
-    }
-
-    #[rstest]
-    fn list_with_locale_and_coupon_code(endpoint: SitePlansRequestEndpoint) {
-        validate_wp_com_rest_v1_3_endpoint(
-            endpoint.list(
-                &WpComSiteId(12345),
-                &SitePlansParams {
-                    locale: Some(WPComLanguage::Japanese),
-                    coupon_code: Some(CouponCode("SPRING25".to_string())),
-                },
-            ),
-            "/sites/12345/plans?locale=ja&coupon_code=SPRING25",
         );
     }
 

--- a/wp_api/src/wp_com/endpoint/stats_insights_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_insights_endpoint.rs
@@ -1,15 +1,12 @@
 use crate::{
     request::endpoint::{AsNamespace, DerivedRequest},
-    wp_com::{
-        WpComNamespace, WpComSiteId,
-        stats_insights::{StatsInsightsParams, StatsInsightsResponse},
-    },
+    wp_com::{WpComNamespace, WpComSiteId, stats_insights::StatsInsightsResponse},
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum StatsInsightsRequest {
-    #[get(url = "/sites/<wp_com_site_id>/stats/insights", params = &StatsInsightsParams, output = StatsInsightsResponse)]
+    #[get(url = "/sites/<wp_com_site_id>/stats/insights", output = StatsInsightsResponse)]
     GetStatsInsights,
 }
 

--- a/wp_api/src/wp_com/endpoint/stats_summary_endpoint.rs
+++ b/wp_api/src/wp_com/endpoint/stats_summary_endpoint.rs
@@ -1,15 +1,12 @@
 use crate::{
     request::endpoint::{AsNamespace, DerivedRequest},
-    wp_com::{
-        WpComNamespace, WpComSiteId,
-        stats_summary::{StatsSummaryParams, StatsSummaryResponse},
-    },
+    wp_com::{WpComNamespace, WpComSiteId, stats_summary::StatsSummaryResponse},
 };
 use wp_derive_request_builder::WpDerivedRequest;
 
 #[derive(WpDerivedRequest)]
 enum StatsSummaryRequest {
-    #[get(url = "/sites/<wp_com_site_id>/stats", params = &StatsSummaryParams, output = StatsSummaryResponse)]
+    #[get(url = "/sites/<wp_com_site_id>/stats", output = StatsSummaryResponse)]
     GetStatsSummary,
 }
 

--- a/wp_api/src/wp_com/language.rs
+++ b/wp_api/src/wp_com/language.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Debug};
 
-use crate::url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension};
+use crate::url_query::AsQueryValue;
 use serde::{Deserialize, Serialize};
 
 // This file is optimized for really fast code, not to be pretty. Between the compiler
@@ -29,21 +29,6 @@ pub struct WpComRemoteLanguage {
 }
 
 pub type WpComRemoteLanguageMap = HashMap<String, WpComRemoteLanguage>;
-
-/// Parameters for fetching language names from the WordPress.com API.
-#[derive(Debug, Default, Serialize, uniffi::Record)]
-pub struct LanguagesGetParams {
-    /// The locale to use for returning language names.
-    /// When specified, language names will be returned in this locale.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
-}
-
-impl AppendUrlQueryPairs for LanguagesGetParams {
-    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut.append_option_query_value_pair("_locale", self.locale.as_ref());
-    }
-}
 
 /// WordPress.com language codes with their IDs as discriminants
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, uniffi::Enum)]
@@ -1568,43 +1553,5 @@ mod tests {
                 id
             );
         }
-    }
-
-    #[test]
-    fn test_languages_get_params_with_english_locale() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/wpcom/v2/i18n/language-names")
-                .expect("Failed to parse url");
-
-        let params = LanguagesGetParams {
-            locale: Some(WPComLanguage::English),
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/wpcom/v2/i18n/language-names?_locale=en"
-        );
-    }
-
-    #[test]
-    fn test_languages_get_params_with_portuguese_brazil_locale() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/wpcom/v2/i18n/language-names")
-                .expect("Failed to parse url");
-
-        let params = LanguagesGetParams {
-            locale: Some(WPComLanguage::PortugueseBrazil),
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/wpcom/v2/i18n/language-names?_locale=pt-br"
-        );
     }
 }

--- a/wp_api/src/wp_com/products.rs
+++ b/wp_api/src/wp_com/products.rs
@@ -2,7 +2,7 @@ use crate::{
     date::WpGmtDateTime,
     decimal2::Decimal2,
     url_query::{AppendUrlQueryPairs, AsQueryValue, QueryPairs, QueryPairsExtension},
-    wp_com::{CurrencyCode, TimeSpanUnit, language::WPComLanguage},
+    wp_com::{CurrencyCode, TimeSpanUnit},
     wp_content_string_id,
 };
 use serde::{Deserialize, Serialize};
@@ -119,16 +119,11 @@ pub struct ProductsParams {
     /// Filter by product type.
     #[uniffi(default = None)]
     pub product_type: Option<ProductTypeFilter>,
-    /// Locale for localized product names and descriptions.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
 }
 
 impl AppendUrlQueryPairs for ProductsParams {
     fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut
-            .append_option_query_value_pair("type", self.product_type.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref());
+        query_pairs_mut.append_option_query_value_pair("type", self.product_type.as_ref());
     }
 }
 

--- a/wp_api/src/wp_com/site_plans.rs
+++ b/wp_api/src/wp_com/site_plans.rs
@@ -4,7 +4,6 @@ use crate::{
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
     wp_com::{
         CostOverrideCode, CouponCode, CurrencyCode, TimeSpanUnit,
-        language::WPComLanguage,
         products::{BillPeriodDays, ProductId, ProductSlug, ProductTierId},
         purchases::PurchaseId,
     },
@@ -18,10 +17,6 @@ wp_content_string_id!(PlanFeatureKey);
 /// Query parameters for `GET /sites/<site_id>/plans`.
 #[derive(Debug, Default, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct SitePlansParams {
-    /// Locale for the response's translated strings — taglines, badges, feature
-    /// titles and discount reasons.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Coupon code to price the plans with. Plans the coupon doesn't apply to
     /// are returned at their normal price.
     #[uniffi(default = None)]
@@ -30,9 +25,7 @@ pub struct SitePlansParams {
 
 impl AppendUrlQueryPairs for SitePlansParams {
     fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut
-            .append_option_query_value_pair("locale", self.locale.as_ref())
-            .append_option_query_value_pair("coupon_code", self.coupon_code.as_ref());
+        query_pairs_mut.append_option_query_value_pair("coupon_code", self.coupon_code.as_ref());
     }
 }
 

--- a/wp_api/src/wp_com/stats_city_views.rs
+++ b/wp_api/src/wp_com/stats_city_views.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -57,9 +56,6 @@ pub struct StatsCityViewsParams {
     /// The number of days to include in the response.
     #[uniffi(default = None)]
     pub days: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated city
@@ -80,7 +76,6 @@ impl Default for StatsCityViewsParams {
             max: None,
             num: None,
             days: None,
-            locale: None,
             summarize: true,
         }
     }
@@ -95,7 +90,6 @@ impl AppendUrlQueryPairs for StatsCityViewsParams {
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("days", self.days.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32));
     }
 }
@@ -198,7 +192,6 @@ mod tests {
             max: Some(10),
             num: Some(1),
             days: Some(1),
-            locale: Some(WPComLanguage::English),
             summarize: true,
         };
 
@@ -207,7 +200,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/city?period=day&date=2026-02-05&start_date=2026-01-30&max=10&num=1&days=1&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/city?period=day&date=2026-02-05&start_date=2026-01-30&max=10&num=1&days=1&summarize=1"
         );
     }
 
@@ -222,7 +215,6 @@ mod tests {
             period: Some(StatsCityViewsPeriod::Day),
             date: Some(WpDateString::new("2026-02-05".to_string())),
             start_date: Some(WpDateString::new("2026-01-30".to_string())),
-            locale: Some(WPComLanguage::English),
             ..Default::default()
         };
 
@@ -231,7 +223,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/city?period=day&date=2026-02-05&start_date=2026-01-30&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/city?period=day&date=2026-02-05&start_date=2026-01-30&summarize=1"
         );
     }
 

--- a/wp_api/src/wp_com/stats_clicks.rs
+++ b/wp_api/src/wp_com/stats_clicks.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsClicksParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -78,7 +74,6 @@ impl Default for StatsClicksParams {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         }
@@ -93,7 +88,6 @@ impl AppendUrlQueryPairs for StatsClicksParams {
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
@@ -181,7 +175,6 @@ mod tests {
             start_date: Some(WpDateString::new("2026-02-18".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             skip_archives: true,
         };
@@ -191,7 +184,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/clicks?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&summarize=1&skip_archives=1"
         );
     }
 
@@ -207,7 +200,6 @@ mod tests {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         };

--- a/wp_api/src/wp_com/stats_country_views.rs
+++ b/wp_api/src/wp_com/stats_country_views.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -57,9 +56,6 @@ pub struct StatsCountryViewsParams {
     /// The number of days to include in the response.
     #[uniffi(default = None)]
     pub days: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated country
@@ -80,7 +76,6 @@ impl Default for StatsCountryViewsParams {
             max: None,
             num: None,
             days: None,
-            locale: None,
             summarize: true,
         }
     }
@@ -95,7 +90,6 @@ impl AppendUrlQueryPairs for StatsCountryViewsParams {
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("days", self.days.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32));
     }
 }
@@ -187,7 +181,6 @@ mod tests {
             max: Some(10),
             num: Some(1),
             days: Some(1),
-            locale: Some(WPComLanguage::English),
             summarize: true,
         };
 
@@ -196,7 +189,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/country-views?period=day&date=2026-01-29&start_date=2026-01-29&max=10&num=1&days=1&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/country-views?period=day&date=2026-01-29&start_date=2026-01-29&max=10&num=1&days=1&summarize=1"
         );
     }
 
@@ -211,7 +204,6 @@ mod tests {
             period: Some(StatsCountryViewsPeriod::Day),
             date: Some(WpDateString::new("2026-01-29".to_string())),
             start_date: Some(WpDateString::new("2026-01-23".to_string())),
-            locale: Some(WPComLanguage::English),
             ..Default::default()
         };
 
@@ -221,7 +213,7 @@ mod tests {
         // Default summarize is true, which serializes to summarize=1
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/country-views?period=day&date=2026-01-29&start_date=2026-01-23&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/country-views?period=day&date=2026-01-29&start_date=2026-01-23&summarize=1"
         );
     }
 

--- a/wp_api/src/wp_com/stats_file_downloads.rs
+++ b/wp_api/src/wp_com/stats_file_downloads.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsFileDownloadsParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -78,7 +74,6 @@ impl Default for StatsFileDownloadsParams {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         }
@@ -93,7 +88,6 @@ impl AppendUrlQueryPairs for StatsFileDownloadsParams {
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
@@ -169,7 +163,6 @@ mod tests {
             start_date: Some(WpDateString::new("2026-02-18".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             skip_archives: true,
         };
@@ -179,7 +172,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/file-downloads?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&summarize=1&skip_archives=1"
         );
     }
 
@@ -196,7 +189,6 @@ mod tests {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         };

--- a/wp_api/src/wp_com/stats_insights.rs
+++ b/wp_api/src/wp_com/stats_insights.rs
@@ -1,7 +1,3 @@
-use crate::{
-    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
-};
 use serde::{
     Deserialize, Serialize,
     de::{self, DeserializeOwned},
@@ -26,20 +22,6 @@ where
         serde_json::from_value(serde_json::Value::Object(map)).map_err(de::Error::custom)
     } else {
         Ok(HashMap::new())
-    }
-}
-
-/// Parameters for the stats insights endpoint.
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
-pub struct StatsInsightsParams {
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
-}
-
-impl AppendUrlQueryPairs for StatsInsightsParams {
-    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut.append_option_query_value_pair("locale", self.locale.as_ref());
     }
 }
 
@@ -99,42 +81,6 @@ pub struct StatsInsightsYearData {
 mod tests {
     use super::*;
     use rstest::*;
-
-    #[test]
-    fn test_stats_insights_params_serialization_with_locale() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/insights")
-                .expect("Failed to parse url");
-
-        let params = StatsInsightsParams {
-            locale: Some(WPComLanguage::Spanish),
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/insights?locale=es"
-        );
-    }
-
-    #[test]
-    fn test_stats_insights_params_serialization_default() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/insights")
-                .expect("Failed to parse url");
-
-        let params = StatsInsightsParams::default();
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/insights?"
-        );
-    }
 
     #[test]
     fn test_stats_insights_response_deserialization() {

--- a/wp_api/src/wp_com/stats_referrers.rs
+++ b/wp_api/src/wp_com/stats_referrers.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsReferrersParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -79,7 +75,6 @@ impl Default for StatsReferrersParams {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: Some(true),
         }
@@ -94,7 +89,6 @@ impl AppendUrlQueryPairs for StatsReferrersParams {
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_option_query_value_pair(
                 "skip_archives",
@@ -274,7 +268,6 @@ mod tests {
             start_date: Some(WpDateString::new("2026-01-26".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             skip_archives: Some(true),
         };
@@ -284,7 +277,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/referrers?period=day&date=2026-01-26&start_date=2026-01-26&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/referrers?period=day&date=2026-01-26&start_date=2026-01-26&max=10&num=30&summarize=1&skip_archives=1"
         );
     }
 
@@ -301,7 +294,6 @@ mod tests {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: Some(true),
         };

--- a/wp_api/src/wp_com/stats_region_views.rs
+++ b/wp_api/src/wp_com/stats_region_views.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -57,9 +56,6 @@ pub struct StatsRegionViewsParams {
     /// The number of days to include in the response.
     #[uniffi(default = None)]
     pub days: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated region
@@ -80,7 +76,6 @@ impl Default for StatsRegionViewsParams {
             max: None,
             num: None,
             days: None,
-            locale: None,
             summarize: true,
         }
     }
@@ -95,7 +90,6 @@ impl AppendUrlQueryPairs for StatsRegionViewsParams {
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
             .append_option_query_value_pair("days", self.days.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32));
     }
 }
@@ -187,7 +181,6 @@ mod tests {
             max: Some(10),
             num: Some(1),
             days: Some(1),
-            locale: Some(WPComLanguage::English),
             summarize: true,
         };
 
@@ -196,7 +189,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/region?period=day&date=2026-02-05&start_date=2026-01-30&max=10&num=1&days=1&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/region?period=day&date=2026-02-05&start_date=2026-01-30&max=10&num=1&days=1&summarize=1"
         );
     }
 
@@ -211,7 +204,6 @@ mod tests {
             period: Some(StatsRegionViewsPeriod::Day),
             date: Some(WpDateString::new("2026-02-05".to_string())),
             start_date: Some(WpDateString::new("2026-01-30".to_string())),
-            locale: Some(WPComLanguage::English),
             ..Default::default()
         };
 
@@ -220,7 +212,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/region?period=day&date=2026-02-05&start_date=2026-01-30&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/location-views/region?period=day&date=2026-02-05&start_date=2026-01-30&summarize=1"
         );
     }
 

--- a/wp_api/src/wp_com/stats_search_terms.rs
+++ b/wp_api/src/wp_com/stats_search_terms.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsSearchTermsParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -78,7 +74,6 @@ impl Default for StatsSearchTermsParams {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         }
@@ -93,7 +88,6 @@ impl AppendUrlQueryPairs for StatsSearchTermsParams {
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_query_value_pair("skip_archives", &(self.skip_archives as u32));
     }
@@ -169,7 +163,6 @@ mod tests {
             start_date: Some(WpDateString::new("2026-02-18".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             skip_archives: true,
         };
@@ -179,7 +172,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/search-terms?period=day&date=2026-02-18&start_date=2026-02-18&max=10&num=30&summarize=1&skip_archives=1"
         );
     }
 
@@ -196,7 +189,6 @@ mod tests {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: true,
         };

--- a/wp_api/src/wp_com/stats_summary.rs
+++ b/wp_api/src/wp_com/stats_summary.rs
@@ -1,23 +1,8 @@
 use crate::{
     date::{WpDateString, WpGmtDateTime, deserialize_optional_wp_gmt_date_time},
-    url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::{language::WPComLanguage, stats_visits::StatsVisitsResponse},
+    wp_com::stats_visits::StatsVisitsResponse,
 };
 use serde::{Deserialize, Serialize};
-
-/// Parameters for the stats summary endpoint.
-#[derive(Debug, Default, PartialEq, Eq, uniffi::Record)]
-pub struct StatsSummaryParams {
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
-}
-
-impl AppendUrlQueryPairs for StatsSummaryParams {
-    fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut.append_option_query_value_pair("locale", self.locale.as_ref());
-    }
-}
 
 /// Response from the stats summary endpoint.
 ///
@@ -85,42 +70,6 @@ pub struct StatsSummaryStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_stats_summary_params_serialization_with_locale() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats")
-                .expect("Failed to parse url");
-
-        let params = StatsSummaryParams {
-            locale: Some(WPComLanguage::Spanish),
-        };
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats?locale=es"
-        );
-    }
-
-    #[test]
-    fn test_stats_summary_params_serialization_default() {
-        let mut url =
-            url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats")
-                .expect("Failed to parse url");
-
-        let params = StatsSummaryParams::default();
-
-        let mut query_pairs = url.query_pairs_mut();
-        params.append_query_pairs(&mut query_pairs);
-
-        assert_eq!(
-            query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats?"
-        );
-    }
 
     #[test]
     fn test_stats_summary_response_deserialization() {

--- a/wp_api/src/wp_com/stats_tags.rs
+++ b/wp_api/src/wp_com/stats_tags.rs
@@ -1,7 +1,6 @@
 use crate::{
     date::WpDateString,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,16 +10,11 @@ pub struct StatsTagsParams {
     /// The maximum number of tags to return.
     #[uniffi(default = None)]
     pub max: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
 }
 
 impl AppendUrlQueryPairs for StatsTagsParams {
     fn append_query_pairs(&self, query_pairs_mut: &mut QueryPairs) {
-        query_pairs_mut
-            .append_option_query_value_pair("max", self.max.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref());
+        query_pairs_mut.append_option_query_value_pair("max", self.max.as_ref());
     }
 }
 
@@ -64,17 +58,14 @@ mod tests {
             url::Url::parse("https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/tags")
                 .expect("Failed to parse url");
 
-        let params = StatsTagsParams {
-            max: Some(7),
-            locale: Some(WPComLanguage::English),
-        };
+        let params = StatsTagsParams { max: Some(7) };
 
         let mut query_pairs = url.query_pairs_mut();
         params.append_query_pairs(&mut query_pairs);
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/tags?max=7&locale=en"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/tags?max=7"
         );
     }
 

--- a/wp_api/src/wp_com/stats_top_authors.rs
+++ b/wp_api/src/wp_com/stats_top_authors.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsTopAuthorsParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -72,7 +68,6 @@ impl Default for StatsTopAuthorsParams {
             date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
         }
     }
@@ -86,7 +81,6 @@ impl AppendUrlQueryPairs for StatsTopAuthorsParams {
             .append_option_query_value_pair("date", self.date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32));
     }
 }
@@ -215,7 +209,6 @@ mod tests {
             date: Some(WpDateString::new("2026-02-05".to_string())),
             max: Some(10),
             num: Some(7),
-            locale: Some(WPComLanguage::English),
             summarize: true,
         };
 
@@ -224,7 +217,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/top-authors?period=day&start_date=2026-01-30&date=2026-02-05&max=10&num=7&locale=en&summarize=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/top-authors?period=day&start_date=2026-01-30&date=2026-02-05&max=10&num=7&summarize=1"
         );
     }
 
@@ -241,7 +234,6 @@ mod tests {
             date: Some(WpDateString::new("2026-02-05".to_string())),
             max: None,
             num: None,
-            locale: None,
             summarize: true,
         };
 
@@ -286,7 +278,6 @@ mod tests {
         assert!(params.start_date.is_none());
         assert!(params.max.is_none());
         assert!(params.num.is_none());
-        assert!(params.locale.is_none());
     }
 
     #[rstest]

--- a/wp_api/src/wp_com/stats_top_posts.rs
+++ b/wp_api/src/wp_com/stats_top_posts.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -53,9 +52,6 @@ pub struct StatsTopPostsParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains `summary` field with aggregated data
@@ -80,7 +76,6 @@ impl Default for StatsTopPostsParams {
             date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: Some(true),
         }
@@ -95,7 +90,6 @@ impl AppendUrlQueryPairs for StatsTopPostsParams {
             .append_option_query_value_pair("date", self.date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_option_query_value_pair(
                 "skip_archives",
@@ -189,7 +183,6 @@ mod tests {
             date: Some(WpDateString::new("2026-01-26".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             skip_archives: Some(true),
         };
@@ -199,7 +192,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/top-posts?period=day&start_date=2026-01-26&date=2026-01-26&max=10&num=30&locale=en&summarize=1&skip_archives=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/top-posts?period=day&start_date=2026-01-26&date=2026-01-26&max=10&num=30&summarize=1&skip_archives=1"
         );
     }
 
@@ -216,7 +209,6 @@ mod tests {
             date: Some(WpDateString::new("2026-01-19".to_string())),
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             skip_archives: Some(true),
         };

--- a/wp_api/src/wp_com/stats_video_plays.rs
+++ b/wp_api/src/wp_com/stats_video_plays.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -52,9 +51,6 @@ pub struct StatsVideoPlaysParams {
     /// The number of periods to include in the response.
     #[uniffi(default = None)]
     pub num: Option<u32>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
     /// Whether to return a summary of the data.
     ///
     /// - `true` (default): Response contains summarized data
@@ -78,7 +74,6 @@ impl Default for StatsVideoPlaysParams {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             complete_stats: Some(true),
         }
@@ -93,7 +88,6 @@ impl AppendUrlQueryPairs for StatsVideoPlaysParams {
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
             .append_option_query_value_pair("max", self.max.as_ref())
             .append_option_query_value_pair("num", self.num.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref())
             .append_query_value_pair("summarize", &(self.summarize as u32))
             .append_option_query_value_pair(
                 "complete_stats",
@@ -178,7 +172,6 @@ mod tests {
             start_date: Some(WpDateString::new("2026-02-12".to_string())),
             max: Some(10),
             num: Some(30),
-            locale: Some(WPComLanguage::English),
             summarize: true,
             complete_stats: Some(true),
         };
@@ -188,7 +181,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=day&date=2026-02-18&start_date=2026-02-12&max=10&num=30&locale=en&summarize=1&complete_stats=1"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/video-plays?period=day&date=2026-02-18&start_date=2026-02-12&max=10&num=30&summarize=1&complete_stats=1"
         );
     }
 
@@ -205,7 +198,6 @@ mod tests {
             start_date: None,
             max: None,
             num: None,
-            locale: None,
             summarize: true,
             complete_stats: Some(true),
         };

--- a/wp_api/src/wp_com/stats_visits.rs
+++ b/wp_api/src/wp_com/stats_visits.rs
@@ -2,7 +2,6 @@ use crate::{
     date::WpDateString,
     impl_as_query_value_from_to_string,
     url_query::{AppendUrlQueryPairs, QueryPairs, QueryPairsExtension},
-    wp_com::language::WPComLanguage,
 };
 use serde::{Deserialize, Serialize};
 
@@ -82,9 +81,6 @@ pub struct StatsVisitsParams {
     /// When empty, the API returns its default set of fields.
     #[uniffi(default = [])]
     pub stat_fields: Vec<StatsVisitsField>,
-    /// The locale for the response.
-    #[uniffi(default = None)]
-    pub locale: Option<WPComLanguage>,
 }
 
 impl AppendUrlQueryPairs for StatsVisitsParams {
@@ -94,8 +90,7 @@ impl AppendUrlQueryPairs for StatsVisitsParams {
             .append_option_query_value_pair("quantity", self.quantity.as_ref())
             .append_option_query_value_pair("date", self.end_date.as_ref())
             .append_option_query_value_pair("start_date", self.start_date.as_ref())
-            .append_vec_query_value_pair("stat_fields", self.stat_fields.as_ref())
-            .append_option_query_value_pair("locale", self.locale.as_ref());
+            .append_vec_query_value_pair("stat_fields", self.stat_fields.as_ref());
     }
 }
 
@@ -293,7 +288,6 @@ mod tests {
             end_date: Some(WpDateString::new("2025-01-15".to_string())),
             start_date: None,
             stat_fields: vec![],
-            locale: Some(WPComLanguage::English),
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -301,7 +295,7 @@ mod tests {
 
         assert_eq!(
             query_pairs.finish().as_str(),
-            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=hour&quantity=24&date=2025-01-15&locale=en"
+            "https://public-api.wordpress.com/rest/v1.1/sites/1234/stats/visits?unit=hour&quantity=24&date=2025-01-15"
         );
     }
 
@@ -317,7 +311,6 @@ mod tests {
             end_date: None,
             start_date: None,
             stat_fields: vec![],
-            locale: None,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -341,7 +334,6 @@ mod tests {
             end_date: Some(WpDateString::new("2026-07-13".to_string())),
             start_date: Some(WpDateString::new("2025-08-01".to_string())),
             stat_fields: vec![StatsVisitsField::Views, StatsVisitsField::Visitors],
-            locale: None,
         };
 
         let mut query_pairs = url.query_pairs_mut();
@@ -365,7 +357,6 @@ mod tests {
             end_date: None,
             start_date: None,
             stat_fields: vec![],
-            locale: None,
         };
 
         let mut query_pairs = url.query_pairs_mut();

--- a/wp_com_e2e/src/languages_tests.rs
+++ b/wp_com_e2e/src/languages_tests.rs
@@ -1,6 +1,6 @@
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::language::{LanguagesGetParams, WPComLanguage};
+use wp_api::wp_com::language::WPComLanguage;
 
 use crate::context::TestContext;
 
@@ -13,7 +13,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
             ctx.runtime.block_on(async {
                 ctx.client
                     .languages()
-                    .get(&LanguagesGetParams::default())
+                    .get()
                     .await
                     .map_err(|e| e.to_string())?;
                 Ok(())
@@ -28,7 +28,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                 let languages = ctx
                     .client
                     .languages()
-                    .get(&LanguagesGetParams::default())
+                    .get()
                     .await
                     .map_err(|e| e.to_string())?
                     .data;

--- a/wp_com_e2e/src/products_tests.rs
+++ b/wp_com_e2e/src/products_tests.rs
@@ -1,10 +1,7 @@
 use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::{
-    language::WPComLanguage,
-    products::{ProductTypeFilter, ProductsParams},
-};
+use wp_api::wp_com::products::{ProductTypeFilter, ProductsParams};
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     let mut trials = vec![];
@@ -39,7 +36,6 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     .products()
                     .list(&ProductsParams {
                         product_type: Some(ProductTypeFilter::Domains),
-                        ..Default::default()
                     })
                     .await
                     .map_err(|e| e.to_string())?
@@ -74,7 +70,6 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                     .products()
                     .list(&ProductsParams {
                         product_type: Some(ProductTypeFilter::Jetpack),
-                        ..Default::default()
                     })
                     .await
                     .map_err(|e| e.to_string())?
@@ -82,30 +77,6 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
 
                 if products.is_empty() {
                     return Err("expected non-empty jetpack products list".into());
-                }
-
-                Ok(())
-            })
-        }
-    }));
-
-    trials.push(Trial::test("products::list_with_locale", {
-        let ctx = Arc::clone(&ctx);
-        move || {
-            ctx.runtime.block_on(async {
-                let products = ctx
-                    .client
-                    .products()
-                    .list(&ProductsParams {
-                        locale: Some(WPComLanguage::Spanish),
-                        ..Default::default()
-                    })
-                    .await
-                    .map_err(|e| e.to_string())?
-                    .data;
-
-                if products.is_empty() {
-                    return Err("expected non-empty products list with locale".into());
                 }
 
                 Ok(())

--- a/wp_com_e2e/src/site_plans_tests.rs
+++ b/wp_com_e2e/src/site_plans_tests.rs
@@ -1,7 +1,7 @@
 use crate::context::TestContext;
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::{language::WPComLanguage, site_plans::SitePlansParams};
+use wp_api::wp_com::site_plans::SitePlansParams;
 
 pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
     let mut trials = vec![];
@@ -55,33 +55,6 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                 // availability, since there's nothing to transition from.
                 if current[0].transition.is_some() {
                     return Err("the current plan should not report a transition".into());
-                }
-
-                Ok(())
-            })
-        }
-    }));
-
-    trials.push(Trial::test("site_plans::list_with_locale", {
-        let ctx = Arc::clone(&ctx);
-        move || {
-            ctx.runtime.block_on(async {
-                let plans = ctx
-                    .client
-                    .site_plans()
-                    .list(
-                        &site_id,
-                        &SitePlansParams {
-                            locale: Some(WPComLanguage::Spanish),
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                    .map_err(|e| e.to_string())?
-                    .data;
-
-                if plans.is_empty() {
-                    return Err("expected at least one plan with locale".into());
                 }
 
                 Ok(())

--- a/wp_com_e2e/src/stats_insights_tests.rs
+++ b/wp_com_e2e/src/stats_insights_tests.rs
@@ -1,6 +1,6 @@
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::{sites::SitesListParams, stats_insights::StatsInsightsParams};
+use wp_api::wp_com::sites::SitesListParams;
 
 use crate::context::TestContext;
 
@@ -25,7 +25,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                         ctx.runtime.block_on(async {
                             ctx.client
                                 .stats_insights()
-                                .get_stats_insights(&site_id, &StatsInsightsParams::default())
+                                .get_stats_insights(&site_id)
                                 .await
                                 .map_err(|e| e.to_string())?;
                             Ok(())

--- a/wp_com_e2e/src/stats_summary_tests.rs
+++ b/wp_com_e2e/src/stats_summary_tests.rs
@@ -1,6 +1,6 @@
 use libtest_mimic::Trial;
 use std::sync::Arc;
-use wp_api::wp_com::{sites::SitesListParams, stats_summary::StatsSummaryParams};
+use wp_api::wp_com::sites::SitesListParams;
 
 use crate::context::TestContext;
 
@@ -24,7 +24,7 @@ pub fn tests(ctx: Arc<TestContext>) -> Vec<Trial> {
                         ctx.runtime.block_on(async {
                             ctx.client
                                 .stats_summary()
-                                .get_stats_summary(&site_id, &StatsSummaryParams::default())
+                                .get_stats_summary(&site_id)
                                 .await
                                 .map_err(|e| e.to_string())?;
                             Ok(())


### PR DESCRIPTION
## Description

Follow-up to [#1590](https://github.com/Automattic/wordpress-rs/pull/1590).

Now that every WordPress.com request carries a locale from the client's `WpComLanguageProvider`, the endpoints that declared their own `locale` parameter no longer need one — and left in place they'd put the pair on the URL twice.

## Changes

- Dropped the `locale` field and its query pair from `ProductsParams`, `SitePlansParams` and the `Stats*Params` types.
- `StatsSummaryParams`, `StatsInsightsParams` and `LanguagesGetParams` carried nothing else, so they're removed entirely. `get_stats_summary`, `get_stats_insights` and the languages `get` now take one fewer argument.
- Removed the unit and e2e tests that only covered the removed field.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.