### PR TITLE
Release `0.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-01
+
 ### Added
 
 - WordPress.com requests now carry a locale query parameter, taken from a `WpComLanguageProvider` set on `WpApiClientDelegate.language_provider`. `/rest/v1.1`, `/rest/v1.2` and `/rest/v1.3` get `locale`; `/wpcom/v2` gets `_locale`; `/oauth2` and every WordPress.org namespace get neither. The provider is asked once per request, so a client is free to return a live value.

--- a/Makefile
+++ b/Makefile
@@ -54,28 +54,13 @@ swift-docs-only:
 	tar -czf swift-docs.tar.gz docs
 
 release-on-ci:
-	@[ -n "$(BUILDKITE_API_TOKEN)" ] || (echo "BUILDKITE_API_TOKEN is not set" && exit 1)
-	@[ -n "$(WORDPRESS_RS_NEW_VERSION)" ] || (echo "WORDPRESS_RS_NEW_VERSION is not set" && exit 1)
-
-	@echo "Triggering a release job on Buildkite. New version: $(WORDPRESS_RS_NEW_VERSION)"
-
-	@mkdir -p .build
-	@echo '{ \
-			"commit": "HEAD", \
-			"branch": "trunk", \
-			"message": "Publishing a new release", \
-			"env": {"NEW_VERSION":"${WORDPRESS_RS_NEW_VERSION}"} \
-		}' | jq > .build/buildkite_release_job_request.json
-
-	@curl -s "https://api.buildkite.com/v2/organizations/automattic/pipelines/wordpress-rs/builds" \
-		-H "Authorization: Bearer $(BUILDKITE_API_TOKEN)" \
-		--json @.build/buildkite_release_job_request.json \
-		--output .build/buildkite_release_job_response.json
-
-	@echo "Buildkite job triggerd. See .build/buildkite_release_job_response.json for the buildkite job details."
+	@# Help: Deprecated. Cut releases by merging a version bump PR; see Documentation/RELEASING.md.
+	@echo "'make release-on-ci' no longer triggers a release."
 	@echo ""
-	@echo "Swift package will be released by https://buildkite.com/automattic/wordpress-rs/builds/$$(jq -r '.number' .build/buildkite_release_job_response.json)"
-	@echo "Once that job finishes, Android libraries will be release by https://buildkite.com/automattic/wordpress-rs/builds?branch=$(WORDPRESS_RS_NEW_VERSION)"
+	@echo "Releases are cut by merging a version bump PR to trunk."
+	@echo "See Documentation/RELEASING.md for the full process, including how to force"
+	@echo "or re-run a release from the Buildkite UI."
+	@exit 1
 
 apple-platform-targets-macos := x86_64-apple-darwin aarch64-apple-darwin
 apple-platform-targets-ios := aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim


### PR DESCRIPTION
## Description

Cut the `0.8.0` release. Renames the `CHANGELOG.md` `## [Unreleased]` section to `## [0.8.0] - 2026-09-01` and adds a fresh empty `## [Unreleased]` above it. Merging this to `trunk` detects the new version and publishes the release automatically, per `Documentation/RELEASING.md`. `0.8.0` is a minor bump because the notes carry breaking changes and the project is pre-1.0.

## Changes

- Rename `## [Unreleased]` → `## [0.8.0] - 2026-09-01` in `CHANGELOG.md`, and add a fresh empty `## [Unreleased]` above it.
- Point `make release-on-ci` at `Documentation/RELEASING.md` instead of triggering a Buildkite build via `curl`. Releases are now cut by merging a version bump PR, so the target prints where to go and exits non-zero rather than kicking off a build. Requested as part of this release PR.

## Notes

- `Documentation/RELEASING.md` says the version bump PR should only edit `CHANGELOG.md`. This one also touches the `Makefile` by request. Release detection is unaffected — `detect-release.sh` diffs `CHANGELOG.md` alone (`git diff … -- CHANGELOG.md`), and the changelog check passes because emptying `## [Unreleased]` still differs from `trunk`.

## Test plan

- [x] `make help` lists `release-on-ci` with its new description.
- [x] `make release-on-ci` prints the pointer to `Documentation/RELEASING.md` and exits non-zero.
- [x] `extract_added_version` in `.buildkite/commands/detect-release.sh` reads `0.8.0` from the added header (checked against this PR's `CHANGELOG.md` diff).
- [ ] Squash-merge to `trunk`; confirm the `trunk` build detects `0.8.0` and publishes the Swift and Android artifacts.

## Changelog

- [x] I've added an entry to `CHANGELOG.md` under `## [Unreleased]`, using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Prefix breaking changes with `**BREAKING:**`.
