### PR TITLE
Fix Android publish failing when the version is already published to S3

### DIFF
--- a/.buildkite/publish-wp-api-android.sh
+++ b/.buildkite/publish-wp-api-android.sh
@@ -13,6 +13,12 @@ cd ./native/kotlin
 # Calculate the version that would be published
 VERSION=$(./gradlew -q -x cargoBuild :api:android:calculateVersionName $(prepare_to_publish_to_s3_params))
 
+# Add meta-data for the published version so we can use it in subsequent steps.
+# Set it from the calculated version, not a file that prepareToPublishToS3 only
+# writes on publish, so it's also correct when the version is already in S3 and
+# the publish below is skipped (matches publish-wp-api-kotlin.sh).
+buildkite-agent meta-data set "PUBLISHED_WP_API_ANDROID_VERSION" "$VERSION"
+
 # Check if this version is already in S3
 IS_PUBLISHED=$(./gradlew -q -x cargoBuild :api:android:isVersionPublishedToS3 \
     --published-group-id=rs.wordpress.api \
@@ -28,6 +34,3 @@ else
         :api:android:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
         :api:android:publish
 fi
-
-# Add meta-data for the published version so we can use it in subsequent steps
-buildkite-agent meta-data set "PUBLISHED_WP_API_ANDROID_VERSION" < ./api/android/build/published-version.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal:** `publish-wp-api-android.sh` sets the `PUBLISHED_WP_API_ANDROID_VERSION` Buildkite meta-data from the calculated `calculateVersionName` value instead of reading `published-version.txt`, which `prepareToPublishToS3` only writes when it actually uploads — so the "already published to S3, skipping" branch left no file and the read failed (build 6345, a release build re-running a version its trunk-merge build had already published).
 - **Internal:** Require pull requests to update `CHANGELOG.md` and warn when code changes do not update `## [Unreleased]`.
 - **Internal:** Build Rust test binaries with `debug = "line-tables-only"` instead of full debug info, via `[profile.test]` in the workspace `Cargo.toml`. This caps the memory a `cargo test` link consumes on CI, where full debug info was losing Buildkite agents. Backtraces still resolve to file and line; a debugger can no longer print locals. Override with `CARGO_PROFILE_TEST_DEBUG=full`.
 - **Internal:** Bumped the pinned stable Rust toolchain from `1.97.1` to `1.98.0` in lockstep across local development, CI, and the web image. No new clippy lints surfaced ([#1436](https://github.com/Automattic/wordpress-rs/issues/1436)).


### PR DESCRIPTION
## Description

Build [6345](https://buildkite.com/automattic/wordpress-rs/builds/6345)'s `Publish rs.wordpress.api:android` step failed — deterministically, on all three attempts — with:

```
Version 'trunk-fd61f4cf…' is already published to S3. Skipping.
.buildkite/publish-wp-api-android.sh: line 33: ./api/android/build/published-version.txt: No such file or directory
🚨 Error: The command exited with status 1
```

`publish-wp-api-android.sh` set `PUBLISHED_WP_API_ANDROID_VERSION` by reading `published-version.txt`, but that file is only written by `:api:android:prepareToPublishToS3` — which is skipped when the version is already in S3. The release build for `fd61f4cf` re-ran a version its trunk-merge build had already published, hit the "Skipping" branch, found no file, and exited 1. Every retry re-hits the same path, so it can't self-recover.

This re-introduces a bug #1201 already fixed for Kotlin: that PR switched `publish-wp-api-kotlin.sh` to export `"$VERSION"`, but #1203 added the Android meta-data line a day later using the old file-read pattern.

The `trunk-fd61f4cf…` artifact is already in S3 (that is *why* the script skipped), so the publish itself succeeded — only the meta-data hand-off to the downstream `Build Example App` step was broken.

## Changes

- `publish-wp-api-android.sh` sets `PUBLISHED_WP_API_ANDROID_VERSION` from the calculated `$VERSION` (`calculateVersionName`), moved above the publish/skip decision. It no longer reads `published-version.txt`, so the value is correct whether the publish runs or is skipped — the failure mode is removed by construction, not worked around. Matches `publish-wp-api-kotlin.sh`; the publish/skip block is otherwise untouched.
- `CHANGELOG.md`: `### Changed` → `**Internal:**` note under `## [Unreleased]`.

## Test plan

- [ ] `Publish rs.wordpress.api:android` is green on this PR. A fresh PR version isn't in S3 yet, so it takes the publish branch and sets the meta-data from `$VERSION`.
- [ ] Re-run that one step after it succeeds so the version is already in S3 and it takes the "already published" skip branch — the exact circumstance that failed build 6345 — and confirm it still sets the meta-data and exits 0.
- [ ] The downstream `Build Example App` step reads `PUBLISHED_WP_API_ANDROID_VERSION` and builds.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
