### PR TITLE
Accept file URLs for support ticket attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CreateSupportTicketParams` and `AddMessageToSupportConversationParams` accept `attachmentURLs: [URL]` alongside the existing `attachments: [String]`. Attachments cross the bindings as filesystem paths and the request executor opens each one directly, so a caller converting a file URL with `URL.path()` — which percent-encodes by default — produced a path that doesn't exist on disk and failed the request with `MediaFileNotFound`. A filename with a space is enough, and non-ASCII names are escaped too. The new initializers own the conversion.
+
 ## [0.9.0] - 2026-09-07
 
 ### Added

--- a/native/swift/Sources/wordpress-api/WPComExtensions.swift
+++ b/native/swift/Sources/wordpress-api/WPComExtensions.swift
@@ -1,3 +1,4 @@
+import Foundation
 import WordPressAPIInternal
 
 public extension BotMessageContext {
@@ -36,5 +37,60 @@ extension WpComSiteIdentifier: ExpressibleByStringLiteral, ExpressibleByIntegerL
         }
 
         self = WpComSiteIdentifier(integerLiteral: value)
+    }
+}
+
+// MARK: - Attachments
+
+/// Support attachments cross the bindings as filesystem paths, and the request executor opens each
+/// one directly. `URL.path()` percent-encodes by default, so passing it produces a path that
+/// doesn't exist on disk — a filename with a space is enough — and the request fails with
+/// `MediaFileNotFound`:
+///
+/// ```swift
+/// let url = URL(fileURLWithPath: "/tmp/Screen Shot 1.png")
+/// url.path()  // "/tmp/Screen%20Shot%201.png"  ❌
+/// url.path    // "/tmp/Screen Shot 1.png"      ✅
+/// ```
+///
+/// The decoded `path` is also what `MultipartFormContent` uses to open the file, so the value
+/// produced here and the value consumed there are read the same way.
+///
+/// These initializers take the URLs and own the conversion, so a caller holding a file URL — from
+/// a photo picker, say, where the filename comes from the user's library — can't get it wrong.
+///
+/// `attachmentURLs` deliberately has no default value. Giving it one would make a call that
+/// passes no attachments at all match both this initializer and the generated one.
+///
+/// Keep the parameter lists in sync with the generated memberwise initializers in `wp_api.swift`.
+
+public extension CreateSupportTicketParams {
+    init(
+        subject: String,
+        message: String,
+        application: String,
+        wpcomSiteId: UInt64? = nil,
+        tags: [String] = [],
+        encryptedLogIds: [String] = [],
+        attachmentURLs: [URL]
+    ) {
+        self.init(
+            subject: subject,
+            message: message,
+            application: application,
+            wpcomSiteId: wpcomSiteId,
+            tags: tags,
+            encryptedLogIds: encryptedLogIds,
+            attachments: attachmentURLs.map(\.path)
+        )
+    }
+}
+
+public extension AddMessageToSupportConversationParams {
+    init(message: String, attachmentURLs: [URL]) {
+        self.init(
+            message: message,
+            attachments: attachmentURLs.map(\.path)
+        )
     }
 }

--- a/native/swift/Tests/api-compatibility/wpcom/SupportTickets.swift
+++ b/native/swift/Tests/api-compatibility/wpcom/SupportTickets.swift
@@ -24,4 +24,23 @@ struct SupportTicketsCompatTests {
             ]
         )
     }
+
+    @Test func `test ticket creation params with attachment urls`() async throws {
+        _ = CreateSupportTicketParams(
+            subject: "Hello World",
+            message: "Test Message",
+            application: "Test Suite",
+            wpcomSiteId: 1234,
+            tags: ["tag1", "tag2"],
+            encryptedLogIds: [UUID().uuidString],
+            attachmentURLs: [URL(fileURLWithPath: "/path/to/file/on/disk")]
+        )
+    }
+
+    @Test func `test ticket reply params with attachment urls`() async throws {
+        _ = AddMessageToSupportConversationParams(
+            message: "This is a reply",
+            attachmentURLs: [URL(fileURLWithPath: "/path/to/file/on/disk")]
+        )
+    }
 }

--- a/native/swift/Tests/wordpress-api/SupportTicketAttachmentTests.swift
+++ b/native/swift/Tests/wordpress-api/SupportTicketAttachmentTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+import WordPressAPI
+
+@Suite
+struct SupportTicketAttachmentTests {
+
+    /// A photo picked from the library keeps its original filename, and macOS names screenshots
+    /// with spaces. `URL.path()` would hand the request executor `Screen%20Shot%201.png`.
+    @Test func newTicketDecodesPercentEncodingInAttachmentPaths() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "Test Suite",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/Screen Shot 1.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/Screen Shot 1.png"])
+    }
+
+    /// Characters beyond the space get encoded too — including non-ASCII, which `path()` renders as
+    /// UTF-8 escapes.
+    @Test func newTicketDecodesPercentEncodingBeyondSpaces() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "Test Suite",
+            attachmentURLs: [
+                URL(fileURLWithPath: "/tmp/attachments/100% done.png"),
+                URL(fileURLWithPath: "/tmp/attachments/café.png")
+            ]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/100% done.png", "/tmp/attachments/café.png"])
+    }
+
+    /// A name needing no encoding has to survive untouched.
+    @Test func newTicketLeavesAnOrdinaryPathAlone() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "Test Suite",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/IMG_0001.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/IMG_0001.png"])
+    }
+
+    /// The convenience initializer has to carry every other field through unchanged.
+    @Test func newTicketPassesThroughEveryOtherField() {
+        let params = CreateSupportTicketParams(
+            subject: "Subject",
+            message: "Message",
+            application: "Test Suite",
+            wpcomSiteId: 1234,
+            tags: ["tag1", "tag2"],
+            encryptedLogIds: ["log-id"],
+            attachmentURLs: []
+        )
+
+        #expect(params.subject == "Subject")
+        #expect(params.message == "Message")
+        #expect(params.application == "Test Suite")
+        #expect(params.wpcomSiteId == 1234)
+        #expect(params.tags == ["tag1", "tag2"])
+        #expect(params.encryptedLogIds == ["log-id"])
+        #expect(params.attachments.isEmpty)
+    }
+
+    /// The reply path is a different params type, so it needs its own coverage.
+    @Test func replyDecodesPercentEncodingInAttachmentPaths() {
+        let params = AddMessageToSupportConversationParams(
+            message: "Message",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/Screen Shot 1.png")]
+        )
+
+        #expect(params.attachments == ["/tmp/attachments/Screen Shot 1.png"])
+    }
+
+    @Test func replyLeavesAnOrdinaryPathAlone() {
+        let params = AddMessageToSupportConversationParams(
+            message: "Message",
+            attachmentURLs: [URL(fileURLWithPath: "/tmp/attachments/IMG_0001.png")]
+        )
+
+        #expect(params.message == "Message")
+        #expect(params.attachments == ["/tmp/attachments/IMG_0001.png"])
+    }
+
+    @Test func emptyAttachmentsProduceNoPaths() {
+        let params = AddMessageToSupportConversationParams(message: "Message", attachmentURLs: [])
+
+        #expect(params.attachments.isEmpty)
+    }
+}


### PR DESCRIPTION
Adds `attachmentURLs: [URL]` initializers to `CreateSupportTicketParams` and `AddMessageToSupportConversationParams`, so the Swift wrapper owns the URL → filesystem path conversion instead of leaving it to each caller.

## Summary

- Attachments cross the bindings as filesystem paths, and `SafeRequestExecutor` opens each one directly.
- A caller holding a file `URL` has to convert it, and `URL.path()` — the obvious choice — percent-encodes by default. That hands the executor a path that doesn't exist on disk, and the request fails with `MediaFileNotFound`.
- A filename with a space is enough. Non-ASCII names are escaped too.

## Why this belongs in the library

The conversion isn't a caller preference — there is exactly one correct answer, and the library is the only place that knows the string is about to be `open`ed rather than put in a URL. Leaving it to callers means every consumer gets its own chance to be wrong, and the failure is invisible until a user picks a file whose name happens to need encoding.

WordPress-iOS hit this in production on the media path ([WordPress-iOS#26005](https://github.com/wordpress-mobile/WordPress-iOS/pull/26005)) and then again on support attachments ([WordPress-iOS#26008](https://github.com/wordpress-mobile/WordPress-iOS/pull/26008)) — same defect, two call sites, found only by grepping for the shape after the first one. That's the argument for moving it down here.

The attachment filename is user data, not app-generated. On iOS it's whatever PhotosUI exports, which preserves the asset's original name — and macOS names screenshots `Screen Shot 2026-09-08 at 10.31.15.png`.

```swift
let url = URL(fileURLWithPath: "/tmp/Screen Shot 1.png")
url.path()                       // "/tmp/Screen%20Shot%201.png"  ❌
url.path(percentEncoded: false)  // "/tmp/Screen Shot 1.png"      ✅
```

## Changes

**native/swift/Sources/wordpress-api/WPComExtensions.swift**: two convenience initializers taking `attachmentURLs: [URL]`, mirroring the generated memberwise parameter lists so no field is lost.

`attachmentURLs` deliberately has **no default value**. Giving it one would make a call passing no attachments match both this initializer and the generated one.

The existing `attachments: [String]` initializers are **unchanged** — a caller that already has paths keeps working, and this is additive.

## Test plan

- [x] Added `SupportTicketAttachmentTests` — seven cases across both params types: a filename with a space, one with a `%`, one non-ASCII, controls needing no encoding, an empty attachment list, and a pass-through check that every other field survives the convenience initializer.
- [x] Added two cases to `SupportTicketsCompatTests` so the api-compatibility suite pins the new signatures.
- [x] `swift test --filter SupportTicketAttachmentTests` — 7/7 pass.
- [x] `make lint-swift` clean.

## Notes

Two things I did **not** do here, both worth a second opinion:

### `MediaCreateParams` has the same shape

It's the third `RequiresMultipartForm` type and the one that caused the original production bug. It's a `wp_api` type rather than a WP.com one, so it'd land in a different file, and [WordPress-iOS#26005](https://github.com/wordpress-mobile/WordPress-iOS/pull/26005) is currently fixing it caller-side. Happy to add it here instead if you'd rather have all of them consistent. (`ReplyToUnifiedConversationParams` is the fourth; no consumer in WordPress-iOS today.)

### The parameter lists can drift

A convenience initializer that forwards to a generated memberwise initializer has to be updated whenever the Rust record gains a field, and nothing catches it — the new field just isn't reachable through the URL-based initializer. There's a comment saying so, but if you'd rather avoid the maintenance entirely, the drift-free alternative is a named conversion on `URL` that every params type can use:

```swift
public extension URL {
    var multipartFilePath: String { path(percentEncoded: false) }
}
```

That covers all four types at once and never needs syncing, but it doesn't stop a caller from reaching for `path()` anyway. I went with the initializers because preventing the mistake seemed worth more than the upkeep — say the word if you disagree.
